### PR TITLE
Event route

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -823,4 +823,4 @@ class ApiDBTestCase(ApiTestCase):
         self.generate_fixture_scene()
 
     def now(self):
-        return datetime.datetime.now().isoformat()
+        return datetime.datetime.now().replace(microsecond=0).isoformat()

--- a/tests/events/test_event_routes.py
+++ b/tests/events/test_event_routes.py
@@ -1,0 +1,51 @@
+import time
+from tests.base import ApiDBTestCase
+
+from zou.app.utils import fields
+from zou.app.services import (
+    events_service,
+    assets_service
+)
+
+
+class EventsRoutesTestCase(ApiDBTestCase):
+
+    def setUp(self):
+        super(EventsRoutesTestCase, self).setUp()
+
+        self.generate_fixture_project_status()
+        self.generate_fixture_project()
+        self.generate_fixture_asset_type()
+
+    def test_get_last_events(self):
+        asset = assets_service.create_asset(
+            self.project.id,
+            self.asset_type.id,
+            "test 1",
+            "",
+            {}
+        )
+        date = fields.get_date_object(asset["created_at"], "%Y-%m-%dT%H:%M:%S")
+        time.sleep(1)
+        asset = assets_service.create_asset(
+            self.project.id,
+            self.asset_type.id,
+            "test 2",
+            "",
+            {}
+        )
+        time.sleep(1)
+        asset = assets_service.create_asset(
+            self.project.id,
+            self.asset_type.id,
+            "test 3",
+            "",
+            {}
+        )
+        events = self.get("/data/events/last")
+        self.assertEqual(len(events), 3)
+        events = self.get("/data/events/last?page_size=2")
+        self.assertEqual(len(events), 2)
+        date = asset["created_at"]
+        events = self.get("/data/events/last?before=%s" % date)
+        self.assertEqual(len(events), 2)

--- a/tests/files/test_route_working_files.py
+++ b/tests/files/test_route_working_files.py
@@ -1,7 +1,6 @@
-import datetime
+import time
 
 from tests.base import ApiDBTestCase
-from zou.app.utils import fields
 
 from zou.app.models.task import Task
 from zou.app.services import projects_service
@@ -142,11 +141,12 @@ class WorkingFilesTestCase(ApiDBTestCase):
     def test_update_modification_date(self):
         path = "/actions/working-files/%s/modified" % self.working_file.id
         previous_date = self.working_file.serialize()["updated_at"]
+        time.sleep(1)
         working_file = self.put(path, {})
         current_date = working_file["updated_at"]
         self.assertTrue(previous_date < current_date)
 
-        now = fields.serialize_value(datetime.datetime.utcnow())
+        now = self.now()
         self.assertTrue(current_date < now)
 
     def test_get_untyped_file(self):
@@ -170,7 +170,10 @@ class WorkingFilesTestCase(ApiDBTestCase):
         self.log_in_cg_artist()
         path = "/data/files/%s" % output_file_id
         self.get(path, 403)
-        projects_service.add_team_member(self.project_id, self.user_cg_artist.id)
+        projects_service.add_team_member(
+            self.project_id,
+            self.user_cg_artist.id
+        )
         self.get(path)
 
     def test_comment_working_file(self):

--- a/tests/misc/test_plugins.py
+++ b/tests/misc/test_plugins.py
@@ -17,4 +17,4 @@ class PluginTestCase(ApiTestCase):
         plugins = api.load_plugin_modules("tests/fixtures/plugins")
         plugin = plugins[0]
         api.load_plugin(app, plugin)
-        print(self.get("/plugins/hello"))
+        self.get("/plugins/hello")

--- a/tests/services/test_events_service.py
+++ b/tests/services/test_events_service.py
@@ -1,0 +1,51 @@
+import time
+from tests.base import ApiDBTestCase
+
+from zou.app.utils import fields
+from zou.app.services import (
+    events_service,
+    assets_service
+)
+
+
+class EventsServiceTestCase(ApiDBTestCase):
+
+    def setUp(self):
+        super(EventsServiceTestCase, self).setUp()
+
+        self.generate_fixture_project_status()
+        self.generate_fixture_project()
+        self.generate_fixture_asset_type()
+
+    def test_get_last_events(self):
+        asset = assets_service.create_asset(
+            self.project.id,
+            self.asset_type.id,
+            "test 1",
+            "",
+            {}
+        )
+        date = fields.get_date_object(asset["created_at"], "%Y-%m-%dT%H:%M:%S")
+        time.sleep(1)
+        asset = assets_service.create_asset(
+            self.project.id,
+            self.asset_type.id,
+            "test 2",
+            "",
+            {}
+        )
+        time.sleep(1)
+        asset = assets_service.create_asset(
+            self.project.id,
+            self.asset_type.id,
+            "test 3",
+            "",
+            {}
+        )
+        events = events_service.get_last_events()
+        self.assertEqual(len(events), 3)
+        events = events_service.get_last_events(page_size=2)
+        self.assertEqual(len(events), 2)
+        date = fields.get_date_object(asset["created_at"], "%Y-%m-%dT%H:%M:%S")
+        events = events_service.get_last_events(before=date)
+        self.assertEqual(len(events), 2)

