### PR TITLE
Allow to export casting as a CSV file

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,7 @@ install_requires =
     flask_caching==1.7.2
     flask_mail==0.9.1
     flask_fs==0.6.1
+    werkzeug==0.15.5
     redis==3.2.1
     ldap3==2.5
 

--- a/tests/export/test_casting_to_csv.py
+++ b/tests/export/test_casting_to_csv.py
@@ -1,0 +1,50 @@
+from tests.base import ApiDBTestCase
+
+
+class CastingCsvExportTestCase(ApiDBTestCase):
+
+    def setUp(self):
+        super(CastingCsvExportTestCase, self).setUp()
+        self.generate_fixture_project_status()
+        self.generate_fixture_project()
+        self.generate_fixture_asset_type()
+        self.generate_fixture_asset_types()
+
+    def test_import_casting(self):
+        for (name, asset_type_id) in [
+            ("Lake", self.asset_type_environment.id),
+            ("Mine", self.asset_type_environment.id),
+            ("Boat", self.asset_type_props.id),
+            ("Pool", self.asset_type_props.id),
+            ("Flowers", self.asset_type_props.id),
+            ("Block", self.asset_type_props.id),
+            ("Wagon", self.asset_type_props.id),
+            ("Victor", self.asset_type_character.id),
+            ("John", self.asset_type_character.id)
+        ]:
+            self.generate_fixture_asset(name, asset_type_id=asset_type_id)
+            if name == "Lake":
+                self.asset_lake_id = self.asset.id
+            if name == "Mine":
+                self.asset_mine_id = self.asset.id
+
+        self.generate_fixture_episode("E01")
+        self.generate_fixture_sequence("SEQ01")
+        self.generate_fixture_shot("SH01").id
+        self.generate_fixture_shot("SH02").id
+        self.generate_fixture_sequence("SEQ02")
+        self.generate_fixture_shot("SH01").id
+        self.generate_fixture_episode("E02")
+        self.generate_fixture_sequence("SEQ01")
+        self.generate_fixture_shot("SH01").id
+        project_id = str(self.project.id)
+
+        path = "/import/csv/projects/%s/casting" % project_id
+        self.upload_csv(path, "casting")
+
+        self.maxDiff = None
+        path = "/export/csv/projects/%s/casting.csv" % project_id
+        csv = self.get_raw(path)
+
+        self.assertTrue("E01;SEQ01;SH01;Character;John;1;animate" in csv)
+        self.assertTrue(";Environment;Lake;Props;Boat;1;setdress" in csv)

--- a/tests/fixtures/csv/.~lock.casting.csv#
+++ b/tests/fixtures/csv/.~lock.casting.csv#
@@ -1,1 +1,1 @@
-,frankrousseau,sommerless,07.08.2019 15:56,file:///home/frankrousseau/.config/libreoffice/4;
+,frankrousseau,sommerless,09.08.2019 09:22,file:///home/frankrousseau/.config/libreoffice/4;

