### PR TITLE
Only ignore "admin@example.com" to be invalid.

### DIFF
--- a/zou/cli.py
+++ b/zou/cli.py
@@ -66,11 +66,9 @@ def create_admin(email):
     "Set password is 'default'."
 
     try:
-        auth.validate_email(email)
-    except auth.EmailNotValidException:
-        print("WARNING: Email is not valid.")
-
-    try:
+        # Allow "admin@example.com" to be invalid.
+        if email != "admin@example.com":
+            auth.validate_email(email)
         password = auth.encrypt_password("default")
         persons_service.create_person(
             email,
@@ -86,6 +84,9 @@ def create_admin(email):
         sys.exit(1)
     except auth.PasswordTooShortException:
         print("Password is too short.")
+        sys.exit(1)
+    except auth.EmailNotValidException:
+        print("Email is not valid.")
         sys.exit(1)
 
 


### PR DESCRIPTION
**Problem**
Improve on email validation

**Solution**
Only ignore "admin@example.com" when validating admin emails.
