### PR TITLE
Allow to retrieve sequence subscriptions

### DIFF
--- a/zou/app/blueprints/user/__init__.py
+++ b/zou/app/blueprints/user/__init__.py
@@ -26,6 +26,7 @@ from .resources import (
     TaskSubscribeResource,
     TaskUnsubscribeResource,
     HasSequenceSubscribedResource,
+    SequenceSubscriptionsResource,
     SequenceSubscribeResource,
     SequenceUnsubscribeResource
 )
@@ -68,6 +69,10 @@ routes = [
     (
         "/data/user/entities/<entity_id>/task-types/<task_type_id>/subscribed",
         HasSequenceSubscribedResource
+    ),
+    (
+        "/data/user/projects/<project_id>/task-types/<task_type_id>/sequence-subscriptions",
+        SequenceSubscriptionsResource
     ),
     (
         "/actions/user/sequences/<sequence_id>/task-types/<task_type_id>/subscribe",

--- a/zou/app/blueprints/user/resources.py
+++ b/zou/app/blueprints/user/resources.py
@@ -348,3 +348,17 @@ class SequenceUnsubscribeResource(Resource):
             task_type_id
         )
         return '', 204
+
+
+class SequenceSubscriptionsResource(Resource):
+    """
+    Return list of sequence ids to which the current user has subscribed
+    for given task type
+    """
+
+    @jwt_required
+    def get(self, project_id, task_type_id):
+        return user_service.get_sequence_subscriptions(project_id, task_type_id)
+
+
+

--- a/zou/app/services/notifications_service.py
+++ b/zou/app/services/notifications_service.py
@@ -1,10 +1,12 @@
 from sqlalchemy.exc import StatementError
 
 from zou.app.models.comment import Comment
+from zou.app.models.project import Project
 from zou.app.models.entity import Entity
 from zou.app.models.entity_type import EntityType
 from zou.app.models.notifications import Notification
 from zou.app.models.subscription import Subscription
+from zou.app.models.task_type import TaskType
 
 from zou.app.services import (
     tasks_service,
@@ -235,6 +237,24 @@ def unsubscribe_from_sequence(person_id, sequence_id, task_type_id):
         return subscription.serialize()
     else:
         return {}
+
+
+def get_all_sequence_subscriptions(person_id, project_id, task_type_id):
+    """
+    Return list of sequence ids for which given person has subscribed for
+    given project and task type.
+    """
+    subscriptions = Subscription.query \
+        .join(Entity) \
+        .join(Project) \
+        .filter(Project.id == project_id) \
+        .filter(TaskType.id == task_type_id) \
+        .all()
+    print(subscriptions)
+
+    return fields.serialize_value([
+        subscription.entity_id for subscription in subscriptions
+    ])
 
 
 def delete_notifications_for_comment(comment_id):

--- a/zou/app/services/user_service.py
+++ b/zou/app/services/user_service.py
@@ -560,3 +560,16 @@ def unsubscribe_from_sequence(sequence_id, task_type_id):
         sequence_id,
         task_type_id
     )
+
+
+def get_sequence_subscriptions(project_id, task_type_id):
+    """
+    Return list of sequence ids for which the current user has subscriptions
+    for given project and task type.
+    """
+    current_user = persons_service.get_current_user()
+    return notifications_service.get_all_sequence_subscriptions(
+        current_user["id"],
+        project_id,
+        task_type_id
+    )


### PR DESCRIPTION
**Problem**

There is no way to retrieve all sequence subscriptions for a given task type and project.

**Solution**

Add a route and service functions to retrieve all subscriptions for current user, given task type and given project.
