### PR TITLE
list all time spents when getting time spent on a task

### DIFF
--- a/tests/services/test_tasks_service.py
+++ b/tests/services/test_tasks_service.py
@@ -297,24 +297,32 @@ class TaskServiceTestCase(ApiDBTestCase):
         person_id = self.person.id
         user_id = self.user["id"]
         task_id = self.task.id
-        TimeSpent.create(
+        ts1 = TimeSpent.create(
             person_id=person_id,
             task_id=task_id,
             date=datetime.date(2017, 9, 23),
             duration=3600
         )
-        TimeSpent.create(
+        ts2 = TimeSpent.create(
             person_id=user_id,
             task_id=task_id,
             date=datetime.date(2017, 9, 23),
             duration=7200
         )
-        time_spents = self.get(
-            "/actions/tasks/%s/time-spents/2017-09-23/" % task_id
+        ts3 = TimeSpent.create(
+            person_id=user_id,
+            task_id=task_id,
+            date=datetime.date(2017, 9, 24),
+            duration=7200
         )
-        self.assertEqual(time_spents["total"], 10800)
-        self.assertEqual(time_spents[str(user_id)]["duration"], 7200)
-        self.assertEqual(time_spents[str(person_id)]["duration"], 3600)
+        time_spents = self.get(
+            "/actions/tasks/%s/time-spents/" % task_id
+        )
+        self.assertEqual(
+            time_spents["total"],
+            sum([ts['duration'] for ts in [ts1, ts2, ts3]]))
+        self.assertEqual(len(time_spents[str(user_id)]), 1)
+        self.assertEqual(len(time_spents[str(person_id)]), 2)
 
     def test_clear_assignation(self):
         task_id = self.task.id

--- a/tests/services/test_time_spents_service.py
+++ b/tests/services/test_time_spents_service.py
@@ -107,7 +107,6 @@ class TimeSpentsServiceTestCase(ApiDBTestCase):
         self.assertEqual(len(tasks), 1)
         self.assertEqual(tasks[0]["duration"], 850)
 
-
     def test_get_day_time_spents(self):
         tasks = time_spents_service.get_day_time_spents(
             self.person_id,

--- a/zou/app/services/tasks_service.py
+++ b/zou/app/services/tasks_service.py
@@ -1,3 +1,4 @@
+import collections
 import datetime
 import re
 import uuid
@@ -371,10 +372,11 @@ def get_time_spents(task_id):
     """
     Return time spents for given task.
     """
-    result = {"total": 0}
+    result = collections.defaultdict(list)
+    result["total"] = 0
     time_spents = TimeSpent.query.filter_by(task_id=task_id).all()
     for time_spent in time_spents:
-        result[str(time_spent.person_id)] = time_spent.serialize()
+        result[str(time_spent.person_id)].append(time_spent.serialize())
         result["total"] += time_spent.duration
     return result
 


### PR DESCRIPTION
**Problem**
When getting time spent on a task, only the last `time_spent` entry was returned

**Solution**
list all `time_spent` entries when getting time spent on a task
