### PR TITLE
Fix duplicates in asset import

### DIFF
--- a/test/source/csv/test_import_assets.py
+++ b/test/source/csv/test_import_assets.py
@@ -27,3 +27,15 @@ class ImportCsvAssetsTestCase(ApiDBTestCase):
 
         entity_types = EntityType.query.all()
         self.assertEqual(len(entity_types), 2)
+
+    def test_import_assets_duplicates(self):
+        path = "/data/import/csv/assets"
+
+        file_path_fixture = self.get_fixture_file_path(
+            os.path.join("csv", "assets.csv")
+        )
+        self.upload_file(path, file_path_fixture)
+        self.upload_file(path, file_path_fixture)
+
+        entities = Entity.query.all()
+        self.assertEqual(len(entities), 3)

--- a/zou/app/resources/source/csv/assets.py
+++ b/zou/app/resources/source/csv/assets.py
@@ -36,17 +36,20 @@ class AssetsCsvImportResource(BaseCsvImportResource):
         )
 
         try:
-            entity = Entity.create(
-                name=name,
-                description=description,
-                project_id=project_id,
-                entity_type_id=entity_type_id
-            )
-        except IntegrityError:
             entity = Entity.get_by(
                 name=name,
                 project_id=project_id,
                 entity_type_id=entity_type_id
             )
+
+            if entity is None:
+                entity = Entity.create(
+                    name=name,
+                    description=description,
+                    project_id=project_id,
+                    entity_type_id=entity_type_id
+                )
+        except IntegrityError:
+            pass
 
         return entity


### PR DESCRIPTION
The chekcking of duplicates relied on the unique constraint from the database. But this constraint doesn't apply if parent_id is null. To fix it, it now checks the existence of the asset before inserting it.