### PR TITLE
Base permissions on teams instead of assignation

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -14,22 +14,22 @@ from zou.app.services import (
     tasks_service
 )
 
-from zou.app.models.project import Project
-from zou.app.models.person import Person
+from zou.app.models.asset_instance import AssetInstance
 from zou.app.models.department import Department
-from zou.app.models.working_file import WorkingFile
-from zou.app.models.output_file import OutputFile
-from zou.app.models.preview_file import PreviewFile
-from zou.app.models.output_type import OutputType
-from zou.app.models.software import Software
-from zou.app.models.project_status import ProjectStatus
 from zou.app.models.entity import Entity
 from zou.app.models.entity_type import EntityType
-from zou.app.models.task import Task
-from zou.app.models.task_type import TaskType
-from zou.app.models.task_status import TaskStatus
 from zou.app.models.file_status import FileStatus
-from zou.app.models.asset_instance import AssetInstance
+from zou.app.models.output_file import OutputFile
+from zou.app.models.output_type import OutputType
+from zou.app.models.project import Project
+from zou.app.models.project_status import ProjectStatus
+from zou.app.models.person import Person
+from zou.app.models.preview_file import PreviewFile
+from zou.app.models.task import Task
+from zou.app.models.task_status import TaskStatus
+from zou.app.models.task_type import TaskType
+from zou.app.models.software import Software
+from zou.app.models.working_file import WorkingFile
 
 
 class ApiTestCase(unittest.TestCase):
@@ -246,6 +246,7 @@ class ApiDBTestCase(ApiTestCase):
             name=name,
             project_status_id=self.open_status.id
         )
+        self.project_id = self.project.id
         self.project.update({
             "file_tree": file_tree_service.get_tree_from_file("simple")
         })
@@ -558,6 +559,9 @@ class ApiDBTestCase(ApiTestCase):
             due_date=due_date,
             real_start_date=real_start_date
         )
+        self.task_id = self.task.id
+        self.project.team.append(self.person)
+        self.project.save()
         return self.task
 
     def generate_fixture_task_standard(self):
@@ -578,6 +582,9 @@ class ApiDBTestCase(ApiTestCase):
             due_date=due_date,
             real_start_date=real_start_date
         )
+        self.project.team.append(self.person)
+        self.project.save()
+        return self.task_standard
 
     def generate_fixture_shot_task(self, name="Master"):
         self.shot_task = Task.create(
@@ -589,6 +596,8 @@ class ApiDBTestCase(ApiTestCase):
             assignees=[self.person],
             assigner_id=self.assigner.id,
         )
+        self.project.team.append(self.person)
+        self.project.save()
         return self.shot_task
 
     def generate_fixture_scene_task(self, name="Master"):
@@ -601,6 +610,8 @@ class ApiDBTestCase(ApiTestCase):
             assignees=[self.person],
             assigner_id=self.assigner.id,
         )
+        self.project.team.append(self.person)
+        self.project.save()
         return self.scene_task
 
     def generate_fixture_sequence_task(self, name="Master"):
@@ -613,6 +624,9 @@ class ApiDBTestCase(ApiTestCase):
             assignees=[self.person],
             assigner_id=self.assigner.id,
         )
+        self.project.team.append(self.person)
+        self.project.save()
+        return self.sequence_task
 
     def generate_fixture_shot_task_standard(self):
         self.shot_task_standard = Task.create(
@@ -624,6 +638,9 @@ class ApiDBTestCase(ApiTestCase):
             assignees=[self.person],
             assigner_id=self.assigner.id
         )
