### PR TITLE
Fix recent optimisation needed to retrieve entities with tasks

### DIFF
--- a/test/base.py
+++ b/test/base.py
@@ -311,9 +311,9 @@ class ApiDBTestCase(ApiTestCase):
         )
         self.episode.save()
 
-    def generate_fixture_shot(self):
+    def generate_fixture_shot(self, name="P01"):
         self.shot = Entity(
-            name="P01",
+            name=name,
             description="Description Shot 01",
             data={
                 "fps": 25,
@@ -378,7 +378,7 @@ class ApiDBTestCase(ApiTestCase):
 
     def generate_fixture_asset_types(self):
         self.entity_type_character = EntityType(name="Character")
-        self.entity_type_character .save()
+        self.entity_type_character.save()
         self.entity_type_environment = EntityType(name="Environment")
         self.entity_type_environment.save()
 

--- a/test/services/test_assets_service.py
+++ b/test/services/test_assets_service.py
@@ -40,7 +40,19 @@ class AssetServiceTestCase(ApiDBTestCase):
         self.assertEqual(len(assets), 1)
         self.assertEqual(assets[0].name, "Tree")
 
+    def test_get_asset_map(self):
+        self.generate_fixture_asset_types()
+        self.generate_fixture_entity_character()
+        asset_map = assets_service.get_asset_map()
+        self.assertEquals(len(asset_map.keys()), 2)
+        self.assertEquals(
+            asset_map[str(self.entity.id)]["name"],
+            self.entity.name
+        )
+
     def test_get_assets_and_tasks(self):
+        self.generate_fixture_asset_types()
+        self.generate_fixture_entity_character()
         self.generate_fixture_person()
         self.generate_fixture_assigner()
         self.generate_fixture_department()
@@ -49,7 +61,7 @@ class AssetServiceTestCase(ApiDBTestCase):
         self.generate_fixture_task()
         self.generate_fixture_task(name="Secondary")
         assets = assets_service.all_assets_and_tasks()
-        self.assertEqual(len(assets), 1)
+        self.assertEqual(len(assets), 2)
         self.assertEqual(len(assets[0]["tasks"]), 2)
         self.assertEqual(
             assets[0]["tasks"][0]["task_status_name"], "Open"

--- a/test/services/test_shots_service.py
+++ b/test/services/test_shots_service.py
@@ -51,13 +51,22 @@ class ShotUtilsTestCase(ApiDBTestCase):
             self.sequence.serialize()
         )
 
+    def test_get_shot_map(self):
+        self.generate_fixture_shot("P02")
+        shot_map = shots_service.get_shot_map()
+        self.assertEquals(len(shot_map.keys()), 2)
+        self.assertEquals(
+            shot_map[str(self.shot.id)]["name"],
+            self.shot.name
+        )
+
     def test_get_shots(self):
         shots = shots_service.get_shots()
         self.shot_dict = self.shot.serialize(obj_type="Shot")
         self.shot_dict["project_name"] = self.project.name
         self.shot_dict["sequence_name"] = self.sequence.name
-
         self.assertDictEqual(shots[0], self.shot_dict)
+
 
     def test_get_shots_and_tasks(self):
         self.generate_fixture_person()
@@ -67,11 +76,14 @@ class ShotUtilsTestCase(ApiDBTestCase):
         self.generate_fixture_task_type()
         self.generate_fixture_shot_task()
         self.generate_fixture_shot_task(name="Secondary")
+        self.generate_fixture_shot("P02")
         shots = shots_service.get_shots_and_tasks()
-        self.assertEqual(len(shots), 1)
+        shots = sorted(shots, key=lambda s: s["name"])
+        self.assertEqual(len(shots), 2)
         self.assertEqual(len(shots[0]["tasks"]), 2)
+        self.assertEqual(len(shots[1]["tasks"]), 0)
         self.assertEqual(
-            shots[0]["tasks"][0]["task_status_name"], "Open"
+            shots[0]["tasks"][1]["task_status_name"], "Open"
         )
         self.assertEqual(
             shots[0]["tasks"][0]["task_type_name"], "Animation"

--- a/zou/app/services/assets_service.py
+++ b/zou/app/services/assets_service.py
@@ -245,14 +245,51 @@ def get_task_type_map():
     }
 
 
+def get_asset_map(criterions={}):
+    asset_map = {}
+
+    shot_type = shots_service.get_shot_type()
+    sequence_type = shots_service.get_sequence_type()
+    episode_type = shots_service.get_episode_type()
+    asset_query = Entity.query \
+        .join(EntityType) \
+        .filter(
+            ~Entity.entity_type_id.in_([
+                shot_type.id,
+                sequence_type.id,
+                episode_type.id
+            ])
+        ) \
+        .add_columns(EntityType.name)
+
+    if "project_id" in criterions:
+        asset_query = \
+            asset_query.filter(Entity.project_id == criterions["project_id"])
+
+    assets = asset_query.all()
+
+    for (asset, entity_type_name) in assets:
+        asset_id = str(asset.id)
+        asset_map[asset_id] = {
+            "id": str(asset.id),
+            "name": asset.name,
+            "description": asset.description,
+            "asset_type_name": entity_type_name,
+            "canceled": asset.canceled,
+            "data": fields.serialize_value(asset.data)
+        }
+
+    return asset_map
+
+
 def all_assets_and_tasks(criterions={}):
     shot_type = shots_service.get_shot_type()
     sequence_type = shots_service.get_sequence_type()
     episode_type = shots_service.get_episode_type()
     task_status_map = get_task_status_map()
     task_type_map = get_task_type_map()
+    asset_map = get_asset_map(criterions)
     task_map = {}
-    asset_map = {}
 
     query = Task.query \
         .join(Entity) \
@@ -263,38 +300,19 @@ def all_assets_and_tasks(criterions={}):
                 sequence_type.id,
                 episode_type.id
             ])
