### PR TITLE
Create a blueprint for breakdown functions and more

### DIFF
--- a/tests/services/test_breakdown_service.py
+++ b/tests/services/test_breakdown_service.py
@@ -56,6 +56,54 @@ class BreakdownServiceTestCase(ApiDBTestCase):
         self.assertEqual(len(casting[self.shot_id]), 2)
         self.assertEqual(len(casting[str(self.shot.id)]), 1)
 
+    def test_get_asset_type_casting(self):
+        self.shot_id = str(self.shot.id)
+        self.sequence_id = str(self.sequence.id)
+        self.asset_type_environment_id = str(self.asset_type_environment.id)
+        self.asset_props_id = str(self.asset.id)
+        self.asset_character_id = str(self.asset_character.id)
+        self.generate_fixture_asset(
+            "Forest", "", self.asset_type_environment_id
+        )
+        self.forest_id = str(self.asset.id)
+
+        casting = breakdown_service.get_asset_type_casting(
+            self.project_id,
+            self.asset_type_environment_id
+        )
+        self.assertDictEqual(casting, {})
+        new_casting = [
+            {
+                "asset_id": self.asset_props_id,
+                "nb_occurences": 3
+            },
+            {
+                "asset_id": self.asset_character_id,
+                "nb_occurences": 1
+            }
+        ]
+        breakdown_service.update_casting(self.asset.id, new_casting)
+        self.generate_fixture_asset(
+            "Park", "", self.asset_type_environment_id
+        )
+        new_casting = [
+            {
+                "asset_id": self.asset_props_id,
+                "nb_occurences": 1
+            }
+        ]
+        breakdown_service.update_casting(self.asset.id, new_casting)
+        casting = breakdown_service.get_asset_type_casting(
+            self.project_id,
+            self.asset_type_environment_id
+        )
+        self.maxDiff = 10000
+        self.assertTrue(self.forest_id in casting)
+        self.assertTrue(str(self.asset.id) in casting)
+        self.assertEqual(len(casting[self.forest_id]), 2)
+        self.assertEqual(len(casting[str(self.asset.id)]), 1)
+
+
     def new_shot_instance(self, asset_instance_id):
         return breakdown_service.add_asset_instance_to_shot(
             self.shot_id, asset_instance_id

--- a/tests/shots/test_breakdown.py
+++ b/tests/shots/test_breakdown.py
@@ -18,6 +18,7 @@ class BreakdownTestCase(ApiDBTestCase):
         self.generate_fixture_asset_character()
 
     def test_update_casting(self):
+        self.project_id = str(self.project.id)
         self.shot_id = str(self.shot.id)
         self.asset_id = str(self.asset.id)
         self.asset_character_id = str(self.asset_character.id)
@@ -26,7 +27,10 @@ class BreakdownTestCase(ApiDBTestCase):
         self.sequence_name = self.sequence.name
         self.episode_name = self.episode.name
 
-        casting = self.get("/data/shots/%s/casting" % self.shot_id)
+        casting = self.get("/data/projects/%s/entities/%s/casting" % (
+            self.project_id,
+            self.shot_id
+        ))
         self.assertListEqual(casting, [])
         newCasting = [
             {
@@ -39,9 +43,16 @@ class BreakdownTestCase(ApiDBTestCase):
             }
         ]
         path = "/data/shots/%s/casting" % str(self.shot_id)
+        path = "/data/projects/%s/entities/%s/casting" % (
+            self.project_id,
+            self.shot_id
+        )
         self.put(path, newCasting, 200)
 
-        casting = self.get("/data/shots/%s/casting" % self.shot_id)
+        casting = self.get("/data/projects/%s/entities/%s/casting" % (
+            self.project_id,
+            self.shot_id
+        ))
         casting = sorted(casting, key=lambda x: x["nb_occurences"])
         self.assertEqual(casting[0]["asset_id"], newCasting[0]["asset_id"])
         self.assertEqual(

--- a/zou/app/api.py
+++ b/zou/app/api.py
@@ -7,6 +7,7 @@ from flask import Blueprint
 
 from .blueprints.assets import blueprint as assets_blueprint
 from .blueprints.auth import blueprint as auth_blueprint
+from .blueprints.breakdown import blueprint as breakdown_blueprint
 from .blueprints.crud import blueprint as crud_blueprint
 from .blueprints.events import blueprint as events_blueprint
 from .blueprints.export import blueprint as export_blueprint
@@ -42,6 +43,7 @@ def configure_api_routes(app):
     """
     app.register_blueprint(auth_blueprint)
     app.register_blueprint(assets_blueprint)
+    app.register_blueprint(breakdown_blueprint)
     app.register_blueprint(crud_blueprint)
     app.register_blueprint(export_blueprint)
     app.register_blueprint(events_blueprint)

--- a/zou/app/blueprints/breakdown/__init__.py
+++ b/zou/app/blueprints/breakdown/__init__.py
@@ -1,0 +1,45 @@
+from flask import Blueprint
+from zou.app.utils.api import configure_api_from_blueprint
+
+from .resources import (
+    ProjectEntityLinksResource,
+
+    ShotAssetInstancesResource,
+    RemoveShotAssetInstanceResource,
+    SceneAssetInstancesResource,
+    SceneCameraInstancesResource,
+
+    CastingResource,
+    AssetTypeCastingResource,
+    SequenceCastingResource
+)
+
+
+routes = [
+    (
+        "/data/projects/<project_id>/entities/<entity_id>/casting",
+        CastingResource
+    ),
+    (
+        "/data/projects/<project_id>/asset-types/<asset_type_id>/casting",
+        AssetTypeCastingResource
+    ),
+    (
+        "/data/projects/<project_id>/sequences/<sequence_id>/casting",
+        SequenceCastingResource
+    ),
+
+    ("/data/projects/<project_id>/entity-links", ProjectEntityLinksResource),
+
+    ("/data/scenes/<scene_id>/asset-instances", SceneAssetInstancesResource),
+    ("/data/scenes/<scene_id>/camera-instances", SceneCameraInstancesResource),
+    ("/data/shots/<shot_id>/asset-instances", ShotAssetInstancesResource),
+    (
+        "/data/shots/<shot_id>/asset-instances/<asset_instance_id>",
+        RemoveShotAssetInstanceResource
+    )
+]
+
+
+blueprint = Blueprint("breakdown", "breakdown")
+api = configure_api_from_blueprint(blueprint, routes)

--- a/zou/app/blueprints/breakdown/resources.py
+++ b/zou/app/blueprints/breakdown/resources.py
@@ -1,0 +1,161 @@
+from flask import request
+from flask_restful import Resource
+from flask_jwt_extended import jwt_required
+
+from zou.app.services import (
+    assets_service,
+    breakdown_service,
+    entities_service,
+    projects_service,
+    shots_service,
+    user_service
+)
+
+from zou.app.mixin import ArgsMixin
+from zou.app.utils import permissions
+
+
+class CastingResource(Resource):
+
+    @jwt_required
+    def get(self, project_id, entity_id):
+        """
+        Resource to retrieve the casting of a given entity.
+        """
+        user_service.check_project_access(project_id)
+        return breakdown_service.get_casting(entity_id)
+
+    @jwt_required
+    def put(self, project_id, entity_id):
+        """
+        Resource to allow the modification of assets linked to an entity.
+        """
+        casting = request.json
+        user_service.check_project_access(project_id)
+        return breakdown_service.update_casting(entity_id, casting)
+
+
+class SequenceCastingResource(Resource):
+
+    @jwt_required
+    def get(self, project_id, sequence_id):
+        """
+        Resource to retrieve the casting of shots from given sequence.
+        """
+        user_service.check_project_access(project_id)
+        shots_service.get_sequence(sequence_id)
+        return breakdown_service.get_sequence_casting(sequence_id)
+
+
+class AssetTypeCastingResource(Resource):
+
+    @jwt_required
+    def get(self, project_id, asset_type_id):
+        """
+        Resource to retrieve the casting of assets from given asset type.
+        """
+        user_service.check_project_access(project_id)
+        assets_service.get_asset_type(asset_type_id)
+        return breakdown_service.get_asset_type_casting(
+            project_id,
+            asset_type_id
+        )
+
+
+class ShotAssetInstancesResource(Resource, ArgsMixin):
+
+    @jwt_required
+    def get(self, shot_id):
+        """
+        Retrieve all asset instances linked to shot.
+        """
+        shot = shots_service.get_shot(shot_id)
+        user_service.check_project_access(shot["project_id"])
+        return breakdown_service.get_asset_instances_for_shot(shot_id)
+
+    @jwt_required
+    def post(self, shot_id):
+        """
+        Add an asset instance to given shot.
+        """
+        args = self.get_args([
+            ("asset_instance_id", None, True)
+        ])
+        shot = shots_service.get_shot(shot_id)
+        user_service.check_project_access(shot["project_id"])
+        shot = breakdown_service.add_asset_instance_to_shot(
+            shot_id,
+            args["asset_instance_id"]
+        )
+        return shot, 201
+
+
+class RemoveShotAssetInstanceResource(Resource, ArgsMixin):
+
+    @jwt_required
+    def delete(self, shot_id, asset_instance_id):
+        """
+        Remove an asset instance from given shot.
+        """
+        shot = shots_service.get_shot(shot_id)
+        user_service.check_project_access(shot["project_id"])
+        shot = breakdown_service.remove_asset_instance_for_shot(
+            shot_id,
+            asset_instance_id
+        )
+        return '', 204
+
+
+class SceneAssetInstancesResource(Resource, ArgsMixin):
+
+    @jwt_required
+    def get(self, scene_id):
+        """
+        Retrieve all asset instances linked to scene.
+        """
+        scene = shots_service.get_scene(scene_id)
+        user_service.check_project_access(scene["project_id"])
+        return breakdown_service.get_asset_instances_for_scene(scene_id)
+
+    @jwt_required
+    def post(self, scene_id):
+        """
+        Create an asset instance on given scene.
+        """
+        args = self.get_args([
+            ("asset_id", None, True),
+            ("description", None, False)
+        ])
+        scene = shots_service.get_scene(scene_id)
+        user_service.check_project_access(scene["project_id"])
+        asset_instance = breakdown_service.add_asset_instance_to_scene(
+            scene_id,
+            args["asset_id"],
+            args["description"]
+        )
+        return asset_instance, 201
+
+
+class SceneCameraInstancesResource(Resource):
+
+    @jwt_required
+    def get(self, scene_id):
+        """
+        Retrieve all asset instances linked to scene.
+        """
+        scene = shots_service.get_scene(scene_id)
+        user_service.check_project_access(scene["project_id"])
+        return breakdown_service.get_camera_instances_for_scene(scene_id)
+
+
+class ProjectEntityLinksResource(Resource):
+
+    @jwt_required
+    def get(self, project_id):
+        """
+        Retrieve all entity links related to given project.
+        It's mainly used for synchronisation purpose.
+        """
+        permissions.check_admin_permissions()
+        projects_service.get_project(project_id)
+        return entities_service.get_entity_links_for_project(project_id)

--- a/zou/app/blueprints/shots/__init__.py
+++ b/zou/app/blueprints/shots/__init__.py
@@ -23,7 +23,6 @@ from .resources import (
     ProjectSequencesResource,
     ProjectEpisodesResource,
     ProjectEpisodeStatsResource,
-    ProjectEntityLinksResource,
 
     EpisodeResource,
     EpisodesResource,
@@ -39,14 +38,6 @@ from .resources import (
     SequenceScenesResource,
     SequenceTasksResource,
     SequenceTaskTypesResource,
-
-    ShotAssetInstancesResource,
-    RemoveShotAssetInstanceResource,
-    SceneAssetInstancesResource,
-    SceneCameraInstancesResource,
-
-    CastingResource,
-    SequenceCastingResource
 )
 
 
@@ -89,18 +80,6 @@ routes = [
     (
         "/data/projects/<project_id>/episodes/stats",
         ProjectEpisodeStatsResource
-    ),
-
-    ("/data/shots/<shot_id>/casting", CastingResource),
-    ("/data/sequences/<sequence_id>/casting", SequenceCastingResource),
-    ("/data/projects/<project_id>/entity-links", ProjectEntityLinksResource),
-
-    ("/data/scenes/<scene_id>/asset-instances", SceneAssetInstancesResource),
-    ("/data/scenes/<scene_id>/camera-instances", SceneCameraInstancesResource),
-    ("/data/shots/<shot_id>/asset-instances", ShotAssetInstancesResource),
-    (
-        "/data/shots/<shot_id>/asset-instances/<asset_instance_id>",
-        RemoveShotAssetInstanceResource
     )
 ]
 

--- a/zou/app/blueprints/shots/resources.py
+++ b/zou/app/blueprints/shots/resources.py
@@ -458,40 +458,6 @@ class SequenceShotsResource(Resource):
         return shots_service.get_shots(criterions)
 
 
-class CastingResource(Resource):
-
-    @jwt_required
-    def get(self, shot_id):
-        """
-        Resource to retrieve the casting of a given shot.
-        """
-        shot = shots_service.get_shot(shot_id)
-        user_service.check_project_access(shot["project_id"])
-        return breakdown_service.get_casting(shot_id)
-
-    @jwt_required
-    def put(self, shot_id):
-        """
-        Resource to allow the modification of assets linked to a shot.
-        """
-        casting = request.json
-        shot = shots_service.get_shot(shot_id)
-        user_service.check_project_access(shot["project_id"])
-        return breakdown_service.update_casting(shot_id, casting)
-
-
-class SequenceCastingResource(Resource):
-
-    @jwt_required
-    def get(self, sequence_id):
-        """
-        Resource to retrieve the casting of shots from given sequence.
-        """
-        sequence = shots_service.get_sequence(sequence_id)
-        user_service.check_project_access(sequence["project_id"])
-        return breakdown_service.get_sequence_casting(sequence_id)
-
-
 class ProjectScenesResource(Resource):
 
     @jwt_required
@@ -562,92 +528,6 @@ class SceneTasksResource(Resource):
         return tasks_service.get_tasks_for_scene(scene_id)
 
 
-class ShotAssetInstancesResource(Resource, ArgsMixin):
-
-    @jwt_required
-    def get(self, shot_id):
-        """
-        Retrieve all asset instances linked to shot.
-        """
-        shot = shots_service.get_shot(shot_id)
-        user_service.check_project_access(shot["project_id"])
-        return breakdown_service.get_asset_instances_for_shot(shot_id)
-
-    @jwt_required
-    def post(self, shot_id):
-        """
-        Add an asset instance to given shot.
-        """
-        args = self.get_args([
-            ("asset_instance_id", None, True)
-        ])
-        shot = shots_service.get_shot(shot_id)
-        user_service.check_project_access(shot["project_id"])
-        shot = breakdown_service.add_asset_instance_to_shot(
-            shot_id,
-            args["asset_instance_id"]
-        )
-        return shot, 201
-
-
-class RemoveShotAssetInstanceResource(Resource, ArgsMixin):
-
-    @jwt_required
-    def delete(self, shot_id, asset_instance_id):
-        """
-        Remove an asset instance from given shot.
-        """
-        shot = shots_service.get_shot(shot_id)
-        user_service.check_project_access(shot["project_id"])
-        shot = breakdown_service.remove_asset_instance_for_shot(
-            shot_id,
-            asset_instance_id
-        )
-        return '', 204
-
-
-class SceneAssetInstancesResource(Resource, ArgsMixin):
-
-    @jwt_required
-    def get(self, scene_id):
-        """
-        Retrieve all asset instances linked to scene.
-        """
-        scene = shots_service.get_scene(scene_id)
-        user_service.check_project_access(scene["project_id"])
-        return breakdown_service.get_asset_instances_for_scene(scene_id)
-
-    @jwt_required
-    def post(self, scene_id):
-        """
-        Create an asset instance on given scene.
-        """
-        args = self.get_args([
-            ("asset_id", None, True),
-            ("description", None, False)
-        ])
-        scene = shots_service.get_scene(scene_id)
-        user_service.check_project_access(scene["project_id"])
-        asset_instance = breakdown_service.add_asset_instance_to_scene(
-            scene_id,
-            args["asset_id"],
-            args["description"]
-        )
-        return asset_instance, 201
-
-
-class SceneCameraInstancesResource(Resource):
-
-    @jwt_required
-    def get(self, scene_id):
-        """
-        Retrieve all asset instances linked to scene.
-        """
-        scene = shots_service.get_scene(scene_id)
-        user_service.check_project_access(scene["project_id"])
-        return breakdown_service.get_camera_instances_for_scene(scene_id)
-
-
 class SceneShotsResource(Resource, ArgsMixin):
 
     @jwt_required
@@ -682,16 +562,3 @@ class RemoveShotFromSceneResource(Resource):
         shot = shots_service.get_shot(shot_id)
         scenes_service.remove_shot_from_scene(scene, shot)
         return '', 204
-
-
-class ProjectEntityLinksResource(Resource):
-    """
-    Retrieve all entity links related to given project.
-    It's mainly used for synchronisation purpose.
-    """
-
-    @jwt_required
-    def get(self, project_id):
-        permissions.check_admin_permissions()
-        projects_service.get_project(project_id)
-        return entities_service.get_entity_links_for_project(project_id)


### PR DESCRIPTION

**Problem**

* Shot blueprint was getting too big
* Breakdown is not only linked to shot casting. It includes asset casting too.
* It is not possible to get assets in asset castings for an asset type for a given production.

**Solution**

* Create a new blueprint including breakdown routes only.
* Contextualize breakdown routes with project information.
* Allow to retrieve asset casting in assets (for set dressing) for an asset type in a production.

