### PR TITLE
Add cast in route and add more information to entity routes

### DIFF
--- a/tests/assets/test_assets.py
+++ b/tests/assets/test_assets.py
@@ -11,6 +11,13 @@ class AssetsTestCase(ApiDBTestCase):
         self.generate_fixture_entity()
         self.generate_fixture_sequence()
         self.generate_fixture_shot()
+        self.generate_fixture_person()
+        self.generate_fixture_assigner()
+        self.generate_fixture_department()
+        self.generate_fixture_task_status()
+        self.generate_fixture_task_type()
+        self.generate_fixture_task()
+        self.generate_fixture_task(name="Secondary")
         self.entity_dict = self.entity.serialize(obj_type="Asset")
         self.maxDiff = None
 
@@ -21,10 +28,11 @@ class AssetsTestCase(ApiDBTestCase):
 
     def test_get_asset(self):
         asset = self.get("data/assets/%s" % self.entity.id)
-        self.entity_dict["project_name"] = self.project.name
-        self.entity_dict["asset_type_id"] = str(self.entity_type.id)
-        self.entity_dict["asset_type_name"] = self.entity_type.name
-        self.assertDictEqual(asset, self.entity_dict)
+        self.assertEquals(asset["id"], str(self.entity.id))
+        self.assertEquals(asset["project_name"], self.project.name)
+        self.assertEquals(asset["asset_type_id"], str(self.entity_type.id))
+        self.assertEquals(asset["asset_type_name"], str(self.entity_type.name))
+        self.assertEquals(len(asset["tasks"]), 2)
 
     def test_get_project_assets(self):
         assets = self.get("data/projects/%s/assets" % self.project.id)

--- a/tests/services/test_assets_service.py
+++ b/tests/services/test_assets_service.py
@@ -57,10 +57,17 @@ class AssetServiceTestCase(ApiDBTestCase):
         self.assertEqual(
             assets[1]["tasks"][0]["assignees"][0], str(self.person.id)
         )
+        self.assertEqual(
+            assets[1]["tasks"][0]["task_status_id"], str(self.task_status.id)
+        )
+        self.assertEqual(
+            assets[1]["tasks"][0]["task_type_id"], str(self.task_type.id)
+        )
 
     def test_get_asset(self):
         asset = assets_service.get_asset(self.entity.id)
         self.assertEqual(asset["id"], str(self.entity.id))
+
         assets_service.remove_asset(asset["id"])
         self.assertRaises(
             AssetNotFoundException,

--- a/tests/services/test_breakdown_service.py
+++ b/tests/services/test_breakdown_service.py
@@ -43,6 +43,7 @@ class BreakdownServiceTestCase(ApiDBTestCase):
             }
         ]
         breakdown_service.update_casting(self.shot.id, newCasting)
+
         casting = breakdown_service.get_casting(self.shot.id)
         casting = sorted(casting, key=lambda x: x["nb_occurences"])
         self.assertEquals(casting[0]["asset_id"], newCasting[0]["asset_id"])
@@ -55,6 +56,19 @@ class BreakdownServiceTestCase(ApiDBTestCase):
             casting[1]["nb_occurences"],
             newCasting[1]["nb_occurences"]
         )
+        self.assertEquals(
+            casting[1]["asset_name"],
+            self.entity_character.name
+        )
+        self.assertEquals(
+            casting[1]["asset_type_name"],
+            self.entity_type_character.name
+        )
+
+        cast_in = breakdown_service.get_cast_in(self.entity_character.id)
+        self.assertEquals(cast_in[0]["shot_name"], self.shot.name)
+        self.assertEquals(cast_in[0]["sequence_name"], self.sequence.name)
+        self.assertEquals(cast_in[0]["episode_name"], self.episode.name)
 
     def test_add_instance_to_shot(self):
         instances = breakdown_service.get_asset_instances_for_shot(self.shot.id)

--- a/tests/services/test_shots_service.py
+++ b/tests/services/test_shots_service.py
@@ -99,6 +99,14 @@ class ShotUtilsTestCase(ApiDBTestCase):
         self.assertEqual(
             shots[0]["tasks"][0]["assignees"][0], str(self.person.id)
         )
