### PR TITLE
Add missing tests for task comments

### DIFF
--- a/tests/services/test_tasks_service.py
+++ b/tests/services/test_tasks_service.py
@@ -376,5 +376,22 @@ class TaskServiceTestCase(ApiDBTestCase):
         tasks = tasks_service.get_person_tasks(self.user.id, projects)
         self.assertEqual(len(tasks), 1)
 
+        tasks_service.create_comment(
+            self.task.id,
+            self.task_status.id,
+            self.person.id,
+            "first comment"
+        )
+        tasks_service.create_comment(
+            self.task.id,
+            self.task_status.id,
+            self.person.id,
+            "last comment"
+        )
         tasks = tasks_service.get_person_tasks(self.person.id, projects)
         self.assertEqual(len(tasks), 2)
+        self.assertEqual(tasks[0]["last_comment"]["text"], "last comment")
+        self.assertEqual(
+            tasks[0]["last_comment"]["person_id"],
+            str(self.person.id)
+        )

--- a/tests/tasks/test_route_tasks_for_entity.py
+++ b/tests/tasks/test_route_tasks_for_entity.py
@@ -1,5 +1,7 @@
 from tests.base import ApiDBTestCase
 
+from zou.app.services import tasks_service
+
 
 class RouteCreateTasksTestCase(ApiDBTestCase):
 
@@ -32,7 +34,25 @@ class RouteCreateTasksTestCase(ApiDBTestCase):
         self.assertEquals(len(tasks), 0)
 
     def test_get_tasks_for_person(self):
+        tasks_service.create_comment(
+            self.task.id,
+            self.task_status.id,
+            self.person.id,
+            "first comment"
+        )
+        tasks_service.create_comment(
+            self.task.id,
+            self.task_status.id,
+            self.person.id,
+            "last comment"
+        )
         tasks = self.get("/data/persons/%s/tasks" % self.person.id)
+        self.assertEqual(len(tasks), 1)
+        self.assertEqual(tasks[0]["last_comment"]["text"], "last comment")
+        self.assertEqual(
+            tasks[0]["last_comment"]["person_id"],
+            str(self.person.id)
+        )
         self.assertEquals(len(tasks), 1)
         self.assertTrue(str(self.person.id) in tasks[0]["assignees"])
 

--- a/zou/app/services/tasks_service.py
+++ b/zou/app/services/tasks_service.py
@@ -608,4 +608,27 @@ def get_person_tasks(person_id, projects):
         })
         tasks.append(task_dict)
 
+    task_ids = [task["id"] for task in tasks]
+
+    task_comment_map = {}
+    comments = Comment.query \
+        .filter(Comment.object_id.in_(task_ids)) \
+        .order_by(Comment.object_id, Comment.created_at) \
+        .all()
+
+    task_id = None
+    for comment in comments:
+        if comment.object_id != task_id:
+            task_id = fields.serialize_value(comment.object_id)
+            task_comment_map[task_id] = {
+                "text": comment.text,
+                "date": fields.serialize_value(comment.created_at),
+                "person_id": fields.serialize_value(comment.person_id)
+            }
+    for task in tasks:
+        if task["id"] in task_comment_map:
+            task["last_comment"] = task_comment_map[task["id"]]
+        else:
+            task["last_comment"] = {}
+
     return tasks


### PR DESCRIPTION
**Problem**

Todo lists doesn't include last comment text

**Solution**

When building the todo list, grab related comments and add comment information from more recent comment for each task (based on creation date).
