### PR TITLE
Fixes, emails and timesheets

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,7 @@ install_requires =
     flask-socketio
     flask_principal
     flask_caching
+    flask_mail
     redis==2.10.6
     ldap3
 

--- a/tests/persons/test_time_spents.py
+++ b/tests/persons/test_time_spents.py
@@ -1,0 +1,57 @@
+from tests.base import ApiDBTestCase
+
+
+class PersonTimeSpentsTestCase(ApiDBTestCase):
+
+    def setUp(self):
+        super(PersonTimeSpentsTestCase, self).setUp()
+
+    def test_get_time_spents(self):
+        self.generate_fixture_person()
+        self.generate_fixture_project_status()
+        self.generate_fixture_project()
+        self.generate_fixture_asset_type()
+        self.generate_fixture_asset()
+        self.generate_fixture_department()
+        self.generate_fixture_task_type()
+        self.generate_fixture_task_status()
+        self.generate_fixture_assigner()
+
+        self.generate_fixture_task()
+        task_id = str(self.task.id)
+
+        self.generate_fixture_sequence()
+        self.generate_fixture_shot()
+        self.generate_fixture_shot_task()
+        shot_task_id = str(self.shot_task.id)
+        person_id = str(self.person.id)
+        self.post(
+            "/actions/tasks/%s/time-spents/2018-06-04/persons/%s" % (
+                task_id,
+                person_id
+            ),
+            {"duration": 500}
+        )
+        self.post(
+            "/actions/tasks/%s/time-spents/2018-06-04/persons/%s" % (
+                shot_task_id,
+                person_id
+            ),
+            {"duration": 300}
+        )
+        self.post(
+            "/actions/tasks/%s/time-spents/2018-06-03/persons/%s" % (
+                task_id,
+                person_id
+            ),
+            {"duration": 600}
+        )
+        time_spents = self.get(
+            "/data/persons/%s/time-spents/2018-06-04" % person_id
+        )
+        duration = 0
+        for time_spent in time_spents:
+            duration += time_spent["duration"]
+
+        self.assertEqual(len(time_spents), 2)
+        self.assertEqual(duration, 800)

--- a/tests/services/test_time_spents_service.py
+++ b/tests/services/test_time_spents_service.py
@@ -1,0 +1,62 @@
+from tests.base import ApiDBTestCase
+
+from zou.app.services import tasks_service, time_spents_service
+
+
+class TimeSpentsServiceTestCase(ApiDBTestCase):
+
+    def setUp(self):
+        super(TimeSpentsServiceTestCase, self).setUp()
+
+        self.generate_fixture_person()
+        self.person_id = str(self.person.id)
+        self.user_id = str(self.user.id)
+
+        self.generate_fixture_project_status()
+        self.generate_fixture_project()
+        self.generate_fixture_asset_type()
+        self.generate_fixture_asset()
+        self.generate_fixture_department()
+        self.generate_fixture_task_type()
+        self.generate_fixture_task_status()
+        self.generate_fixture_assigner()
+
+        self.generate_fixture_task()
+        task_id = str(self.task.id)
+
+        self.generate_fixture_sequence()
+        self.generate_fixture_shot()
+        self.generate_fixture_shot_task()
+        shot_task_id = str(self.shot_task.id)
+
+        tasks_service.create_or_update_time_spent(
+            task_id, self.person_id, "2018-06-04", 500
+        )
+        tasks_service.create_or_update_time_spent(
+            shot_task_id, self.person_id, "2018-06-04", 300
+        )
+        tasks_service.create_or_update_time_spent(
+            task_id, self.person_id, "2018-06-03", 600
+        )
+        tasks_service.create_or_update_time_spent(
+            task_id, self.person_id, "2018-05-03", 600
+        )
+        tasks_service.create_or_update_time_spent(
+            task_id, self.person_id, "2018-05-03", 600
+        )
+        tasks_service.create_or_update_time_spent(
+            task_id, self.user_id, "2018-06-03", 600
+        )
+
+    def test_get_month_table(self):
+        month_table = time_spents_service.get_month_table("2018")
+        self.assertEqual(month_table["6"][self.person_id], 1400)
+        self.assertEqual(month_table["6"][self.user_id], 600)
+        self.assertTrue("1" not in month_table)
+
+    def test_get_day_table(self):
+        day_table = time_spents_service.get_day_table("2018", "06")
+        self.assertEqual(day_table["3"][self.person_id], 600)
+        self.assertEqual(day_table["4"][self.person_id], 800)
+        self.assertEqual(day_table["3"][self.user_id], 600)
+        self.assertTrue("1" not in day_table)

