### PR TITLE
add file status id to output file creation

### DIFF
--- a/zou/app/blueprints/files/resources.py
+++ b/zou/app/blueprints/files/resources.py
@@ -532,6 +532,7 @@ class NewEntityOutputFileResource(Resource, ArgsMixin):
                 representation=args["representation"],
                 extension=args["extension"],
                 nb_elements=int(args["nb_elements"]),
+                file_status_id=args['file_status_id'],
             )
 
             output_file_dict = self.add_path_info(
@@ -570,6 +571,7 @@ class NewEntityOutputFileResource(Resource, ArgsMixin):
                 ("representation", "", False),
                 ("nb_elements", 1, False),
                 ("sep", "/", False),
+                ("file_status_id", None, False),
             ]
         )
 
@@ -674,6 +676,7 @@ class NewInstanceOutputFileResource(Resource, ArgsMixin):
                 comment=args["comment"],
                 nb_elements=int(args["nb_elements"]),
                 extension=args["extension"],
+                file_status_id=args['file_status_id'],
             )
 
             output_file_dict = self.add_path_info(
@@ -714,6 +717,7 @@ class NewInstanceOutputFileResource(Resource, ArgsMixin):
                 ("is_sequence", False, False),
                 ("nb_elements", 1, False),
                 ("sep", "/", False),
+                ("file_status_id", None, False),
             ]
         )
 

--- a/zou/app/services/files_service.py
+++ b/zou/app/services/files_service.py
@@ -226,6 +226,7 @@ def create_new_output_revision(
     nb_elements=1,
     asset_instance_id=None,
     temporal_entity_id=None,
+    file_status_id=None
 ):
     """
     Create a new ouput file for given entity. Output type, task type, author
@@ -257,7 +258,7 @@ def create_new_output_revision(
         except NoOutputFileException:
             revision = 1
 
-    file_status_id = get_default_status()["id"]
+    file_status_id = file_status_id or get_default_status()["id"]
 
     try:
         output_file = OutputFile.get_by(


### PR DESCRIPTION
**Problem**
Previously there was no other way than to create the output file and then change its file status.

**Solution**
Add a file_status_id parameter at output file creation
