### PR TITLE
Missing "" to encapsulate path

### DIFF
--- a/docs/log_rotation.md
+++ b/docs/log_rotation.md
@@ -16,14 +16,14 @@ chown zou: /var/run/zou
 Add this line to Zou gunicorn configuration file (`/etc/zou/gunicorn.conf`):
 
 ```
-PIDFile=/var/run/zou/zou.pid
+PIDFile = "/var/run/zou/zou.pid"
 ```
 
 Add this line to Zou Events gunicorn configuration file 
 (`/etc/zou/gunicorn-events.conf`):
 
 ```
-PIDFile=/var/run/zou/zou-events.pid
+PIDFile = "/var/run/zou/zou-events.pid"
 ```
 
 PIDs are now stored in mentioned files. 


### PR DESCRIPTION
**Problem**
<!--- Explain the problem -->
Missing " " to encapsulate path, zou process fails to work, throws errors like:

Dec 07 14:27:52 ip-172-31-4-xxx gunicorn[27113]:     execfile_(filename, cfg, cfg)
Dec 07 14:27:52 ip-172-31-4-xxx gunicorn[27113]:   File "/opt/zou/zouenv/lib/python3.5/site-packages
Dec 07 14:27:52 ip-172-31-4-xxx gunicorn[27113]:     code = compile(open(fname, 'rb').read(), fname,
Dec 07 14:27:52 ip-172-31-4-xxx gunicorn[27113]:   File "/etc/zou/gunicorn.conf", line 5
Dec 07 14:27:52 ip-172-31-4-xxx gunicorn[27113]:     PIDFile = /var/run/zou/zou.pid


**Solution**
<!--- Describe the change, including rationale and design decisions -->
PIDFile = "/var/run/zou/zou.pid"
PIDFile = "/var/run/zou/zou-events.pid"
