### PR TITLE
Upgrade pyscopg version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ install_requires =
 
     sqlalchemy==1.2.0
     sqlalchemy_utils==0.32.21
-    psycopg2==2.7.1
+    psycopg2==2.7.6
 
     python-slugify==1.2.4
 


### PR DESCRIPTION
**Problem**

Current version of psycopg is not compatible with Ubuntu 18.04

**Solution**

Upgrade `psycopg` version to latest version (2.7.6).