+        self.project.team.append(self.person)
+        self.project.save()
+        return self.shot_task_standard
 
     def generate_fixture_comment(self):
         self.comment = tasks_service.create_comment(

--- a/tests/files/test_route_working_files.py
+++ b/tests/files/test_route_working_files.py
@@ -4,7 +4,7 @@ from tests.base import ApiDBTestCase
 from zou.app.utils import fields
 
 from zou.app.models.task import Task
-from zou.app.services import tasks_service
+from zou.app.services import projects_service
 
 
 class WorkingFilesTestCase(ApiDBTestCase):
@@ -163,16 +163,15 @@ class WorkingFilesTestCase(ApiDBTestCase):
         self.assertEquals(remote_file["id"], output_file_id)
         self.assertEquals(remote_file["type"], "OutputFile")
 
-        path = "/data/files/%s" % self.task.id
+        path = "/data/files/%s" % self.task_id
         self.get(path, 404)
 
         self.generate_fixture_user_cg_artist()
         self.log_in_cg_artist()
         path = "/data/files/%s" % output_file_id
         self.get(path, 403)
-
-        tasks_service.assign_task(self.task.id, self.user_cg_artist.id)
-        remote_file = self.get(path)
+        projects_service.add_team_member(self.project_id, self.user_cg_artist.id)
+        self.get(path)
 
     def test_comment_working_file(self):
         comment_data = {
@@ -187,7 +186,6 @@ class WorkingFilesTestCase(ApiDBTestCase):
 
     def test_update_working_file_permission(self):
         working_file = self.working_file.serialize()
-        task = self.task.serialize()
         self.generate_fixture_user_cg_artist()
         user = self.user_cg_artist.serialize()
         self.log_in_cg_artist()
@@ -200,7 +198,7 @@ class WorkingFilesTestCase(ApiDBTestCase):
             comment_data,
             403
         )
-        tasks_service.assign_task(task["id"], user["id"])
+        projects_service.add_team_member(self.project_id, user["id"])
         self.put(
             "/actions/working-files/%s/comment" % working_file["id"],
             comment_data

--- a/tests/models/test_output_file.py
+++ b/tests/models/test_output_file.py
@@ -3,7 +3,7 @@ from tests.base import ApiDBTestCase
 from zou.app.models.output_file import OutputFile
 
 from zou.app.utils import fields
-from zou.app.services import tasks_service
+from zou.app.services import projects_service
 
 
 class OutputFileTestCase(ApiDBTestCase):
@@ -80,7 +80,6 @@ class OutputFileTestCase(ApiDBTestCase):
         self.delete_404("data/output-files/%s" % fields.gen_uuid())
 
     def test_get_output_file_permission(self):
-        task_id = self.task.id
         output_file_id = self.get_first("data/output-files")["id"]
         self.generate_fixture_user_cg_artist()
         cg_artist_id = self.user_cg_artist.id
@@ -90,7 +89,7 @@ class OutputFileTestCase(ApiDBTestCase):
         self.assertEquals(len(output_files), 0)
         self.get("data/output-files/%s" % output_file_id, 403)
 
-        tasks_service.assign_task(task_id, cg_artist_id)
+        projects_service.add_team_member(self.project_id, cg_artist_id)
         self.get("data/output-files/%s" % output_file_id)
         output_files = self.get("data/output-files")
         self.assertEquals(len(output_files), 3)

--- a/tests/models/test_working_file.py
+++ b/tests/models/test_working_file.py
@@ -3,7 +3,7 @@ from tests.base import ApiDBTestCase
 from zou.app.models.working_file import WorkingFile
 
 from zou.app.utils import fields
-from zou.app.services import tasks_service
+from zou.app.services import projects_service
 
 
 class WorkingFileTestCase(ApiDBTestCase):
@@ -37,7 +37,6 @@ class WorkingFileTestCase(ApiDBTestCase):
 
     def test_get_working_file(self):
         self.generate_fixture_user_cg_artist()
-        task_id = self.task.id
         user_cg_artist_id = self.user_cg_artist.id
 
         working_file = self.get_first("data/working-files")
@@ -49,7 +48,7 @@ class WorkingFileTestCase(ApiDBTestCase):
         self.log_in_cg_artist()
         working_file_again = self.get(
             "data/working-files/%s" % working_file["id"], 403)
-        tasks_service.assign_task(task_id, user_cg_artist_id)
+        projects_service.add_team_member(self.project_id, user_cg_artist_id)
         working_file_again = self.get(
             "data/working-files/%s" % working_file["id"])
 

--- a/tests/projects/test_route_open_projects.py
+++ b/tests/projects/test_route_open_projects.py
@@ -1,5 +1,7 @@
 from tests.base import ApiDBTestCase
 
+from zou.app.services import projects_service
+
 
 class OpenProjectRouteTestCase(ApiDBTestCase):
 
@@ -16,3 +18,18 @@ class OpenProjectRouteTestCase(ApiDBTestCase):
 
         self.assertEqual(len(projects), 1)
         self.assertEqual(projects[0]["name"], self.project.name)
+
+    def test_add_team_member(self):
+        self.generate_fixture_person()
+        self.post("data/projects/%s/team" % self.project.id, {
+            "person_id": self.person.id
+        })
+        project = projects_service.get_project(self.project.id)
+        self.assertEqual(project["team"], [str(self.person.id)])
+
+    def test_remove_team_member(self):
+        self.generate_fixture_person()
+        projects_service.add_team_member(self.project.id, self.person.id)
+        self.delete("data/projects/%s/team/%s" % (self.project.id, self.person.id))
+        project = projects_service.get_project(self.project.id)
+        self.assertEqual(project["team"], [])

--- a/tests/services/test_projects_service.py
+++ b/tests/services/test_projects_service.py
@@ -80,3 +80,16 @@ class ProjectServiceTestCase(ApiDBTestCase):
         projects_service.update_project(self.project.id, {"name": new_name})
         project = projects_service.get_project(self.project.id)
         self.assertEqual(project["name"], new_name)
+
+    def test_add_team_member(self):
+        self.generate_fixture_person()
+        projects_service.add_team_member(self.project.id, self.person.id)
+        project = projects_service.get_project(self.project.id)
+        self.assertEqual(project["team"], [str(self.person.id)])
+
+    def test_remove_team_member(self):
+        self.generate_fixture_person()
+        projects_service.add_team_member(self.project.id, self.person.id)
+        projects_service.remove_team_member(self.project.id, self.person.id)
+        project = projects_service.get_project(self.project.id)
+        self.assertEqual(project["team"], [])

--- a/tests/tasks/test_route_tasks.py
+++ b/tests/tasks/test_route_tasks.py
@@ -30,6 +30,7 @@ class TaskRoutesTestCase(ApiDBTestCase):
 
     def test_create_asset_tasks(self):
         path = "/actions/task-types/%s/assets/create-tasks" % self.task_type_id
+        path += "?project_id=%s" % self.project.id
         tasks = self.post(path, {})
         self.assertEqual(len(tasks), 1)
 
@@ -42,6 +43,7 @@ class TaskRoutesTestCase(ApiDBTestCase):
 
     def test_create_shot_tasks(self):
         path = "/actions/task-types/%s/shots/create-tasks" % self.task_type_id
+        path += "?project_id=%s" % self.project.id
         tasks = self.post(path, {})
         self.assertEqual(len(tasks), 1)
 

--- a/zou/app/blueprints/assets/resources.py
+++ b/zou/app/blueprints/assets/resources.py
@@ -25,12 +25,13 @@ class AssetResource(Resource):
 
     @jwt_required
     def delete(self, asset_id):
-        permissions.check_manager_permissions()
-
         parser = reqparse.RequestParser()
         parser.add_argument("force", default=False, type=bool)
         args = parser.parse_args()
         force = args["force"]
+
+        asset = assets_service.get_full_asset(asset_id)
+        user_service.check_manager_project_access(asset["project_id"])
         if force:
             permissions.check_admin_permissions()
         deleted_asset = assets_service.remove_asset(asset_id, force=force)
@@ -170,7 +171,7 @@ class NewAssetResource(Resource):
             data
         ) = self.get_arguments()
 
-        permissions.check_manager_permissions()
+        user_service.check_manager_project_access(project_id)
         asset = assets_service.create_asset(
             project_id,
             asset_type_id,

--- a/zou/app/blueprints/crud/asset_instance.py
+++ b/zou/app/blueprints/crud/asset_instance.py
@@ -19,16 +19,16 @@ class AssetInstanceResource(BaseModelResource):
         self.protected_fields.append("number")
 
     def check_read_permissions(self, instance):
-        if permissions.has_manager_permissions():
+        if permissions.has_admin_permissions():
             return True
         else:
             asset_instance = self.get_model_or_404(instance["id"])
             asset = assets_service.get_asset(asset_instance.asset_id)
-            return user_service.check_has_task_related(asset["project_id"])
+            return user_service.check_project_access(asset["project_id"])
 
     def check_update_permissions(self, asset_instance, data):
-        if permissions.has_manager_permissions():
+        if permissions.has_admin_permissions():
             return True
         else:
             asset = assets_service.get_asset(asset_instance["asset_id"])
-            return user_service.check_has_task_related(asset["project_id"])
+            return user_service.check_project_access(asset["project_id"])

--- a/zou/app/blueprints/crud/base.py
+++ b/zou/app/blueprints/crud/base.py
@@ -100,13 +100,13 @@ class BaseModelsResource(Resource):
         return query
 
     def check_read_permissions(self):
-        return permissions.check_manager_permissions()
+        return permissions.check_admin_permissions()
 
     def add_project_permission_filter(self, query):
         return query
 
     def check_create_permissions(self, data):
-        return permissions.check_manager_permissions()
+        return permissions.check_admin_permissions()
 
     def update_data(self, data):
         return data
@@ -196,13 +196,13 @@ class BaseModelResource(Resource):
         return instance
 
     def check_read_permissions(self, instance):
-        return permissions.check_manager_permissions()
+        return permissions.check_admin_permissions()
 
     def check_update_permissions(self, instance, data):
-        return permissions.check_manager_permissions()
+        return permissions.check_admin_permissions()
 
     def check_delete_permissions(self, instance):
-        return permissions.check_manager_permissions()
+        return permissions.check_admin_permissions()
 
     def get_arguments(self):
         return request.json

--- a/zou/app/blueprints/crud/comments.py
+++ b/zou/app/blueprints/crud/comments.py
@@ -18,9 +18,9 @@ class CommentResource(BaseModelResource):
         BaseModelResource.__init__(self, Comment)
 
     def check_read_permissions(self, instance):
-        if permissions.has_manager_permissions():
+        if permissions.has_admin_permissions():
             return True
         else:
             comment = self.get_model_or_404(instance["id"])
             task = tasks_service.get_task(comment.object_id)
-            return user_service.check_has_task_related(task["project_id"])
+            return user_service.check_project_access(task["project_id"])

--- a/zou/app/blueprints/crud/entity.py
+++ b/zou/app/blueprints/crud/entity.py
@@ -18,6 +18,9 @@ class EntitiesResource(BaseModelsResource):
     def __init__(self):
         BaseModelsResource.__init__(self, Entity)
 
+    def check_create_permissions(self, entity):
+        user_service.check_manager_project_access(entity["project_id"])
+
 
 class EntityResource(BaseModelResource):
 

--- a/zou/app/blueprints/crud/output_file.py
+++ b/zou/app/blueprints/crud/output_file.py
@@ -16,7 +16,7 @@ class OutputFilesResource(BaseModelsResource):
         return True
 
     def add_project_permission_filter(self, query):
-        if user_service.is_current_user_manager():
+        if permissions.has_admin_permissions():
             return query
         else:
             query = query \

--- a/zou/app/blueprints/crud/playlist.py
+++ b/zou/app/blueprints/crud/playlist.py
@@ -12,6 +12,9 @@ class PlaylistsResource(BaseModelsResource):
     def check_read_permissions(self):
         return True
 
+    def check_create_permissions(self, playlist):
+        user_service.check_manager_project_access(playlist["project_id"])
+
 
 class PlaylistResource(BaseModelResource):
 
@@ -19,4 +22,7 @@ class PlaylistResource(BaseModelResource):
         BaseModelResource.__init__(self, Playlist)
 
     def check_read_permissions(self, playlist):
+        user_service.check_project_access(playlist["project_id"])
+
+    def check_update_permissions(self, playlist, data):
         user_service.check_project_access(playlist["project_id"])

--- a/zou/app/blueprints/crud/preview_file.py
+++ b/zou/app/blueprints/crud/preview_file.py
@@ -1,6 +1,5 @@
 from zou.app.models.preview_file import PreviewFile
 from zou.app.services import tasks_service, user_service
-from zou.app.utils import permissions
 
 from .base import BaseModelsResource, BaseModelResource
 
@@ -21,7 +20,5 @@ class PreviewFileResource(BaseModelResource):
         return user_service.check_project_access(task["project_id"])
 
     def check_update_permissions(self, preview_file, data):
-        if permissions.has_manager_permissions():
-            return True
-        else:
-            return user_service.check_assigned(preview_file["task_id"])
+        task = tasks_service.get_task(preview_file["task_id"])
+        return user_service.check_project_access(task["project_id"])

--- a/zou/app/blueprints/crud/project.py
+++ b/zou/app/blueprints/crud/project.py
@@ -11,7 +11,7 @@ class ProjectsResource(BaseModelsResource):
         BaseModelsResource.__init__(self, Project)
 
     def add_project_permission_filter(self, query):
-        if permissions.has_manager_permissions():
+        if permissions.has_admin_permissions():
             return query
         else:
             return query.filter(user_service.build_related_projects_filter())

--- a/zou/app/blueprints/crud/search_filters.py
+++ b/zou/app/blueprints/crud/search_filters.py
@@ -9,20 +9,8 @@ class SearchFiltersResource(BaseModelsResource):
     def __init__(self):
         BaseModelsResource.__init__(self, SearchFilter)
 
-    def check_create_permissions(self, data):
-        return permissions.check_admin_permissions()
-
 
 class SearchFilterResource(BaseModelResource):
 
     def __init__(self):
         BaseModelResource.__init__(self, SearchFilterResource)
-
-    def check_read_permissions(self, instance):
-        return permissions.check_admin_permissions()
-
-    def check_update_permissions(self, instance, data):
-        return permissions.check_admin_permissions()
-
-    def check_delete_permissions(self, instance):
-        return permissions.check_admin_permissions()

--- a/zou/app/blueprints/crud/task.py
+++ b/zou/app/blueprints/crud/task.py
@@ -58,9 +58,6 @@ class TaskResource(BaseModelResource):
     def check_read_permissions(self, task):
         user_service.check_project_access(task["project_id"])
 
-    def check_delete_permissions(self, task):
-        permissions.check_admin_permissions()
-
     @jwt_required
     def delete(self, instance_id):
         """

--- a/zou/app/blueprints/crud/working_file.py
+++ b/zou/app/blueprints/crud/working_file.py
@@ -6,7 +6,6 @@ from zou.app.services import (
     tasks_service,
     files_service
 )
-from zou.app.utils import permissions
 
 
 class WorkingFilesResource(BaseModelsResource):
@@ -27,5 +26,5 @@ class WorkingFileResource(BaseModelResource):
 
     def check_update_permissions(self, instance, data):
         working_file = files_service.get_working_file(instance["id"])
-        return permissions.has_manager_permissions or \
-            user_service.check_assigned(working_file["task_id"])
+        task = tasks_service.get_task(working_file["task_id"])
+        user_service.check_project_access(task["project_id"])

--- a/zou/app/blueprints/files/resources.py
+++ b/zou/app/blueprints/files/resources.py
@@ -710,8 +710,7 @@ class GetNextEntityOutputFileRevisionResource(Resource, ArgsMixin):
         entity = entities_service.get_entity(entity_id)
         output_type = files_service.get_output_type(args["output_type_id"])
         task_type = tasks_service.get_task_type(args["task_type_id"])
-        if not permissions.has_manager_permissions():
-            user_service.check_has_task_related(entity["project_id"])
+        user_service.check_project_access(entity["project_id"])
 
         next_revision_number = \
             files_service.get_next_output_file_revision(
@@ -746,8 +745,7 @@ class GetNextInstanceOutputFileRevisionResource(Resource, ArgsMixin):
         asset = entities_service.get_entity(asset_instance["asset_id"])
         output_type = files_service.get_output_type(args["output_type_id"])
         task_type = tasks_service.get_task_type(args["task_type_id"])
-        if not permissions.has_manager_permissions():
-            user_service.check_has_task_related(asset["project_id"])
+        user_service.check_project_access(asset["project_id"])
 
         next_revision_number = \
             files_service.get_next_output_file_revision(
@@ -780,8 +778,7 @@ class LastEntityOutputFilesResource(Resource):
     @jwt_required
     def get(self, entity_id):
         entity = entities_service.get_entity(entity_id)
-        if not permissions.has_manager_permissions():
-            user_service.check_has_task_related(entity["project_id"])
+        user_service.check_project_access(entity["project_id"])
         return files_service.get_last_output_files_for_entity(entity["id"])
 
 
@@ -795,8 +792,7 @@ class LastInstanceOutputFilesResource(Resource):
     def get(self, asset_instance_id, temporal_entity_id):
         asset_instance = assets_service.get_asset_instance(asset_instance_id)
         entity = entities_service.get_entity(asset_instance["asset_id"])
-        if not permissions.has_manager_permissions():
-            user_service.check_has_task_related(entity["project_id"])
+        user_service.check_project_access(entity["project_id"])
         return files_service.get_last_output_files_for_instance(
             asset_instance["id"],
             temporal_entity_id,
@@ -909,7 +905,7 @@ class SetTreeResource(Resource):
         tree_name = self.get_arguments()
 
         try:
-            permissions.check_manager_permissions()
+            user_service.check_project_access(project_id)
             tree = file_tree_service.get_tree_from_file(tree_name)
             project = projects_service.update_project(
                 project_id,

--- a/zou/app/blueprints/persons/__init__.py
+++ b/zou/app/blueprints/persons/__init__.py
@@ -4,20 +4,22 @@ from zou.app.utils.api import configure_api_from_blueprint
 from .resources import (
     DesktopLoginsResource,
     NewPersonResource,
+    PersonMonthTimeSpentsResource,
+    PersonWeekTimeSpentsResource,
+    PersonDayTimeSpentsResource,
     PresenceLogsResource,
     TimeSpentsResource,
     TimeSpentMonthResource,
     TimeSpentWeekResource,
-    TimeSpentYearResource,
-    PersonMonthTimeSpentsResource,
-    PersonWeekTimeSpentsResource,
-    PersonDayTimeSpentsResource
+    TimeSpentYearResource
 )
 
 routes = [
     ("/data/persons/new", NewPersonResource),
+
     ("/data/persons/<person_id>/desktop-login-logs", DesktopLoginsResource),
     ("/data/persons/presence-logs/<month_date>", PresenceLogsResource),
+
     ("/data/persons/<person_id>/time-spents/<date>", TimeSpentsResource),
     ("/data/persons/<person_id>/time-spents/month/<year>/<month>", PersonMonthTimeSpentsResource),
     ("/data/persons/<person_id>/time-spents/week/<year>/<week>", PersonWeekTimeSpentsResource),

--- a/zou/app/blueprints/persons/resources.py
+++ b/zou/app/blueprints/persons/resources.py
@@ -4,7 +4,10 @@ from flask import abort
 from flask_restful import Resource, reqparse
 from flask_jwt_extended import jwt_required
 
-from zou.app.services import persons_service, time_spents_service
+from zou.app.services import (
+    persons_service,
+    time_spents_service
+)
 from zou.app.utils import auth, permissions, csv_utils
 from zou.app.services.exception import WrongDateFormatException
 
@@ -109,6 +112,7 @@ class TimeSpentsResource(Resource):
 
     @jwt_required
     def get(self, person_id, date):
+        permissions.check_admin_permissions()
         try:
             return time_spents_service.get_time_spents(person_id, date)
         except WrongDateFormatException:
@@ -122,6 +126,7 @@ class PersonMonthTimeSpentsResource(Resource):
 
     @jwt_required
     def get(self, person_id, year, month):
+        permissions.check_admin_permissions()
         try:
             return time_spents_service.get_month_time_spents(
                 person_id,
@@ -139,6 +144,7 @@ class PersonWeekTimeSpentsResource(Resource):
 
     @jwt_required
     def get(self, person_id, year, week):
+        permissions.check_admin_permissions()
         try:
             return time_spents_service.get_week_time_spents(
                 person_id,
@@ -156,6 +162,7 @@ class PersonDayTimeSpentsResource(Resource):
 
     @jwt_required
     def get(self, person_id, year, month, day):
+        permissions.check_admin_permissions()
         try:
             return time_spents_service.get_day_time_spents(
                 person_id,
@@ -175,7 +182,7 @@ class TimeSpentMonthResource(Resource):
 
     @jwt_required
     def get(self, year, month):
-        permissions.check_manager_permissions()
+        permissions.check_admin_permissions()
         return time_spents_service.get_day_table(year, month)
 
 
@@ -186,7 +193,7 @@ class TimeSpentYearResource(Resource):
 
     @jwt_required
     def get(self, year):
-        permissions.check_manager_permissions()
+        permissions.check_admin_permissions()
         return time_spents_service.get_month_table(year)
 
 
@@ -197,5 +204,5 @@ class TimeSpentWeekResource(Resource):
 
     @jwt_required
     def get(self, year):
-        permissions.check_manager_permissions()
+        permissions.check_admin_permissions()
         return time_spents_service.get_week_table(year)

--- a/zou/app/blueprints/projects/__init__.py
+++ b/zou/app/blueprints/projects/__init__.py
@@ -1,12 +1,19 @@
 from flask import Blueprint
 from zou.app.utils.api import configure_api_from_blueprint
 
-from .resources import AllProjectsResource
-from .resources import OpenProjectsResource
+from .resources import (
+    AllProjectsResource,
+    OpenProjectsResource,
+    ProductionTeamResource,
+    ProductionTeamRemoveResource
+)
 
 routes = [
     ("/data/projects/open", OpenProjectsResource),
-    ("/data/projects/all", AllProjectsResource)
+    ("/data/projects/all", AllProjectsResource),
+
+    ("/data/projects/<project_id>/team", ProductionTeamResource),
+    ("/data/projects/<project_id>/team/<person_id>", ProductionTeamRemoveResource)
 ]
 
 blueprint = Blueprint("projects", "projects")

--- a/zou/app/blueprints/projects/resources.py
+++ b/zou/app/blueprints/projects/resources.py
@@ -3,8 +3,9 @@ from flask_jwt_extended import jwt_required
 
 from flask import request
 
+from zou.app.mixin import ArgsMixin
 from zou.app.services import projects_service, user_service
-from zou.app.utils import permissions
+from zou.app.utils import permissions, fields
 
 
 class OpenProjectsResource(Resource):
@@ -17,7 +18,7 @@ class OpenProjectsResource(Resource):
     def get(self):
         name = request.args.get("name", None)
         try:
-            permissions.check_manager_permissions()
+            permissions.check_admin_permissions()
 
             return projects_service.open_projects(name=name)
         except permissions.PermissionDenied:
@@ -34,7 +35,7 @@ class AllProjectsResource(Resource):
     def get(self):
         name = request.args.get("name", None)
         try:
-            permissions.check_manager_permissions()
+            permissions.check_admin_permissions()
 
             if name is None:
                 return projects_service.get_projects()
@@ -45,3 +46,38 @@ class AllProjectsResource(Resource):
                 return user_service.get_projects()
             else:
                 return [user_service.get_project_by_name(name)]
+
+
+class ProductionTeamResource(Resource, ArgsMixin):
+    """
+    Allow to manage the people listed in a production team.
+    """
+
+    @jwt_required
+    def get(self, project_id):
+        user_service.check_project_access(project_id)
+        project = projects_service.get_project()
+        return fields.serialize_value(project.team)
+
+    @jwt_required
+    def post(self, project_id):
+        args = self.get_args([
+            ("person_id", "", True)
+        ])
+        user_service.check_manager_project_access(project_id)
+        return projects_service.add_team_member(
+            project_id,
+            args["person_id"]
+        ), 201
+
+
+class ProductionTeamRemoveResource(Resource, ArgsMixin):
+    """
+    Allow to remove people listed in a production team.
+    """
+
+    @jwt_required
+    def delete(self, project_id, person_id):
+        user_service.check_manager_project_access(project_id)
+        project = projects_service.remove_team_member(project_id, person_id)
+        return fields.serialize_value(project), 204

--- a/zou/app/blueprints/source/csv/base.py
+++ b/zou/app/blueprints/source/csv/base.py
@@ -8,6 +8,7 @@ from flask_jwt_extended import jwt_required
 
 from zou.app import app
 from zou.app.utils import fields, permissions
+from zou.app.services import user_service
 
 
 class BaseCsvImportResource(Resource):
@@ -69,7 +70,7 @@ class BaseCsvProjectImportResource(BaseCsvImportResource):
         result = []
 
         try:
-            self.check_permissions()
+            self.check_project_permissions(project_id)
             self.prepare_import()
             with open(file_path) as csvfile:
                 reader = csv.DictReader(csvfile)
@@ -80,6 +81,9 @@ class BaseCsvProjectImportResource(BaseCsvImportResource):
         except KeyError as e:
             print(e)
             return {"error": "A column is missing: %s" % e}, 400
+
+    def check_project_permissions(self, project_id):
+        return user_service.check_manager_project_access(project_id)
 
     def import_row(self, project_id):
         pass

--- a/zou/app/blueprints/source/shotgun/base.py
+++ b/zou/app/blueprints/source/shotgun/base.py
@@ -73,7 +73,7 @@ class BaseImportShotgunResource(Resource):
         return self.sg_entries
 
     def check_permissions(self):
-        return permissions.check_manager_permissions()
+        return permissions.check_admin_permissions()
 
     def prepare_import(self):
         pass

--- a/zou/app/models/person.py
+++ b/zou/app/models/person.py
@@ -77,3 +77,9 @@ class Person(db.Model, BaseMixin, SerializerMixin):
         data["full_name"] = self.full_name()
         del data["password"]
         return data
+
+    def serialize_without_info(self):
+        data = self.serialize_safe()
+        del data["phone"]
+        del data["email"]
+        return data

--- a/zou/app/services/persons_service.py
+++ b/zou/app/services/persons_service.py
@@ -4,19 +4,17 @@ import datetime
 from calendar import monthrange
 from dateutil import relativedelta
 
-from sqlalchemy.exc import StatementError, DataError
+from sqlalchemy.exc import StatementError
 
 from flask_jwt_extended import get_jwt_identity
 
 from zou.app.models.person import Person
 from zou.app.models.desktop_login_logs import DesktopLoginLog
-from zou.app.models.time_spent import TimeSpent
 
 from zou.app.utils import fields, events, cache
 
 from zou.app.services.exception import (
-    PersonNotFoundException,
-    WrongDateFormatException
+    PersonNotFoundException
 )
 
 

--- a/zou/app/services/projects_service.py
+++ b/zou/app/services/projects_service.py
@@ -1,4 +1,5 @@
 from zou.app.models.project import Project
+from zou.app.models.person import Person
 from zou.app.models.project_status import ProjectStatus
 from zou.app.services.exception import ProjectNotFoundException
 
@@ -150,4 +151,26 @@ def update_project(project_id, data):
     events.emit("project:update", {
         "project_id": project_id
     })
+    return project.serialize()
+
+
+def add_team_member(project_id, person_id):
+    """
+    Add a a person listed in database to the the project team.
+    """
+    project = get_project_raw(project_id)
+    person = Person.get(person_id)
+    project.team.append(person)
+    project.save()
+    return project.serialize()
+
+
+def remove_team_member(project_id, person_id):
+    """
+    Remove a a person listed in database from the the project team.
+    """
+    project = get_project_raw(project_id)
+    person = Person.get(person_id)
+    project.team.remove(person)
+    project.save()
     return project.serialize()

--- a/zou/cli.py
+++ b/zou/cli.py
@@ -279,5 +279,21 @@ def patch_task_type_allow_timelog():
             print(task_type.serialize())
 
 
+@cli.command()
+def patch_team():
+    """
+    Patch to run after upgrade from 0.7.10 or lower to 0.8.0 or superior.
+    """
+    from zou.app.models.project import Project
+    from zou.app.models.person import Person
+    from zou.app.models.task import Task
+    for project in Project.query.all():
+        for person in Person.query.all():
+            task = Task.get_by(project_id=project.id, assignee_id=person.id)
+            if task is not None:
+                project.team.append(person)
+                project.save()
+
+
 if __name__ == '__main__':
     cli()


### PR DESCRIPTION
**Problem**

* Managers can see everything
* To see a project it's required to have at least one task assigned

**Solution**

* Make manager permissions restricted to the project they are part of
* Allow to access project when the user is part of the team or when it's an admin
