### PR TITLE
Add routes for task commenting

### DIFF
--- a/test/tasks/test_route_task_comment.py
+++ b/test/tasks/test_route_task_comment.py
@@ -1,0 +1,83 @@
+from test.base import ApiDBTestCase
+
+
+class RouteTaskChangeTestCase(ApiDBTestCase):
+
+    def setUp(self):
+        super(RouteTaskChangeTestCase, self).setUp()
+
+        self.generate_fixture_project_status()
+        self.generate_fixture_project()
+        self.generate_fixture_entity_type()
+        self.generate_fixture_entity()
+        self.generate_fixture_sequence()
+        self.generate_fixture_shot()
+        self.generate_fixture_department()
+        self.generate_fixture_task_type()
+        self.generate_fixture_task_status()
+        self.generate_fixture_task_status_wip()
+        self.generate_fixture_person()
+        self.generate_fixture_assigner()
+        self.generate_fixture_task()
+
+        self.wip_status_id = self.task_status_wip.id
+        self.person_id = self.person.id
+
+    def test_comment_task(self):
+        path = "project/tasks/%s/comment/" % self.task.id
+        data = {
+            "task_status_id": self.wip_status_id,
+            "comment": "comment test"
+        }
+        comment = self.post(path, data)
+        self.assertEqual(comment["text"], data["comment"])
+        self.assertEqual(
+            comment["person"]["first_name"],
+            str(self.user.first_name)
+        )
+        self.assertEqual(comment["task_status"]["short_name"], "wip")
+
+        tasks = self.get("data/tasks")
+        self.assertEqual(len(tasks), 1)
+        self.assertEqual(tasks[0]["task_status_id"], str(self.wip_status_id))
+
+        comments = self.get("data/comments/")
+        self.assertEqual(len(comments), 1)
+        self.assertEqual(comments[0]["text"], data["comment"])
+        self.assertEqual(comments[0]["person_id"], str(self.user.id))
+
+    def test_task_comments(self):
+        self.generate_fixture_project_standard()
+        self.generate_fixture_entity_standard()
+        self.generate_fixture_task_standard()
+
+        self.task_id = str(self.task.id)
+        self.task_2_id = str(self.task_standard.id)
+
+        path = "project/tasks/%s/comment/" % self.task_id
+        data = {
+            "task_status_id": self.wip_status_id,
+            "comment": "comment test"
+        }
+        self.post(path, data)
+        data = {
+            "task_status_id": self.wip_status_id,
+            "comment": "comment test 2"
+        }
+        self.post(path, data)
+
+        path = "project/tasks/%s/comment/" % self.task_2_id
+        self.post(path, data)
+
+        path = "data/tasks/%s/comments/" % self.task_id
+        comments = self.get(path)
+        self.assertEqual(len(comments), 2)
+        self.assertEqual(comments[0]["text"], data["comment"])
+        self.assertEqual(
+            comments[0]["person"]["first_name"],
+            str(self.user.first_name)
+        )
+        self.assertEqual(comments[0]["task_status"]["short_name"], "wip")
+
+        path = "data/tasks/unknown/comments/"
+        comments = self.get(path, 404)

--- a/zou/app/api.py
+++ b/zou/app/api.py
@@ -41,6 +41,10 @@ from .resources.project.task_start import (
     TaskStartResource,
     StartTaskFromShotAssetResource
 )
