### PR TITLE
Allow supervisor to delete tasks

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -78,6 +78,9 @@ class ApiTestCase(unittest.TestCase):
     def log_in_cg_artist(self):
         self.log_in(self.user_cg_artist["email"])
 
+    def log_in_cg_artist(self):
+        self.log_in(self.user_client["email"])
+
     def log_out(self):
         try:
             self.get("auth/logout")
@@ -502,6 +505,17 @@ class ApiDBTestCase(ApiTestCase):
         ).serialize()
         return self.user_cg_artist
 
+    def generate_fixture_user_client(self):
+        self.user_client = Person.create(
+            first_name="John",
+            last_name="Did4",
+            role="client",
+            email=u"john.did.client@gmail.com",
+            password=auth.encrypt_password("mypassword")
+        ).serialize()
+        return self.user_client
+
+
     def generate_fixture_person(
         self,
         first_name="John",
@@ -725,11 +739,13 @@ class ApiDBTestCase(ApiTestCase):
         self.project.save()
         return self.shot_task_standard
 
-    def generate_fixture_comment(self):
+    def generate_fixture_comment(self, person=None):
+        if person is None:
+            person = self.person.serialize()
         self.comment = tasks_service.create_comment(
             self.task.id,
             self.task_status.id,
-            self.person.id,
+            person["id"],
             "first comment"
         )
         return self.comment

--- a/tests/base.py
+++ b/tests/base.py
@@ -78,7 +78,7 @@ class ApiTestCase(unittest.TestCase):
     def log_in_cg_artist(self):
         self.log_in(self.user_cg_artist["email"])
 
-    def log_in_cg_artist(self):
+    def log_in_client(self):
         self.log_in(self.user_client["email"])
 
     def log_out(self):

--- a/tests/services/test_tasks_service.py
+++ b/tests/services/test_tasks_service.py
@@ -438,8 +438,16 @@ class TaskServiceTestCase(ApiDBTestCase):
         self.assertEqual(mentions[0], self.person)
 
     def test_get_comments(self):
+        self.generate_fixture_user_client()
         self.generate_fixture_comment()
-        comments = tasks_service.get_comments(self.task_id)
+        self.generate_fixture_comment()
+        self.generate_fixture_comment(person=self.user_client)
+        self.generate_fixture_comment()
+        comments = tasks_service.get_comments(self.task_id, is_manager=True)
+        self.assertEqual(len(comments), 4)
+        comments = tasks_service.get_comments(self.task_id, is_manager=False)
+        self.assertEqual(len(comments), 3)
+        comments = tasks_service.get_comments(self.task_id, is_client=True)
         self.assertEqual(len(comments), 1)
 
     def test_create_comment(self):
@@ -450,3 +458,14 @@ class TaskServiceTestCase(ApiDBTestCase):
             "Test @John Doe"
         )
         self.assertEqual(comment["mentions"][0], str(self.person.id))
+
+    def test_get_full_task(self):
+        task = tasks_service.get_full_task(self.task.id)
+        self.assertEqual(task["project"]["name"], self.project.name)
+        self.assertEqual(task["assigner"]["id"], str(self.assigner.id))
+        self.assertEqual(task["persons"][0]["id"], str(self.person.id))
+        self.assertEqual(task["task_status"]["id"], str(self.task_status.id))
+        self.assertEqual(task["task_type"]["id"], str(self.task_type.id))
+
+        task = tasks_service.get_full_task(self.shot_task.id)
+        self.assertEqual(task["sequence"]["id"], str(self.sequence.id))

--- a/zou/app/blueprints/crud/task.py
+++ b/zou/app/blueprints/crud/task.py
@@ -59,6 +59,9 @@ class TaskResource(BaseModelResource):
     def check_update_permissions(self, task, data):
         user_service.check_manager_project_access(task["project_id"])
 