--- a/tests/tasks/test_route_task_change.py
+++ b/tests/tasks/test_route_task_change.py
@@ -1,4 +1,4 @@
-import datetime
+import time
 
 from tests.base import ApiDBTestCase
 
@@ -50,12 +50,13 @@ class RouteTaskChangeTestCase(ApiDBTestCase):
             self
         )
 
-        now = datetime.datetime.now()
+        now = self.now()
+        time.sleep(1)
         self.put("/actions/tasks/%s/start" % self.task.id, {})
         task = self.get("data/tasks/%s" % self.task.id)
 
         self.assertEqual(task["task_status_id"], self.wip_status_id)
-        self.assertGreater(task["real_start_date"], now.isoformat())
+        self.assertGreater(task["real_start_date"], now)
         self.assert_event_is_fired()
 
     def test_status_to_wip_again(self):
@@ -65,4 +66,7 @@ class RouteTaskChangeTestCase(ApiDBTestCase):
         real_start_date = Task.get(task_id).real_start_date
         self.put("/actions/tasks/%s/start" % task_id, {})
         task = self.get("data/tasks/%s" % task_id)
-        self.assertEquals(real_start_date.isoformat(), task["real_start_date"])
+        self.assertEquals(
+            real_start_date.replace(microsecond=0).isoformat(),
+            task["real_start_date"]
+        )

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -19,11 +19,14 @@ class UtilsTestCase(unittest.TestCase):
 
     def test_serialize_value(self):
         now = datetime.datetime.now()
-        self.assertEqual(now.isoformat(), fields.serialize_value(now))
+        self.assertEqual(
+            now.replace(microsecond=0).isoformat(),
+            fields.serialize_value(now)
+        )
         unique_id = uuid.uuid4()
         self.assertEqual(str(unique_id), fields.serialize_value(unique_id))
         self.assertEqual(
-            {"now": now.isoformat()},
+            {"now": now.replace(microsecond=0).isoformat()},
             fields.serialize_value({"now": now})
         )
         self.assertEqual(
@@ -49,7 +52,7 @@ class UtilsTestCase(unittest.TestCase):
             "string": "test"
         }
         result = {
-            "now": now.isoformat(),
+            "now": now.replace(microsecond=0).isoformat(),
             "unique_id": str(unique_id),
             "string": "test"
         }

--- a/zou/app/api.py
+++ b/zou/app/api.py
@@ -8,6 +8,7 @@ from flask import Blueprint
 from .blueprints.assets import blueprint as assets_blueprint
 from .blueprints.auth import blueprint as auth_blueprint
 from .blueprints.crud import blueprint as crud_blueprint
+from .blueprints.events import blueprint as events_blueprint
 from .blueprints.files import blueprint as files_blueprint
 from .blueprints.export import blueprint as export_blueprint
 from .blueprints.source import blueprint as import_blueprint
@@ -42,6 +43,7 @@ def configure_api_routes(app):
     app.register_blueprint(assets_blueprint)
     app.register_blueprint(crud_blueprint)
     app.register_blueprint(export_blueprint)
+    app.register_blueprint(events_blueprint)
     app.register_blueprint(files_blueprint)
     app.register_blueprint(import_blueprint)
     app.register_blueprint(index_blueprint)

--- a/zou/app/api.py
+++ b/zou/app/api.py
@@ -9,16 +9,16 @@ from .blueprints.assets import blueprint as assets_blueprint
 from .blueprints.auth import blueprint as auth_blueprint
 from .blueprints.crud import blueprint as crud_blueprint
 from .blueprints.events import blueprint as events_blueprint
-from .blueprints.files import blueprint as files_blueprint
 from .blueprints.export import blueprint as export_blueprint
+from .blueprints.files import blueprint as files_blueprint
 from .blueprints.source import blueprint as import_blueprint
 from .blueprints.index import blueprint as index_blueprint
 from .blueprints.persons import blueprint as persons_blueprint
 from .blueprints.playlists import blueprint as playlists_blueprint
 from .blueprints.projects import blueprint as projects_blueprint