--- a/tests/fixtures/csv/casting.csv
+++ b/tests/fixtures/csv/casting.csv
@@ -1,15 +1,15 @@
-Entity Type,Episode,Parent,Name,Asset Type,Asset,Occurences,Label
-Asset,,Environment,Lake,Props,Boat,1,setdress
-Asset,,Environment,Lake,Props,Pool,1,setdress
-Asset,,Environment,Lake,Props,Flowers,12,setdress
-Asset,,Environment,Mine,Props,Block,2,setdress
-Asset,,Environment,Mine,Props,Wagon,3,setdress
-Shot,E01,SEQ01,SH01,Character,Victor,1,animate
-Shot,E01,SEQ01,SH01,Character,John,1,animate
-Shot,E01,SEQ02,SH01,Environment,Lake,12,layout
-Shot,E01,SEQ01,SH02,Character,Victor,1,animate
-Shot,E01,SEQ01,SH02,Environment,Mine,2,layout
-Shot,E02,SEQ02,SH01,Character,John,1,animate
-Shot,E02,SEQ02,SH01,Environment,Lake,2,layout
-Shot,E02,SEQ01,SH01,Character,Victor,1,animate
-Shot,E02,SEQ01,SH01,Environment,Mine,2,layout
+Episode,Parent,Name,Asset Type,Asset,Occurences,Label
+,Environment,Lake,Props,Boat,1,setdress
+,Environment,Lake,Props,Pool,1,setdress
+,Environment,Lake,Props,Flowers,12,setdress
+,Environment,Mine,Props,Block,2,setdress
+,Environment,Mine,Props,Wagon,3,setdress
+E01,SEQ01,SH01,Character,Victor,1,animate
+E01,SEQ01,SH01,Character,John,1,animate
+E01,SEQ02,SH01,Environment,Lake,1,layout
+E01,SEQ01,SH02,Character,Victor,1,animate
+E01,SEQ01,SH02,Environment,Mine,1,layout
+E02,SEQ02,SH01,Character,John,1,animate
+E02,SEQ02,SH01,Environment,Lake,1,layout
+E02,SEQ01,SH01,Character,Victor,1,animate
+E02,SEQ01,SH01,Environment,Mine,1,layout

--- a/zou/app/blueprints/export/__init__.py
+++ b/zou/app/blueprints/export/__init__.py
@@ -6,6 +6,7 @@ from flask import Blueprint
 from zou.app.utils.api import configure_api_from_blueprint
 
 from .csv.assets import AssetsCsvExport
+from .csv.casting import CastingCsvExport
 from .csv.projects import ProjectsCsvExport
 from .csv.shots import ShotsCsvExport
 from .csv.persons import PersonsCsvExport
