### PR TITLE
Allow to force task, asset and shot deletion

### DIFF
--- a/tests/services/test_tasks_service.py
+++ b/tests/services/test_tasks_service.py
@@ -179,16 +179,6 @@ class TaskServiceTestCase(ApiDBTestCase):
             self.task_id
         )
 
-    def test_remove_task(self):
-        self.working_file.delete()
-        self.output_file.delete()
-        tasks_service.remove_task(self.task_id)
-        self.assertRaises(
-            TaskNotFoundException,
-            tasks_service.get_task,
-            self.task_id
-        )
-
     def test_get_tasks_for_sequence(self):
         self.generate_fixture_sequence_task()
         tasks = tasks_service.get_tasks_for_sequence(self.sequence.id)
@@ -388,3 +378,27 @@ class TaskServiceTestCase(ApiDBTestCase):
         self.assertEquals(str(self.task.task_status_id), done_status["id"])
         self.assertIsNotNone(self.task.end_date)
         self.assertLess(self.task.end_date, datetime.datetime.now())
+
+    def test_remove_task(self):
+        self.working_file.delete()
+        self.output_file.delete()
+        tasks_service.remove_task(self.task_id)
+        self.assertRaises(
+            TaskNotFoundException,
+            tasks_service.get_task,
+            self.task_id
+        )
+
+    def test_remove_task_force(self):
+        tasks_service.create_comment(
+            self.task.id,
+            self.task_status.id,
+            self.person.id,
+            "first comment"
+        )
+        tasks_service.remove_task(self.task_id, force=True)
+        self.assertRaises(
+            TaskNotFoundException,
+            tasks_service.get_task,
+            self.task_id
+        )

--- a/zou/app/blueprints/assets/resources.py
+++ b/zou/app/blueprints/assets/resources.py
@@ -26,7 +26,14 @@ class AssetResource(Resource):
     @jwt_required
     def delete(self, asset_id):
         permissions.check_manager_permissions()
-        deleted_asset = assets_service.remove_asset(asset_id)
+
+        parser = reqparse.RequestParser()
+        parser.add_argument("force", default=False, type=bool)
+        args = parser.parse_args()
+        force = args["force"]
+        if force:
+            permissions.check_admin_permissions()
+        deleted_asset = assets_service.remove_asset(asset_id, force=force)
         return deleted_asset, 204
 
 

