### PR TITLE
Use filtering on resizing to thumbnail

### DIFF
--- a/zou/app/utils/thumbnail.py
+++ b/zou/app/utils/thumbnail.py
@@ -72,7 +72,7 @@ def turn_into_thumbnail(file_path, size=None):
     else:
         size = im.size
 
-    im = im.resize(size)
+    im = im.resize(size, Image.LANCZOS)
     im.save(file_path)
     return file_path
 


### PR DESCRIPTION
**Problem**

The thumbnails that were being generated were using the default NEAREST pixel filtering making them appear super sharp and pixelated. 


**Solution**

This change will enable LANCZOS filtering which is the replacement in Pillow for the ANTIALIAS filter.

See:

- https://pillow.readthedocs.io/en/4.0.x/handbook/concepts.html#concept-filters

---

Note: I don't have this running as a local server so I was unable to test this code whether it fixes the issue. But this was the only code I could find that was related to thumbnails and resizing the files. However, please test. ;)

Note 2: Not sure how often thumbnails are generated but note that this filtering is slower in performance to nearest neighbour, also see the [filter comparison chart here](https://pillow.readthedocs.io/en/4.0.x/handbook/concepts.html#filters-comparison-table)