--- a/tests/tasks/test_route_time_spent.py
+++ b/tests/tasks/test_route_time_spent.py
@@ -29,8 +29,7 @@ class RouteTimeSpentTestCase(ApiDBTestCase):
                 self.task.id,
                 self.person.id
             ),
-            data,
-            200
+            data
         )
         time_spents = self.get("data/time-spents")
         self.assertEquals(time_spents[0]["date"], "2017-09-23")
@@ -59,14 +58,14 @@ class RouteTimeSpentTestCase(ApiDBTestCase):
             task_id,
             person_id
         )
-        self.post(path, data, 200)
+        self.post(path, data)
 
         data = {"duration": 7200}
         path = "/actions/tasks/%s/time-spents/2017-09-27/persons/%s" % (
             task_id,
             user_id
         )
-        self.post(path, data, 200)
+        self.post(path, data)
 
         time_spents = self.get(
             "/actions/tasks/%s/time-spents/2017-09-23/" % task_id
@@ -85,8 +84,7 @@ class RouteTimeSpentTestCase(ApiDBTestCase):
                 task_id,
                 person_id
             ),
-            data,
-            200
+            data
         )
 
         data = {"duration": 10800}
@@ -95,8 +93,7 @@ class RouteTimeSpentTestCase(ApiDBTestCase):
                 task_id,
                 person_id
             ),
-            data,
-            200
+            data
         )
         time_spents = self.get("data/time-spents")
         self.assertEquals(time_spents[0]["duration"], 14400)

--- a/zou/app/__init__.py
+++ b/zou/app/__init__.py
@@ -6,12 +6,14 @@ from flask_jwt_extended import JWTManager
 from flask_principal import Principal, identity_changed, Identity
 from flask_sqlalchemy import SQLAlchemy
 from flask_migrate import Migrate
+from flask_mail import Mail
 
 from . import config
 from .stores import auth_tokens_store
 from .services.exception import PersonNotFoundException
 
 from zou.app.utils import cache
+
 
 
 app = Flask(__name__)
@@ -34,7 +36,8 @@ app.secret_key = app.config["SECRET_KEY"]
 jwt = JWTManager(app)  # JWT auth tokens
 Principal(app)  # Permissions
 cache.cache.init_app(app)  # Function caching
-
+mail = Mail()
+mail.init_app(app) # To send emails
 
 # Hack required during development, because Flask SocketIO changes the default
 # Flask CLI.

--- a/zou/app/blueprints/auth/__init__.py
+++ b/zou/app/blueprints/auth/__init__.py
@@ -8,6 +8,7 @@ from .resources import (
     ChangePasswordResource,
     RegistrationResource,
     RefreshTokenResource,
+    ResetPasswordResource,
     PersonListResource
 )
 
@@ -17,6 +18,7 @@ routes = [
     ("/auth/authenticated", AuthenticatedResource),
     ("/auth/register", RegistrationResource),
     ("/auth/change-password", ChangePasswordResource),
+    ("/auth/reset-password", ResetPasswordResource),
     ("/auth/refresh-token", RefreshTokenResource),
     ("/auth/person-list", PersonListResource)
 ]