+        self.assertEqual(
+            shots[0]["tasks"][0]["task_status_id"],
+            str(self.shot_task.task_status_id)
+        )
+        self.assertEqual(
+            shots[0]["tasks"][0]["task_type_id"],
+            str(self.shot_task.task_type_id)
+        )
 
     def test_is_shot(self):
         self.assertTrue(shots_service.is_shot(self.shot.serialize()))

--- a/tests/shots/test_breakdown.py
+++ b/tests/shots/test_breakdown.py
@@ -17,22 +17,50 @@ class BreakdownTestCase(ApiDBTestCase):
 
     def test_update_casting(self):
         self.shot_id = str(self.shot.id)
-        self.entity_id = str(self.entity.id)
-        self.entity_character_id = str(self.entity_character.id)
+        self.asset_id = str(self.entity.id)
+        self.asset_character_id = str(self.entity_character.id)
+        self.asset_type_character_id = str(self.entity_type_character.id)
+        self.shot_name = self.shot.name
+        self.sequence_name = self.sequence.name
+        self.episode_name = self.episode.name
 
         casting = self.get("/data/shots/%s/casting" % self.shot_id)
         self.assertListEqual(casting, [])
         newCasting = [
             {
-                "asset_id": self.entity_id,
+                "asset_id": self.asset_id,
                 "nb_occurences": 1
             },
             {
-                "asset_id": self.entity_character_id,
+                "asset_id": self.asset_character_id,
                 "nb_occurences": 3
             }
         ]
         path = "/data/shots/%s/casting" % str(self.shot_id)
         self.put(path, newCasting, 200)
+
         casting = self.get("/data/shots/%s/casting" % self.shot_id)
-        self.assertListEqual(casting, newCasting)
+        casting = sorted(casting, key=lambda x: x["nb_occurences"])
+        self.assertEquals(casting[0]["asset_id"], newCasting[0]["asset_id"])
+        self.assertEquals(
+            casting[0]["nb_occurences"],
+            newCasting[0]["nb_occurences"]
+        )
+        self.assertEquals(casting[1]["asset_id"], newCasting[1]["asset_id"])
+        self.assertEquals(
+            casting[1]["nb_occurences"],
+            newCasting[1]["nb_occurences"]
+        )
+        self.assertEquals(
+            casting[1]["asset_name"],
+            self.entity_character.name
+        )
+        self.assertEquals(
+            casting[1]["asset_type_name"],
+            self.entity_type_character.name
+        )
+
+        cast_in = self.get("/data/assets/%s/cast-in" % self.asset_id)
+        self.assertEquals(cast_in[0]["shot_name"], self.shot.name)
+        self.assertEquals(cast_in[0]["sequence_name"], self.sequence.name)
+        self.assertEquals(cast_in[0]["episode_name"], self.episode.name)

--- a/tests/shots/test_shots.py
+++ b/tests/shots/test_shots.py
@@ -14,7 +14,6 @@ class ShotTestCase(ApiDBTestCase):
         self.generate_fixture_episode()
         self.generate_fixture_sequence()
         self.generate_fixture_shot()
-
         self.shot_dict = self.shot.serialize(obj_type="Shot")
         self.shot_dict["project_name"] = self.project.name
         self.shot_dict["sequence_name"] = self.sequence.name
@@ -43,7 +42,23 @@ class ShotTestCase(ApiDBTestCase):
         self.assertEquals(len(shots), 3)
         self.assertDictEqual(shots[0], self.shot_dict)
 
+    def test_remove_shot(self):
+        self.generate_fixture_entity()
+        path = "data/shots/%s" % self.shot.id
+        shots = shots_service.get_shots()
+        self.assertEquals(len(shots), 3)
+        self.delete(path)
+        shots = shots_service.get_shots()
+        self.assertEquals(len(shots), 2)
+
     def test_get_shot(self):
+        self.generate_fixture_person()
+        self.generate_fixture_assigner()
+        self.generate_fixture_department()
+        self.generate_fixture_task_status()
+        self.generate_fixture_task_type()
+        self.generate_fixture_shot_task()
+
         shot = self.get("data/shots/%s" % self.shot.id)
         self.assertEquals(shot["id"], str(self.shot.id))
         self.assertEquals(shot["name"], self.shot.name)
