### PR TITLE
Synchronisation improvement

### DIFF
--- a/zou/app/blueprints/crud/base.py
+++ b/zou/app/blueprints/crud/base.py
@@ -245,6 +245,7 @@ class BaseModelResource(Resource):
             instance = self.get_model_or_404(instance_id)
             result = self.serialize_instance(instance)
             self.check_read_permissions(result)
+            result = self.clean_get_result(result)
 
         except StatementError as exception:
             current_app.logger.error(str(exception))

--- a/zou/app/blueprints/crud/entity.py
+++ b/zou/app/blueprints/crud/entity.py
@@ -30,7 +30,10 @@ class EntityEventMixin(object):
         type_name = self.get_type_name(entity_dict)
         events.emit(
             "%s:%s" % (type_name, event_name),
-            {"%s_id" % type_name: instance_id}
+            {
+                "%s_id" % type_name: instance_id,
+                "project_id": entity_dict["project_id"]
+            }
         )
 
 

--- a/zou/app/blueprints/crud/project.py
+++ b/zou/app/blueprints/crud/project.py
@@ -1,4 +1,5 @@
 from zou.app.models.project import Project
+from zou.app.models.project_status import ProjectStatus
 from zou.app.services import user_service, projects_service, shots_service
 from zou.app.utils import permissions, fields
 
@@ -51,3 +52,8 @@ class ProjectResource(BaseModelResource):
             project_dict["first_episode_id"] = \
                 fields.serialize_value(episode["id"])
         return project_dict
+
+    def clean_get_result(self, data):
+        project_status = ProjectStatus.get(data["project_status_id"])
+        data["project_status_name"] = project_status.name
+        return data

