### PR TITLE
Various fixes

### DIFF
--- a/zou/app/blueprints/previews/resources.py
+++ b/zou/app/blueprints/previews/resources.py
@@ -97,7 +97,7 @@ def send_storage_file(
             config.TMP_DIR,
             "cache-%s-%s.%s" % (prefix, preview_file_id, extension)
         )
-        if not os.path.exists(file_path):
+        if not os.path.exists(file_path) or os.path.getsize(file_path) == 0:
             with open(file_path, 'wb') as tmp_file:
                 for chunk in open_file(prefix, preview_file_id):
                     tmp_file.write(chunk)

--- a/zou/app/utils/thumbnail.py
+++ b/zou/app/utils/thumbnail.py
@@ -73,7 +73,7 @@ def turn_into_thumbnail(file_path, size=None):
         size = im.size
 
     im = im.resize(size, Image.LANCZOS)
-    im.save(file_path)
+    im.save(file_path, "PNG")
     return file_path
 
 


### PR DESCRIPTION
**Problem**

* PNG files are not always properly saved as PNG files.
* When using object storage for files, sometimes, the cached file is empty. If the cache file is empty, it should reload the cache.

**Solution**

* Enforce PNG format on thumbnail save
* Reload cached file when the cached file is empty