@@ -52,22 +67,16 @@ class ShotTestCase(ApiDBTestCase):
         self.assertEquals(shot["episode_name"], self.episode.name)
         self.assertEquals(shot["episode_id"], str(self.episode.id))
         self.assertEquals(shot["project_name"], self.project.name)
-
-    def test_remove_shot(self):
-        self.generate_fixture_entity()
-        path = "data/shots/%s" % self.shot.id
-        self.delete(path)
-        shots = shots_service.get_shots()
-        self.assertEquals(len(shots), 2)
+        self.assertEquals(len(shot["tasks"]), 1)
 
     def test_remove_shot_with_tasks(self):
-        self.generate_fixture_entity()
         self.generate_fixture_person()
         self.generate_fixture_assigner()
         self.generate_fixture_department()
-        self.generate_fixture_task_type()
         self.generate_fixture_task_status()
+        self.generate_fixture_task_type()
         self.generate_fixture_shot_task()
+
         path = "data/shots/%s" % self.shot.id
         self.delete(path)
         shots = shots_service.get_shots()

--- a/zou/app/blueprints/assets/__init__.py
+++ b/zou/app/blueprints/assets/__init__.py
@@ -7,6 +7,7 @@ from .resources import (
     AssetResource,
     AllAssetsResource,
     AssetsAndTasksResource,
+    CastInResource,
     ProjectAssetTypesResource,
     ShotAssetTypesResource,
     NewAssetResource,
@@ -27,6 +28,8 @@ routes = [
     ("/data/assets/<asset_id>/tasks", AssetTasksResource),
     ("/data/assets/<asset_id>/task-types", AssetTaskTypesResource),
     ("/data/assets/<asset_id>/asset-instances", AssetAssetInstancesResource),
+    ("/data/assets/<asset_id>/cast-in", CastInResource),
+
     (
         "/data/projects/<project_id>/asset-types/<asset_type_id>/assets",
         ProjectAssetTypeAssetsResource
@@ -46,7 +49,7 @@ routes = [
     (
         "/data/projects/<project_id>/assets",
         ProjectAssetsResource
-    ),
+    )
 ]
 
 blueprint = Blueprint("assets", "assets")

--- a/zou/app/blueprints/assets/resources.py
+++ b/zou/app/blueprints/assets/resources.py
@@ -209,3 +209,16 @@ class AssetAssetInstancesResource(Resource):
         asset = assets_service.get_asset(asset_id)
         user_service.check_project_access(asset["project_id"])
         return breakdown_service.get_asset_instances_for_asset(asset_id)
+
+
+class CastInResource(Resource):
+
+    @jwt_required
+    def get(self, asset_id):
+        """
+        Resource to retrieve the casting of a given asset.
+        """
+        asset = assets_service.get_asset(asset_id)
+        if not permissions.has_manager_permissions():
+            user_service.check_has_task_related(asset["project_id"])
+        return breakdown_service.get_cast_in(asset_id)

--- a/zou/app/services/assets_service.py
+++ b/zou/app/services/assets_service.py
@@ -113,11 +113,26 @@ def get_asset_instance(asset_instance_id):
 
 def get_full_asset(asset_id):
     asset = get_asset(asset_id)
-    project = Project.get(asset["project_id"])
     asset_type = get_asset_type_raw(asset["entity_type_id"])
+    project = Project.get(asset["project_id"])
+
     asset["project_name"] = project.name
     asset["asset_type_id"] = str(asset_type.id)
     asset["asset_type_name"] = asset_type.name
+
+    tasks = Task.query \
+        .filter_by(entity_id=asset_id) \
+        .all()
+    task_dicts = []
+    for task in tasks:
+        task_dicts.append({
+            "id": str(task.id),
+            "task_status_id": str(task.task_status_id),
+            "task_type_id": str(task.task_type_id),
+            "assignees": [str(assignee.id) for assignee in task.assignees]
+        })
+    asset["tasks"] = task_dicts
+
     return asset
 
 

--- a/zou/app/services/breakdown_service.py
+++ b/zou/app/services/breakdown_service.py
@@ -1,17 +1,29 @@
 from sqlalchemy import desc
+from sqlalchemy.orm import aliased
 
 from zou.app.models.asset_instance import AssetInstance
 from zou.app.models.entity import Entity, EntityLink
+from zou.app.models.entity_type import EntityType
 
 from zou.app.services import shots_service
+from zou.app.utils import fields
 
 
 def get_casting(shot_id):
     casting = []
-    links = EntityLink.get_all_by(entity_in_id=shot_id)
-    for link in links:
+    links = EntityLink.query \
+        .filter_by(entity_in_id=shot_id) \
+        .join(Entity, EntityLink.entity_out_id == Entity.id) \
+        .join(EntityType, Entity.entity_type_id == EntityType.id) \
+        .add_columns(Entity.name, EntityType.name, Entity.preview_file_id) \
+        .order_by(EntityType.name, Entity.name)
+
+    for (link, entity_name, entity_type_name, entity_preview_file_id) in links:
         casting.append({
-            "asset_id": str(link.entity_out_id),
+            "asset_id": fields.serialize_value(link.entity_out_id),
+            "asset_name": entity_name,
+            "asset_type_name": entity_type_name,
+            "preview_file_id": fields.serialize_value(entity_preview_file_id),
             "nb_occurences": link.nb_occurences
         })
     return casting
@@ -26,8 +38,47 @@ def update_casting(shot_id, casting):
             entity_out_id=cast["asset_id"],
             nb_occurences=cast["nb_occurences"]
         )
-    shot = Entity.get(shot.id)
     return casting
+
+
+def get_cast_in(asset_id):
+    cast_in = []
+    Sequence = aliased(Entity, name="sequence")
+    Episode = aliased(Entity, name="episode")
+    links = EntityLink.query \
+        .filter_by(entity_out_id=asset_id) \
+        .join(Entity, EntityLink.entity_in_id == Entity.id) \
+        .join(Sequence, Entity.parent_id == Sequence.id) \
+        .outerjoin(Episode, Sequence.parent_id == Episode.id) \
+        .add_columns(
+            Entity.name,
+            Sequence.name,
+            Episode.name,
+            Entity.preview_file_id
+        ) \
+        .order_by(
+            Episode.name,
+            Sequence.name,
+            Entity.name
+        )
+
+    for (
+        link,
+        entity_name,
+        sequence_name,
+        episode_name,
+        entity_preview_file_id
+    ) in links:
+        shot = {
+            "shot_id": fields.serialize_value(link.entity_in_id),
+            "shot_name": entity_name,
+            "sequence_name": sequence_name,
+            "episode_name": episode_name,
+            "preview_file_id": fields.serialize_value(entity_preview_file_id),
+            "nb_occurences": link.nb_occurences
+        }
+        cast_in.append(shot)
+    return cast_in
 
 
 def get_asset_instances_for_shot(shot_id):

--- a/zou/app/services/shots_service.py
+++ b/zou/app/services/shots_service.py
@@ -224,8 +224,8 @@ def get_shot(shot_id):
 
 def get_full_shot(shot_id):
     shot = get_shot(shot_id)
-    project = Project.get(shot["project_id"])
     sequence = Entity.get(shot["parent_id"])
+    project = Project.get(shot["project_id"])
     shot["project_name"] = project.name
     shot["sequence_id"] = str(sequence.id)
     shot["sequence_name"] = sequence.name
@@ -235,6 +235,18 @@ def get_full_shot(shot_id):
         shot["episode_id"] = str(episode.id)
         shot["episode_name"] = episode.name
 
+    tasks = Task.query \
+        .filter_by(entity_id=shot_id) \
+        .all()
+    task_dicts = []
+    for task in tasks:
+        task_dicts.append({
+            "id": str(task.id),
+            "task_status_id": str(task.task_status_id),
+            "task_type_id": str(task.task_type_id),
+            "assignees": [str(assignee.id) for assignee in task.assignees]
+        })
+    shot["tasks"] = task_dicts
     return shot
 
 


### PR DESCRIPTION
**Problem**

* There is no way to know the list of shots where an asset is cast in.
* Asset route does not give related task list.
* Shot route does not give related task list.

**Solution**

* Add a route to retrieve the list of shots where an asset is cast in.
* Add related task list to data returned by asset route.
* Add related task list to data returned by shot route.
