### PR TITLE
Additional information for better task review

### DIFF
--- a/zou/app/blueprints/tasks/resources.py
+++ b/zou/app/blueprints/tasks/resources.py
@@ -84,9 +84,10 @@ class AddPreviewResource(Resource):
         )
         person = persons_service.get_current_user()
 
-        if task_status["short_name"] not in ["wfa", "retake"]:
+        if not task_status["is_reviewable"]:
             return {
-                "error": "Comment status is not waiting for approval."
+                "error": "Comment status is not reviewable, you cannot link a "
+                         "preview to it."
             }, 400
 
         revision = tasks_service.get_next_preview_revision(task_id)

--- a/zou/app/models/task_status.py
+++ b/zou/app/models/task_status.py
@@ -7,4 +7,5 @@ class TaskStatus(db.Model, BaseMixin, SerializerMixin):
     name = db.Column(db.String(40), nullable=False)
     short_name = db.Column(db.String(10), unique=True, nullable=False)
     color = db.Column(db.String(7), nullable=False)
+    is_reviewable = db.Column(db.Boolean(), default=False)
     shotgun_id = db.Column(db.Integer)

--- a/zou/app/services/assets_service.py
+++ b/zou/app/services/assets_service.py
@@ -355,6 +355,7 @@ def all_assets_and_tasks(criterions={}, page=1):
                 "preview_file_id": str(asset.preview_file_id or ""),
                 "description": asset.description,
                 "asset_type_name": entity_type_name,
+                "asset_type_id": str(asset.entity_type_id),
                 "canceled": asset.canceled,
                 "data": fields.serialize_value(asset.data),
                 "tasks": []

--- a/zou/app/services/tasks_service.py
+++ b/zou/app/services/tasks_service.py
@@ -331,7 +331,12 @@ def get_or_create_task_type(
     return task_type.serialize()
 
 
-def get_or_create_status(name, short_name="", color="#f5f5f5"):
+def get_or_create_status(
+    name,
+    short_name="",
+    color="#f5f5f5",
+    is_reviewable=False
+):
     status = TaskStatus.get_by(name=name)
     if status is None and len(short_name) > 0:
         status = TaskStatus.get_by(short_name=short_name)
@@ -340,7 +345,8 @@ def get_or_create_status(name, short_name="", color="#f5f5f5"):
         status = TaskStatus.create(
             name=name,
             short_name=short_name or name.lower(),
-            color=color
+            color=color,
+            is_reviewable=is_reviewable
         )
     return status.serialize()
 
@@ -437,6 +443,7 @@ def get_comments(task_id):
             TaskStatus.name,
             TaskStatus.short_name,
             TaskStatus.color,
+            TaskStatus.is_reviewable,
             Person.first_name,
             Person.last_name,
             Person.has_avatar
@@ -448,6 +455,7 @@ def get_comments(task_id):
             task_status_name,
             task_status_short_name,
             task_status_color,
+            task_status_is_reviewable,
             person_first_name,
             person_last_name,
             person_has_avatar
@@ -464,6 +472,7 @@ def get_comments(task_id):
             "name": task_status_name,
             "short_name": task_status_short_name,
             "color": task_status_color,
+            "is_reviewable": task_status_is_reviewable,
             "id": str(comment.task_status_id)
         }
 

--- a/zou/cli.py
+++ b/zou/cli.py
@@ -118,13 +118,34 @@ def init_data():
         compositing, "Compositing", "#ff5252", 7, True)
     print("Task types initialized.")
 
-    tasks_service.get_or_create_status("Todo", "todo", "#f5f5f5")
-    tasks_service.get_or_create_status("Work In Progress", "wip", "#3273dc")
     tasks_service.get_or_create_status(
-        "Waiting For Approval", "wfa", "#ab26ff"
+        "Todo",
+        "todo",
+        "#f5f5f5"
     )
-    tasks_service.get_or_create_status("Retake", "retake", "#ff3860")
-    tasks_service.get_or_create_status("Done", "done", "#22d160")
+    tasks_service.get_or_create_status(
+        "Work In Progress",
+        "wip",
+        "#3273dc"
+    )
+    tasks_service.get_or_create_status(
+        "Waiting For Approval",
+        "wfa",
+        "#ab26ff",
+        is_reviewable=True
+    )
+    tasks_service.get_or_create_status(
+        "Retake",
+        "retake",
+        "#ff3860",
+        is_reviewable=True
+    )
+    tasks_service.get_or_create_status(
+        "Done",
+        "done",
+        "#22d160",
+        is_reviewable=True
+    )
     print("Task status initialized.")
 
 


### PR DESCRIPTION
**Problem**

* Asset type ID information is missing in the asset and task list route.
* There is no way to define if a task status is reviewable or not.

**Solution**

* Add asset ID to information returned on each asset.
* Add an "Is reviewable" field to task status model to identify which task status can have a preview linked to it.
