### PR TITLE
Error management improvement and fixes

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -334,6 +334,7 @@ class ApiDBTestCase(ApiTestCase):
             entity_type_id=self.sequence_type.id,
             parent_id=episode_id
         )
+        return self.sequence
 
     def generate_fixture_sequence_standard(self):
         self.sequence_standard = Entity.create(
@@ -341,6 +342,7 @@ class ApiDBTestCase(ApiTestCase):
             project_id=self.project_standard.id,
             entity_type_id=self.sequence_type.id
         )
+        return self.sequence_standard
 
     def generate_fixture_episode(self, name="E01", project_id=None):
         if project_id is None:

--- a/tests/shots/test_episodes.py
+++ b/tests/shots/test_episodes.py
@@ -9,6 +9,7 @@ class EpisodeTestCase(ApiDBTestCase):
         self.generate_fixture_project()
         self.generate_fixture_asset_type()
         self.generate_fixture_episode("E01")
+        self.project_id = str(self.project.id)
         self.serialized_episode = self.episode.serialize(obj_type="Episode")
         self.episode_id = str(self.episode.id)
 
@@ -24,6 +25,7 @@ class EpisodeTestCase(ApiDBTestCase):
         self.generate_fixture_sequence("SE04")
 
         episode_02 = self.generate_fixture_episode("E02")
+        self.episode_02_id = str(episode_02.id)
         self.generate_fixture_sequence("SE01", episode_id=episode_02.id)
         self.generate_fixture_episode("E03")
 
@@ -64,3 +66,16 @@ class EpisodeTestCase(ApiDBTestCase):
 
     def test_get_episodes_for_project_404(self):
         self.get("data/projects/unknown/episodes", 404)
+
+    def test_get_episodes_by_project_and_name(self):
+        self.get("data/episodes?project_id=undefined&name=E01", 400)
+        episodes = self.get(
+            "data/episodes?project_id=%s&name=E02" % self.project_id
+        )
+        self.assertEquals(episodes[0]["id"], str(self.episode_02_id))
+
+        self.generate_fixture_user_cg_artist()
+        self.log_in_cg_artist()
+        episodes = self.get(
+            "data/episodes?project_id=%s&name=E01" % self.project_id, 403
+        )

--- a/tests/shots/test_scenes.py
+++ b/tests/shots/test_scenes.py
@@ -8,13 +8,16 @@ class SceneTestCase(ApiDBTestCase):
     def setUp(self):
         super(SceneTestCase, self).setUp()
         self.generate_shot_suite()
+        self.project_id = str(self.project.id)
         self.serialized_shot = self.shot.serialize(obj_type="Shot")
         self.serialized_scene = self.scene.serialize(obj_type="Scene")
+        self.scene_id = str(self.scene.id)
         self.serialized_sequence = self.sequence.serialize(obj_type="Sequence")
-        self.sequence_id = self.sequence.id
+        self.sequence_id = str(self.sequence.id)
         self.generate_fixture_shot("S02")
         self.serialized_shot_02 = self.shot.serialize(obj_type="Shot")
-        self.generate_fixture_scene("SC02")
+        scene_02 = self.generate_fixture_scene("SC02")
+        self.scene_02_id = str(scene_02.id)
         self.generate_fixture_scene("SC03")
         self.generate_fixture_scene("SC04")
         self.generate_assigned_task()
@@ -108,3 +111,16 @@ class SceneTestCase(ApiDBTestCase):
         shots = self.get("data/scenes/%s/shots" % self.serialized_scene["id"])
         self.assertEqual(len(shots), 1)
         self.assertEqual(shots[0]["id"], self.serialized_shot_02["id"])
+
+    def test_get_scenes_by_project_and_name(self):
+        self.get("data/scenes/all?project_id=undefined&name=SC01", 400)
+        scenes = self.get(
+            "data/scenes/all?project_id=%s&name=SC02" % self.project_id
+        )
+        self.assertEquals(scenes[0]["id"], str(self.scene_02_id))
+
+        self.generate_fixture_user_cg_artist()
+        self.log_in_cg_artist()
+        scenes = self.get(
+            "data/scenes/all?project_id=%s&name=SC01" % self.project_id, 403
+        )

