### PR TITLE
Added section on authentication on the REST API.

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,5 +1,27 @@
 # API
 
+The Zou API is REST-based. If you are looking for a Python client, see [Gazu](https://github.com/cgwire/gazu).
+
+## Authentication
+
+Before you can use any of the endpoints outline below, you will have to get a JWT to authorize your requests.
+
+You can get a authorization token using a (form-encoded) POST request to `/auth/login`. With
+`curl` this would look something like `curl -X POST <server_address>/auth/login -d "email=<youremail>&password=<yourpassword>`.
+
+The response is a JSON object, specifically you'll need to provide the `access_token` for your future requests. 
+ 
+Here is a complete authentication process as an example (again using `curl`):
+
+    $ curl -X POST <server_address>/auth/login -d "email=<youremail>&password=<yourpassword>
+    {"login": true", "access_token": "eyJ0e...", ...}
+    
+    $ jwt=eyJ0e...  # Store the access token for easier use
+    
+    $ curl -H "Authorization: Bearer $jwt" <server_address>/data/projects
+    [{...},
+     {...}]
+
 ## Available data
 
 Data you can store and retrieve are from the following type :


### PR DESCRIPTION
**Problem**
During testing of the API, the authentication mechanism is not explained in the Zou docs.

**Solution**
I added a short section in `api.md` detailing the authentication mechanism (using curl). I believe this should be sufficient for someone to get their own setup going if they are not using Gazu.

*Sidenote*

Why are the docs in a completely separate branch? Just curious as to why this decision was made.