### PR TITLE
Allow preview publishing on all task status

### DIFF
--- a/zou/app/blueprints/tasks/resources.py
+++ b/zou/app/blueprints/tasks/resources.py
@@ -109,12 +109,6 @@ class AddPreviewResource(Resource):
             comment["task_status_id"]
         )
         person = persons_service.get_current_user()
-        if not task_status["is_reviewable"]:
-            return {
-                "error": "Comment status is not reviewable, you cannot link a "
-                         "preview to it."
-            }, 400
-
         preview_file = tasks_service.add_preview_file_to_comment(
             comment_id, person["id"], task_id
         )

--- a/zou/app/models/task_status.py
+++ b/zou/app/models/task_status.py
@@ -13,8 +13,8 @@ class TaskStatus(db.Model, BaseMixin, SerializerMixin):
         db.Column(db.String(10), unique=True, nullable=False, index=True)
     color = db.Column(db.String(7), nullable=False)
 
-    is_reviewable = db.Column(db.Boolean(), default=False)
     is_done = db.Column(db.Boolean(), default=False, index=True)
     is_artist_allowed = db.Column(db.Boolean(), default=True)
 
     shotgun_id = db.Column(db.Integer)
+    is_reviewable = db.Column(db.Boolean(), default=False) # deprecated

--- a/zou/app/services/tasks_service.py
+++ b/zou/app/services/tasks_service.py
@@ -54,8 +54,7 @@ def get_wip_status():
 def get_to_review_status():
     return get_or_create_status(
         app.config["TO_REVIEW_TASK_STATUS"],
-        "pndng",
-        is_reviewable=True
+        "pndng"
     )
 
 
@@ -324,7 +323,6 @@ def get_comments(task_id):
             TaskStatus.name,
             TaskStatus.short_name,
             TaskStatus.color,
-            TaskStatus.is_reviewable,
             Person.first_name,
             Person.last_name,
             Person.has_avatar
@@ -336,7 +334,6 @@ def get_comments(task_id):
             task_status_name,
             task_status_short_name,
             task_status_color,
-            task_status_is_reviewable,
             person_first_name,
             person_last_name,
             person_has_avatar
@@ -353,7 +350,6 @@ def get_comments(task_id):
             "name": task_status_name,
             "short_name": task_status_short_name,
             "color": task_status_color,
-            "is_reviewable": task_status_is_reviewable,
             "id": str(comment.task_status_id)
         }
 
@@ -678,7 +674,6 @@ def get_or_create_status(
     name,
     short_name="",
     color="#f5f5f5",
-    is_reviewable=False,
     is_done=False
 ):
     """
@@ -694,7 +689,7 @@ def get_or_create_status(
             name=name,
             short_name=short_name or name.lower(),
             color=color,
-            is_reviewable=is_reviewable,
+            is_reviewable=True,
             is_done=is_done
         )
         events.emit("task_status:new", {

--- a/zou/app/utils/commands.py
+++ b/zou/app/utils/commands.py
@@ -106,14 +106,12 @@ def init_data():
     tasks_service.get_or_create_status(
         "Waiting For Approval",
         "wfa",
-        "#ab26ff",
-        is_reviewable=True
+        "#ab26ff"
     )
     tasks_service.get_or_create_status(
         "Retake",
         "retake",
-        "#ff3860",
-        is_reviewable=True
+        "#ff3860"
     )
     tasks_service.get_or_create_status(
         "Done",


### PR DESCRIPTION
**Problem**

It brings no value to allow to block preview publishing on a given task status. 

**Solution**

Removes the `is_reviewable` from task status and related to make things simpler.
