### PR TITLE
Improvements and temporary fix

### DIFF
--- a/test/assets/test_route_create_asset.py
+++ b/test/assets/test_route_create_asset.py
@@ -58,16 +58,12 @@ class CreateAssetsTestCase(ApiDBTestCase):
 
     def test_remove_asset(self):
         self.generate_fixture_entity()
-        path = "data/projects/%s/asset-types/%s/assets/%s" % (
-            self.project.id,
-            self.entity_type.id,
-            self.entity.id
-        )
+        path = "data/assets/%s" % self.entity.id
         self.delete(path)
         assets = assets_service.get_assets()
         self.assertEquals(len(assets), 0)
 
-    def test_remove_linked_asset(self):
+    def test_remove_asset_with_tasks(self):
         self.generate_fixture_entity()
         self.generate_fixture_person()
         self.generate_fixture_assigner()
@@ -75,11 +71,7 @@ class CreateAssetsTestCase(ApiDBTestCase):
         self.generate_fixture_task_type()
         self.generate_fixture_task_status()
         self.generate_fixture_task()
-        path = "data/projects/%s/asset-types/%s/assets/%s" % (
-            self.project.id,
-            self.entity_type.id,
-            self.entity.id
-        )
+        path = "data/assets/%s" % self.entity.id
         self.delete(path)
         assets = assets_service.get_assets()
         self.assertEquals(len(assets), 1)

--- a/test/assets/test_route_create_asset.py
+++ b/test/assets/test_route_create_asset.py
@@ -66,3 +66,21 @@ class CreateAssetsTestCase(ApiDBTestCase):
         self.delete(path)
         assets = assets_service.get_assets()
         self.assertEquals(len(assets), 0)
+
+    def test_remove_linked_asset(self):
+        self.generate_fixture_entity()
+        self.generate_fixture_person()
+        self.generate_fixture_assigner()
+        self.generate_fixture_department()
+        self.generate_fixture_task_type()
+        self.generate_fixture_task_status()
+        self.generate_fixture_task()
+        path = "data/projects/%s/asset-types/%s/assets/%s" % (
+            self.project.id,
+            self.entity_type.id,
+            self.entity.id
+        )
+        self.delete(path)
+        assets = assets_service.get_assets()
+        self.assertEquals(len(assets), 1)
+        self.assertEquals(assets[0].canceled, True)

--- a/test/misc/test_commands.py
+++ b/test/misc/test_commands.py
@@ -39,7 +39,7 @@ class CommandsTestCase(ApiTestCase):
             print(self.store.get(key))
         commands.clean_auth_tokens()
         self.assertEquals(len(self.store.keys()), 1)
-        self.assertEquals(self.store.keys()[0], b"testkey")
+        self.assertEquals(self.store.keys()[0], "testkey")
 
     def test_clean_auth_tokens_expired(self):
         now = datetime.datetime.now()
@@ -59,4 +59,4 @@ class CommandsTestCase(ApiTestCase):
         self.assertEquals(len(self.store.keys()), 2)
         commands.clean_auth_tokens()
         self.assertEquals(len(self.store.keys()), 1)
-        self.assertEquals(self.store.keys()[0], b"testkey2")
+        self.assertEquals(self.store.keys()[0], "testkey2")

--- a/test/shots/test_shots.py
+++ b/test/shots/test_shots.py
@@ -1,5 +1,7 @@
 from test.base import ApiDBTestCase
+
 from zou.app.models.entity import Entity
+from zou.app.services import shots_service
 
 
 class ShotTestCase(ApiDBTestCase):
@@ -39,3 +41,25 @@ class ShotTestCase(ApiDBTestCase):
             shot,
             self.shot.serialize(obj_type="Shot")
         )
