### PR TITLE
Do not modify original file name when downloading a file

### DIFF
--- a/zou/app/services/names_service.py
+++ b/zou/app/services/names_service.py
@@ -62,7 +62,8 @@ def get_preview_file_name(preview_file_id):
             task_type["name"],
             preview_file["revision"],
         )
+        name = slugify.slugify(name, separator="_")
     return "%s.%s" % (
-        slugify.slugify(name, separator="_"),
-        preview_file["extension"],
+        name,
+        preview_file["extension"]
     )


### PR DESCRIPTION
**Problem**

When the project was configured to keep the original file names, it slugified
the file name. Which is not what is expected. 

**Solution**

This commit removes this slugify operation made on the file name before being sent.