--- a/tests/shots/test_sequences.py
+++ b/tests/shots/test_sequences.py
@@ -17,7 +17,9 @@ class SequenceTestCase(ApiDBTestCase):
         self.generate_fixture_episode()
         self.generate_fixture_sequence()
         self.serialized_sequence = self.sequence.serialize(obj_type="Sequence")
-        self.generate_fixture_sequence("SE02")
+        self.sequence_id = str(self.serialized_sequence["id"])
+        sequence_02 = self.generate_fixture_sequence("SE02")
+        self.sequence_02_id = str(sequence_02.id)
         self.generate_fixture_sequence("SE03")
 
     def test_get_sequences(self):
@@ -75,3 +77,16 @@ class SequenceTestCase(ApiDBTestCase):
         shots = self.get("data/sequences/%s/shots" % self.sequence.id)
         self.assertEquals(len(shots), 1)
         self.assertEqual(shots[0]["id"], shot["id"])
+
+    def test_get_sequences_by_project_and_name(self):
+        self.get("data/sequences?project_id=undefined&name=S01", 400)
+        sequences = self.get(
+            "data/sequences?project_id=%s&name=SE02" % self.project_id
+        )
+        self.assertEquals(sequences[0]["id"], str(self.sequence_02_id))
+
+        self.generate_fixture_user_cg_artist()
+        self.log_in_cg_artist()
+        sequences = self.get(
+            "data/sequences?project_id=%s&name=SE01" % self.project_id, 403
+        )

--- a/tests/shots/test_shots.py
+++ b/tests/shots/test_shots.py
@@ -9,6 +9,7 @@ class ShotTestCase(ApiDBTestCase):
         super(ShotTestCase, self).setUp()
         self.generate_fixture_project_status()
         self.generate_fixture_project()
+        self.project_id = str(self.project.id)
         self.generate_fixture_asset_type()
         self.generate_fixture_episode()
         self.generate_fixture_sequence()
@@ -17,9 +18,11 @@ class ShotTestCase(ApiDBTestCase):
         self.shot_dict["project_name"] = self.project.name
         self.shot_dict["sequence_name"] = self.sequence.name
         self.serialized_shot = self.shot.serialize(obj_type="Shot")
+        self.shot_id = str(self.shot.id)
         self.serialized_sequence = self.sequence.serialize(obj_type="Sequence")
 
-        self.generate_fixture_shot("SH02")
+        shot_02 = self.generate_fixture_shot("SH02")
+        self.shot_02_id = str(shot_02.id)
         self.generate_fixture_shot("SH03")
         self.generate_fixture_asset()
 
@@ -106,3 +109,16 @@ class ShotTestCase(ApiDBTestCase):
 
     def test_get_shots_for_project_404(self):
         self.get("data/projects/unknown/shots", 404)
+
+    def test_get_shots_by_project_and_name(self):
+        self.get("data/shots/all?project_id=undefined&name=SH01", 400)
+        shots = self.get(
+            "data/shots/all?project_id=%s&name=SH02" % self.project_id
+        )
+        self.assertEquals(shots[0]["id"], str(self.shot_02_id))
+
+        self.generate_fixture_user_cg_artist()
+        self.log_in_cg_artist()
+        shots = self.get(
+            "data/shots/all?project_id=%s&name=SH01" % self.project_id, 403
+        )

--- a/zou/app/__init__.py
+++ b/zou/app/__init__.py
@@ -12,7 +12,7 @@ from flask_mail import Mail
 
 from . import config
 from .stores import auth_tokens_store
-from .services.exception import PersonNotFoundException
+from .services.exception import PersonNotFoundException, WrongIdFormatException
 from .utils import fs
 
 from zou.app.utils import cache
