### PR TITLE
Fix authentification with auth_local_no_password strategy

### DIFF
--- a/zou/app/blueprints/auth/resources.py
+++ b/zou/app/blueprints/auth/resources.py
@@ -188,7 +188,7 @@ class LoginResource(Resource):
             user = auth_service.check_auth(app, email, password)
             del user["password"]
 
-            if password == "default":
+            if auth_service.is_default_password(app, password):
                 token = uuid.uuid4()
                 auth_tokens_store.add(
                     "reset-%s" % token,
@@ -214,6 +214,7 @@ class LoginResource(Resource):
                 'HTTP_X_REAL_IP',
                 request.remote_addr
             )
+
             if is_from_browser(request.user_agent):
                 organisation = persons_service.get_organisation()
                 response = jsonify({
@@ -278,6 +279,7 @@ class LoginResource(Resource):
                 "message": "Database doesn't seem reachable."
             }, 500
         except Exception as exception:
+            current_app.logger.error(exception, exc_info=1)
             if hasattr(exception, "message"):
                 message = exception.message
             else:

--- a/zou/app/services/auth_service.py
+++ b/zou/app/services/auth_service.py
@@ -203,3 +203,8 @@ def revoke_tokens(app, jti):
         'true',
         app.config["JWT_ACCESS_TOKEN_EXPIRES"]
     )
+
+def is_default_password(app, password):
+    return \
+        password == "default" and \
+        app.config["AUTH_STRATEGY"] != "auth_local_no_password"


### PR DESCRIPTION
**Problem**
The error raised when user keeps the default password is raised even when the authentification strategy is set to `auth_local_no_password`.

**Solution**
(credit @frankrousseau)
Take the authentification strategy into account when checking if password is default.