### PR TITLE
Various fixes

### DIFF
--- a/zou/app/blueprints/assets/resources.py
+++ b/zou/app/blueprints/assets/resources.py
@@ -74,10 +74,6 @@ class AssetsAndTasksResource(Resource):
         page = query.get_page_from_request(request)
         user_service.check_project_access(criterions.get("project_id", None))
         assets = assets_service.get_assets_and_tasks(criterions, page)
-        if "episode_id" in criterions:
-            criterions["episode_id"] = None
-            assets += assets_service.get_assets_and_tasks(criterions, page)
-
         return assets
 
 

--- a/zou/app/blueprints/crud/playlist.py
+++ b/zou/app/blueprints/crud/playlist.py
@@ -14,6 +14,11 @@ class PlaylistsResource(BaseModelsResource):
     def check_create_permissions(self, playlist):
         user_service.check_manager_project_access(playlist["project_id"])
 
+    def update_data(self, data):
+        if ("episode_id" in data and data["episode_id"] == "main"):
+            data["episode_id"] = None
+        return data
+
 
 class PlaylistResource(BaseModelResource):
     def __init__(self):

--- a/zou/app/blueprints/playlists/resources.py
+++ b/zou/app/blueprints/playlists/resources.py
@@ -33,9 +33,10 @@ class EpisodePlaylistsResource(Resource):
     @jwt_required
     def get(self, project_id, episode_id):
         user_service.check_project_access(project_id)
-        shots_service.get_episode(episode_id)
+        if episode_id != "main":
+            shots_service.get_episode(episode_id)
         return playlists_service.all_playlists_for_episode(
-            episode_id, permissions.has_client_permissions()
+            project_id, episode_id, permissions.has_client_permissions()
         )
 
 

--- a/zou/app/services/assets_service.py
+++ b/zou/app/services/assets_service.py
@@ -151,7 +151,10 @@ def get_assets_and_tasks(criterions={}, page=1):
         query = query.filter(Entity.project_id == criterions["project_id"])
 
     if "episode_id" in criterions:
-        query = query.filter(Entity.source_id == criterions["episode_id"])
+        if criterions["episode_id"] == "main":
+            query = query.filter(Entity.source_id == None)
+        elif criterions["episode_id"] != "all":
+            query = query.filter(Entity.source_id == criterions["episode_id"])
 
     for (
         asset,

--- a/zou/app/services/playlists_service.py
+++ b/zou/app/services/playlists_service.py
@@ -52,15 +52,23 @@ def all_playlists_for_project(project_id, for_client=False):
     return result
 
 
-def all_playlists_for_episode(episode_id, for_client=False):
+def all_playlists_for_episode(project_id, episode_id, for_client=False):
     """
     Return all playlists created for given episode.
     """
     result = []
+    query = Playlist.query
     if for_client:
-        playlists = Playlist.get_all_by(episode_id=episode_id, for_client=True)
+        query = query.filter(Playlist.for_client == True)
+
+    if episode_id == "main":
+        query = query \
+            .filter(Playlist.episode_id == None) \
+            .filter(Playlist.project_id == project_id)
     else:
-        playlists = Playlist.get_all_by(episode_id=episode_id)
+        query = query.filter(Playlist.episode_id == episode_id)
+
+    playlists = query.all()
     for playlist in playlists:
         playlist_dict = build_playlist_dict(playlist)
         result.append(playlist_dict)

--- a/zou/app/services/user_service.py
+++ b/zou/app/services/user_service.py
@@ -349,7 +349,7 @@ def check_manager_project_access(project_id):
 def check_playlist_access(playlist):
     check_project_access(playlist["project_id"])
     is_manager = permissions.has_manager_permissions()
-    is_client = permissions.has_manager_permissions()
+    is_client = permissions.has_client_permissions()
     has_client_access = is_client and playlist["for_client"]
     if not is_manager and not has_client_access:
         raise permissions.PermissionDenied


### PR DESCRIPTION
**Problem**

* Playlist download access is broken for clients.
* In a TV show, it is not possible to retrieve assets that are not linked to an episode.

**Solution**

* Fix wrong permission claim in `get_playlists_access` function.
* Allow to give `main` as id to filter on. In that case, it returns only assets that are not linked to an episode (from the main pack).