@@ -58,13 +58,22 @@ def page_not_found(error):
     return jsonify(error=404, text=str(error)), 404
 
 
-@app.errorhandler(Exception)
-def server_error(error):
+@app.errorhandler(WrongIdFormatException)
+def id_parameter_format_error(error):
     return jsonify(
-        error=500,
-        message=str(error),
-        stacktrace=traceback.format_exc()
-    ), 500
+        error=True,
+        message="One of the ID sent in parameter is not properly formatted."
+    ), 400
+
+
+if not config.DEBUG:
+    @app.errorhandler(Exception)
+    def server_error(error):
+        return jsonify(
+            error=500,
+            message=str(error),
+            stacktrace=traceback.format_exc()
+        ), 500
 
 
 def configure_auth():

--- a/zou/app/__init__.py
+++ b/zou/app/__init__.py
@@ -1,5 +1,6 @@
 import os
 import flask_fs
+import traceback
 
 from flask import Flask, jsonify
 from flask_restful import current_app
@@ -51,9 +52,20 @@ if config.DEBUG:
 def shutdown_session(exception=None):
     db.session.remove()
 
+
 @app.errorhandler(404)
 def page_not_found(error):
     return jsonify(error=404, text=str(error)), 404
+
+
+@app.errorhandler(Exception)
+def server_error(error):
+    return jsonify(
+        error=500,
+        message=str(error),
+        stacktrace=traceback.format_exc()
+    ), 500
+
 
 def configure_auth():
     from zou.app.services import persons_service

--- a/zou/app/blueprints/crud/base.py
+++ b/zou/app/blueprints/crud/base.py
@@ -232,8 +232,10 @@ class BaseModelResource(Resource):
             instance = self.get_model_or_404(instance_id)
             result = self.serialize_instance(instance)
             self.check_read_permissions(result)
-        except StatementError:
-            return {"message": "Wrong id format"}, 400
+
+        except StatementError as exception:
+            current_app.logger.error(str(exception))
+            return {"message": str(exception)}, 400
         return result, 200
 
     def post_update(self, instance_dict):
@@ -263,10 +265,6 @@ class BaseModelResource(Resource):
             instance_dict = instance.serialize()
             self.post_update(instance_dict)
             return instance_dict, 200
-
-        except StatementError as exception:
-            current_app.logger.error(str(exception))
-            return {"message": "Wrong id format"}, 400
 
         except TypeError as exception:
             current_app.logger.error(str(exception))
@@ -303,6 +301,10 @@ class BaseModelResource(Resource):
             self.post_delete(instance_dict)
 
         except IntegrityError as exception:
+            current_app.logger.error(str(exception))
+            return {"message": str(exception)}, 400
+
+        except StatementError as exception:
             current_app.logger.error(str(exception))
             return {"message": str(exception)}, 400
 

