### PR TITLE
emit asset-type event only at creation

### DIFF
--- a/zou/app/services/assets_service.py
+++ b/zou/app/services/assets_service.py
@@ -389,6 +389,11 @@ def get_or_create_asset_type(name):
     if asset_type is None:
         asset_type = EntityType.create(name=name)
         clear_asset_type_cache()
+
+        events.emit(
+            "asset-type:new", {"name": asset_type.name, "id": asset_type.id}
+        )
+
     return asset_type.serialize(obj_type="AssetType")
 
 
@@ -445,9 +450,6 @@ def create_asset_types(asset_type_names):
         asset_type = get_or_create_asset_type(asset_type_name)
         asset_types.append(asset_type)
 
-        events.emit(
-            "asset-type:new", {"name": asset_type_name, "id": asset_type["id"]}
-        )
     return asset_types
 
 


### PR DESCRIPTION
**Problem**
`asset-type:new` event is emitted even though it is already existing.

**Solution**
Move `asset-type:new` at asset type creation.
