### PR TITLE
Allow to remove all tasks for given task type and project

### DIFF
--- a/tests/services/test_tasks_service.py
+++ b/tests/services/test_tasks_service.py
@@ -408,3 +408,19 @@ class TaskServiceTestCase(ApiDBTestCase):
             tasks_service.get_task,
             self.task_id
         )
+
+    def test_delete_all_task_types(self):
+        self.generate_fixture_project_standard()
+        self.generate_fixture_asset_standard()
+        task_1_id = str(self.task.id)
+        task_2_id = str(self.generate_fixture_task(name="second task").id)
+        task_3_id = str(self.shot_task.id)
+        task_4_id = str(self.generate_fixture_task_standard().id)
+        deletion_service.remove_tasks_for_project_and_task_type(
+            self.project.id,
+            self.task_type.id
+        )
+        self.assertIsNone(Task.get(task_1_id))
+        self.assertIsNone(Task.get(task_2_id))
+        self.assertIsNotNone(Task.get(task_3_id))
+        self.assertIsNotNone(Task.get(task_4_id))

--- a/tests/tasks/test_route_tasks.py
+++ b/tests/tasks/test_route_tasks.py
@@ -256,3 +256,21 @@ class TaskRoutesTestCase(ApiDBTestCase):
 
         tasks = self.get("/data/persons/%s/done-tasks" % self.person.id)
         self.assertEquals(len(tasks), 1)
+
+    def test_delete_all_task_types(self):
+        self.generate_fixture_project_standard()
+        self.generate_fixture_asset_standard()
+        task_1_id = str(self.generate_fixture_task().id)
+        task_2_id = str(self.generate_fixture_task(name="second task").id)
+        task_3_id = str(self.generate_fixture_shot_task().id)
+        task_4_id = str(self.generate_fixture_task_standard().id)
+        self.delete(
+            "/data/projects/%s/task-types/%s/tasks" % (
+                self.project.id,
+                self.task_type.id
+            )
+        )
+        self.get("/data/tasks/%s" % task_1_id, 404)
+        self.get("/data/tasks/%s" % task_2_id, 404)
+        self.get("/data/tasks/%s" % task_3_id)
+        self.get("/data/tasks/%s" % task_4_id)

--- a/zou/app/blueprints/tasks/__init__.py
+++ b/zou/app/blueprints/tasks/__init__.py
@@ -4,6 +4,7 @@ from zou.app.utils.api import configure_api_from_blueprint
 from .resources import (
     TaskFullResource,
     TaskForEntityResource,
+    DeletAllTasksForTaskTypeResource,
 
     TaskAssignResource,
     TasksAssignResource,
@@ -41,6 +42,10 @@ routes = [
         "/data/entities/<entity_id>/task-types/<task_type_id>/tasks",
         TaskForEntityResource
     ),
+    (
+        "/data/projects/<project_id>/task-types/<task_type_id>/tasks/",
+        DeletAllTasksForTaskTypeResource
+    ),
 
     ("/actions/tasks/<task_id>/comment", CommentTaskResource),
     ("/actions/tasks/<task_id>/assign", TaskAssignResource),
@@ -61,7 +66,8 @@ routes = [
         AddPreviewResource
     ),
     (
-        "/actions/tasks/<task_id>/comments/<comment_id>/preview-files/<preview_file_id>",
+        "/actions/tasks/<task_id>/comments/<comment_id>/preview-files/"
+        "<preview_file_id>",
         AddExtraPreviewResource
     ),
     (

--- a/zou/app/blueprints/tasks/resources.py
+++ b/zou/app/blueprints/tasks/resources.py
@@ -631,3 +631,22 @@ class GetTimeSpentResource(Resource):
             return tasks_service.get_time_spents(task_id)
         except WrongDateFormatException:
             abort(404)
+
+
+class DeletAllTasksForTaskTypeResource(Resource):
+    """
+    Delete all tasks for a given task type and project. It's mainly used
+    when tasks are created by mistake at the beginning of the project.
+    """
+
+    @jwt_required
+    def delete(self, project_id, task_type_id):
+        if permissions.has_admin_permissions():
+            projects_service.get_project(project_id)
+            deletion_service.remove_tasks_for_project_and_task_type(
+                project_id,
+                task_type_id
+            )
+            return None, 204
+        else:
+            return 403

--- a/zou/app/blueprints/tasks/resources.py
+++ b/zou/app/blueprints/tasks/resources.py
@@ -635,7 +635,7 @@ class GetTimeSpentResource(Resource):
 
 class DeletAllTasksForTaskTypeResource(Resource):
     """
-    Delete all tasks for a given task type and project. It's mainly used
+    Delete all tasks for a given task type and project. It's mainly used
     when tasks are created by mistake at the beginning of the project.
     """
 

--- a/zou/app/blueprints/thumbnails/resources.py
+++ b/zou/app/blueprints/thumbnails/resources.py
@@ -98,6 +98,14 @@ def send_storage_file(
             conditional=True,
             mimetype=mimetype
         )
+    except IOError:
+        return {
+            "error": True,
+            "message": "File not found for: %s %s" % (
+                prefix,
+                preview_file_id
+            )
+        }, 404
     except FileNotFound:
         return {
             "error": True,

--- a/zou/app/services/deletion_service.py
+++ b/zou/app/services/deletion_service.py
@@ -153,3 +153,14 @@ def clear_generic_files(preview_file_id):
         file_store.remove_file("previews", preview_file_id)
     except:
         pass
+
+
+def remove_tasks_for_project_and_task_type(project_id, task_type_id):
+    """
+    Remove fully all tasks and related for given project and task type.
+    """
+    tasks = Task.query.filter_by(
+        project_id=project_id, task_type_id=task_type_id
+    )
+    for task in tasks:
+        remove_task(task.id, force=True)


### PR DESCRIPTION
**Problem**

There is no straightforward way to remove a full list of tasks for given task type and project.

**Solution**

Add a dedicated route to handle that use case.

```
DEL /data/projects/<project_id>/task-types/<task_type_id>/tasks
```