### PR TITLE
Add DOMAIN_PROTOCOL env var

### DIFF
--- a/zou/app/blueprints/auth/resources.py
+++ b/zou/app/blueprints/auth/resources.py
@@ -528,13 +528,14 @@ class ResetPasswordResource(Resource, ArgsMixin):
 
 You have requested for a password reset. You can connect here to change your
 password:
-https://%s/reset-change-password/%s
+%s://%s/reset-change-password/%s
 
 Regards,
 
 CGWire Team
 """ % (
             user["first_name"],
+            current_app.config["DOMAIN_PROTOCOL"],
             current_app.config["DOMAIN_NAME"],
             token
         )

--- a/zou/app/config.py
+++ b/zou/app/config.py
@@ -68,6 +68,7 @@ MAIL_USE_TLS = os.getenv("MAIL_USE_TLS", False)
 MAIL_USE_SSL = os.getenv("MAIL_USE_SSL", False)
 MAIL_DEFAULT_SENDER = os.getenv("MAIL_DEFAULT_SENDER", "no-reply@cg-wire.com")
 DOMAIN_NAME = os.getenv("DOMAIN_NAME", "localhost:8080")
+DOMAIN_PROTOCOL = os.getenv("DOMAIN_PROTOCOL", "https")
 
 PLUGIN_FOLDER = os.getenv(
     "PLUGIN_FOLDER",


### PR DESCRIPTION
**Problem**
If domain is only http (I know it's bad ;) ), link in password recovery email was https. So the link was wrong.

**Solution**
Use a DOMAIN_PROTOCOL environment variable to handle https or http in the link.