--- a/zou/app/blueprints/tasks/__init__.py
+++ b/zou/app/blueprints/tasks/__init__.py
@@ -22,10 +22,11 @@ from .resources import (
     AddPreviewResource,
     AddExtraPreviewResource,
 
-    ProjectSubscriptionsResource,
-    ProjectNotificationsResource,
     ProjectCommentsResource,
+    ProjectNotificationsResource,
     ProjectPreviewFilesResource,
+    ProjectSubscriptionsResource,
+    ProjectTasksResource,
 
     CreateShotTasksResource,
     CreateAssetTasksResource,
@@ -51,10 +52,11 @@ routes = [
         "/data/projects/<project_id>/task-types/<task_type_id>/tasks/",
         DeleteAllTasksForTaskTypeResource
     ),
-    ("/data/projects/<project_id>/subscriptions", ProjectSubscriptionsResource),
-    ("/data/projects/<project_id>/notifications", ProjectNotificationsResource),
     ("/data/projects/<project_id>/comments", ProjectCommentsResource),
+    ("/data/projects/<project_id>/notifications", ProjectNotificationsResource),
     ("/data/projects/<project_id>/preview-files", ProjectPreviewFilesResource),
+    ("/data/projects/<project_id>/subscriptions", ProjectSubscriptionsResource),
+    ("/data/projects/<project_id>/tasks", ProjectTasksResource),
 
     ("/actions/tasks/<task_id>/comment", CommentTaskResource),
     ("/actions/tasks/<task_id>/assign", TaskAssignResource),

--- a/zou/app/blueprints/tasks/resources.py
+++ b/zou/app/blueprints/tasks/resources.py
@@ -25,6 +25,7 @@ from zou.app.services import (
     user_service
 )
 from zou.app.utils import query, permissions
+from zou.app.mixin import ArgsMixin
 
 
 class CommentTaskResource(Resource):
@@ -673,7 +674,7 @@ class ProjectSubscriptionsResource(Resource):
         return notifications_service.get_subscriptions_for_project(project_id)
 
 
-class ProjectNotificationsResource(Resource):
+class ProjectNotificationsResource(Resource, ArgsMixin):
     """
     Retrieve all notifications related to given project.
     It's mainly used for synchronisation purpose.
@@ -683,10 +684,28 @@ class ProjectNotificationsResource(Resource):
     def get(self, project_id):
         permissions.check_admin_permissions()
         projects_service.get_project(project_id)
-        return notifications_service.get_notifications_for_project(project_id)
+        page = self.get_page()
+        return notifications_service.get_notifications_for_project(
+            project_id,
+            page
+        )
 
 
-class ProjectCommentsResource(Resource):
+class ProjectTasksResource(Resource, ArgsMixin):
+    """
+    Retrieve all tasks related to given project.
+    It's mainly used for synchronisation purpose.
+    """
+
+    @jwt_required
+    def get(self, project_id):
+        permissions.check_admin_permissions()
+        projects_service.get_project(project_id)
+        page = self.get_page()
+        return tasks_service.get_tasks_for_project(project_id, page)
+
+
+class ProjectCommentsResource(Resource, ArgsMixin):
     """
     Retrieve all comments to tasks related to given project.
     It's mainly used for synchronisation purpose.
@@ -696,10 +715,11 @@ class ProjectCommentsResource(Resource):
     def get(self, project_id):
         permissions.check_admin_permissions()
         projects_service.get_project(project_id)
-        return tasks_service.get_comments_for_project(project_id)
+        page = self.get_page()
+        return tasks_service.get_comments_for_project(project_id, page)
 
 
-class ProjectPreviewFilesResource(Resource):
+class ProjectPreviewFilesResource(Resource, ArgsMixin):
     """
     Retrieve all comments to tasks related to given project.
     It's mainly used for synchronisation purpose.
@@ -709,4 +729,5 @@ class ProjectPreviewFilesResource(Resource):
     def get(self, project_id):
         permissions.check_admin_permissions()
         projects_service.get_project(project_id)
-        return files_service.get_preview_files_for_project(project_id)
+        page = self.get_page()
+        return files_service.get_preview_files_for_project(project_id, page)

--- a/zou/app/mixin.py
+++ b/zou/app/mixin.py
@@ -1,7 +1,12 @@
 from flask_restful import reqparse
+from flask import request
 
 
 class ArgsMixin(object):
+    """
+    Helpers to retrieve parameters from GET or POST queries.
+    """
+
     def get_args(self, descriptors):
         parser = reqparse.RequestParser()
         for descriptor in descriptors:
@@ -20,3 +25,10 @@ class ArgsMixin(object):
             )
 
         return parser.parse_args()
+
+    def get_page(self):
+        """
+        Returns page requested by the user.
+        """
+        options = request.args
+        return int(options.get("page", "-1"))

--- a/zou/app/models/project.py
+++ b/zou/app/models/project.py
@@ -72,6 +72,9 @@ class Project(db.Model, BaseMixin, SerializerMixin):
         del data["team"]
         del data["type"]
 
+        if "project_status_name" in data:
+            del data["project_status_name"]
+
         if previous_project is None:
             previous_project = cls.create(**data)
             previous_project.save()

--- a/zou/app/services/deletion_service.py
+++ b/zou/app/services/deletion_service.py
@@ -102,7 +102,7 @@ def reset_task_data(task_id):
         "end_date": end_date,
         "task_status_id": task_status_id
     })
-    events.emit("task:new", {
+    events.emit("task:update", {
         "task_id": task.id
     })
     return task.serialize()

--- a/zou/app/services/files_service.py
+++ b/zou/app/services/files_service.py
@@ -24,7 +24,7 @@ from zou.app.services.exception import (
     EntryAlreadyExistsException
 )
 
-from zou.app.utils import fields, events
+from zou.app.utils import fields, events, query as query_utils
 
 from sqlalchemy import desc
 from sqlalchemy.exc import StatementError, IntegrityError
@@ -651,11 +651,11 @@ def get_project_from_preview_file(preview_file_id):
     return project.serialize()
 
 
-def get_preview_files_for_project(project_id):
+def get_preview_files_for_project(project_id, page=-1):
     """
     Return all preview files for given project.
     """
-    preview_files = PreviewFile.query \
-        .join(Task) \
-        .filter(Task.project_id == project_id)
-    return fields.serialize_list(preview_files)
+    query = PreviewFile.query \
+       .join(Task) \
+       .filter(Task.project_id == project_id)
+    return query_utils.get_paginated_results(query, page)

--- a/zou/app/services/notifications_service.py
+++ b/zou/app/services/notifications_service.py
@@ -15,7 +15,7 @@ from zou.app.services import (
 from zou.app.services.exception import (
     PersonNotFoundException
 )
-from zou.app.utils import events, fields
+from zou.app.utils import events, fields, query as query_utils
 
 
 def create_notification(
@@ -366,11 +366,11 @@ def get_subscriptions_for_project(project_id):
     return fields.serialize_list(subscriptions)
 
 
-def get_notifications_for_project(project_id):
+def get_notifications_for_project(project_id, page=0):
     """
     Return all notifications for given project.
     """
-    notifications = Notification.query \
+    query = Notification.query \
         .join(Task) \
         .filter(Task.project_id == project_id)
-    return fields.serialize_list(notifications)
+    return query_utils.get_paginated_results(query, page)

--- a/zou/app/services/playlists_service.py
+++ b/zou/app/services/playlists_service.py
@@ -132,6 +132,9 @@ def set_preview_files_for_shots(playlist_dict):
             "revision": preview_file.revision,
             "extension": preview_file.extension,
             "annotations": preview_file.annotations,
+            "created_at": fields.serialize_value(
+                preview_file.created_at
+            ),
             "task_id": task_id
         })  # Do not add too much field to avoid building too big responses
 
@@ -175,6 +178,9 @@ def get_preview_files_for_shot(shot_id):
                     "revision": preview_file.revision,
                     "extension": preview_file.extension,
                     "annotations": preview_file.annotations,
+                    "created_at": fields.serialize_value(
+                        preview_file.created_at
+                    ),
                     "task_id": str(preview_file.task_id)
                 }
                 for preview_file in preview_files

--- a/zou/app/services/tasks_service.py
+++ b/zou/app/services/tasks_service.py
@@ -21,7 +21,7 @@ from zou.app.models.project import Project
 from zou.app.models.entity_type import EntityType
 from zou.app.models.preview_file import PreviewFile
 
-from zou.app.utils import fields
+from zou.app.utils import fields, query as query_utils
 
 from zou.app.services.exception import (
     CommentNotFoundException,
@@ -1013,21 +1013,30 @@ def reset_mentions(comment):
     return comment_to_update.serialize()
 
 
-def get_comments_for_project(project_id):
+def get_comments_for_project(project_id, page=0):
     """
     Return all comments for given project.
     """
-    comments = Comment.query \
+    query = Comment.query \
         .join(Task, Task.id == Comment.object_id) \
         .filter(Task.project_id == project_id)
-    return fields.serialize_list(comments)
+    return query_utils.get_paginated_results(query, page)
 
 
-def get_time_spents_for_project(project_id):
+def get_time_spents_for_project(project_id, page=0):
     """
     Return all time spents for given project.
     """
-    time_spents = TimeSpent.query \
+    query = TimeSpent.query \
         .join(Task) \
         .filter(Task.project_id == project_id)
-    return fields.serialize_list(time_spents)
+    return query_utils.get_paginated_results(query, page)
+
+
+def get_tasks_for_project(project_id, page=0):
+    """
+    Return all tasks for given project.
+    """
+    query = Task.query \
+        .filter(Task.project_id == project_id)
+    return query_utils.get_paginated_results(query, page)

--- a/zou/app/utils/commands.py
+++ b/zou/app/utils/commands.py
@@ -303,7 +303,7 @@ def import_data_from_another_instance(target, login, password):
     sync_service.run_other_sync()
 
 
-def run_sync_change_daemon(event_target, target, login, password):
+def run_sync_change_daemon(event_target, target, login, password, logs_dir):
     """
     Listen to event websocket. Each time a change occurs, it retreves the
     related data and save it in the current instance.
@@ -312,7 +312,8 @@ def run_sync_change_daemon(event_target, target, login, password):
         target,
         event_target,
         login,
-        password
+        password,
+        logs_dir
     )
     sync_service.add_main_sync_listeners(event_client)
     sync_service.add_project_sync_listeners(event_client)

