### PR TITLE
Add custom EVENT_STREAM_HOST support

### DIFF
--- a/zou/app/blueprints/index/resources.py
+++ b/zou/app/blueprints/index/resources.py
@@ -40,8 +40,10 @@ class BaseStatusResource(Resource):
 
         is_es_up = True
         try:
-            requests.get("http://localhost:%s" % config.EVENT_STREAM_PORT)
-        except:
+            requests.get("http://{host}:{port}".format(
+                host=config.EVENT_STREAM_HOST,
+                port=config.EVENT_STREAM_PORT))
+        except Exception:
             is_es_up = False
 
         version = __version__

--- a/zou/app/config.py
+++ b/zou/app/config.py
@@ -81,6 +81,7 @@ EVENT_HANDLERS_FOLDER = os.getenv(
 )
 TMP_DIR = os.getenv("TMP_DIR", os.path.join(os.sep, "tmp", "zou"))
 
+EVENT_STREAM_HOST = os.getenv("EVENT_STREAM_HOST", "localhost")
 EVENT_STREAM_PORT = os.getenv("EVENT_STREAM_PORT", 5001)
 
 FS_BACKEND = os.getenv("FS_BACKEND", "local")

--- a/zou/event_stream.py
+++ b/zou/event_stream.py
@@ -38,4 +38,6 @@ redis_url = get_redis_url()
 (app, socketio) = create_app(redis_url)
 
 if __name__ == "main":
-    socketio.run(app, debug=False, port=config["EVENT_STREAM_PORT"])
+    socketio.run(app, debug=False,
+                 host=config["EVENT_STREAM_HOST"],
+                 port=config["EVENT_STREAM_PORT"])


### PR DESCRIPTION
**Problem**
Configuration would not allow to use a custom host for the event stream.
This is an issue if separating _zou_ and _zou-events_ services into different containers.
(for instance when working with docker compose and sticking to one service per container)

**Solution**
Allow to define a custom host for the events service through project configuration.