### PR TITLE
add comment id to preview-file:create event data

### DIFF
--- a/zou/app/services/tasks_service.py
+++ b/zou/app/services/tasks_service.py
@@ -1014,7 +1014,10 @@ def add_preview_file_to_comment(comment_id, person_id, task_id, revision=0):
     preview_file = files_service.create_preview_file_raw(
         str(uuid.uuid4())[:13], revision, task_id, person_id
     )
-    events.emit("preview-file:create", {"preview_file_id": preview_file.id})
+    events.emit("preview-file:create", {
+        "preview_file_id": preview_file.id,
+        "comment_id": comment_id,
+    })
     comment.previews.append(preview_file)
     comment.save()
     if news is not None:


### PR DESCRIPTION
**Problem**
Currently there is no way to access a comment from a preview while dealing with preview creation.

**Solution**
Add the comment id to the data sent at preview file creation.

Another way might would be the implementation of a method to retrieve the comment from a preview (and the other way around).