--- a/zou/app/blueprints/auth/resources.py
+++ b/zou/app/blueprints/auth/resources.py
@@ -422,3 +422,17 @@ class PersonListResource(Resource):
                 "active": person["active"]
             })
         return person_names
+
+
+class ResetPasswordResource(Resource):
+    """
+    Ressource to allow a user to change his password.
+    """
+
+    @jwt_required
+    def get(self):
+        pass
+
+    @jwt_required
+    def post(self):
+        pass

--- a/zou/app/blueprints/files/resources.py
+++ b/zou/app/blueprints/files/resources.py
@@ -270,6 +270,7 @@ class NewWorkingFileResource(Resource):
     def post(self, task_id):
         (
             name,
+            mode,
             description,
             comment,
             person_id,
@@ -293,7 +294,7 @@ class NewWorkingFileResource(Resource):
                     name
                 )
 
-            path = self.build_path(task, name, revision, software, sep)
+            path = self.build_path(task, name, revision, software, sep, mode)
 
             working_file = files_service.create_new_working_revision(
                 task_id,
@@ -309,17 +310,19 @@ class NewWorkingFileResource(Resource):
 
         return working_file, 201
 
-    def build_path(self, task, name, revision, software, sep):
+    def build_path(self, task, name, revision, software, sep, mode):
         folder_path = file_tree_service.get_working_folder_path(
             task,
             name=name,
-            software=software
+            software=software,
+            mode=mode
         )
         file_name = file_tree_service.get_working_file_name(
             task,
             name=name,
             software=software,
-            revision=revision
+            revision=revision,
+            mode=mode
         )
         return "%s%s%s" % (folder_path, sep, file_name)
 
@@ -334,6 +337,7 @@ class NewWorkingFileResource(Resource):
             required=True
         )
         parser.add_argument("description", default="")
+        parser.add_argument("mode", default="working")
         parser.add_argument("comment", default="")
         parser.add_argument("person_id", default=person["id"])
         parser.add_argument("software_id", default=maxsoft["id"])