--- a/zou/app/utils/movie_utils.py
+++ b/zou/app/utils/movie_utils.py
@@ -125,4 +125,10 @@ def build_playlist_movie(
                 .run()
         except Exception as e:
             print(e)
-    return movie_file_path
+            return {
+                "success": False,
+                "message": str(e)
+            }
+    return {
+        "success": True
+    }

--- a/zou/cli.py
+++ b/zou/cli.py
@@ -351,7 +351,8 @@ def sync_full(target):
 @cli.command()
 @click.option("--event-target", default="http://localhost:8080")
 @click.option("--target", default="http://localhost:8080/api")
-def sync_changes(event_target, target):
+@click.option("--logs-directory", default=None)
+def sync_changes(event_target, target, logs_directory):
     """
     Run a daemon that import data related to any change happening on target
     instance. It expects that credentials to connect to target instance are
@@ -359,7 +360,13 @@ def sync_changes(event_target, target):
     """
     login = os.getenv("SYNC_LOGIN")
     password = os.getenv("SYNC_PASSWORD")
-    commands.run_sync_change_daemon(event_target, target, login, password)
+    commands.run_sync_change_daemon(
+        event_target,
+        target,
+        login,
+        password,
+        logs_directory
+    )
 
 
 @cli.command()


### PR DESCRIPTION
**Problem**

Sync problems:

* Task update event is not sent when a comment is deleted.
* `create_from_import` sometimes fail for entities.
* It's not possible to link an event to a production.
* Some project routes returns too many results.
* Realtime syncing output cannot be saved to a file.

Other:

* When a playlist fails to build, the problem is not well described.
* Preview file listing in playlists don't return the creation date.

**Solution**

* Send the right event on comment deletion (`task:update` instead of `task:new`).
* Handle properly all entity fields when dealing with import data.
* Add the project ID to the event data.
* Allow to paginate results returned by these routes.
* Format logs properly and add an option to store sync output to a file.
* Returns error message when playlist build fails.
* Add creation date to preview file listing of playlists.
