### PR TITLE
readd asset attributes in get_full_assets

### DIFF
--- a/zou/app/services/assets_service.py
+++ b/zou/app/services/assets_service.py
@@ -332,10 +332,7 @@ def get_full_asset(asset_id):
         asset["asset_type_id"] = asset_type["id"]
         asset["asset_type_name"] = asset_type["name"]
         del asset["source_id"]
-        del asset["shotgun_id"]
         del asset["nb_frames"]
-        del asset["parent_id"]
-        del asset["entities_in"]
         asset.update(assets[0])
         return asset
     else:


### PR DESCRIPTION
**Problem**
We need `entities_in` field when retrieving all fields of an asset.
I don't see any other way to retrieve it from any route.
I am not sure though why it has been removed so @frankrousseau might have to check it out. The related commit is  https://github.com/cgwire/zou/commit/8eddf59605f7aa4cc013d233b9239c34b6904c73

**Solution**
do not delete attributes.
