### PR TITLE
Add a route build temporary playlists

### DIFF
--- a/zou/app/blueprints/playlists/__init__.py
+++ b/zou/app/blueprints/playlists/__init__.py
@@ -13,6 +13,7 @@ from .resources import (
     ProjectPlaylistResource,
     PlaylistDownloadResource,
     PlaylistZipDownloadResource,
+    TempPlaylistResource
 )
 
 
@@ -39,6 +40,7 @@ routes = [
         PlaylistDownloadResource,
     ),
     ("/data/playlists/<playlist_id>/download/zip", PlaylistZipDownloadResource),
+    ("/data/projects/<project_id>/playlists/temp", TempPlaylistResource),
 ]
 
 blueprint = Blueprint("playlists", "playlists")

--- a/zou/app/blueprints/playlists/resources.py
+++ b/zou/app/blueprints/playlists/resources.py
@@ -1,6 +1,6 @@
 import slugify
 
-from flask import send_file as flask_send_file
+from flask import request, send_file as flask_send_file
 from flask_restful import Resource
 from flask_jwt_extended import jwt_required
 
@@ -189,3 +189,16 @@ class ProjectAllPlaylistsResource(Resource, ArgsMixin):
         projects_service.get_project(project_id)
         page = self.get_page()
         return playlists_service.get_playlists_for_project(project_id, page)
+
+
+class TempPlaylistResource(Resource, ArgsMixin):
+    """
+    Retrieve all playlists related to given project.
+    It's mainly used for synchronisation purpose.
+    """
+
+    @jwt_required
+    def post(self, project_id):
+        user_service.check_project_access(project_id)
+        task_ids = request.json.get("task_ids", [])
+        return playlists_service.generate_temp_playlist(task_ids) or []


### PR DESCRIPTION
**Problem**

Building a temporary playlist from the frontend requires information about the previews that are not listed in the shot list. But no route can provide this information easily.

**Solution**

Add a route that generates from a list of tasks a playlist by using the latest movie uploaded as a preview for each task.
