### PR TITLE
Add more information when sending entity details

### DIFF
--- a/test/assets/test_assets.py
+++ b/test/assets/test_assets.py
@@ -21,6 +21,9 @@ class AssetsTestCase(ApiDBTestCase):
 
     def test_get_asset(self):
         asset = self.get("data/assets/%s" % self.entity.id)
+        self.entity_dict["project_name"] = self.project.name
+        self.entity_dict["asset_type_id"] = str(self.entity_type.id)
+        self.entity_dict["asset_type_name"] = self.entity_type.name
         self.assertDictEqual(asset, self.entity_dict)
 
     def test_get_project_assets(self):

--- a/test/shots/test_episodes.py
+++ b/test/shots/test_episodes.py
@@ -1,4 +1,5 @@
 from test.base import ApiDBTestCase
+
 from zou.app.models.entity import Entity
 
 
@@ -45,10 +46,9 @@ class EpisodeTestCase(ApiDBTestCase):
 
     def test_get_episode(self):
         episode = self.get("data/episodes/%s" % self.episode.id)
-        self.assertDictEqual(
-            episode,
-            self.episode.serialize(obj_type="Episode")
-        )
+        self.assertEquals(episode["id"], str(self.episode.id))
+        self.assertEquals(episode["name"], self.episode.name)
+        self.assertEquals(episode["project_name"], self.project.name)
 
     def test_create_episode(self):
         episode_name = "NE01"

--- a/test/shots/test_scenes.py
+++ b/test/shots/test_scenes.py
@@ -3,10 +3,10 @@ from test.base import ApiDBTestCase
 from zou.app.models.entity import Entity
 
 
-class SequenceTestCase(ApiDBTestCase):
+class SceneTestCase(ApiDBTestCase):
 
     def setUp(self):
-        super(SequenceTestCase, self).setUp()
+        super(SceneTestCase, self).setUp()
         self.generate_shot_suite()
         self.generate_assigned_task()
 
@@ -52,10 +52,13 @@ class SequenceTestCase(ApiDBTestCase):
 
     def test_get_scene(self):
         scene = self.get("data/scenes/%s" % self.scene.id)
-        self.assertDictEqual(
-            scene,
-            self.scene.serialize(obj_type="Scene")
-        )
+        self.assertEquals(scene["id"], str(self.scene.id))
+        self.assertEquals(scene["name"], self.scene.name)
+        self.assertEquals(scene["sequence_name"], self.sequence.name)
+        self.assertEquals(scene["sequence_id"], str(self.sequence.id))
+        self.assertEquals(scene["episode_name"], self.episode.name)
+        self.assertEquals(scene["episode_id"], str(self.episode.id))
+        self.assertEquals(scene["project_name"], self.project.name)
 
     def test_create_scene(self):
         scene_name = "NSC01"

--- a/test/shots/test_sequences.py
+++ b/test/shots/test_sequences.py
@@ -9,6 +9,7 @@ class SequenceTestCase(ApiDBTestCase):
         self.generate_fixture_project_status()
         self.generate_fixture_project()
         self.generate_fixture_entity_type()
+        self.generate_fixture_episode()
         self.generate_fixture_sequence()
         self.generate_fixture_department()
         self.generate_fixture_task_type()
@@ -42,10 +43,11 @@ class SequenceTestCase(ApiDBTestCase):
 
     def test_get_sequence(self):
         sequence = self.get("data/sequences/%s" % self.sequence.id)
-        self.assertDictEqual(
-            sequence,
-            self.sequence.serialize(obj_type="Sequence")
-        )
+        self.assertEquals(sequence["id"], str(self.sequence.id))
+        self.assertEquals(sequence["name"], self.sequence.name)
+        self.assertEquals(sequence["episode_name"], self.episode.name)
+        self.assertEquals(sequence["episode_id"], str(self.episode.id))
+        self.assertEquals(sequence["project_name"], self.project.name)
 
     def test_get_sequence_tasks(self):
         self.generate_fixture_sequence_task()

--- a/test/shots/test_shots.py
+++ b/test/shots/test_shots.py
@@ -11,6 +11,7 @@ class ShotTestCase(ApiDBTestCase):
         self.generate_fixture_project_status()
         self.generate_fixture_project()
         self.generate_fixture_entity_type()
