### PR TITLE
Add a route to retrieve preview info for a given enttiy

### DIFF
--- a/zou/app/blueprints/playlists/__init__.py
+++ b/zou/app/blueprints/playlists/__init__.py
@@ -2,6 +2,7 @@ from flask import Blueprint
 from zou.app.utils.api import configure_api_from_blueprint
 
 from .resources import (
+    EntityPreviewsResource,
     EpisodePlaylistsResource,
     ProjectPlaylistsResource,
     ProjectPlaylistResource
@@ -17,6 +18,10 @@ routes = [
     (
         "/data/projects/<project_id>/playlists/<playlist_id>",
         ProjectPlaylistResource
+    ),
+    (
+        "/data/playlists/entities/<entity_id>/preview-files",
+        EntityPreviewsResource
     )
 ]
 

--- a/zou/app/blueprints/playlists/resources.py
+++ b/zou/app/blueprints/playlists/resources.py
@@ -1,7 +1,12 @@
 from flask_restful import Resource
 from flask_jwt_extended import jwt_required
 
-from zou.app.services import playlists_service, user_service, shots_service
+from zou.app.services import (
+    playlists_service,
+    user_service,
+    shots_service,
+    entities_service
+)
 
 
 class ProjectPlaylistsResource(Resource):
@@ -29,3 +34,17 @@ class ProjectPlaylistResource(Resource):
         return playlists_service.get_playlist_with_preview_file_revisions(
             playlist_id
         )
+
+
+class EntityPreviewsResource(Resource):
+
+    @jwt_required
+    def get(self, entity_id):
+        """
+        Retrieve all previews related to a given entity. It sends them
+        as a dict. Keys are related task type ids and values are arrays
+        of preview for this task type.
+        """
+        entity = entities_service.get_entity(entity_id)
+        user_service.check_project_access(entity["project_id"])
+        return playlists_service.get_preview_files_for_entity(entity_id)

--- a/zou/app/blueprints/thumbnails/resources.py
+++ b/zou/app/blueprints/thumbnails/resources.py
@@ -80,14 +80,6 @@ def send_storage_file(
     """
     if config.FS_BACKEND == "local":
         file_path = get_path(prefix, preview_file_id)
-        if not os.path.exists(file_path):
-            return {
-                "error": True,
-                "message": "File not found for: %s %s" % (
-                    prefix,
-                    preview_file_id
-                )
-            }, 404
     else:
         file_path = os.path.join(
             config.TMP_DIR,
@@ -97,11 +89,21 @@ def send_storage_file(
             with open(file_path, 'wb') as tmp_file:
                 for chunk in open_file(prefix, preview_file_id):
                     tmp_file.write(chunk)
-    return flask_send_file(
-        file_path,
-        conditional=True,
-        mimetype=mimetype
-    )
+
+    try:
+        return flask_send_file(
+            file_path,
+            conditional=True,
+            mimetype=mimetype
+        )
+    except FileNotFoundError:
+        return {
+            "error": True,
+            "message": "File not found for: %s %s" % (
+                prefix,
+                preview_file_id
+            )
+        }, 404
 
 
 class CreatePreviewFilePictureResource(Resource):

--- a/zou/app/services/playlists_service.py
+++ b/zou/app/services/playlists_service.py
@@ -68,3 +68,30 @@ def get_preview_files_for_shot(shot_id):
             ]  # Do not add too much field to avoid building too big responses
 
     return previews
+
+
+def get_preview_files_for_entity(entity_id):
+    """
+    Get all preview files available for given entity.
+    """
+    tasks = tasks_service.get_task_dicts_for_entity(entity_id)
+    previews = {}
+
+    for task in tasks:
+        preview_files = PreviewFile.query \
+            .filter_by(task_id=task["id"]) \
+            .filter_by(extension="mp4") \
+            .order_by(PreviewFile.revision.desc()) \
+            .all()
+        task_type_id = task["task_type_id"]
+
+        if len(preview_files) > 0:
+            previews[task_type_id] = [
+                {
+                    "id": str(preview_file.id),
+                    "revision": preview_file.revision
+                }
+                for preview_file in preview_files
+            ]  # Do not add too much field to avoid building too big responses
+
+    return previews


### PR DESCRIPTION
**Problem**

There is no way to list all the preview available for an entity.

**Solution**

Add an endpoint returning for each task type of the entity, the list of available previews (id + revision).