+from .resources.project.tasks import (
+    CommentTaskResource,
+    TaskCommentsResource
+)
 from .resources.project.files import (
     FolderPathResource,
     FilePathResource,
@@ -253,6 +257,8 @@ def configure_api_routes(api):
 
     # Task routes
     api.add_resource(TaskFullResource, "/data/tasks/<instance_id>/full")
+    api.add_resource(CommentTaskResource, "/project/tasks/<task_id>/comment")
+    api.add_resource(TaskCommentsResource, "/data/tasks/<task_id>/comments")
     api.add_resource(TaskAssignResource, "/data/tasks/<instance_id>/assign")
     api.add_resource(TaskStartResource, "/data/tasks/<instance_id>/start")
     api.add_resource(

--- a/zou/app/models/comment.py
+++ b/zou/app/models/comment.py
@@ -14,6 +14,8 @@ class Comment(db.Model, BaseMixin, SerializerMixin):
     text = db.Column(db.Text())
     data = db.Column(JSONB)
 
+    task_status_id = db.Column(
+        UUIDType(binary=False), db.ForeignKey("task_status.id"))
     person_id = db.Column(
         UUIDType(binary=False), db.ForeignKey("person.id"), nullable=False)
 

--- a/zou/app/resources/project/task_full.py
+++ b/zou/app/resources/project/task_full.py
@@ -39,8 +39,8 @@ class TaskFullResource(BaseModelResource):
         result["task_status"] = task_status.serialize()
         entity = Entity.get(task.entity_id)
         result["entity"] = entity.serialize()
-        parent = Entity.get(entity.parent_id)
-        if parent is not None:
+        if entity.parent_id is not None:
+            parent = Entity.get(entity.parent_id)
             result["entity_parent"] = parent.serialize()
         entity_type = EntityType.get(entity.entity_type_id)
         result["entity_type"] = entity_type.serialize()

--- a/zou/app/resources/project/task_full.py
+++ b/zou/app/resources/project/task_full.py
@@ -5,6 +5,7 @@ from zou.app.models.task import Task
 from zou.app.models.project import Project
 from zou.app.models.person import Person
 from zou.app.models.entity import Entity
+from zou.app.models.entity_type import EntityType
 from zou.app.models.task_status import TaskStatus
 from zou.app.models.task_type import TaskType
 
@@ -38,6 +39,11 @@ class TaskFullResource(BaseModelResource):
         result["task_status"] = task_status.serialize()
         entity = Entity.get(task.entity_id)
         result["entity"] = entity.serialize()
+        parent = Entity.get(entity.parent_id)
+        if parent is not None:
+            result["entity_parent"] = parent.serialize()
+        entity_type = EntityType.get(entity.entity_type_id)
+        result["entity_type"] = entity_type.serialize()
         assignees = []
         for assignee in task.assignees:
             assignees.append(assignee.serialize())

--- a/zou/app/resources/project/tasks.py
+++ b/zou/app/resources/project/tasks.py
@@ -1,0 +1,108 @@
+from flask import abort
+from flask_restful import Resource, reqparse
+from flask_login import login_required, current_user
+
+from zou.app.models.task import Task
+from zou.app.models.task_status import TaskStatus
+from zou.app.models.comment import Comment
+from zou.app.models.person import Person
+
+from zou.app.project.exception import TaskNotFoundException
+from zou.app.project import task_info
+
+
+class CommentTaskResource(Resource):
+
+    def __init__(self):
+        Resource.__init__(self)
+
+    @login_required
+    def post(self, task_id):
+        (
+            task_status_id,
+            comment
+        ) = self.get_arguments()
+
+        task = Task.get(task_id)
+        task_status = TaskStatus.get(task_status_id)
+        person = Person.get(current_user.id)
+        comment = Comment.create(
+            object_id=task_id,
+            object_type="Task",
+            task_status_id=task_status_id,
+            person_id=current_user.id,
+            text=comment
+        )
+        task.update({"task_status_id": task_status_id})
+        comment_dict = comment.serialize()
+        comment_dict["task_status"] = task_status.serialize()
+        comment_dict["person"] = person.serialize()
+
+        return comment_dict, 201
+
+    def get_arguments(self):
+        parser = reqparse.RequestParser()
+        parser.add_argument(
+            "task_status_id",
+            required=True,
+            help="Task Status ID is missing"
+        )
+        parser.add_argument("comment", default="")
+        args = parser.parse_args()
+
+        return (
+            args["task_status_id"],
+            args["comment"]
+        )
+
+
+class TaskCommentsResource(Resource):
+
+    def __init__(self):
+        Resource.__init__(self)
+
+    @login_required
+    def get(self, task_id):
+        try:
+            comments = []
+            task = task_info.get_task(task_id)
+            query = Comment.query.order_by(Comment.created_at.desc())
+            query = query.filter_by(
+                object_id=task.id
+            )
+            query = query.join(Person)
+            query = query.join(TaskStatus)
+            query = query.add_columns(TaskStatus.name)
+            query = query.add_columns(TaskStatus.short_name)
+            query = query.add_columns(TaskStatus.color)
+            query = query.add_columns(Person.first_name)
+            query = query.add_columns(Person.last_name)
+            results = query.all()
+
+            for result in results:
+                (
+                    comment,
+                    task_status_name,
+                    task_status_short_name,
+                    task_status_color,
+                    person_first_name,
+                    person_last_name
+                ) = result
+                comment_dict = comment.serialize()
+                comment_dict["person"] = {
+                    "first_name": person_first_name,
+                    "last_name": person_last_name,
+                    "id": str(comment.person_id)
+                }
+                comment_dict["task_status"] = {
+                    "name": task_status_name,
+                    "short_name": task_status_short_name,
+                    "color": task_status_color,
+                    "id": str(comment.task_status_id)
+                }
+                comments.append(comment_dict)
+
+        except TaskNotFoundException:
+            abort(404)
+
+        return comments


### PR DESCRIPTION
There was no way to add and read comments related to a task. 

To fix it, this PR adds:

* A route to post comment on a task (and change its status)
* A route to retrieve comments for a given task