### PR TITLE
Fixed problem with slugify lowering the case of asset instance names

### DIFF
--- a/tests/services/test_breakdown_service.py
+++ b/tests/services/test_breakdown_service.py
@@ -103,7 +103,6 @@ class BreakdownServiceTestCase(ApiDBTestCase):
         self.assertEqual(len(casting[self.forest_id]), 2)
         self.assertEqual(len(casting[str(self.asset.id)]), 1)
 
-
     def new_shot_instance(self, asset_instance_id):
         return breakdown_service.add_asset_instance_to_shot(
             self.shot_id, asset_instance_id
@@ -177,7 +176,7 @@ class BreakdownServiceTestCase(ApiDBTestCase):
         self.assertEqual(instances[self.asset_id][1]["number"], 2)
         self.assertEqual(
             instances[self.asset_id][1]["name"],
-            "tree_0002"
+            "Tree_0002"
         )
         self.assertEqual(instances[self.asset_character_id][0]["number"], 1)
 
@@ -190,10 +189,10 @@ class BreakdownServiceTestCase(ApiDBTestCase):
     def test_build_asset_instance_name(self):
         name = breakdown_service.build_asset_instance_name(
             self.asset_id, 3)
-        self.assertEqual(name, "tree_0003")
+        self.assertEqual(name, "Tree_0003")
         name = breakdown_service.build_asset_instance_name(
             self.asset_character_id, 5)
-        self.assertEqual(name, "rabbit_0005")
+        self.assertEqual(name, "Rabbit_0005")
 
     def test_get_shot_asset_instances_for_asset(self):
         instances = breakdown_service.get_shot_asset_instances_for_asset(

--- a/tests/shots/test_asset_instances.py
+++ b/tests/shots/test_asset_instances.py
@@ -58,7 +58,7 @@ class AssetInstanceInShotTestCase(ApiDBTestCase):
         self.assertEqual(instances[self.asset_id][1]["number"], 2)
         self.assertEqual(
             instances[self.asset_id][1]["name"],
-            "tree_0002"
+            "Tree_0002"
         )
         self.assertEqual(instances[self.asset_character_id][0]["number"], 1)
 
@@ -118,7 +118,7 @@ class AssetInstanceInShotTestCase(ApiDBTestCase):
         self.assertEqual(instances[self.asset_id][1]["number"], 2)
         self.assertEqual(
             instances[self.asset_id][1]["name"],
-            "tree_0002"
+            "Tree_0002"
         )
         self.assertEqual(instances[self.asset_character_id][0]["number"], 1)
 
@@ -178,6 +178,6 @@ class AssetInstanceInShotTestCase(ApiDBTestCase):
         self.assertEqual(instances[self.asset_character_id][1]["number"], 2)
         self.assertEqual(
             instances[self.asset_character_id][1]["name"],
-            "rabbit_0002"
+            "Rabbit_0002"
         )
         self.assertEqual(instances[self.asset_character_2_id][0]["number"], 1)

--- a/zou/app/services/breakdown_service.py
+++ b/zou/app/services/breakdown_service.py
@@ -407,7 +407,7 @@ def build_asset_instance_name(asset_id, number):
     default instance names.
     """
     asset = Entity.get(asset_id)
-    asset_name = slugify(asset.name, separator="_")
+    asset_name = slugify(asset.name, separator="_", lowercase=False)
     number = str(number).zfill(4)
     return "%s_%s" % (asset_name, number)
 


### PR DESCRIPTION
**Problem**
The `build_asset_instance_name()` called the `slugify()` function and it lowered the case of the asset name, which was problematic for assets that contain upper case letters, since it created instances with a name different from the asset's name.

**Solution**
Use the `lowercase` keyword in the `slugify()` function so it does not change the case when building an asset instance name.