-        ) \
-        .add_columns(EntityType.name) \
-        .add_columns(Entity.name) \
-        .add_columns(Entity.description) \
-        .add_columns(Entity.data) \
-        .add_columns(Entity.canceled)
+        )
 
     if "project_id" in criterions:
         query = query.filter(Entity.project_id == criterions["project_id"])
 
     tasks = query.all()
 
-    for (
-        task,
-        entity_type_name,
-        entity_name,
-        entity_description,
-        entity_data,
-        entity_canceled
-    ) in tasks:
+    for task in tasks:
         asset_id = str(task.entity_id)
-        if task.entity_id not in asset_map:
-            asset_map[asset_id] = {
-                "id": asset_id,
-                "name": entity_name,
-                "asset_type_name": entity_type_name,
-                "canceled": entity_canceled,
-                "data": fields.serialize_value(entity_data)
-            }
 
         if asset_id not in task_map:
             task_map[asset_id] = []
+
         task_dict = {"id": str(task.id)}
         task_status = task_status_map[task.task_status_id]
         task_type = task_type_map[task.task_type_id]

--- a/zou/app/services/assets_service.py
+++ b/zou/app/services/assets_service.py
@@ -267,7 +267,8 @@ def all_assets_and_tasks(criterions={}):
         .add_columns(EntityType.name) \
         .add_columns(Entity.name) \
         .add_columns(Entity.description) \
-        .add_columns(Entity.data)
+        .add_columns(Entity.data) \
+        .add_columns(Entity.canceled)
 
     if "project_id" in criterions:
         query = query.filter(Entity.project_id == criterions["project_id"])
@@ -279,7 +280,8 @@ def all_assets_and_tasks(criterions={}):
         entity_type_name,
         entity_name,
         entity_description,
-        entity_data
+        entity_data,
+        entity_canceled
     ) in tasks:
         asset_id = str(task.entity_id)
         if task.entity_id not in asset_map:
@@ -287,6 +289,7 @@ def all_assets_and_tasks(criterions={}):
                 "id": asset_id,
                 "name": entity_name,
                 "asset_type_name": entity_type_name,
+                "canceled": entity_canceled,
                 "data": fields.serialize_value(entity_data)
             }
 

