### PR TITLE
Project avatar and comment deletion

### DIFF
--- a/zou/app/blueprints/tasks/__init__.py
+++ b/zou/app/blueprints/tasks/__init__.py
@@ -16,6 +16,7 @@ from .resources import (
 
     CommentTaskResource,
     TaskCommentsResource,
+    TaskCommentResource,
     TaskPreviewsResource,
     AddPreviewResource,
 
@@ -30,6 +31,7 @@ from .resources import (
 
 routes = [
     ("/data/tasks/<task_id>/comments", TaskCommentsResource),
+    ("/data/tasks/<task_id>/comments/<comment_id>", TaskCommentResource),
     ("/data/tasks/<task_id>/previews", TaskPreviewsResource),
     ("/data/tasks/<task_id>/full", TaskFullResource),
     ("/data/persons/<person_id>/tasks", PersonTasksResource),

--- a/zou/app/blueprints/thumbnails/resources.py
+++ b/zou/app/blueprints/thumbnails/resources.py
@@ -321,6 +321,12 @@ class CreateProjectThumbnailResource(BaseCreatePictureResource):
     def is_exist(self, project_id):
         return projects_service.get_project(project_id) is not None
 
+    def prepare_creation(self, instance_id):
+        return projects_service.update_project(
+            instance_id,
+            {"has_avatar": True}
+        )
+
 
 class ProjectThumbnailResource(BasePictureResource):
 

--- a/zou/app/models/project.py
+++ b/zou/app/models/project.py
@@ -30,6 +30,7 @@ class Project(db.Model, BaseMixin, SerializerMixin):
     shotgun_id = db.Column(db.Integer)
     file_tree = db.Column(JSONB)
     data = db.Column(JSONB)
+    has_avatar = db.Column(db.Boolean(), default=False)
 
     project_status_id = db.Column(
         UUIDType(binary=False),

--- a/zou/app/services/files_service.py
+++ b/zou/app/services/files_service.py
@@ -458,9 +458,9 @@ def get_last_output_files_for_instance(
     return result
 
 
-def get_preview_file(preview_file_id):
+def get_preview_file_raw(preview_file_id):
     """
-    Get preview file as dict.
+    Get preview file as active record.
     """
     try:
         preview_file = PreviewFile.get(preview_file_id)
@@ -470,6 +470,14 @@ def get_preview_file(preview_file_id):
     if preview_file is None:
         raise PreviewFileNotFoundException()
 
+    return preview_file
+
+
+def get_preview_file(preview_file_id):
+    """
+    Get preview file as dict.
+    """
+    preview_file = get_preview_file_raw(preview_file_id)
     return preview_file.serialize()
 
 
@@ -587,3 +595,9 @@ def get_output_files_for_output_type_and_asset_instance(
 
     output_files = query.all()
     return OutputFile.serialize_list(output_files)
+
+
+def remove_preview_file(preview_file_id):
+    preview_file = get_preview_file_raw(preview_file_id)
+    preview_file.remove()
+    return preview_file.serialize()

--- a/zou/app/services/notifications_service.py
+++ b/zou/app/services/notifications_service.py
@@ -14,7 +14,7 @@ from zou.app.services import (
 from zou.app.services.exception import (
     PersonNotFoundException
 )
-from zou.app.utils import events
+from zou.app.utils import events, fields
 
 
 def get_full_entity_name(entity_id):
@@ -235,3 +235,10 @@ def unsubscribe_from_sequence(person_id, sequence_id, task_type_id):
         return subscription.serialize()
     else:
         return {}
+
+
+def delete_notifications_for_comment(comment_id):
+    notifications = Notification.get_all_by(comment_id=comment_id)
+    for notification in notifications:
+        notification.remove()
+    return fields.serialize_list(notifications)


### PR DESCRIPTION
**Problem**

* There is no way to display an avatar set on a project.
* When a comment is deleted, the task status is not updated.

**Solution**

* Add a `has_avatar` field to the project model.
* Deleting a comment remove everything related: previews and notifications. Task status is set to previous comment status
