### PR TITLE
group and filter ONLY if file_status is specified

### DIFF
--- a/zou/app/services/files_service.py
+++ b/zou/app/services/files_service.py
@@ -498,32 +498,43 @@ def get_last_output_files_for_entity(
     params.
     """
     # Query maximum revision for each possible arguments.
-    # Only query, group and filter by file status if specified.
-    # Otherwise this could lead to different groups of files sharing the same
-    # history but with different status.
+    # Only group and filter by file status if specified. Otherwise this could
+    # lead to different groups of files sharing the same history but with
+    # different status.
     # This could be very misleading when the user would want to get the last.
-    query = OutputFile.query.with_entities(
-        OutputFile.task_type_id,
-        OutputFile.output_type_id,
-        OutputFile.name,
-        OutputFile.representation,
-        func.max(OutputFile.revision).label("MAX"),)
     if file_status_id:
-        query = query.with_entities(OutputFile.file_status_id)
-
-    query = query.group_by(
-        OutputFile.task_type_id,
-        OutputFile.output_type_id,
-        OutputFile.name,
-        OutputFile.representation,)
-    if file_status_id:
-        query = query.group_by(OutputFile.file_status_id)
+        query = OutputFile.query.with_entities(
+            OutputFile.task_type_id,
+            OutputFile.output_type_id,
+            OutputFile.name,
+            OutputFile.representation,
+            OutputFile.file_status_id,
+            func.max(OutputFile.revision).label("MAX"),
+        ).group_by(
+            OutputFile.task_type_id,
+            OutputFile.output_type_id,
+            OutputFile.name,
+            OutputFile.representation,
+            OutputFile.file_status_id,
+        )
+    else:
+        query = OutputFile.query.with_entities(
+            OutputFile.task_type_id,
+            OutputFile.output_type_id,
+            OutputFile.name,
+            OutputFile.representation,
+            func.max(OutputFile.revision).label("MAX"),
+        ).group_by(
+            OutputFile.task_type_id,
+            OutputFile.output_type_id,
+            OutputFile.name,
+            OutputFile.representation,
+        )
 
     query = query.filter(OutputFile.entity_id == entity_id)
     query = query.filter(OutputFile.asset_instance_id == None)
     if file_status_id:
         query = query.filter(OutputFile.file_status_id == file_status_id)
-
     statement = query.subquery()
 
     # Create a join query to retrieve maximum revision and filter by
@@ -570,34 +581,46 @@ def get_last_output_files_for_instance(
     Get last output files for given entity grouped by output type and name.
     """
     # Query maximum revision for each possible arguments
-    # Only query, group and filter by file status if specified.
-    # Otherwise this could lead to different groups of files sharing the same
-    # history but with different status.
+    # Only group and filter by file status if specified. Otherwise this could
+    # lead to different groups of files sharing the same history but with
+    # different status.
     # This could be very misleading when the user would want to get the last.
-    query = OutputFile.query.with_entities(
-        OutputFile.temporal_entity_id,
-        OutputFile.task_type_id,
-        OutputFile.output_type_id,
-        OutputFile.name,
-        OutputFile.representation,
-        func.max(OutputFile.revision).label("MAX"),)
     if file_status_id:
-        query = query.with_entities(OutputFile.file_status_id)
-
-    query = query.group_by(
-        OutputFile.temporal_entity_id,
-        OutputFile.task_type_id,
-        OutputFile.output_type_id,
-        OutputFile.name,
-        OutputFile.representation)
-    if file_status_id:
-        query = query.group_by(OutputFile.file_status_id)
-
+        query = OutputFile.query.with_entities(
+            OutputFile.temporal_entity_id,
+            OutputFile.task_type_id,
+            OutputFile.output_type_id,
+            OutputFile.name,
+            OutputFile.representation,
+            OutputFile.file_status_id,
+            func.max(OutputFile.revision).label("MAX"),
+        ).group_by(
+            OutputFile.temporal_entity_id,
+            OutputFile.task_type_id,
+            OutputFile.output_type_id,
+            OutputFile.name,
+            OutputFile.representation,
+            OutputFile.file_status_id,
+        )
+    else:
+        query = OutputFile.query.with_entities(
+            OutputFile.temporal_entity_id,
+            OutputFile.task_type_id,
+            OutputFile.output_type_id,
+            OutputFile.name,
+            OutputFile.representation,
+            func.max(OutputFile.revision).label("MAX"),
+        ).group_by(
+            OutputFile.temporal_entity_id,
+            OutputFile.task_type_id,
+            OutputFile.output_type_id,
+            OutputFile.name,
+            OutputFile.representation,
+        )
     query = query.filter(OutputFile.asset_instance_id == asset_instance_id)
     query = query.filter(OutputFile.temporal_entity_id == temporal_entity_id)
     if file_status_id:
         query = query.filter(OutputFile.file_status_id == file_status_id)
-
     statement = query.subquery()
 
     # Create a join query to retrieve maximum revision

--- a/zou/app/services/files_service.py
+++ b/zou/app/services/files_service.py
@@ -498,43 +498,32 @@ def get_last_output_files_for_entity(
     params.
     """
     # Query maximum revision for each possible arguments.
-    # Only group and filter by file status if specified. Otherwise this could
-    # lead to different groups of files sharing the same history but with
-    # different status.
+    # Only query, group and filter by file status if specified.
+    # Otherwise this could lead to different groups of files sharing the same
+    # history but with different status.
     # This could be very misleading when the user would want to get the last.
+    query = OutputFile.query.with_entities(
+        OutputFile.task_type_id,
+        OutputFile.output_type_id,
+        OutputFile.name,
+        OutputFile.representation,
+        func.max(OutputFile.revision).label("MAX"),)
     if file_status_id:
-        query = OutputFile.query.with_entities(
-            OutputFile.task_type_id,
-            OutputFile.output_type_id,
-            OutputFile.name,
-            OutputFile.representation,
-            OutputFile.file_status_id,
-            func.max(OutputFile.revision).label("MAX"),
-        ).group_by(
-            OutputFile.task_type_id,
-            OutputFile.output_type_id,
-            OutputFile.name,
-            OutputFile.representation,
-            OutputFile.file_status_id,
-        )
-    else:
-        query = OutputFile.query.with_entities(
-            OutputFile.task_type_id,
-            OutputFile.output_type_id,
-            OutputFile.name,
-            OutputFile.representation,
-            func.max(OutputFile.revision).label("MAX"),
-        ).group_by(
-            OutputFile.task_type_id,
-            OutputFile.output_type_id,
-            OutputFile.name,
-            OutputFile.representation,
-        )
+        query = query.with_entities(OutputFile.file_status_id)
+
+    query = query.group_by(
+        OutputFile.task_type_id,
+        OutputFile.output_type_id,
+        OutputFile.name,
+        OutputFile.representation,)
+    if file_status_id:
+        query = query.group_by(OutputFile.file_status_id)
 
     query = query.filter(OutputFile.entity_id == entity_id)
     query = query.filter(OutputFile.asset_instance_id == None)
     if file_status_id:
         query = query.filter(OutputFile.file_status_id == file_status_id)
+
     statement = query.subquery()
 
     # Create a join query to retrieve maximum revision and filter by
@@ -581,46 +570,34 @@ def get_last_output_files_for_instance(
     Get last output files for given entity grouped by output type and name.
     """
     # Query maximum revision for each possible arguments
-    # Only group and filter by file status if specified. Otherwise this could
-    # lead to different groups of files sharing the same history but with
-    # different status.
+    # Only query, group and filter by file status if specified.
+    # Otherwise this could lead to different groups of files sharing the same
+    # history but with different status.
     # This could be very misleading when the user would want to get the last.
+    query = OutputFile.query.with_entities(
+        OutputFile.temporal_entity_id,
+        OutputFile.task_type_id,
+        OutputFile.output_type_id,
+        OutputFile.name,
+        OutputFile.representation,
+        func.max(OutputFile.revision).label("MAX"),)
     if file_status_id:
-        query = OutputFile.query.with_entities(
-            OutputFile.temporal_entity_id,
-            OutputFile.task_type_id,
-            OutputFile.output_type_id,
-            OutputFile.name,
-            OutputFile.representation,
-            OutputFile.file_status_id,
-            func.max(OutputFile.revision).label("MAX"),
-        ).group_by(
-            OutputFile.temporal_entity_id,
-            OutputFile.task_type_id,
-            OutputFile.output_type_id,
-            OutputFile.name,
-            OutputFile.representation,
-            OutputFile.file_status_id,
-        )
-    else:
-        query = OutputFile.query.with_entities(
-            OutputFile.temporal_entity_id,
-            OutputFile.task_type_id,
-            OutputFile.output_type_id,
-            OutputFile.name,
-            OutputFile.representation,
-            func.max(OutputFile.revision).label("MAX"),
-        ).group_by(
-            OutputFile.temporal_entity_id,
-            OutputFile.task_type_id,
-            OutputFile.output_type_id,
-            OutputFile.name,
-            OutputFile.representation,
-        )
+        query = query.with_entities(OutputFile.file_status_id)
+
+    query = query.group_by(
+        OutputFile.temporal_entity_id,
+        OutputFile.task_type_id,
+        OutputFile.output_type_id,
+        OutputFile.name,
+        OutputFile.representation)
+    if file_status_id:
+        query = query.group_by(OutputFile.file_status_id)
+
     query = query.filter(OutputFile.asset_instance_id == asset_instance_id)
     query = query.filter(OutputFile.temporal_entity_id == temporal_entity_id)
     if file_status_id:
         query = query.filter(OutputFile.file_status_id == file_status_id)
+
     statement = query.subquery()
 
     # Create a join query to retrieve maximum revision

--- a/zou/app/services/files_service.py
+++ b/zou/app/services/files_service.py
@@ -497,21 +497,44 @@ def get_last_output_files_for_entity(
     We use a subquery to get maximum revision and then filter with given
     params.
     """
-    # Query maximum revision for each possible arguments
-    query = OutputFile.query.with_entities(
-        OutputFile.task_type_id,
-        OutputFile.output_type_id,
-        OutputFile.name,
-        OutputFile.representation,
-        func.max(OutputFile.revision).label("MAX"),
-    ).group_by(
-        OutputFile.task_type_id,
-        OutputFile.output_type_id,
-        OutputFile.name,
-        OutputFile.representation,
-    )
+    # Query maximum revision for each possible arguments.
+    # Only group and filter by file status if specified. Otherwise this could
+    # lead to different groups of files sharing the same history but with
+    # different status.
+    # This could be very misleading when the user would want to get the last.
+    if file_status_id:
+        query = OutputFile.query.with_entities(
+            OutputFile.task_type_id,
+            OutputFile.output_type_id,
+            OutputFile.name,
+            OutputFile.representation,
+            OutputFile.file_status_id,
+            func.max(OutputFile.revision).label("MAX"),
+        ).group_by(
+            OutputFile.task_type_id,
+            OutputFile.output_type_id,
+            OutputFile.name,
+            OutputFile.representation,
+            OutputFile.file_status_id,
+        )
+    else:
+        query = OutputFile.query.with_entities(
+            OutputFile.task_type_id,
+            OutputFile.output_type_id,
+            OutputFile.name,
+            OutputFile.representation,
+            func.max(OutputFile.revision).label("MAX"),
+        ).group_by(
+            OutputFile.task_type_id,
+            OutputFile.output_type_id,
+            OutputFile.name,
+            OutputFile.representation,
+        )
+
     query = query.filter(OutputFile.entity_id == entity_id)
     query = query.filter(OutputFile.asset_instance_id == None)
+    if file_status_id:
+        query = query.filter(OutputFile.file_status_id == file_status_id)
     statement = query.subquery()
 
     # Create a join query to retrieve maximum revision and filter by
@@ -536,8 +559,6 @@ def get_last_output_files_for_entity(
         query = query.filter(OutputFile.name == name)
     if representation:
         query = query.filter(OutputFile.representation == representation)
-    if file_status_id:
-        query = query.filter(OutputFile.file_status_id == file_status_id)
 
     query = query.filter(OutputFile.entity_id == entity_id)
     query = query.filter(OutputFile.asset_instance_id == None)
@@ -560,22 +581,46 @@ def get_last_output_files_for_instance(
     Get last output files for given entity grouped by output type and name.
     """
     # Query maximum revision for each possible arguments
-    query = OutputFile.query.with_entities(
-        OutputFile.temporal_entity_id,
-        OutputFile.task_type_id,
-        OutputFile.output_type_id,
-        OutputFile.name,
-        OutputFile.representation,
-        func.max(OutputFile.revision).label("MAX"),
-    ).group_by(
-        OutputFile.temporal_entity_id,
-        OutputFile.task_type_id,
-        OutputFile.output_type_id,
-        OutputFile.name,
-        OutputFile.representation,
-    )
+    # Only group and filter by file status if specified. Otherwise this could
+    # lead to different groups of files sharing the same history but with
+    # different status.
+    # This could be very misleading when the user would want to get the last.
+    if file_status_id:
+        query = OutputFile.query.with_entities(
+            OutputFile.temporal_entity_id,
+            OutputFile.task_type_id,
+            OutputFile.output_type_id,
+            OutputFile.name,
+            OutputFile.representation,
+            OutputFile.file_status_id,
+            func.max(OutputFile.revision).label("MAX"),
+        ).group_by(
+            OutputFile.temporal_entity_id,
+            OutputFile.task_type_id,
+            OutputFile.output_type_id,
+            OutputFile.name,
+            OutputFile.representation,
+            OutputFile.file_status_id,
+        )
+    else:
+        query = OutputFile.query.with_entities(
+            OutputFile.temporal_entity_id,
+            OutputFile.task_type_id,
+            OutputFile.output_type_id,
+            OutputFile.name,
+            OutputFile.representation,
+            func.max(OutputFile.revision).label("MAX"),
+        ).group_by(
+            OutputFile.temporal_entity_id,
+            OutputFile.task_type_id,
+            OutputFile.output_type_id,
+            OutputFile.name,
+            OutputFile.representation,
+        )
     query = query.filter(OutputFile.asset_instance_id == asset_instance_id)
     query = query.filter(OutputFile.temporal_entity_id == temporal_entity_id)
+    if file_status_id:
+        query = query.filter(OutputFile.file_status_id == file_status_id)
     statement = query.subquery()
 
     # Create a join query to retrieve maximum revision


### PR DESCRIPTION
**Problem**
I messed up with the previous pr : https://github.com/cgwire/zou/pull/259
Let's say we have 3 files.
`v1` and `v2` are of status `s1`
`v3` is of status `s2`
Lets say I'd like the last output file of status `s1` wich is `v2`.
Previously the query would get the higher version, and check if match a status if specified. If not it was discarded leading the user to not get the right file.
Now, ONLY if the status is specified, the files are grouped by status, and then groups are filtered, leading the user to get the right file.

**Solution**
Only group otuput files if the file status is specified.
