### PR TITLE
Only warn about non-valid email.

### DIFF
--- a/zou/cli.py
+++ b/zou/cli.py
@@ -67,6 +67,10 @@ def create_admin(email):
 
     try:
         auth.validate_email(email)
+    except auth.EmailNotValidException:
+        print("WARNING: Email is not valid.")
+
+    try:
         password = auth.encrypt_password("default")
         persons_service.create_person(
             email,
@@ -82,9 +86,6 @@ def create_admin(email):
         sys.exit(1)
     except auth.PasswordTooShortException:
         print("Password is too short.")
-        sys.exit(1)
-    except auth.EmailNotValidException:
-        print("Email is not valid.")
         sys.exit(1)
 
 


### PR DESCRIPTION
**Problem**
When creating an admin user, the email has to be valid.

**Solution**
Instead failing to create an admin user with an invalid email. Just warn about the validity of the email.
