### PR TITLE
Various fixes and improvements

### DIFF
--- a/tests/services/playlists_service.py
+++ b/tests/services/playlists_service.py
@@ -1,0 +1,78 @@
+from tests.base import ApiDBTestCase
+
+from zou.app.models.playlist import Playlist
+from zou.app.services import (
+    files_service,
+    playlists_service,
+    tasks_service
+)
+
+
+class PlaylistsServiceTestCase(ApiDBTestCase):
+
+    def setUp(self):
+        super(PlaylistsServiceTestCase, self).setUp()
+
+        self.generate_fixture_project_status()
+        self.generate_fixture_project_standard()
+        self.generate_fixture_project()
+        self.generate_fixture_asset_type()
+        self.generate_fixture_asset()
+        self.episode_2 = self.generate_fixture_episode("E02")
+        self.generate_fixture_episode()
+        self.generate_fixture_sequence()
+        self.generate_fixture_shot()
+        self.sequence_dict = self.sequence.serialize()
+        self.project_dict = self.sequence.serialize()
+
+    def generate_fixture_playlist(self):
+        self.playlist = Playlist.create(
+            name="Playlist 1",
+            shots={},
+            project_id=self.project.id,
+            episode_id=self.episode.id
+        )
+        Playlist.create(
+            name="Playlist 2",
+            shots={},
+            project_id=self.project_standard.id
+        )
+        self.playlist = Playlist.create(
+            name="Playlist 3",
+            shots={},
+            project_id=self.project.id,
+            episode_id=self.episode_2.id
+        )
+        return self.playlist.serialize()
+
+    def test_get_playlist_for_project(self):
+        self.generate_fixture_playlist()
+        playlists = playlists_service.all_playlists_for_project(self.project.id)
+        self.assertEquals(len(playlists), 2)
+        self.assertTrue(
+            "Playlist 2" not in [playlists[0]["name"], playlists[1]["name"]]
+        )
+
+    def test_get_playlist_for_episode(self):
+        self.generate_fixture_playlist()
+        playlists = playlists_service.all_playlists_for_episode(self.episode.id)
+        self.assertEquals(len(playlists), 1)
+        self.assertEquals(playlists[0]["name"], "Playlist 1")
+
+    def test_get_playlist(self):
+        pass
+    """
+    def test_retrieve_playlist_tmp_files(self):
+    def test_get_playlist_with_preview_file_revisions(self):
+    def test_set_preview_files_for_shots(self):
+    def test_build_playlist_zip_file(self):
+    def test_build_playlist_movie_file(self):
+    def test_start_build_job(self):
+    def test_end_build_job(self):
+    def test_build_playlist_job(self):
+    def test_get_playlist_file_name(self):
+    def test_get_playlist_movie_file_path(self):
+    def test_get_playlist_zip_file_path(self):
+    def test_get_build_job(self):
+    def test_remove_build_job(self):
+    """

--- a/zou/app/blueprints/crud/comments.py
+++ b/zou/app/blueprints/crud/comments.py
@@ -5,6 +5,7 @@ from zou.app.models.comment import Comment
 from zou.app.services import (
     deletion_service,
     notifications_service,
+    persons_service,
     tasks_service,
     user_service
 )
@@ -36,6 +37,14 @@ class CommentResource(BaseModelResource):
             comment = self.get_model_or_404(instance["id"])
             task = tasks_service.get_task(comment.object_id)
             return user_service.check_project_access(task["project_id"])
+
+    def check_update_permissions(self, instance, data):
+        if permissions.has_admin_permissions():
+            return True
+        else:
+            comment = self.get_model_or_404(instance["id"])
+            current_user = persons_service.get_current_user()
+            return current_user["id"] == str(comment.person_id)
 
     @jwt_required
     def delete(self, instance_id):

--- a/zou/app/blueprints/crud/playlist.py
+++ b/zou/app/blueprints/crud/playlist.py
@@ -1,5 +1,5 @@
 from zou.app.models.playlist import Playlist
-from zou.app.services import user_service
+from zou.app.services import user_service, playlists_service
 
 from .base import BaseModelResource, BaseModelsResource
 
