### PR TITLE
Add routes for task mass creation

### DIFF
--- a/test/base.py
+++ b/test/base.py
@@ -430,7 +430,7 @@ class ApiDBTestCase(ApiTestCase):
 
     def generate_fixture_shot_task(self, name="Master"):
         self.shot_task = Task(
-            name="Master",
+            name=name,
             project_id=self.project.id,
             task_type_id=self.task_type_animation.id,
             task_status_id=self.task_status.id,

--- a/test/project/test_task_info.py
+++ b/test/project/test_task_info.py
@@ -81,6 +81,10 @@ class TaskInfoTestCase(ApiDBTestCase):
         task_status = task_info.get_to_review_status()
         self.assertEqual(task_status.name, "To review")
 
+    def test_get_todo_status(self):
+        task_status = task_info.get_todo_status()
+        self.assertEqual(task_status.name, "Todo")
+
     def test_status_to_wip(self):
         events.register(
             "task:start",
@@ -166,6 +170,17 @@ class TaskInfoTestCase(ApiDBTestCase):
     def test_get_department_from_task_type(self):
         department = task_info.get_department_from_task_type(self.task_type)
         self.assertEqual(department.name, "Modeling")
+
+    def test_create_task(self):
+        shot = self.shot.serialize()
+        task_type = self.task_type.serialize()
+        status = task_info.get_todo_status().serialize()
+        task = task_info.create_task(task_type, shot)
+        task = task_info.get_task(task["id"]).serialize()
+        self.assertEquals(task["entity_id"], shot["id"])
+        self.assertEquals(task["task_type_id"], task_type["id"])
+        self.assertEquals(task["project_id"], shot["project_id"])
+        self.assertEquals(task["task_status_id"], status["id"])
 
     def test_get_task(self):
         self.assertRaises(

--- a/test/tasks/test_route_create_tasks.py
+++ b/test/tasks/test_route_create_tasks.py
@@ -1,0 +1,49 @@
+from test.base import ApiDBTestCase
+
+from zou.app.project import task_info
+
+
+class RouteCreateTasksTestCase(ApiDBTestCase):
+
+    def setUp(self):
+        super(RouteCreateTasksTestCase, self).setUp()
+
+        self.generate_fixture_project_status()
+        self.generate_fixture_project()
+        self.generate_fixture_entity_type()
+        self.generate_fixture_entity()
+        self.generate_fixture_sequence()
+        self.generate_fixture_shot()
+        self.generate_fixture_department()
+        self.generate_fixture_task_type()
+        self.generate_fixture_task_status()
+        self.generate_fixture_person()
+        self.generate_fixture_assigner()
+        self.todo_status = task_info.get_or_create_status("Todo")
+        self.entity_id = str(self.entity.id)
+        self.shot_id = str(self.shot.id)
+        self.task_type_id = str(self.task_type.id)
+
+    def test_create_asset_tasks(self):
+        path = "/project/assets/task-types/%s/create-tasks" % self.task_type_id
+        tasks = self.post(path, {})
+        self.assertEqual(len(tasks), 1)
+
+        tasks = self.get("/data/tasks")
+        self.assertEqual(len(tasks), 1)
+        task = tasks[0]
+        self.assertEqual(task["name"], "main")
+        self.assertEqual(task["task_type_id"], self.task_type_id)
+        self.assertEqual(task["entity_id"], self.entity_id)
+
+    def test_create_shot_tasks(self):
+        path = "/project/shots/task-types/%s/create-tasks" % self.task_type_id
+        tasks = self.post(path, {})
+        self.assertEqual(len(tasks), 1)
+
+        tasks = self.get("/data/tasks")
+        self.assertEqual(len(tasks), 1)
+        task = tasks[0]
+        self.assertEqual(task["name"], "main")
+        self.assertEqual(task["task_type_id"], self.task_type_id)
+        self.assertEqual(task["entity_id"], self.shot_id)

--- a/zou/app/api.py
+++ b/zou/app/api.py
@@ -43,7 +43,9 @@ from .resources.project.task_start import (
 )
 from .resources.project.tasks import (
     CommentTaskResource,
-    TaskCommentsResource
+    TaskCommentsResource,
+    CreateShotTasksResource,
+    CreateAssetTasksResource
 )
 from .resources.project.files import (
     FolderPathResource,
@@ -264,6 +266,14 @@ def configure_api_routes(api):
     api.add_resource(
         StartTaskFromShotAssetResource,
         "/data/tasks/task-type/<task_type_id>/entity/<entity_id>/start"
+    )
+    api.add_resource(
+        CreateShotTasksResource,
+        "/project/shots/task-types/<task_type_id>/create-tasks"
+    )
+    api.add_resource(
+        CreateAssetTasksResource,
+        "/project/assets/task-types/<task_type_id>/create-tasks"
     )
 
     # Project routes

--- a/zou/app/models/task.py
+++ b/zou/app/models/task.py
@@ -40,5 +40,15 @@ class Task(db.Model, BaseMixin, SerializerMixin):
         secondary=association_table
     )
 
+    __table_args__ = (
+        db.UniqueConstraint(
+            'name',
+            'project_id',
+            'task_type_id',
+            'entity_id',
+            name='task_uc'
+        ),
+    )
+
     def assignees_as_string(self):
         return ", ".join([x.full_name() for x in self.assignees])

--- a/zou/app/project/exception.py
+++ b/zou/app/project/exception.py
@@ -22,6 +22,10 @@ class TaskNotFoundException(Exception):
     pass
 
 
+class TaskTypeNotFoundException(Exception):
+    pass
+
+
 class PersonNotFoundException(Exception):
     pass
 

--- a/zou/app/project/person_info.py
+++ b/zou/app/project/person_info.py
@@ -1,5 +1,7 @@
 from sqlalchemy.exc import StatementError
 
+from flask_login import current_user
+
 from zou.app.models.person import Person
 from zou.app.project.exception import PersonNotFoundException
 
@@ -40,3 +42,10 @@ def get_by_email(email):
     if person is None:
         raise PersonNotFoundException()
     return person
+
+
+def get_current_user():
+    if current_user:
+        return current_user
+    else:
+        return Person.query.first()


### PR DESCRIPTION
Prior that, there were no way to create a lot of tasks easily.

These new routes allow:

* to create tasks for all shots and a given task type.
* to create tasks for all assets and a given task type.