+
+    def test_remove_shot(self):
+        self.generate_fixture_entity()
+        path = "data/shots/%s" % self.shot.id
+        self.delete(path)
+        shots = shots_service.get_shots()
+        self.assertEquals(len(shots), 2)
+
+    def test_remove_shot_with_tasks(self):
+        self.generate_fixture_entity()
+        self.generate_fixture_person()
+        self.generate_fixture_assigner()
+        self.generate_fixture_department()
+        self.generate_fixture_task_type()
+        self.generate_fixture_task_status()
+        self.generate_fixture_shot_task()
+        path = "data/shots/%s" % self.shot.id
+        print(path)
+        self.delete(path)
+        shots = shots_service.get_shots()
+        self.assertEquals(len(shots), 3)
+        self.assertEquals(shots[2]["canceled"], True)

--- a/zou/app/blueprints/assets/__init__.py
+++ b/zou/app/blueprints/assets/__init__.py
@@ -11,7 +11,6 @@ from .resources import (
     ProjectAssetTypesResource,
     ShotAssetTypesResource,
     NewAssetResource,
-    RemoveAssetResource,
     ProjectAssetsResource,
     ProjectAssetTypeAssetsResource,
     AssetTasksResource,
@@ -25,7 +24,7 @@ routes = [
     ("/data/assets", AssetsResource),
     ("/data/assets/all", AllAssetsResource),
     ("/data/assets/with-tasks", AssetsAndTasksResource),
-    ("/data/assets/<instance_id>", AssetResource),
+    ("/data/assets/<asset_id>", AssetResource),
     ("/data/assets/<instance_id>/tasks", AssetTasksResource),
     ("/data/assets/<instance_id>/task-types", AssetTaskTypesResource),
     (
@@ -35,11 +34,6 @@ routes = [
     (
         "/data/projects/<project_id>/asset-types/<asset_type_id>/assets/new",
         NewAssetResource
-    ),
-    (
-        "/data/projects/<project_id>/asset-types/<asset_type_id>/"
-        "assets/<asset_id>",
-        RemoveAssetResource
     ),
     (
         "/data/projects/<project_id>/asset-types",

--- a/zou/app/blueprints/assets/resources.py
+++ b/zou/app/blueprints/assets/resources.py
@@ -14,7 +14,6 @@ from zou.app.services.exception import (
     AssetNotFoundException
 )
 
-from sqlalchemy.exc import IntegrityError
 
 class AssetResource(Resource):
 
@@ -22,15 +21,24 @@ class AssetResource(Resource):
         Resource.__init__(self)
 
     @jwt_required
-    def get(self, instance_id):
+    def get(self, asset_id):
         """
         Retrieve given asset.
         """
         try:
-            asset = assets_service.get_asset(instance_id)
+            asset = assets_service.get_asset(asset_id)
         except AssetNotFoundException:
             abort(404)
         return asset.serialize(obj_type="Asset")
+
+    @jwt_required
+    def delete(self, asset_id):
+        try:
+            deleted_asset = assets_service.remove_asset(asset_id)
+        except AssetNotFoundException:
+            abort(404)
+        print(deleted_asset["canceled"])
+        return deleted_asset, 204
 
 
 class AssetsResource(Resource):
@@ -247,32 +255,3 @@ class NewAssetResource(Resource):
             args["name"],
             args.get("description", ""),
         )
-
-
-class RemoveAssetResource(Resource):
-
-    @jwt_required
-    def delete(self, project_id, asset_type_id, asset_id):
-        try:
-            project = projects_service.get_project(project_id)
-            asset_type = assets_service.get_asset_type(asset_type_id)
-            asset = assets_service.get_asset(asset_id)
-
-            if asset.project_id != project.id:
-                abort(404)
-
-            if asset.entity_type_id != asset_type.id:
-                abort(404)
-
-            deleted_asset = assets_service.remove_asset(asset_id)
-        except ProjectNotFoundException:
-            abort(404)
-        except AssetTypeNotFoundException:
-            abort(404)
-        except AssetNotFoundException:
-            abort(404)
-        except IntegrityError:
-            asset.update({"canceled": True})
-            deleted_asset = asset.serialize()
-
-        return deleted_asset, 204

--- a/zou/app/blueprints/assets/resources.py
+++ b/zou/app/blueprints/assets/resources.py
@@ -14,6 +14,7 @@ from zou.app.services.exception import (
     AssetNotFoundException
 )
 
+from sqlalchemy.exc import IntegrityError
 
 class AssetResource(Resource):
 
@@ -270,5 +271,8 @@ class RemoveAssetResource(Resource):
             abort(404)
         except AssetNotFoundException:
             abort(404)
+        except IntegrityError:
+            asset.update({"canceled": True})
+            deleted_asset = asset.serialize()
 
         return deleted_asset, 204

--- a/zou/app/blueprints/shots/__init__.py
+++ b/zou/app/blueprints/shots/__init__.py
@@ -24,7 +24,8 @@ from .resources import (
 
 routes = [
     ("/data/shots/all", ShotsResource),
-    ("/data/shots/<instance_id>", ShotResource),
+    ("/data/shots/with-tasks", ShotsAndTasksResource),
+    ("/data/shots/<shot_id>", ShotResource),
     ("/data/episodes", EpisodesResource),
     ("/data/episodes/<instance_id>", EpisodeResource),
     ("/data/episodes/<instance_id>/sequences", EpisodeSequencesResource),
@@ -34,7 +35,6 @@ routes = [
     ("/data/shots/<instance_id>/assets", ShotAssetsResource),
     ("/data/shots/<shot_id>/task-types", ShotTaskTypesResource),
     ("/data/shots/<instance_id>/tasks", ShotTasksResource),
-    ("/data/shots/with-tasks", ShotsAndTasksResource),
     ("/data/projects/<project_id>/shots", ProjectShotsResource),
     ("/data/projects/<project_id>/sequences", ProjectSequencesResource),
     ("/data/projects/<project_id>/episodes", ProjectEpisodesResource)

--- a/zou/app/blueprints/shots/resources.py
+++ b/zou/app/blueprints/shots/resources.py
@@ -25,15 +25,24 @@ class ShotResource(Resource):
         Resource.__init__(self)
 
     @jwt_required
-    def get(self, instance_id):
+    def get(self, shot_id):
         """
         Retrieve given shot.
         """
         try:
-            shot = shots_service.get_shot(instance_id)
+            shot = shots_service.get_shot(shot_id)
         except ShotNotFoundException:
             abort(404)
         return shot.serialize(obj_type="Shot")
+
+    @jwt_required
+    def delete(self, shot_id):
+        try:
+            deleted_shot = shots_service.remove_shot(shot_id)
+        except ShotNotFoundException:
+            abort(404)
+
+        return deleted_shot, 204
 
 
 class ShotsResource(Resource):

--- a/zou/app/config.py
+++ b/zou/app/config.py
@@ -23,6 +23,7 @@ JWT_ACCESS_TOKEN_EXPIRES = datetime.timedelta(days=7)
 JWT_REFRESH_TOKEN_EXPIRES = datetime.timedelta(days=15)
 JWT_TOKEN_LOCATION = ['cookies', 'headers']
 JWT_REFRESH_COOKIE_PATH = '/auth/refresh-token'
+JWT_COOKIE_CSRF_PROTECT = False
 
 RESTFUL_JSON = {
     "ensure_ascii": False

--- a/zou/app/config.py
+++ b/zou/app/config.py
@@ -24,6 +24,7 @@ JWT_REFRESH_TOKEN_EXPIRES = datetime.timedelta(days=15)
 JWT_TOKEN_LOCATION = ['cookies', 'headers']
 JWT_REFRESH_COOKIE_PATH = '/auth/refresh-token'
 JWT_COOKIE_CSRF_PROTECT = False
+JWT_SESSION_COOKIE = False
 
 RESTFUL_JSON = {
     "ensure_ascii": False

--- a/zou/app/models/entity.py
+++ b/zou/app/models/entity.py
@@ -33,6 +33,7 @@ class Entity(db.Model, BaseMixin, SerializerMixin):
     name = db.Column(db.String(160), nullable=False)
     description = db.Column(db.String(600))
     shotgun_id = db.Column(db.Integer)
+    canceled = db.Column(db.Boolean, default=False)
 
     project_id = db.Column(
         UUIDType(binary=False), db.ForeignKey('project.id'), nullable=False)

--- a/zou/app/services/assets_service.py
+++ b/zou/app/services/assets_service.py
@@ -1,4 +1,4 @@
-from sqlalchemy.exc import StatementError
+from sqlalchemy.exc import StatementError, IntegrityError
 
 from zou.app.utils import events
 
@@ -170,8 +170,11 @@ def create_asset(project, asset_type, name, description):
 
 def remove_asset(asset_id):
     asset = get_asset(asset_id)
+    try:
+        asset.delete()
+    except IntegrityError:
+        asset.update({"canceled": True})
     deleted_asset = asset.serialize(obj_type="Asset")
-    asset.delete()
     events.emit("asset:deletion", {
         "deleted_asset": deleted_asset
     })

--- a/zou/app/stores/auth_tokens_store.py
+++ b/zou/app/stores/auth_tokens_store.py
@@ -22,22 +22,34 @@ except:
 
 
 def add(key, token, ttl=None):
-    return revoked_tokens_store.set(key, token, ex=ttl)
+    return revoked_tokens_store.set(key.encode("utf-8"), token, ex=ttl)
 
 
 def get(key):
-    return revoked_tokens_store.get(key)
+    value = revoked_tokens_store.get(key)
+    if value is not None and hasattr(value, 'decode'):
+        value = is_revoked.decode("utf-8")
+    return value
 
 
 def delete(key):
-    return revoked_tokens_store.delete(key)
+    return revoked_tokens_store.delete(key.encode("utf-8"))
 
 
 def keys():
-    return revoked_tokens_store.keys()
+    keys = revoked_tokens_store.keys()
+    if len(keys) > 0 and hasattr(keys[0], 'decode'):
+        return [x.decode("utf-8") for x in revoked_tokens_store.keys()]
+    else:
+        return [x for x in revoked_tokens_store.keys()]
+
+
+def clear():
+    for key in keys():
+        delete(key)
 
 
 def is_revoked(decrypted_token):
     jti = decrypted_token["jti"]
     is_revoked = get(jti)
-    return (is_revoked is None) or (is_revoked.decode("utf-8") == "true")
+    return (is_revoked is None) or (is_revoked == "true")

--- a/zou/app/stores/auth_tokens_store.py
+++ b/zou/app/stores/auth_tokens_store.py
@@ -28,7 +28,7 @@ def add(key, token, ttl=None):
 def get(key):
     value = revoked_tokens_store.get(key)
     if value is not None and hasattr(value, 'decode'):
-        value = is_revoked.decode("utf-8")
+        value = value.decode("utf-8")
     return value
 
 

--- a/zou/app/utils/commands.py
+++ b/zou/app/utils/commands.py
@@ -7,7 +7,7 @@ from zou.app.stores import auth_tokens_store as store
 def clean_auth_tokens():
 
     for key in store.keys():
-        value = json.loads(store.get(key).decode("utf-8"))
+        value = json.loads(store.get(key))
 
         is_revoked = value["revoked"] == True
         expiration = datetime.datetime.fromtimestamp(value["token"]["exp"])


### PR DESCRIPTION
**Problems**

* When an asset or a shot has something linked to it, it can't be deleted.
* Frontend is not ready to handle CSRF protection, so POST and DELETE requests get 401 response even if the user is authenticated.
* Session closes when browser is closed.
* Store tests fail.

**Solutions**

* Add a cancel flag to asset and shots. When deletion raises an integrity error, it sets a cancel flag to true instead of removing the element.
* Disable temporarly the CSRF protection.
* Change the session mode in Flask JWT Extended options.
* Fix tests by enforcing string instead of bytes when dealing with stores.