@@ -15,6 +16,7 @@ from .csv.tasks import TasksCsvExport
 routes = [
     ("/export/csv/projects/<project_id>/assets.csv", AssetsCsvExport),
     ("/export/csv/projects/<project_id>/shots.csv", ShotsCsvExport),
+    ("/export/csv/projects/<project_id>/casting.csv", CastingCsvExport),
     ("/export/csv/persons.csv", PersonsCsvExport),
     ("/export/csv/projects.csv", ProjectsCsvExport),
     ("/export/csv/tasks.csv", TasksCsvExport),

--- a/zou/app/blueprints/export/csv/assets.py
+++ b/zou/app/blueprints/export/csv/assets.py
@@ -1,5 +1,3 @@
-import sys
-
 from flask_restful import Resource
 from flask_jwt_extended import jwt_required
 from slugify import slugify

--- a/zou/app/blueprints/export/csv/casting.py
+++ b/zou/app/blueprints/export/csv/casting.py
@@ -1,0 +1,124 @@
+from flask_restful import Resource
+from flask_jwt_extended import jwt_required
+from slugify import slugify
+from sqlalchemy.orm import aliased
+
+from zou.app.models.entity import Entity, EntityLink
+from zou.app.models.entity_type import EntityType
+
+from zou.app.services import (
+    projects_service,
+    user_service
+)
+from zou.app.utils import csv_utils
+
+
+class CastingCsvExport(Resource):
+
+    @jwt_required
+    def get(self, project_id):
+        project = projects_service.get_project(project_id)  # Check existence
+        self.check_permissions(project_id)
+
+        results = self.build_results(project_id)
+        headers = self.build_headers()
+
+        csv_content = [headers]
+        for result in results:
+            csv_content.append(self.build_row(result))
+
+        print(csv_content)
+        file_name = "%s casting" % project["name"]
+        return csv_utils.build_csv_response(csv_content, slugify(file_name))
+
+    def check_permissions(self, project_id):
+        user_service.check_project_access(project_id)
+
+    def build_headers(self):
+        return [
+            "Episode",
+            "Parent",
+            "Name",
+            "Asset Type",
+            "Asset",
+            "Occurences",
+            "Label"
+        ]
+
+    def build_row(self, result):
+        (
+            episode_name,
+            target_parent_name,
+            target_entity_type_name,
+            target_name,
+            asset_type_name,
+            asset_name,
+            entity_link_nb_occurences,
+            entity_link_label
+        ) = result
+        row = [
+            episode_name or "",
+            target_parent_name or target_entity_type_name,
+            target_name,
+            asset_type_name,
+            asset_name,
+            entity_link_nb_occurences,
+            entity_link_label or ""
+        ]
+        return row
+
+    def build_results(self, project_id):
+        results = []
+
+        Target = aliased(Entity, name='target')
+        Asset = aliased(Entity, name='asset')
+        Parent = aliased(Entity, name='parent')
+        Episode = aliased(Entity, name='episode')
+        AssetType = aliased(EntityType, name='asset_type')
+        query = EntityLink.query \
+            .join(Target, EntityLink.entity_in_id == Target.id) \
+            .join(Asset, EntityLink.entity_out_id == Asset.id) \
+            .join(AssetType, Asset.entity_type_id == AssetType.id) \
+            .outerjoin(Parent, Target.parent_id == Parent.id) \
+            .outerjoin(
+                EntityType, Target.entity_type_id == EntityType.id
+            ) \
+            .outerjoin(
+                Episode, Parent.parent_id == Episode.id
+            ) \
+            .filter(Target.project_id == project_id) \
+            .add_columns(
+                Episode.name,
+                Parent.name,
+                EntityType.name,
+                Target.name,
+                AssetType.name,
+                Asset.name
+            ).order_by(
+                Episode.name,
+                Parent.name,
+                EntityType.name,
+                Target.name,
+                AssetType.name,
+                Asset.name
+            )
+        for (
+            entity_link,
+            episode_name,
+            target_parent_name,
+            target_entity_type_name,
+            target_name,
+            asset_type_name,
+            asset_name
+        ) in query.all():
+            results.append((
+                episode_name,
+                target_parent_name,
+                target_entity_type_name,
+                target_name,
+                asset_type_name,
+                asset_name,
+                entity_link.nb_occurences,
+                entity_link.label
+            ))
+        return results

--- a/zou/app/blueprints/source/csv/base.py
+++ b/zou/app/blueprints/source/csv/base.py
@@ -32,6 +32,7 @@ class BaseCsvImportResource(Resource):
                 result = self.run_import(file_path, ";")
                 return result, 201
             except KeyError as e:
+                print(e)
                 return {
                     "error": True,
                     "message": "A column is missing: %s" % e

--- a/zou/app/services/breakdown_service.py
+++ b/zou/app/services/breakdown_service.py
@@ -72,12 +72,23 @@ def update_casting(shot_id, casting):
 
 
 def create_casting_link(entity_in_id, asset_id, nb_occurences=1, label=""):
-    return EntityLink.create(
+    link = EntityLink.get_by(
         entity_in_id=entity_in_id,
-        entity_out_id=asset_id,
-        nb_occurences=nb_occurences,
-        label=label
+        entity_out_id=asset_id
     )
+    if link is None:
+        link = EntityLink.create(
+            entity_in_id=entity_in_id,
+            entity_out_id=asset_id,
+            nb_occurences=nb_occurences,
+            label=label
+        )
+    else:
+        link.update({
+            "nb_occurences": nb_occurences,
+            "label": label
+        })
+    return link
 
 
 def get_cast_in(asset_id):


### PR DESCRIPTION
**Problem**

* There is no way to export casting data as CSV
* Werkzeug version must be set to not break upgrades
* Importing twice casting via CSV creates duplicates

**Solution**

* Add missing route following the scheme of other CSV export routes
* Force Werkzeug version
* Before creating a new link, check if it exists and update it in that case