### PR TITLE
Fixes and improvements

### DIFF
--- a/zou/app/blueprints/crud/project.py
+++ b/zou/app/blueprints/crud/project.py
@@ -80,7 +80,10 @@ class ProjectResource(BaseModelResource):
         project = self.get_model_or_404(instance_id)
         project_dict = project.serialize()
         if projects_service.is_open(project_dict):
-            return {"error": "Only closed projects can be deleted"}, 400
+            return {
+                "error": True,
+                "message": "Only closed projects can be deleted"
+            }, 400
         else:
             if args["force"] == True:
                 self.check_delete_permissions(project_dict)

--- a/zou/app/services/projects_service.py
+++ b/zou/app/services/projects_service.py
@@ -264,6 +264,7 @@ def add_metadata_descriptor(project_id, entity_type, name, choices):
         "metadata-descriptor:new",
         {"metadata_descriptor_id": str(descriptor.id)},
     )
+    clear_project_cache(project_id)
     return descriptor.serialize()
 
 
@@ -318,6 +319,7 @@ def update_metadata_descriptor(metadata_descriptor_id, changes):
         "metadata-descriptor:update",
         {"metadata_descriptor_id": str(descriptor.id)},
     )
+    clear_project_cache(str(descriptor.project_id))
     return descriptor.serialize()
 
 
@@ -340,6 +342,7 @@ def remove_metadata_descriptor(metadata_descriptor_id):
         "metadata-descriptor:delete",
         {"metadata_descriptor_id": str(descriptor.id)},
     )
+    clear_project_cache(str(descriptor.project_id))
     return descriptor.serialize()
 
 

--- a/zou/app/utils/commands.py
+++ b/zou/app/utils/commands.py
@@ -369,6 +369,15 @@ def import_last_file_changes_from_another_instance(
     print("Syncing ended.")
 
 
+def import_files_from_another_instance(target, login, password):
+    """
+    Retrieve and save all the data related most recent events from another API
+    instance. It doesn't change the IDs.
+    """
+    sync_service.init(target, login, password)
+    sync_service.download_files_from_another_instance()
+
+
 def download_file_from_storage():
     sync_service.download_entity_thumbnails_from_storage()
     sync_service.download_preview_files_from_storage()


### PR DESCRIPTION
**Problem**

* When adding a metadata descriptor, it is not displayed during minutes.
* The project deletion doesn't return a properly formatted message when it fails because the project is still open.
* It's not possible to download all files from a target instance to a local instance.

**Solution**

* Clear the project caches when a change occurs on metadata descriptors.
* Format properly the error message (to match Gazu specs) when project deletion fails because the project is still open.
* Add a command to download all preview files from a target instance.