### PR TITLE
Various fixes

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -231,7 +231,7 @@ class ApiDBTestCase(ApiTestCase):
         )
 
     def generate_fixture_project_status(self):
-        self.open_status = ProjectStatus.create(name="open", color="#FFFFFF")
+        self.open_status = ProjectStatus.create(name="Open", color="#FFFFFF")
 
     def generate_fixture_project_closed_status(self):
         self.closed_status = ProjectStatus.create(

--- a/tests/export/test_projects_to_csv.py
+++ b/tests/export/test_projects_to_csv.py
@@ -12,5 +12,5 @@ class OutputFileTestCase(ApiDBTestCase):
     def test_get_output_files(self):
         csv_projects = self.get_raw("/export/csv/projects.csv")
         expected_result = """Name,Status\r
-Cosmos Landromat,open\r\n"""
+Cosmos Landromat,Open\r\n"""
         self.assertEqual(csv_projects, expected_result)

--- a/tests/models/test_project.py
+++ b/tests/models/test_project.py
@@ -11,6 +11,7 @@ class ProjectTestCase(ApiDBTestCase):
         self.generate_fixture_project()
         self.generate_fixture_project("Agent 327")
         self.generate_fixture_project("Big Buck Bunny")
+        self.open_status_id = str(self.open_status.id)
 
     def test_get_projects(self):
         projects = self.get("data/projects")
@@ -29,6 +30,10 @@ class ProjectTestCase(ApiDBTestCase):
         }
         self.project = self.post("data/projects", data)
         self.assertIsNotNone(self.project["id"])
+        self.assertEquals(
+            self.project["project_status_id"],
+            str(self.open_status_id)
+        )
 
         projects = self.get("data/projects")
         self.assertEquals(len(projects), 4)

--- a/tests/projects/test_route_all_projects.py
+++ b/tests/projects/test_route_all_projects.py
@@ -16,7 +16,7 @@ class OpenProjectRouteTestCase(ApiDBTestCase):
 
         self.assertEqual(len(projects), 2)
         self.assertEqual(projects[0]["name"], self.project.name)
-        self.assertEqual(projects[0]["project_status_name"], "open")
+        self.assertEqual(projects[0]["project_status_name"], "Open")
         self.assertEqual(projects[1]["project_status_name"], "closed")
 
     def test_get_project_by_name(self):

--- a/tests/services/test_projects_service.py
+++ b/tests/services/test_projects_service.py
@@ -23,7 +23,7 @@ class ProjectServiceTestCase(ApiDBTestCase):
     def test_get_projects(self):
         projects = projects_service.get_projects()
         self.assertEqual(len(projects), 2)
-        self.assertEqual(projects[0]["project_status_name"], "open")
+        self.assertEqual(projects[0]["project_status_name"], "Open")
 
     def test_get_or_create_status(self):
         project_status = projects_service.get_or_create_status("Frozen")

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -9,7 +9,6 @@ from pytz import timezone
 from zou.app.utils import colors, fields, query, fs
 from zou.app.models.person import Person
 from zou.app.models.task import Task
-from zou.app.models.working_file import WorkingFile
 
 
 class UtilsTestCase(unittest.TestCase):
@@ -30,6 +29,10 @@ class UtilsTestCase(unittest.TestCase):
         self.assertEqual(
             "Europe/Paris",
             fields.serialize_value(timezone("Europe/Paris"))
+        )
+        self.assertEqual(
+            "Europe/Brussels",
+            fields.serialize_value(timezone("Europe/Brussels"))
         )
         self.assertEqual(
             "en_US",

--- a/zou/app/blueprints/crud/project.py
+++ b/zou/app/blueprints/crud/project.py
@@ -22,7 +22,6 @@ class ProjectsResource(BaseModelsResource):
     def update_data(self, data):
         open_status = projects_service.get_or_create_open_status()
         if "project_status_id" not in data:
-            print(open_status["id"])
             data["project_status_id"] = open_status["id"]
         return data
 

--- a/zou/app/blueprints/crud/project.py
+++ b/zou/app/blueprints/crud/project.py
@@ -19,6 +19,13 @@ class ProjectsResource(BaseModelsResource):
     def check_read_permissions(self):
         return True
 
+    def update_data(self, data):
+        open_status = projects_service.get_or_create_open_status()
+        if "project_status_id" not in data:
+            print(open_status["id"])
+            data["project_status_id"] = open_status["id"]
+        return data
+
 
 class ProjectResource(BaseModelResource):
 
@@ -27,8 +34,3 @@ class ProjectResource(BaseModelResource):
 
     def check_read_permissions(self, project):
         user_service.check_project_access(project["id"])
-
-    def update_data(self, data):
-        open_status = projects_service.get_or_create_open_status()
-        data["open_status_id"] = open_status["id"]
-        return data

--- a/zou/app/blueprints/files/resources.py
+++ b/zou/app/blueprints/files/resources.py
@@ -70,10 +70,9 @@ class WorkingFilePathResource(Resource):
                 software=software,
                 name=name
             )
-        except MalformedFileTreeException:
+        except MalformedFileTreeException as exception:
             return {
-                "error":
-                    "Tree is not properly written, check modes and variables",
+                "message": str(exception),
                 "received_data": request.json,
             }, 400
 
@@ -145,10 +144,9 @@ class EntityOutputFilePathResource(Resource, ArgsMixin):
                 task_type=task_type,
                 name=args["name"]
             )
-        except MalformedFileTreeException:
+        except MalformedFileTreeException as exception:
             return {
-                "error":
-                    "Tree is not properly written, check modes and variables",
+                "message": str(exception),
                 "received_data": request.json,
             }, 400
 
@@ -205,11 +203,9 @@ class InstanceOutputFilePathResource(Resource, ArgsMixin):
                 name=args["name"],
                 revision=args["revision"]
             )
-        except MalformedFileTreeException as e:
-            current_app.logger.error(e)
+        except MalformedFileTreeException as exception:
             return {
-                "error":
-                    "Tree is not properly written, check modes and variables",
+                "message": str(exception),
                 "received_data": request.json,
             }, 400
 

--- a/zou/app/services/file_tree_service.py
+++ b/zou/app/services/file_tree_service.py
@@ -380,6 +380,16 @@ def change_folder_path_separators(folder_path, sep):
 
 
 def get_root_path(tree, mode, sep):
+    if tree is None:
+        raise MalformedFileTreeException(
+            "No tree can be found for given project."
+        )
+
+    if mode not in tree:
+        raise MalformedFileTreeException(
+            "Mode %s cannot be found on given tree." % mode
+        )
+
     try:
         mountpoint = tree[mode]["mountpoint"]
         root = tree[mode]["root"]

--- a/zou/app/utils/fields.py
+++ b/zou/app/utils/fields.py
@@ -2,7 +2,7 @@ import datetime
 import uuid
 import sqlalchemy.orm as orm
 
-from pytz import timezone
+from pytz import tzinfo
 from babel import Locale
 
 
@@ -29,7 +29,7 @@ def serialize_value(value):
         return value
     elif isinstance(value, Locale):
         return str(value)
-    elif isinstance(value, type(timezone("Europe/Paris"))):
+    elif isinstance(value, tzinfo.DstTzInfo):
         return str(value)
     elif isinstance(value, list):
         return serialize_list(value)


### PR DESCRIPTION
**Problem**

* Project creation did not set a status by default
* Timezone serialization was wrong which leads to server error when retrieving timezone information.
* When a file tree is malformed, it leads either to a server error or to a non explicit 400 error.

**Solution**

* Set open status if no status is given at project creation.
* Identify properly timezone object type during serialization.
* Handle better cases where information is missing by setting the right messag when raising malformed tree exception. Return exception messages in the response body when a malformed tree exception is caught.
