### PR TITLE
Fix filtering results in last output file for entity resource

### DIFF
--- a/zou/app/blueprints/files/resources.py
+++ b/zou/app/blueprints/files/resources.py
@@ -745,7 +745,12 @@ class LastEntityOutputFilesResource(Resource):
     def get(self, entity_id):
         entity = entities_service.get_entity(entity_id)
         user_service.check_project_access(entity["project_id"])
-        return files_service.get_last_output_files_for_entity(entity["id"])
+        return files_service.get_last_output_files_for_entity(
+            entity["id"],
+            output_type_id=request.args.get("output_type_id", None),
+            task_type_id=request.args.get("task_type_id", None),
+            representation=request.args.get("representation", None),
+        )
 
 
 class LastInstanceOutputFilesResource(Resource):


### PR DESCRIPTION
**Problem**
`files_service.get_last_output_files_for_entity` offers additional filtering arguments, but they are not exposed to the REST API.

**Solution**
Get optional arguments from the request arguments, and pass them to `files_service.get_last_output_files_for_entity`
