### PR TITLE
Fix shot CSV import

### DIFF
--- a/tests/fixtures/csv/shots.csv
+++ b/tests/fixtures/csv/shots.csv
@@ -2,3 +2,4 @@ Episode,Sequence,Name,Description,FPS,Frame In,Frame Out
 E01,SE01,S01,Description 01,25,0,100
 E01,SE01,S02,Description 02,25,100,200
 E01,SE02,S01,Description 03,25,200,300
+E02,SE01,S01,Description 01,25,300,400

--- a/tests/source/csv/test_import_shots.py
+++ b/tests/source/csv/test_import_shots.py
@@ -23,9 +23,9 @@ class ImportCsvShotsTestCase(ApiDBTestCase):
         self.upload_file(path, file_path_fixture)
 
         sequences = shots_service.get_sequences()
-        self.assertEqual(len(sequences), 2)
+        self.assertEqual(len(sequences), 3)
         shots = shots_service.get_shots()
-        self.assertEqual(len(shots), 3)
+        self.assertEqual(len(shots), 4)
 
         entity_types = EntityType.query.all()
         self.assertEqual(len(entity_types), 3)

--- a/zou/app/blueprints/source/csv/shots.py
+++ b/zou/app/blueprints/source/csv/shots.py
@@ -25,7 +25,7 @@ class ShotsCsvImportResource(BaseCsvProjectImportResource):
             self.episodes[episode_key] = \
                 shots_service.get_or_create_episode(project_id, episode_name)
 
-        sequence_key = "%s-%s" % (project_id, sequence_name)
+        sequence_key = "%s-%s-%s" % (project_id, episode_name, sequence_name)
         if sequence_key not in self.sequences:
             episode = self.episodes[episode_key]
             self.sequences[sequence_key] = \


### PR DESCRIPTION
**Problem**

During a shot CSV import, sequences are not imported when they have the sane name (which occurs often when there are episodes).

**Solution**

Do not determine if a sequence exists only by looking for similar sequences with same name. It now takes the episode name in consideration too.
