### PR TITLE
Update sqlalchemy-utils dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ ldap3
 email_validator==1.0.2
 
 sqlalchemy==1.1.10
-sqlalchemy_utils==0.32.14
+sqlalchemy_utils==0.32.21
 psycopg2==2.7.1
 
 python-slugify==1.2.4


### PR DESCRIPTION
Default URL scheme used in [zou/app/config.py](https://github.com/cgwire/zou/blob/80d33727a781dd1635027bf3e8e084bce6c3278a/zou/app/config.py#L35) is `postgres` then this `sqlalchemy-utils` [bugfix](https://github.com/kvesteri/sqlalchemy-utils/pull/284) is required in order to use PostgreSQL Unix-domain socket.

This command allows to use Unix-domain socket:
`DB_HOST='' zou init_db`
