### PR TITLE
fix ProductionTeamResource get

### DIFF
--- a/zou/app/blueprints/projects/resources.py
+++ b/zou/app/blueprints/projects/resources.py
@@ -56,7 +56,7 @@ class ProductionTeamResource(Resource, ArgsMixin):
     @jwt_required
     def get(self, project_id):
         user_service.check_project_access(project_id)
-        project = projects_service.get_project()
+        project = projects_service.get_project_raw(project_id)
         return fields.serialize_value(project.team)
 
     @jwt_required


### PR DESCRIPTION
**Problem**
Could not get a project team because `get_project` method missed an argument

**Solution**
Add missing argument and use `get_project_raw`