@@ -342,6 +346,7 @@ class NewWorkingFileResource(Resource):
         args = parser.parse_args()
         return (
             args["name"],
+            args["mode"],
             args["description"],
             args["comment"],
             args["person_id"],

--- a/zou/app/blueprints/persons/__init__.py
+++ b/zou/app/blueprints/persons/__init__.py
@@ -4,13 +4,15 @@ from zou.app.utils.api import configure_api_from_blueprint
 from .resources import (
     DesktopLoginsResource,
     NewPersonResource,
-    PresenceLogsResource
+    PresenceLogsResource,
+    TimeSpentsResource
 )
 
 routes = [
     ("/data/persons/new", NewPersonResource),
     ("/data/persons/<person_id>/desktop-login-logs", DesktopLoginsResource),
-    ("/data/persons/presence-logs/<month_date>", PresenceLogsResource)
+    ("/data/persons/presence-logs/<month_date>", PresenceLogsResource),
+    ("/data/persons/<person_id>/time-spents/<date>", TimeSpentsResource)
 ]
 
 blueprint = Blueprint("persons", "persons")

--- a/zou/app/blueprints/persons/__init__.py
+++ b/zou/app/blueprints/persons/__init__.py
@@ -5,14 +5,18 @@ from .resources import (
     DesktopLoginsResource,
     NewPersonResource,
     PresenceLogsResource,
-    TimeSpentsResource
+    TimeSpentsResource,
+    TimeSpentMonthResource,
+    TimeSpentYearResource
 )
 
 routes = [
     ("/data/persons/new", NewPersonResource),
     ("/data/persons/<person_id>/desktop-login-logs", DesktopLoginsResource),
     ("/data/persons/presence-logs/<month_date>", PresenceLogsResource),
-    ("/data/persons/<person_id>/time-spents/<date>", TimeSpentsResource)
+    ("/data/persons/<person_id>/time-spents/<date>", TimeSpentsResource),
+    ("/data/persons/time-spents/month-table/<year>", TimeSpentYearResource),
+    ("/data/persons/time-spents/day-table/<year>/<month>", TimeSpentMonthResource)
 ]
 
 blueprint = Blueprint("persons", "persons")

--- a/zou/app/blueprints/persons/resources.py
+++ b/zou/app/blueprints/persons/resources.py
@@ -1,10 +1,12 @@
 import datetime
 
+from flask import abort
 from flask_restful import Resource, reqparse
 from flask_jwt_extended import jwt_required
 
 from zou.app.services import persons_service
 from zou.app.utils import auth, permissions, csv_utils
+from zou.app.services.exception import WrongDateFormatException
 
 
 class NewPersonResource(Resource):
@@ -98,3 +100,16 @@ class PresenceLogsResource(Resource):
         date = datetime.datetime.strptime(month_date, "%Y-%m")
         presence_logs = persons_service.get_presence_logs(date.year, date.month)
         return csv_utils.build_csv_response(presence_logs)
+
+
+class TimeSpentsResource(Resource):
+    """
+    Get time spents given person and date.
+    """
+
+    @jwt_required
+    def get(self, person_id, date):
+        try:
+            return persons_service.get_time_spents(person_id, date)
+        except WrongDateFormatException:
+            abort(404)

--- a/zou/app/blueprints/persons/resources.py
+++ b/zou/app/blueprints/persons/resources.py
@@ -4,7 +4,7 @@ from flask import abort
 from flask_restful import Resource, reqparse
 from flask_jwt_extended import jwt_required
 
-from zou.app.services import persons_service
+from zou.app.services import persons_service, time_spents_service
 from zou.app.utils import auth, permissions, csv_utils
 from zou.app.services.exception import WrongDateFormatException
 
@@ -113,3 +113,26 @@ class TimeSpentsResource(Resource):
             return persons_service.get_time_spents(person_id, date)
         except WrongDateFormatException:
             abort(404)
+
+
+class TimeSpentMonthResource(Resource):
+    """
+    Return a table giving time spent by user and by month for given year.
+    """
+
+    @jwt_required
+    def get(self, year, month):
+        permissions.check_manager_permissions()
+        return time_spents_service.get_day_table(year, month)
+
+
+class TimeSpentYearResource(Resource):
+    """
+    Return a table giving time spent by user and by day for given year and
+    month.
+    """
+
+    @jwt_required
+    def get(self, year):
+        permissions.check_manager_permissions()
+        return time_spents_service.get_month_table(year)

--- a/zou/app/blueprints/tasks/resources.py
+++ b/zou/app/blueprints/tasks/resources.py
@@ -547,6 +547,8 @@ class SetTimeSpentResource(Resource):
                 args["duration"]
             )
             return time_spent, 201
+        except ValueError:
+            abort(404)
         except WrongDateFormatException:
             abort(404)
 
@@ -579,7 +581,9 @@ class AddTimeSpentResource(Resource):
                 args["duration"],
                 add=True
             )
-            return time_spent, 200
+            return time_spent, 201
+        except ValueError:
+            abort(404)
         except WrongDateFormatException:
             abort(404)
 

--- a/zou/app/blueprints/tasks/resources.py
+++ b/zou/app/blueprints/tasks/resources.py
@@ -1,3 +1,5 @@
+import datetime
+
 from flask import abort, request, current_app
 from flask_restful import Resource, reqparse
 from flask_jwt_extended import jwt_required
@@ -541,10 +543,10 @@ class SetTimeSpentResource(Resource):
             time_spent = tasks_service.create_or_update_time_spent(
                 task_id,
                 person_id,
-                date,
+                datetime.datetime.strptime(date, '%Y-%m-%d'),
                 args["duration"]
             )
