### PR TITLE
Sequence notifications + Fix CG artists permission 

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -588,6 +588,7 @@ class ApiDBTestCase(ApiTestCase):
             assignees=[self.person],
             assigner_id=self.assigner.id,
         )
+        return self.shot_task
 
     def generate_fixture_scene_task(self, name="Master"):
         self.scene_task = Task.create(

--- a/tests/misc/test_commands.py
+++ b/tests/misc/test_commands.py
@@ -35,8 +35,6 @@ class CommandsTestCase(ApiTestCase):
             "revoked": True
         }).encode("utf-8"))
         self.assertEquals(len(self.store.keys()), 2)
-        for key in self.store.keys():
-            print(self.store.get(key))
         commands.clean_auth_tokens()
         self.assertEquals(len(self.store.keys()), 1)
         self.assertEquals(self.store.keys()[0], "testkey")

--- a/zou/app/blueprints/assets/resources.py
+++ b/zou/app/blueprints/assets/resources.py
@@ -53,7 +53,7 @@ class AssetsAndTasksResource(Resource):
         """
         criterions = query.get_query_criterions_from_request(request)
         page = query.get_page_from_request(request)
-        user_service.check_project_access(criterions)
+        user_service.check_project_access(criterions.get("project_id", None))
         return assets_service.get_assets_and_tasks(criterions, page)
 
 

--- a/zou/app/blueprints/shots/resources.py
+++ b/zou/app/blueprints/shots/resources.py
@@ -177,7 +177,7 @@ class ShotsAndTasksResource(Resource):
         related tasks.
         """
         criterions = query.get_query_criterions_from_request(request)
-        user_service.check_project_access(criterions)
+        user_service.check_project_access(criterions.get("project_id", None))
         return shots_service.get_shots_and_tasks(criterions)
 
 

--- a/zou/app/blueprints/tasks/resources.py
+++ b/zou/app/blueprints/tasks/resources.py
@@ -158,8 +158,9 @@ class TaskCommentsResource(Resource):
 
     @jwt_required
     def get(self, task_id):
+        task = tasks_service.get_task(task_id)
         if not permissions.has_manager_permissions():
-            user_service.check_has_task_related(task_id)
+            user_service.check_has_task_related(task["project_id"])
         return tasks_service.get_comments(task_id)
 
 