@@ -26,3 +26,7 @@ class PlaylistResource(BaseModelResource):
 
     def check_update_permissions(self, playlist, data):
         user_service.check_project_access(playlist["project_id"])
+
+    def delete(self, instance_id):
+        playlists_service.remove_playlist(instance_id)
+        return "", 204

--- a/zou/app/blueprints/previews/resources.py
+++ b/zou/app/blueprints/previews/resources.py
@@ -20,6 +20,7 @@ from zou.app.services import (
     user_service,
 )
 from zou.app.utils import (
+    fs,
     events,
     movie_utils,
     permissions,
@@ -81,7 +82,7 @@ def send_picture_file(prefix, preview_file_id, as_attachment=False):
 
 
 def send_storage_file(
-    get_path,
+    get_local_path,
     open_file,
     prefix,
     preview_file_id,
@@ -93,17 +94,14 @@ def send_storage_file(
     Send file from storage. If it's not a local storage, cache the file in
     a temporary folder before sending it. It accepts conditional headers.
     """
-    if config.FS_BACKEND == "local":
-        file_path = get_path(prefix, preview_file_id)
-    else:
-        file_path = os.path.join(
-            config.TMP_DIR,
-            "cache-%s-%s.%s" % (prefix, preview_file_id, extension)
-        )
-        if not os.path.exists(file_path) or os.path.getsize(file_path) == 0:
-            with open(file_path, 'wb') as tmp_file:
-                for chunk in open_file(prefix, preview_file_id):
-                    tmp_file.write(chunk)
+    file_path = fs.get_file_path(
+        config,
+        get_local_path,
+        open_file,
+        prefix,
+        preview_file_id,
+        extension
+    )
 
     attachment_filename = ""
     if as_attachment:

--- a/zou/app/services/news_service.py
+++ b/zou/app/services/news_service.py
@@ -1,4 +1,5 @@
 from zou.app.models.comment import Comment
+from zou.app.models.entity import Entity
 from zou.app.models.news import News
 from zou.app.models.preview_file import PreviewFile
 from zou.app.models.project import Project
@@ -84,6 +85,7 @@ def get_last_news_for_project(
         .order_by(News.created_at.desc()) \
         .join(Task, News.task_id == Task.id) \
         .join(Project) \
+        .join(Entity, Task.entity_id == Entity.id) \
         .outerjoin(Comment, News.comment_id == Comment.id) \
         .outerjoin(PreviewFile, News.preview_file_id == PreviewFile.id) \
         .filter(Task.project_id == project_id) \
@@ -94,7 +96,8 @@ def get_last_news_for_project(
             Comment.id,
             Comment.task_status_id,
             Task.entity_id,
-            PreviewFile.extension
+            PreviewFile.extension,
+            Entity.preview_file_id
         )
 
     if news_id is not None:
@@ -122,7 +125,8 @@ def get_last_news_for_project(
         comment_id,
         task_status_id,
         task_entity_id,
-        preview_file_extension
+        preview_file_extension,
+        entity_preview_file_id
     ) in news_list:
         (full_entity_name, episode_id) = \
             names_service.get_full_entity_name(task_entity_id)
@@ -134,6 +138,7 @@ def get_last_news_for_project(
             "task_id": news.task_id,
             "task_type_id": task_type_id,
             "task_status_id": task_status_id,
+            "task_entity_id": task_entity_id,
             "preview_file_id": news.preview_file_id,
             "preview_file_extension": preview_file_extension,
             "project_id": project_id,
@@ -141,6 +146,7 @@ def get_last_news_for_project(
             "created_at": news.created_at,
             "change": news.change,
             "full_entity_name": full_entity_name,
-            "episode_id": episode_id
+            "episode_id": episode_id,
+            "entity_preview_file_id": entity_preview_file_id
         }))
     return result

--- a/zou/app/services/playlists_service.py
+++ b/zou/app/services/playlists_service.py
@@ -281,6 +281,8 @@ def build_playlist_zip_file(playlist):
     """
     tmp_file_paths = retrieve_playlist_tmp_files(playlist)
     zip_file_path = get_playlist_zip_file_path(playlist)
+    if os.path.exists(zip_file_path):
+        os.remove(zip_file_path)
     with ZipFile(zip_file_path, 'w') as zip:
         for file_path, file_name in tmp_file_paths:
             zip.write(file_path, file_name)

--- a/zou/app/services/shots_service.py
+++ b/zou/app/services/shots_service.py
@@ -1,3 +1,5 @@
+import re
+
 from sqlalchemy import func
 from sqlalchemy.orm import aliased
 from sqlalchemy.exc import IntegrityError, StatementError
@@ -904,3 +906,29 @@ def get_episode_stats_for_project(project_id):
         }
 
     return results
+
+
+def get_preview_dimensions(project):
+    """
+    Return dimensions set at project level or default dimensions if the
+    dimensions are not set.
+    """
+    resolution = project["resolution"]
+    height = 1080
+    width = None
+    if resolution is not None and bool(re.match(r"\d*x\d*", resolution)):
+        [width, height] = resolution.split("x")
+        width = int(width)
+        height = int(height)
+    return (width, height)
+
+
+def get_preview_fps(project):
+    """
+    Return fps set at project level or default fps if the dimensions are not
+    set.
+    """
+    fps = "24.00"
+    if project["fps"] is not None:
+        fps = "%.2f" % float(project["fps"].replace(",", "."))
+    return fps

--- a/zou/app/utils/fs.py
+++ b/zou/app/utils/fs.py
@@ -26,3 +26,25 @@ def rm_file(path):
 
 def copyfile(src, dest):
     shutil.copyfile(src, dest)
+
+
+def get_file_path(
+    config,
+    get_local_path,
+    open_file,
+    prefix,
+    instance_id,
+    extension
+):
+    if config.FS_BACKEND == "local":
+        file_path = get_local_path(prefix, instance_id)
+    else:
+        file_path = os.path.join(
+            config.TMP_DIR,
+            "cache-%s-%s.%s" % (prefix, instance_id, extension)
+        )
+        if not os.path.exists(file_path) or os.path.getsize(file_path) == 0:
+            with open(file_path, 'wb') as tmp_file:
+                for chunk in open_file(prefix, instance_id):
+                    tmp_file.write(chunk)
+    return file_path

--- a/zou/app/utils/movie_utils.py
+++ b/zou/app/utils/movie_utils.py
@@ -90,18 +90,29 @@ def normalize_movie(movie_path, fps="24.00", width=None, height=1080):
     return file_target_path
 
 
-def build_playlist_movie(tmp_file_paths, movie_file_path, fps="24.00"):
+def build_playlist_movie(
+    tmp_file_paths,
+    movie_file_path,
+    width=None,
+    height=1080,
+    fps="24.00"
+):
     """
     Build a single movie file from a playlist.
     """
     in_files = []
     if len(tmp_file_paths) > 0:
         (first_movie_file_path, _) = tmp_file_paths[0]
-        (width, height) = get_movie_size(first_movie_file_path)
+        if width is None:
+            (width, height) = get_movie_size(first_movie_file_path)
 
         for tmp_file_path, file_name in tmp_file_paths:
             in_file = ffmpeg.input(tmp_file_path)
-            in_files.append(in_file['v'])
+            in_files.append(
+                in_file['v']
+                    .filter('setsar', '1/1')
+                    .filter('scale', width, height)
+            )
             in_files.append(in_file['a'])
         joined = ffmpeg.concat(*in_files, v=1, a=1).node
         video = joined[0]


### PR DESCRIPTION
**Problem**

* The news feed lack of information to display entity thumbnail
* A user can't edit his own comment if he is not admin
* Playlist loading is too long
* When modifying a playlist, the corresponding archive is not modified
* When movies have different SAR or resolution, the playlist can't be built
* Playlists with build jobs can't be deleted anymore
* Playlist builds are not saved in the storage

**Solution**

* Add preview file thumbnail information to the news feed
* Allow user to edit his own comment when he is not admin
* Do not retrieve preview information since they are retrieved before
* Force SAR and resolution at playlist creation
* Remove build jobs before deleting a playlist
* Save playlist builds in storage. Use it if the cached playlist disappeared