+        self.generate_fixture_episode()
         self.generate_fixture_sequence()
         self.generate_fixture_shot()
 
@@ -45,10 +46,12 @@ class ShotTestCase(ApiDBTestCase):
     def test_get_shot(self):
         shot = self.get("data/shots/%s" % self.shot.id)
         self.assertEquals(shot["id"], str(self.shot.id))
-        self.assertDictEqual(
-            shot,
-            self.shot.serialize(obj_type="Shot")
-        )
+        self.assertEquals(shot["name"], self.shot.name)
+        self.assertEquals(shot["sequence_name"], self.sequence.name)
+        self.assertEquals(shot["sequence_id"], str(self.sequence.id))
+        self.assertEquals(shot["episode_name"], self.episode.name)
+        self.assertEquals(shot["episode_id"], str(self.episode.id))
+        self.assertEquals(shot["project_name"], self.project.name)
 
     def test_remove_shot(self):
         self.generate_fixture_entity()

--- a/zou/app/blueprints/assets/resources.py
+++ b/zou/app/blueprints/assets/resources.py
@@ -18,7 +18,7 @@ class AssetResource(Resource):
         """
         Retrieve given asset.
         """
-        asset = assets_service.get_asset(asset_id)
+        asset = assets_service.get_full_asset(asset_id)
         if not permissions.has_manager_permissions():
             user_service.check_has_task_related(asset["project_id"])
         return asset

--- a/zou/app/blueprints/shots/resources.py
+++ b/zou/app/blueprints/shots/resources.py
@@ -26,7 +26,7 @@ class ShotResource(Resource):
         """
         Retrieve given shot.
         """
-        shot = shots_service.get_shot(shot_id)
+        shot = shots_service.get_full_shot(shot_id)
         if not permissions.has_manager_permissions():
             user_service.check_has_task_related(shot["project_id"])
         return shot
@@ -51,7 +51,7 @@ class SceneResource(Resource):
         """
         Retrieve given scene.
         """
-        scene = shots_service.get_scene(scene_id)
+        scene = shots_service.get_full_scene(scene_id)
         if not permissions.has_manager_permissions():
             user_service.check_has_task_related(scene["project_id"])
 
@@ -277,7 +277,7 @@ class EpisodeResource(Resource):
         """
         Retrieve given episode.
         """
-        episode = shots_service.get_episode(episode_id)
+        episode = shots_service.get_full_episode(episode_id)
         if not permissions.has_manager_permissions():
             user_service.check_has_task_related(episode["project_id"])
         return episode
@@ -321,7 +321,7 @@ class SequenceResource(Resource):
         """
         Retrieve given sequence.
         """
-        sequence = shots_service.get_sequence(sequence_id)
+        sequence = shots_service.get_full_sequence(sequence_id)
         if not permissions.has_manager_permissions():
             user_service.check_has_task_related(sequence["project_id"])
         return sequence

--- a/zou/app/services/assets_service.py
+++ b/zou/app/services/assets_service.py
@@ -94,6 +94,16 @@ def get_asset(entity_id):
     return get_asset_raw(entity_id).serialize(obj_type="Asset")
 
 
+def get_full_asset(asset_id):
+    asset = get_asset(asset_id)
+    project = Project.get(asset["project_id"])
+    asset_type = get_asset_type_raw(asset["entity_type_id"])
+    asset["project_name"] = project.name
+    asset["asset_type_id"] = str(asset_type.id)
+    asset["asset_type_name"] = asset_type.name
+    return asset
+
+
 def get_asset_type_raw(asset_type_id):
     try:
         asset_type = EntityType.get(asset_type_id)
@@ -381,6 +391,7 @@ def all_assets_and_tasks(criterions={}):
             "task_status_name": task_status["name"],
             "task_status_short_name": task_status["short_name"],
             "task_status_color": task_status["color"],
+            "task_type_id": task_type["id"],
             "task_type_name": task_type["name"],
             "task_type_color": task_type["color"],
             "task_type_priority": task_type["priority"],


### PR DESCRIPTION
**Problem**

When retrieving the details of an entity (Asset, Shot, Sequence, Episode), there is no context information. Which require to do more requests for basic information See https://github.com/cgwire/gazu/issues/12 for details.

**Solution**

Add more data (project and parent names) to returned data by retrieving full information on related information on the server side.