### PR TITLE
Fix add preview resource

### DIFF
--- a/zou/app/blueprints/tasks/resources.py
+++ b/zou/app/blueprints/tasks/resources.py
@@ -102,7 +102,7 @@ class AddPreviewResource(Resource):
         events.emit("preview:add", {
             "comment_id": comment_id,
             "task_id": task_id,
-            "preview": preview.serialize()
+            "preview": preview
         })
 
         return preview, 201


### PR DESCRIPTION
**Problem**

When a preview was added, it raised a server error.

**Solutions**

Do not try to JSON serialize the dictionary representing the preview when adding a preview. It is already ready to be sent as JSON.