### PR TITLE
Various improvements

### DIFF
--- a/zou/app/blueprints/news/resources.py
+++ b/zou/app/blueprints/news/resources.py
@@ -1,8 +1,4 @@
-import os
-
-from flask import request
-
-from flask_restful import Resource
+from flask_restful import Resource, reqparse
 from flask_jwt_extended import jwt_required
 
 from zou.app.services import (
@@ -16,13 +12,39 @@ class ProjectNewsResource(Resource):
 
     @jwt_required
     def get(self, project_id):
-        options = request.args
-        page = int(options.get("page", "1"))
+        (
+            only_preview,
+            task_type_id,
+            task_status_id,
+            page,
+            page_size
+        ) = self.get_arguments()
         projects_service.get_project(project_id)
         user_service.check_project_access(project_id)
         return news_service.get_last_news_for_project(
             project_id,
-            page=page
+            only_preview=only_preview,
+            task_type_id=task_type_id,
+            task_status_id=task_status_id,
+            page=page,
+            page_size=page_size
+        )
+
+    def get_arguments(self):
+        parser = reqparse.RequestParser()
+        parser.add_argument("only_preview", default=False, type=bool)
+        parser.add_argument("task_type_id", default=None)
+        parser.add_argument("task_status_id", default=None)
+        parser.add_argument("page", default=1, type=int)
+        parser.add_argument("page_size", default=50, type=int)
+        args = parser.parse_args()
+
+        return (
+            args["only_preview"],
+            args["task_type_id"],
+            args["task_status_id"],
+            args["page"],
+            args["page_size"]
         )
 
 

--- a/zou/app/blueprints/previews/resources.py
+++ b/zou/app/blueprints/previews/resources.py
@@ -31,8 +31,8 @@ ALLOWED_MOVIE_EXTENSION = [
     ".mp4", ".mov", ".wmv", ".m4v", ".MP4", ".MOV", ".WMV", ".M4V"
 ]
 ALLOWED_FILE_EXTENSION = [
-    ".obj", ".pdf", ".ma", ".mb", ".rar", ".zip", ".blend",
-    ".OBJ", ".PDF", ".MA", ".MB", ".RAR", ".ZIP", ".BLEND",
+    ".obj", ".pdf", ".ma", ".mb", ".ai", ".rar", ".zip", ".blend",
+    ".OBJ", ".PDF", ".MA", ".MB", ".AI", ".RAR", ".ZIP", ".BLEND",
 ]
 
 


### PR DESCRIPTION
**Problem**

* There is no way to filter news
* There is no way to load few news (needed when loading previews to avoid to download 50 videos at the same time)
* Illustrator files cannot be uploaded as previews

**Solution**

* Allow filtering on task status, task type, and preview file presence
* Allow setting the page size of retrieved news
* Allow illustrator files extension in preview route
