### PR TITLE
Add 1rst episode id when creating/updating a project

### DIFF
--- a/zou/app/blueprints/crud/base.py
+++ b/zou/app/blueprints/crud/base.py
@@ -112,7 +112,7 @@ class BaseModelsResource(Resource):
         return data
 
     def post_creation(self, instance):
-        return instance
+        return instance.serialize()
 
     @jwt_required
     def get(self):
@@ -158,12 +158,12 @@ class BaseModelsResource(Resource):
             data = self.update_data(data)
             instance = self.model(**data)
             instance.save()
-            self.post_creation(instance)
+            instance_dict = self.post_creation(instance)
             events.emit(
                 "%s:new" % self.model.__tablename__,
                 {"%s_id" % self.model.__tablename__: instance.id}
             )
-            return instance.serialize(), 201
+            return instance_dict, 201
 
         except TypeError as exception:
             current_app.logger.error(str(exception))

--- a/zou/app/services/shots_service.py
+++ b/zou/app/services/shots_service.py
@@ -537,6 +537,20 @@ def get_or_create_episode(project_id, name):
     return episode.serialize()
 
 
+def get_or_create_first_episode(project_id):
+    """
+    Get the first episode of the production.
+    """
+    episode = Entity.query \
+        .filter_by(project_id=project_id) \
+        .order_by(Entity.name) \
+        .first()
+    if episode is not None:
+        return episode.serialize()
+    else:
+        return get_or_create_episode(project_id, "E01")
+
+
 def get_or_create_sequence(project_id, episode_id, name):
     """
     Retrieve sequence matching given project, episode and name or create it.


### PR DESCRIPTION
**Problem**

After a TVShow creation or a modification to the TVShow type, the first episode information is not sent to the client. But sometimes, it is required (ex: the web frontend needs it to build its navigation link in the project list).

**Solution**

In the post creation and post update hooks, retrieve the first episode or create the first episode if it doesn't exist. Adds the first episode id to the response.