+from .blueprints.previews import blueprint as previews_blueprint
 from .blueprints.shots import blueprint as shots_blueprint
 from .blueprints.tasks import blueprint as tasks_blueprint
-from .blueprints.previews import blueprint as previews_blueprint
 from .blueprints.user import blueprint as user_blueprint
 
 

--- a/zou/app/blueprints/events/__init__.py
+++ b/zou/app/blueprints/events/__init__.py
@@ -1,0 +1,13 @@
+from flask import Blueprint
+from zou.app.utils.api import configure_api_from_blueprint
+
+from .resources import (
+    EventsResource
+)
+
+routes = [
+    ("/data/events/last", EventsResource),
+]
+
+blueprint = Blueprint("events", "events")
+api = configure_api_from_blueprint(blueprint, routes)

--- a/zou/app/blueprints/events/resources.py
+++ b/zou/app/blueprints/events/resources.py
@@ -1,0 +1,24 @@
+from flask_restful import Resource
+from flask_jwt_extended import jwt_required
+
+from zou.app.mixin import ArgsMixin
+from zou.app.utils import fields
+
+from zou.app.services import (
+    events_service
+)
+
+
+class EventsResource(Resource, ArgsMixin):
+
+    @jwt_required
+    def get(self):
+        args = self.get_args([
+            ("before", None, None),
+            ("page_size", 100, False)
+        ])
+        before = None
+        if args["before"] is not None:
+            before = fields.get_date_object(args["before"], "%Y-%m-%dT%H:%M:%S")
+        page_size = args["page_size"]
+        return events_service.get_last_events(before, page_size)

--- a/zou/app/services/assets_service.py
+++ b/zou/app/services/assets_service.py
@@ -416,7 +416,7 @@ def create_asset(
     )
     asset_dict = asset.serialize(obj_type="Asset")
     events.emit("asset:new", {
-        "asset": asset.id,
+        "asset_id": asset.id,
         "asset_type": asset_type.id,
         "project_id": project.id
     })

--- a/zou/app/services/events_service.py
+++ b/zou/app/services/events_service.py
@@ -2,12 +2,35 @@ from zou.app.models.event import ApiEvent
 from zou.app.utils import fields
 
 
-def get_last_events():
+def get_last_events(before=None, page_size=100):
     """
-    Return last 100 events published.
+    Return last 100 events published. If before parameter is set, it returns
+    last 100 events before this date.
     """
-    events = ApiEvent.query \
+    query = ApiEvent.query \
         .order_by(ApiEvent.created_at.desc()) \
-        .limit(100) \
-        .all()
-    return fields.serialize_list(events)
+        .with_entities(
+            ApiEvent.created_at,
+            ApiEvent.name,
+            ApiEvent.user_id,
+            ApiEvent.data
+        )
+
+    if before is not None:
+        query = query.filter(ApiEvent.created_at < before)
+
+    events = query.limit(page_size).all()
+    return [
+        {
+            "created_at": fields.serialize_value(created_at),
+            "name": fields.serialize_value(name),
+            "user_id": fields.serialize_value(user_id),
+            "data": fields.serialize_value(data),
+        }
+        for (
+            created_at,
+            name,
+            user_id,
+            data
+        ) in events
+    ]

--- a/zou/app/utils/fields.py
+++ b/zou/app/utils/fields.py
@@ -12,9 +12,9 @@ def serialize_value(value):
     The aim is to make the result JSON serializable
     """
     if isinstance(value, datetime.datetime):
-        return value.isoformat()
+        return value.replace(microsecond=0).isoformat()
     if isinstance(value, datetime.date):
-        return value.isoformat()
+        return value.replace(microsecond=0).isoformat()
     elif isinstance(value, uuid.UUID):
         return str(value)
     elif isinstance(value, dict):

--- a/zou/app/utils/fields.py
+++ b/zou/app/utils/fields.py
@@ -14,7 +14,7 @@ def serialize_value(value):
     if isinstance(value, datetime.datetime):
         return value.replace(microsecond=0).isoformat()
     if isinstance(value, datetime.date):
-        return value.replace(microsecond=0).isoformat()
+        return value.isoformat()
     elif isinstance(value, uuid.UUID):
         return str(value)
     elif isinstance(value, dict):


### PR DESCRIPTION
**Problem**

It is not possible to retrieve events easily.

**Solution**

Add a route that allows retrieving last published events. An option `before` can be used to get events before a given date.