--- a/zou/app/services/shots_service.py
+++ b/zou/app/services/shots_service.py
@@ -116,7 +116,8 @@ def get_shots_and_tasks(criterions={}):
         .add_columns(Sequence.name) \
         .add_columns(Entity.name) \
         .add_columns(Entity.description) \
-        .add_columns(Entity.data)
+        .add_columns(Entity.data) \
+        .add_columns(Entity.canceled)
 
     if "project_id" in criterions:
         query = query.filter(Entity.project_id == criterions["project_id"])
@@ -128,7 +129,8 @@ def get_shots_and_tasks(criterions={}):
         sequence_name,
         entity_name,
         entity_description,
-        entity_data
+        entity_data,
+        entity_canceled
     ) in tasks:
         shot_id = str(task.entity_id)
         if task.entity_id not in shot_map:
@@ -136,6 +138,7 @@ def get_shots_and_tasks(criterions={}):
                 "id": shot_id,
                 "name": entity_name,
                 "sequence_name": sequence_name,
+                "canceled": entity_canceled,
                 "data": fields.serialize_dict(entity_data)
             }
 

--- a/zou/app/services/shots_service.py
+++ b/zou/app/services/shots_service.py
@@ -101,49 +101,57 @@ def get_task_type_map():
     }
 
 
+def get_shot_map(criterions={}):
+    shot_map = {}
+
+    shot_type = get_shot_type()
+    Sequence = aliased(Entity, name='sequence')
+    shot_query = Entity.query \
+        .join(EntityType) \
+        .join(Sequence, Sequence.id == Entity.parent_id) \
+        .add_columns(Sequence.name) \
+        .filter(Entity.entity_type_id == shot_type.id)
+    if "project_id" in criterions:
+        shot_query = \
+            shot_query.filter(Entity.project_id == criterions["project_id"])
+    shots = shot_query.all()
+
+    for (shot, sequence_name) in shots:
+        shot_id = str(shot.id)
+        shot_map[shot_id] = {
+            "id": str(shot.id),
+            "name": shot.name,
+            "description": shot.description,
+            "sequence_name": sequence_name,
+            "canceled": shot.canceled,
+            "data": fields.serialize_value(shot.data)
+        }
+
+    return shot_map
+
+
 def get_shots_and_tasks(criterions={}):
     shot_type = get_shot_type()
     task_status_map = get_task_status_map()
     task_type_map = get_task_type_map()
+    shot_map = get_shot_map(criterions)
     task_map = {}
-    shot_map = {}
 
-    Sequence = aliased(Entity, name='sequence')
     query = Task.query \
         .join(Entity) \
-        .filter(Entity.entity_type_id == shot_type.id) \
-        .join(Sequence, Sequence.id == Entity.parent_id) \
-        .add_columns(Sequence.name) \
-        .add_columns(Entity.name) \
-        .add_columns(Entity.description) \
-        .add_columns(Entity.data) \
-        .add_columns(Entity.canceled)
+        .filter(Entity.entity_type_id == shot_type.id)
 
     if "project_id" in criterions:
         query = query.filter(Entity.project_id == criterions["project_id"])
 
     tasks = query.all()
 
-    for (
-        task,
-        sequence_name,
-        entity_name,
-        entity_description,
-        entity_data,
-        entity_canceled
-    ) in tasks:
+    for task in tasks:
         shot_id = str(task.entity_id)
-        if task.entity_id not in shot_map:
-            shot_map[shot_id] = {
-                "id": shot_id,
-                "name": entity_name,
-                "sequence_name": sequence_name,
-                "canceled": entity_canceled,
-                "data": fields.serialize_dict(entity_data)
-            }
 
         if shot_id not in task_map:
             task_map[shot_id] = []
+
         task_dict = {"id": str(task.id)}
         task_status = task_status_map[task.task_status_id]
         task_type = task_type_map[task.task_type_id]


### PR DESCRIPTION
**Problem**

When the list of asset with tasks was retrieved, the *canceled* field was lost and entities without task were not sent.

**Solution**

* Add the canceled field to the result
* Make a second request retrieving entities without join with tasks. Then we reconciliate both queries (asset and tasks).