+    def check_delete_permissions(self, task):
+        user_service.check_manager_project_access(task["project_id"])
+
     def post_update(self, instance_dict):
         tasks_service.clear_task_cache(instance_dict["id"])
 

--- a/zou/app/services/entities_service.py
+++ b/zou/app/services/entities_service.py
@@ -49,6 +49,7 @@ def get_entity_raw(entity_id):
     return base_service.get_instance(Entity, entity_id, EntityNotFoundException)
 
 
+@cache.memoize_function(120)
 def get_entity(entity_id):
     """
     Return an entity type matching given id, as a dict. Raises an exception if

--- a/zou/app/services/playlists_service.py
+++ b/zou/app/services/playlists_service.py
@@ -260,9 +260,9 @@ def retrieve_playlist_tmp_files(playlist):
     preview_file_ids = []
     for shot in playlist["shots"]:
         if (
-            "preview_file_id" in shot
-            and shot["preview_file_id"] is not None
-            and len(shot["preview_file_id"]) > 0
+            "preview_file_id" in shot and
+            shot["preview_file_id"] is not None and
+            len(shot["preview_file_id"]) > 0
         ):
             preview_file = files_service.get_preview_file(
                 shot["preview_file_id"]
@@ -309,7 +309,7 @@ def build_playlist_zip_file(playlist):
     return zip_file_path
 
 
-def build_playlist_movie_file(playlist):
+def build_playlist_movie_file(playlist, app=None):
     """
     Build a movie for all files for a given playlist into the temporary folder.
     """
@@ -323,7 +323,10 @@ def build_playlist_movie_file(playlist):
     result = movie_utils.build_playlist_movie(
         tmp_file_paths, movie_file_path, width, height, fps
     )
-    file_store.add_movie("playlists", job["id"], movie_file_path)
+    if result["success"] == True:
+        file_store.add_movie("playlists", job["id"], movie_file_path)
+    elif app is not None:
+        current_app.logger.error(result["message"])
     end_build_job(playlist, job, result)
     return job
 

--- a/zou/app/services/tasks_service.py
+++ b/zou/app/services/tasks_service.py
@@ -405,6 +405,7 @@ def get_comments(task_id, is_client=False, is_manager=False):
         }
 
         if comment.preview_file_id is not None:
+            # Legacy stuff, should not be used anymore.
             preview = files_service.get_preview_file(comment.preview_file_id)
             comment_dict["previews"] = [
                 {
@@ -1043,9 +1044,10 @@ def get_full_task(task_id):
     task_status = get_task_status(task["task_status_id"])
     entity = entities_service.get_entity(task["entity_id"])
     entity_type = entities_service.get_entity_type(entity["entity_type_id"])
-    assignees = []
-    for assignee_id in task["assignees"]:
-        assignees.append(persons_service.get_person(assignee_id))
+    assignees = [
+        persons_service.get_person(assignee_id)
+        for assignee_id in task["assignees"]
+    ]
 
     task.update({
         "entity": entity,

--- a/zou/app/utils/cache.py
+++ b/zou/app/utils/cache.py
@@ -37,20 +37,6 @@ except redis.ConnectionError:
 memoize_function = cache.memoize
 
 
-def memoize_function(function, timeout=120):
-    function = cache.memoize(function, timeout)
-
-    @wraps(function)
-    def wrapper(*args, **kwargs):
-        result = function(*args, **kwargs)
-        if result is None:
-            cache.delete_memoized(function)
-            result = function(*args, **kwargs)
-        return result
-
-    return wrapper
-
-
 def invalidate(*args):
     cache.delete_memoized(*args)
 


### PR DESCRIPTION
**Problem**

* In a production, supervisors cannot delete tasks.
* Playlist build errors cannot be logged.
* get_entity function is called a lot of times, it could be cached.

**Solution**

* Allow managers to delete tasks, not only admins
* Memoize `get_entity`
* Allow to log errors when a playlist build fails
