### PR TITLE
Fix person full name encoding

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -463,12 +463,18 @@ class ApiDBTestCase(ApiTestCase):
         )
         return self.user_cg_artist
 
-    def generate_fixture_person(self):
+    def generate_fixture_person(
+        self,
+        first_name="John",
+        last_name="Doe",
+        desktop_login="john.doe",
+        email="john.doe@gmail.com"
+    ):
         self.person = Person.create(
-            first_name="John",
-            last_name="Doe",
-            desktop_login="john.doe",
-            email=u"john.doe@gmail.com",
+            first_name=first_name,
+            last_name=last_name,
+            desktop_login=desktop_login,
+            email=email,
             password=auth.encrypt_password("mypassword")
         )
         return self.person

--- a/tests/models/test_person.py
+++ b/tests/models/test_person.py
@@ -1,6 +1,5 @@
 # -*- coding: UTF-8 -*-
 from tests.base import ApiDBTestCase
-from zou.app.models.person import Person
 
 from zou.app.utils import fields
 
@@ -9,10 +8,21 @@ class PersonTestCase(ApiDBTestCase):
 
     def setUp(self):
         super(PersonTestCase, self).setUp()
-        self.generate_data(Person, 3, skills=[])
+        self.generate_fixture_person(
+            first_name="Ema",
+            last_name="Doe",
+            desktop_login="ema.doe",
+            email="ema.doe@gmail.com"
+        )
+        self.generate_fixture_person(
+            first_name="Jérémy",
+            last_name="Utêfœuit",
+            desktop_login="jeremy.utf8",
+            email="jeremy.utf8@gmail.com"
+        )
+        self.generate_fixture_person()
 
     def test_repr(self):
-        self.generate_fixture_person()
         self.assertEqual(str(self.person), "<Person John Doe>")
         self.person.first_name = u"Léon"
         self.assertEqual(str(self.person), "<Person Léon Doe>")
@@ -30,9 +40,9 @@ class PersonTestCase(ApiDBTestCase):
 
     def test_create_person(self):
         data = {
-            "first_name": "John",
+            "first_name": "John2",
             "last_name": "Doe",
-            "email": "john.doe@gmail.com"
+            "email": "john2.doe@gmail.com"
         }
         self.person = self.post("data/persons/new", data)
         self.assertIsNotNone(self.person["id"])

--- a/zou/app/models/person.py
+++ b/zou/app/models/person.py
@@ -56,19 +56,16 @@ class Person(db.Model, BaseMixin, SerializerMixin):
     )
 
     def __repr__(self):
-        return "<Person %s>" % self.full_name()
+        if sys.version_info[0] < 3:
+            return "<Person %s>" % self.full_name().encode("utf-8")
+        else:
+            return "<Person %s>" % self.full_name()
 
     def full_name(self):
-        if sys.version_info[0] < 3:
-            return "%s %s" % (
-                self.first_name.encode("utf-8"),
-                self.last_name.encode("utf-8")
-            )
-        else:
-            return "%s %s" % (
-                self.first_name,
-                self.last_name
-            )
+        return "%s %s" % (
+            self.first_name,
+            self.last_name
+        )
 
     def serialize(self, obj_type="Person"):
         data = SerializerMixin.serialize(self, "Person")


### PR DESCRIPTION
**Problem**

* With Python 2, the encoding of full person name leads to an exception (and ultimately to a server error).

**Solution**

* Add tests related to the `full_name` function 
* Do not try to generate the string differently if it is Python 2 or 3
* Encode differently depending on the Python version for the string representation of the `Person` model.