--- a/zou/app/blueprints/shots/resources.py
+++ b/zou/app/blueprints/shots/resources.py
@@ -15,7 +15,10 @@ from zou.app.services import (
 from zou.app.mixin import ArgsMixin
 from zou.app.utils import query, permissions
 
-from zou.app.services.exception import ShotNotFoundException
+from zou.app.services.exception import (
+    ShotNotFoundException,
+    WrongIdFormatException
+)
 
 
 class ShotResource(Resource):
@@ -85,7 +88,7 @@ class ShotsResource(Resource):
         if "sequence_id" in criterions:
             sequence = shots_service.get_sequence(criterions["sequence_id"])
             criterions["project_id"] = sequence["project_id"]
-        user_service.check_project_access(criterions)
+        user_service.check_project_access(criterions.get("project_id", None))
         return shots_service.get_shots(criterions)
 
 
@@ -98,7 +101,7 @@ class ScenesResource(Resource):
         string.
         """
         criterions = query.get_query_criterions_from_request(request)
-        user_service.check_project_access(criterions)
+        user_service.check_project_access(criterions.get("project_id", None))
         return shots_service.get_scenes(criterions)
 
 
@@ -323,7 +326,7 @@ class EpisodesResource(Resource):
         string.
         """
         criterions = query.get_query_criterions_from_request(request)
-        user_service.check_project_access(criterions)
+        user_service.check_project_access(criterions.get("project_id", None))
         return shots_service.get_episodes(criterions)
 
 
@@ -363,7 +366,7 @@ class SequencesResource(Resource):
         string.
         """
         criterions = query.get_query_criterions_from_request(request)
-        user_service.check_project_access(criterions)
+        user_service.check_project_access(criterions.get("project_id", None))
         return shots_service.get_sequences(criterions)
 
 

--- a/zou/app/services/exception.py
+++ b/zou/app/services/exception.py
@@ -143,3 +143,7 @@ class EntryAlreadyExistsException(Exception):
 
 class ArgumentsException(Exception):
     pass
+
+
+class WrongIdFormatException(Exception):
+    pass

--- a/zou/app/services/shots_service.py
+++ b/zou/app/services/shots_service.py
@@ -20,7 +20,8 @@ from zou.app.services.exception import (
     EpisodeNotFoundException,
     SequenceNotFoundException,
     SceneNotFoundException,
-    ShotNotFoundException
+    ShotNotFoundException,
+    WrongIdFormatException
 )
 
 
@@ -57,7 +58,11 @@ def get_episodes(criterions={}):
     criterions["entity_type_id"] = episode_type["id"]
     query = Entity.query.order_by(Entity.name)
     query = query_utils.apply_criterions_to_db_query(Entity, query, criterions)
-    return Entity.serialize_list(query.all(), obj_type="Episode")
+    try:
+        episodes = query.all()
+    except StatementError:  # Occurs when an id is not properly formatted
+        raise WrongIdFormatException
+    return Entity.serialize_list(episodes, obj_type="Episode")
 
 
 def get_sequences(criterions={}):
@@ -68,7 +73,11 @@ def get_sequences(criterions={}):
     criterions["entity_type_id"] = sequence_type["id"]
     query = Entity.query.order_by(Entity.name)
     query = query_utils.apply_criterions_to_db_query(Entity, query, criterions)
-    return Entity.serialize_list(query.all(), obj_type="Sequence")
+    try:
+        sequences = query.all()
+    except StatementError:  # Occurs when an id is not properly formatted
+        raise WrongIdFormatException
+    return Entity.serialize_list(sequences, obj_type="Sequence")
 
 
 def get_shots(criterions={}):
@@ -85,7 +94,10 @@ def get_shots(criterions={}):
         .add_columns(Project.name) \
         .add_columns(Sequence.name) \
         .order_by(Entity.name)
-    data = query.all()
+    try:
+        data = query.all()
+    except StatementError:  # Occurs when an id is not properly formatted
+        raise WrongIdFormatException
 
     shots = []
     for (shot_model, project_name, sequence_name) in data:
@@ -111,7 +123,10 @@ def get_scenes(criterions={}):
         .join(Sequence, Sequence.id == Entity.parent_id) \
         .add_columns(Project.name) \
         .add_columns(Sequence.name)
-    data = query.all()
+    try:
+        data = query.all()
+    except StatementError:  # Occurs when an id is not properly formatted
+        raise WrongIdFormatException
 
     scenes = []
     for (scene_model, project_name, sequence_name) in data:


### PR DESCRIPTION
**Problem**

* Server errors lead to 500 response with HTML in the body. It's hard to handle for clients.
* Id errors are not properly catched and managed
* Generic routes to access to shots, scenes, sequences and episodes crashes when signed in as a CG artist.

**Solution**

* Configure flask to send properly formatted 500 errors at json format.
* Add a `WrongIdFormatException` to handle these case in a generic way.
* Fix code related to time entities generic routes. They were giving a wrong parameter to authorization checking helpers.
