### PR TITLE
Fix output files from entity request

### DIFF
--- a/zou/app/services/files_service.py
+++ b/zou/app/services/files_service.py
@@ -592,10 +592,13 @@ def get_output_files_for_output_type_and_entity(
     """
     Get output files created for given entity and output type.
     """
-    query = OutputFile.query \
-        .filter(OutputFile.entity_id == entity_id) \
-        .filter(OutputFile.output_type_id == output_type_id) \
-        .order_by(desc(OutputFile.revision)) \
+    query = (
+        OutputFile.query
+        .filter(OutputFile.entity_id == entity_id)
+        .filter(OutputFile.asset_instance_id == None)  # noqa. Entity only
+        .filter(OutputFile.output_type_id == output_type_id)
+        .order_by(desc(OutputFile.revision))
+    )
 
     if representation is not None:
         query = query.filter(OutputFile.representation == representation)


### PR DESCRIPTION
Fix bug returning all asset instances output files for the provided entity.

**Problem**
Using this method to get output types from an entity owuld also return all the the output types from instances of that entity.

**Solution**
Add a filter to the request to ignore records where `asset_instance_id` is defined