--- a/zou/app/blueprints/user/__init__.py
+++ b/zou/app/blueprints/user/__init__.py
@@ -24,7 +24,10 @@ from .resources import (
     NotificationResource,
     HasTaskSubscribedResource,
     TaskSubscribeResource,
-    TaskUnsubscribeResource
+    TaskUnsubscribeResource,
+    HasSequenceSubscribedResource,
+    SequenceSubscribeResource,
+    SequenceUnsubscribeResource
 )
 
 routes = [
@@ -60,7 +63,20 @@ routes = [
 
     ("/data/user/tasks/<task_id>/subscribed", HasTaskSubscribedResource),
     ("/actions/user/tasks/<task_id>/subscribe", TaskSubscribeResource),
-    ("/actions/user/tasks/<task_id>/unsubscribe", TaskUnsubscribeResource)
+    ("/actions/user/tasks/<task_id>/unsubscribe", TaskUnsubscribeResource),
+
+    (
+        "/data/user/entities/<entity_id>/task-types/<task_type_id>/subscribed",
+        HasSequenceSubscribedResource
+    ),
+    (
+        "/actions/user/sequences/<sequence_id>/task-types/<task_type_id>/subscribe",
+        SequenceSubscribeResource
+    ),
+    (
+        "/actions/user/sequences/<sequence_id>/task-types/<task_type_id>/unsubscribe",
+        SequenceUnsubscribeResource
+    )
 ]
 
 blueprint = Blueprint("user", "user")

--- a/zou/app/blueprints/user/resources.py
+++ b/zou/app/blueprints/user/resources.py
@@ -290,7 +290,7 @@ class HasTaskSubscribedResource(Resource):
 class TaskSubscribeResource(Resource):
     """
     Create a subscription entry for given task and current user. When an user
-    subscribe to a notification.
+    subscribe it gets notification everytime a comment is posted on the task.
     """
 
     @jwt_required
@@ -300,11 +300,51 @@ class TaskSubscribeResource(Resource):
 
 class TaskUnsubscribeResource(Resource):
     """
-    Create a subscription entry for given task and current user. When an user
-    subscribe to a notification.
+    Remove the subscription entry matching given task and current user.
+    The user will no longer receive notifications for this task.
     """
 
     @jwt_required
     def delete(self, task_id):
         user_service.unsubscribe_from_task(task_id)
+        return '', 204
+
+
+class HasSequenceSubscribedResource(Resource):
+    """
+    Return true if current user has subscribed to given sequence and task type.
+    """
+
+    @jwt_required
+    def get(self, sequence_id, task_type_id):
+        return user_service.has_sequence_subscription(sequence_id, task_type_id)
+
+
+class SequenceSubscribeResource(Resource):
+    """
+    Create a subscription entry for given sequence and current user. When an
+    subscribe it gets notification everytime a comment is posted on tasks
+    related to the sequence.
+    """
+
+    @jwt_required
+    def post(self, sequence_id, task_type_id):
+        subscription = user_service.subscribe_to_sequence(
+            sequence_id,
+            task_type_id
+        )
+        return subscription, 201
+
+
+class SequenceUnsubscribeResource(Resource):
+    """
+    Create a subscription entry for given sequence, task type and current user.
+    """
+
+    @jwt_required
+    def delete(self, sequence_id, task_type_id):
+        user_service.unsubscribe_from_sequence(
+            sequence_id,
+            task_type_id
+        )
         return '', 204

--- a/zou/app/services/notifications_service.py
+++ b/zou/app/services/notifications_service.py
@@ -12,8 +12,7 @@ from zou.app.services import (
     shots_service
 )
 from zou.app.services.exception import (
-    PersonNotFoundException,
-    SubscriptionNotFoundException
+    PersonNotFoundException
 )
 from zou.app.utils import events
 
@@ -65,7 +64,8 @@ def get_notification_recipients(task):
     """
     recipients = set()
     comments = Comment.get_all_by(object_id=task["id"])
-    subscriptions = Subscription.get_all_by(task_id=task["id"])
+    task_subscriptions = get_task_subscriptions(task)
+    sequence_subscriptions = get_sequence_subscriptions(task)
 
     for assignee_id in task["assignees"]:
         recipients.add(assignee_id)
@@ -73,10 +73,35 @@ def get_notification_recipients(task):
     for comment in comments:
         recipients.add(str(comment.person_id))
 
-    for subscription in subscriptions:
+    for subscription in task_subscriptions:
+        recipients.add(str(subscription.person_id))
+
+    for subscription in sequence_subscriptions:
         recipients.add(str(subscription.person_id))
 
     return recipients
+
+
+def get_task_subscriptions(task):
+    """
+    Return all notification subscriptions related to given task.
+    """
+    return Subscription.get_all_by(task_id=task["id"])
+
+
+def get_sequence_subscriptions(task):
+    """
+    Return all sequence subscriptions for given task. It returns something only
+    if the task is related to a shot of which the sequence has a subscription.
+    """
+    sequence_subscriptions = []
+    entity = Entity.get(task["entity_id"])
+    if entity is not None and entity.parent_id is not None:
+        sequence_subscriptions = Subscription.get_all_by(
+            task_type_id=task["task_type_id"],
+            entity_id=entity.parent_id
+        )
+    return sequence_subscriptions
 
 
 def create_notifications_for_task_and_comment(task, comment, change=False):
@@ -102,7 +127,8 @@ def create_notifications_for_task_and_comment(task, comment, change=False):
             pass
     return recipient_ids
 
-def get_task_subscription(person_id, task_id):
+
+def get_task_subscription_raw(person_id, task_id):
     """
     Return subscription matching given person and task.
     """
@@ -120,7 +146,7 @@ def has_task_subscription(person_id, task_id):
     """
     Return true if a subscription exists for this person and this task.
     """
-    subscription = get_task_subscription(person_id, task_id)
+    subscription = get_task_subscription_raw(person_id, task_id)
     return subscription is not None
 
 
@@ -128,7 +154,7 @@ def subscribe_to_task(person_id, task_id):
     """
     Add a subscription entry for given person and task.
     """
-    subscription = get_task_subscription(person_id, task_id)
+    subscription = get_task_subscription_raw(person_id, task_id)
     if subscription is None:
         subscription = Subscription.create(
             person_id=person_id,
@@ -141,7 +167,69 @@ def unsubscribe_from_task(person_id, task_id):
     """
     Remove subscription entry for given person and task.
     """
-    subscription = get_task_subscription(person_id, task_id)
+    subscription = get_task_subscription_raw(person_id, task_id)
+    if subscription is not None:
+        subscription.delete()
+        return subscription.serialize()
+    else:
+        return {}
+
+
+def get_sequence_subscription_raw(person_id, sequence_id, task_type_id):
+    """
+    Return subscription matching given person, sequence and task type.
+    """
+    try:
+        subscription = Subscription.get_by(
+            person_id=person_id,
+            entity_id=sequence_id,
+            task_type_id=task_type_id
+        )
+        return subscription
+    except StatementError:
+        return None
+
+
+def has_sequence_subscription(person_id, sequence_id, task_type_id):
+    """
+    Return true if a subscription exists for this person, sequence and task
+    type.
+    """
+    subscription = get_sequence_subscription_raw(
+        person_id,
+        sequence_id,
+        task_type_id
+    )
+    return subscription is not None
+
+
+def subscribe_to_sequence(person_id, sequence_id, task_type_id):
+    """
+    Add a subscription entry for given person, sequence and task type.
+    """
+    subscription = get_sequence_subscription_raw(
+        person_id,
+        sequence_id,
+        task_type_id
+    )
+    if subscription is None:
+        subscription = Subscription.create(
+            person_id=person_id,
+            entity_id=sequence_id,
+            task_type_id=task_type_id
+        )
+    return subscription.serialize()
+
+
+def unsubscribe_from_sequence(person_id, sequence_id, task_type_id):
+    """
+    Remove subscription entry for given person, sequence and task type.
+    """
+    subscription = get_sequence_subscription_raw(
+        person_id,
+        sequence_id,
+        task_type_id
+    )
     if subscription is not None:
         subscription.delete()
         return subscription.serialize()

--- a/zou/app/services/user_service.py
+++ b/zou/app/services/user_service.py
@@ -523,3 +523,40 @@ def unsubscribe_from_task(task_id):
         current_user["id"],
         task_id
     )
+
+
+def has_sequence_subscription(sequence_id, task_type_id):
+    """
+    Returns true if a subscription entry exists for current user and given
+    sequence.
+    """
+    current_user = persons_service.get_current_user()
+    return notifications_service.has_sequence_subscription(
+        current_user["id"],
+        sequence_id,
+        task_type_id
+    )
+
+
+def subscribe_to_sequence(sequence_id, task_type_id):
+    """
+    Create a subscription entry for current user and given sequence
+    """
+    current_user = persons_service.get_current_user()
+    return notifications_service.subscribe_to_sequence(
+        current_user["id"],
+        sequence_id,
+        task_type_id
+    )
+
+
+def unsubscribe_from_sequence(sequence_id, task_type_id):
+    """
+    Remove subscription entry for current user and given sequence
+    """
+    current_user = persons_service.get_current_user()
+    return notifications_service.unsubscribe_from_sequence(
+        current_user["id"],
+        sequence_id,
+        task_type_id
+    )


### PR DESCRIPTION
**Problem**

* There is no way to subscribe to notifications for a sequence / task type couple
* CG artists can't access to shot and asset lists

**Solution**

* Allow to create subscription entries for sequence / task type couple
* Generate a notification for comment of each subscriber to sequence / task type couple for a given task.
* Wrong parameter was given to check permission access