--- a/zou/app/blueprints/shots/resources.py
+++ b/zou/app/blueprints/shots/resources.py
@@ -35,8 +35,15 @@ class ShotResource(Resource):
         Delete given shot.
         """
         try:
+            parser = reqparse.RequestParser()
+            parser.add_argument("force", default=False, type=bool)
+            args = parser.parse_args()
+            force = args["force"]
+
             permissions.check_manager_permissions()
-            deleted_shot = shots_service.remove_shot(shot_id)
+            if force:
+                permissions.check_admin_permissions()
+            deleted_shot = shots_service.remove_shot(shot_id, force=force)
         except ShotNotFoundException:
             abort(404)
         except permissions.PermissionDenied:

--- a/zou/app/blueprints/tasks/resources.py
+++ b/zou/app/blueprints/tasks/resources.py
@@ -180,10 +180,10 @@ class TaskCommentResource(Resource):
 
     def remove_comment_and_related(self, comment_id):
         comment = tasks_service.get_comment(comment_id)
-        if comment["preview_file_id"] is not None:
-            files_service.remove_preview_file(comment["preview_file_id"])
         notifications_service.delete_notifications_for_comment(comment["id"])
         tasks_service.delete_comment(comment["id"])
+        if comment["preview_file_id"] is not None:
+            files_service.remove_preview_file(comment["preview_file_id"])
 
     def update_task_status(self, task_id):
         tasks_service.get_task(task_id)

--- a/zou/app/config.py
+++ b/zou/app/config.py
@@ -54,7 +54,10 @@ DEFAULT_FILE_STATUS = "To review"
 
 DEFAULT_FILE_TREE = os.getenv("DEFAULT_FILE_TREE", "default")
 FILE_TREE_FOLDER = os.getenv("FILE_TREE_FOLDER")
-PREVIEW_FOLDER = os.getenv("PREVIEW_FOLDER", "previews")
+PREVIEW_FOLDER = os.getenv(
+    "PREVIEW_FOLDER",
+    os.getenv("THUMBNAIL_FOLDER", "previews")
+)
 
 MAIL_SERVER = os.getenv("MAIL_SERVER", "localhost")
 MAIL_PORT = os.getenv("MAIL_PORT", 25)

--- a/zou/app/services/deletion_service.py
+++ b/zou/app/services/deletion_service.py
@@ -1,0 +1,116 @@
+from zou.app.models.comment import Comment
+from zou.app.models.entity import Entity
+from zou.app.models.subscription import Subscription
+from zou.app.models.notifications import Notification
+from zou.app.models.output_file import OutputFile
+from zou.app.models.preview_file import PreviewFile
+from zou.app.models.task import Task
+from zou.app.models.working_file import WorkingFile
+
+from zou.app.utils import events
+from zou.app.stores import file_store
+
+
+def remove_task(task_id, force=False):
+    """
+    Remove given task. Force deletion if the task has some comments and files
+    related. This will lead to the deletion of all of them.
+    """
+    task = Task.get(task_id)
+    entity = Entity.get(task.entity_id)
+
+    if force:
+        working_files = WorkingFile.query.filter_by(task_id=task_id)
+        for working_file in working_files:
+            output_files = OutputFile.query.filter_by(
+                source_file_id=working_file.id
+            )
+            for output_file in output_files:
+                output_file.delete()
+            working_file.delete()
+
+        comments = Comment.query.filter_by(object_id=task_id)
+        for comment in comments:
+            notifications = Notification.query.filter_by(comment_id=comment.id)
+            for notification in notifications:
+                notification.delete()
+            comment.delete()
+
+        subscriptions = Subscription.query.filter_by(task_id=task_id)
+        for subscription in subscriptions:
+            subscription.delete()
+
+        preview_files = PreviewFile.query.filter_by(task_id=task_id)
+        for preview_file in preview_files:
+            if entity.preview_file_id == preview_file.id:
+                entity.update({"preview_file_id": None})
+            remove_preview_file(preview_file)
+
+    task.delete()
+    events.emit("task:deletion", {
+        "task_id": task_id
+    })
+    return task.serialize()
+
+
+def remove_preview_file(preview_file):
+    """
+    Remove all files related to given preview file, then remove the preview file
+    entry from the database.
+    """
+    if preview_file.extension == "png":
+        clear_picture_files(preview_file.id)
+    elif preview_file.extension == "mp4":
+        clear_movie_files(preview_file.id)
+    else:
+        clear_generic_files(preview_file.id)
+
+    preview_file.delete()
+
+
+def clear_picture_files(preview_file_id):
+    """
+    Remove all files related to given preview file, supposing the original file
+    was a picture.
+    """
+    for image_type in [
+        "originals",
+        "thumbnails",
+        "thumbnails-square",
+        "previews"
+    ]:
+        try:
+            file_store.remove_picture(image_type, preview_file_id)
+        except:
+            pass
+
+
+def clear_movie_files(preview_file_id):
+    """
+    Remove all files related to given preview file, supposing the original file
+    was a movie.
+    """
+    try:
+        file_store.remove_movie("previews", preview_file_id)
+    except:
+        pass
+    for image_type in [
+        "thumbnails",
+        "thumbnails-square",
+        "previews"
+    ]:
+        try:
+            file_store.remove_picture(image_type, preview_file_id)
+        except:
+            pass
+
+
+def clear_generic_files(preview_file_id):
+    """
+    Remove all files related to given preview file, supposing the original file
+    was a generic file.
+    """
+    try:
+        file_store.remove_file("previews", preview_file_id)
+    except:
+        pass


### PR DESCRIPTION
**Problem**

* If there is a comment on a task, it is not possible to remove the task due to database constraints.
* If there are tasks on a shot or an asset, it is not possible to remove the entity due to database constraints.

**Solution**

* Allow to add a force flag to the deletion.
* In that case, if the user is administrator, it removes everything related to the deleted task: subscriptions, working files, preview files and comments.
* In that case, if the user is administrator, it removes all tasks related to the deleted entity.