-            return time_spent, 200
+            return time_spent, 201
         except WrongDateFormatException:
             abort(404)
 

--- a/zou/app/blueprints/user/__init__.py
+++ b/zou/app/blueprints/user/__init__.py
@@ -25,6 +25,7 @@ from .resources import (
     HasTaskSubscribedResource,
     TaskSubscribeResource,
     TaskUnsubscribeResource,
+    TimeSpentsResource,
     HasSequenceSubscribedResource,
     SequenceSubscriptionsResource,
     SequenceSubscribeResource,
@@ -58,6 +59,7 @@ routes = [
     ("/data/user/filters/<filter_id>", FilterResource),
 
     ("/data/user/desktop-login-logs", DesktopLoginLogsResource),
+    ("/data/user/time-spents/<date>", TimeSpentsResource),
 
     ("/data/user/notifications", NotificationsResource),
     ("/data/user/notifications/<notification_id>", NotificationResource),

--- a/zou/app/blueprints/user/resources.py
+++ b/zou/app/blueprints/user/resources.py
@@ -1,6 +1,6 @@
 import datetime
 
-from flask import request
+from flask import request, abort
 from flask_restful import Resource, reqparse
 from flask_jwt_extended import jwt_required
 
@@ -13,6 +13,8 @@ from zou.app.services import (
     projects_service,
     shots_service
 )
+
+from zou.app.services.exception import WrongDateFormatException
 
 
 class AssetTasksResource(Resource):
@@ -361,4 +363,15 @@ class SequenceSubscriptionsResource(Resource):
         return user_service.get_sequence_subscriptions(project_id, task_type_id)
 
 
+class TimeSpentsResource(Resource):
+    """
+    Get time spents on for current user and given date.
+    """
 
+    @jwt_required
+    def get(self, date):
+        try:
+            current_user = persons_service.get_current_user()
+            return persons_service.get_time_spents(current_user["id"], date)
+        except WrongDateFormatException:
+            abort(404)

--- a/zou/app/config.py
+++ b/zou/app/config.py
@@ -6,7 +6,7 @@ from zou.app.utils import dbhelpers
 APP_NAME = "Zou"
 APP_SYSTEM_ERROR_SUBJECT_LINE = "%s system error" % APP_NAME
 
-DEBUG = os.getenv("DEBUG", False)
+DEBUG = os.getenv("DEBUG", 0)
 SECRET_KEY = os.getenv("SECRET_KEY", "mysecretkey")
 
 AUTH_STRATEGY = os.getenv("AUTH_STRATEGY", "auth_local_classic")
@@ -55,6 +55,11 @@ DEFAULT_FILE_STATUS = "To review"
 DEFAULT_FILE_TREE = os.getenv("DEFAULT_FILE_TREE", "default")
 FILE_TREE_FOLDER = os.getenv("FILE_TREE_FOLDER")
 THUMBNAIL_FOLDER = os.getenv("THUMBNAIL_FOLDER")
+
+MAIL_SERVER = os.getenv("MAIL_SERVER", "localhost")
+MAIL_PORT = os.getenv("MAIL_PORT", 25)
+MAIL_USERNAME = os.getenv("MAIL_USERNAME", "user")
+MAIL_PASSWORD = os.getenv("MAIL_PASSWORD", "pwd")
 
 PLUGIN_FOLDER = os.getenv(
     "PLUGIN_FOLDER",

--- a/zou/app/services/time_spents_service.py
+++ b/zou/app/services/time_spents_service.py
@@ -1,0 +1,54 @@
+import datetime
+
+from dateutil import relativedelta
+
+from zou.app.models.time_spent import TimeSpent
+
+
+def get_month_table(year):
+    """
+    Return a table giving time spent by user and by month for given year.
+    """
+    time_spents = TimeSpent.query \
+        .filter(TimeSpent.date.between(
+            "%s-01-01" % year,
+            "%s-12-31" % year
+        )) \
+        .all()
+
+    result = {}
+    for time_spent in time_spents:
+        month = str(time_spent.date.month)
+        person_id = str(time_spent.person_id)
+        if month not in result:
+            result[month] = {}
+        if person_id not in result[month]:
+            result[month][person_id] = 0
+        result[month][person_id] += time_spent.duration
+
+    return result
+
+
+def get_day_table(year, month):
+    """
+    Return a table giving time spent by user and by day for given year and
+    month.
+    """
+    date = datetime.datetime(int(year), int(month), 1)
+    next_month = date + relativedelta.relativedelta(months=1)
+    time_spents = TimeSpent.query \
+        .filter(TimeSpent.date >= date.strftime("%Y-%m-%d")) \
+        .filter(TimeSpent.date < next_month.strftime("%Y-%m-%d")) \
+        .all()
+
+    result = {}
+    for time_spent in time_spents:
+        day = str(time_spent.date.day)
+        person_id = str(time_spent.person_id)
+        if day not in result:
+            result[day] = {}
+        if person_id not in result[day]:
+            result[day][person_id] = 0
+        result[day][person_id] += time_spent.duration
+
+    return result

--- a/zou/app/services/user_service.py
+++ b/zou/app/services/user_service.py
@@ -47,6 +47,7 @@ def build_related_projects_filter():
     """
     projects = Project.query \
         .join(Task) \
+        .join(ProjectStatus) \
         .filter(build_assignee_filter()) \
         .filter(build_open_project_filter()) \
         .all()
@@ -64,6 +65,7 @@ def related_projects():
     """
     projects = Project.query \
         .join(Task) \
+        .join(ProjectStatus) \
         .filter(build_assignee_filter()) \
         .filter(build_open_project_filter()) \
         .all()

--- a/zou/cli.py
+++ b/zou/cli.py
@@ -21,7 +21,13 @@ def init_db():
     "Creates datababase table (database must be created through PG client)."
 
     print("Creating database and tables...")
-    dbhelpers.create_all()
+    from zou.app import app
+    with app.app_context():
+        import zou
+        directory = os.path.join(
+            os.path.dirname(zou.__file__), "migrations"
+        )
+        flask_migrate.upgrade(directory=directory)
     print("Database and tables created.")
 
 

--- a/zou/cli.py
+++ b/zou/cli.py
@@ -45,7 +45,7 @@ def reset_db():
     "Drop all tables then recreates them."
 
     clear_db()
-    init_db()
+    dbhelpers.create_all()
 
 
 @cli.command()
@@ -59,6 +59,19 @@ def upgrade_db():
             os.path.dirname(zou.__file__), "migrations"
         )
         flask_migrate.upgrade(directory=directory)
+
+
+@cli.command()
+def stamp_db():
+    "Upgrade database schema."
+
+    from zou.app import app
+    with app.app_context():
+        import zou
+        directory = os.path.join(
+            os.path.dirname(zou.__file__), "migrations"
+        )
+        flask_migrate.stamp(directory=directory)
 
 
 @cli.command()


### PR DESCRIPTION
**Problem**

* When using `init_db` the database is not stamped by migration tool. Which broke future updates
* Zou cannont send emails
* When creating a new working file, it is not possible to set mode anymore.
* User todo list returns tasks from closed productions
* There is no way to retrieve all time spents for a given person and day
* There is no way to aggregate time spents on monthly and daily level for a given person

**Solution**

* Make `init_db` behaves like `upgrade_db` to avoid confusions (which stamps the database after proceeding)
* Allow to stamp database without running migration scripts to fix unstamped databases
* Add needed configuration to send email (and add `flask_mail` dependency
* Allow mode as argument in new working file resource.
* Fix filter for current user todo list
* Add a route to retrieve all time spents for a given person and day
* Add a  route to aggregate time spents on monthly and daily level for a given person. Results is sent as table materialized through a dict.