### PR TITLE
Improve video encoding settings

### DIFF
--- a/zou/app/utils/movie_utils.py
+++ b/zou/app/utils/movie_utils.py
@@ -68,7 +68,7 @@ def normalize_movie(movie_path, fps="24.00", width=None, height=1080):
             pix_fmt="yuv420p",
             format="mp4",
             r=fps,
-            b="28M",
+            crf="15",
             preset="medium",
             vcodec="libx264",
             s="%sx%s" % (width, height),


### PR DESCRIPTION
**Problem**
Current video encoding settings are not optimal for file size, especially for such content as storyboards, playblasts and renders with low in-frame activity.

**Solution**
Change ffmpeg's rate control mode to Constant Rate Factor instead of Constant Bitrate.

I've tested several ffmpeg options on various types of content and found that CRF value of 15 gives pretty identical quality and reduces overall size almost twice.