### PR TITLE
Add support for multi attachments

### DIFF
--- a/zou/app/blueprints/crud/base.py
+++ b/zou/app/blueprints/crud/base.py
@@ -226,7 +226,8 @@ class BaseModelResource(Resource):
 
     def update_data(self, data, instance_id):
         for field in self.protected_fields:
-            data.pop(field, None)
+            if (data is not None) and field in data:
+                data.pop(field, None)
         return data
 
     def serialize_instance(self, data):

--- a/zou/app/services/tasks_service.py
+++ b/zou/app/services/tasks_service.py
@@ -529,10 +529,10 @@ def create_comment(
         text=text,
     )
     comment = comment.serialize(relations=True)
-    if "file" in files:
-        uploaded_file = files["file"]
+    comment["attachment_files"] = []
+    for uploaded_file in files.values():
         attachment_file = create_attachment(comment, uploaded_file)
-        comment["attachment_files"] = [attachment_file]
+        comment["attachment_files"].append(attachment_file)
 
     events.emit("comment:new", {"comment_id": comment["id"]})
     return comment
@@ -1191,7 +1191,6 @@ def reset_task_data(task_id):
 
 def create_attachment(comment, uploaded_file):
     tmp_folder = current_app.config["TMP_DIR"]
-    uploaded_file = request.files["file"]
     filename = uploaded_file.filename
     mimetype = uploaded_file.mimetype
     extension = fs.get_file_extension(filename)


### PR DESCRIPTION
**Problem**

It is not possible to attache multiple files to a comment.

**Solution**

Look for all files attached when receiving a create comment request.
