### PR TITLE
Various improvements

### DIFF
--- a/zou/app/blueprints/breakdown/resources.py
+++ b/zou/app/blueprints/breakdown/resources.py
@@ -140,7 +140,7 @@ class ProjectEntityLinksResource(Resource):
         Retrieve all entity links related to given project.
         It's mainly used for synchronisation purpose.
         """
-        permissions.check_admin_permissions()
+        user_service.check_manager_project_access(project_id)
         projects_service.get_project(project_id)
         return entities_service.get_entity_links_for_project(project_id)
 
@@ -151,5 +151,5 @@ class ProjectEntityLinkResource(Resource):
         """
         Delete given entity link.
         """
-        permissions.check_admin_permissions()
+        user_service.check_manager_project_access(project_id)
         return entities_service.remove_entity_link(entity_link_id)

--- a/zou/app/blueprints/events/resources.py
+++ b/zou/app/blueprints/events/resources.py
@@ -20,21 +20,36 @@ class EventsResource(Resource, ArgsMixin):
         before = None
         after = None
 
-        try:
-            if args["before"] is not None:
+        if args["before"] is not None:
+            try:
                 before = fields.get_date_object(
                     args["before"], "%Y-%m-%dT%H:%M:%S"
                 )
-            if args["after"] is not None:
+            except Exception:
+                try:
+                    before = fields.get_date_object(args["before"], "%Y-%m-%d")
+                except Exception:
+                    return {
+                        "error": True,
+                        "message": "Wrong date format for before argument."
+                            "Expected format: 2020-01-05T13:23:10 or 2020-01-05"
+                    }, 400
+
+        if args["after"] is not None:
+            try:
                 after = fields.get_date_object(
                     args["after"], "%Y-%m-%dT%H:%M:%S"
                 )
-        except Exception:
-            return {
-                "error": True,
-                "message": "Wrong date format for before or after argument."
-                           "Expected format: 2020-01-05T13:23:10"
-            }, 400
+            except Exception:
+                try:
+                    after = fields.get_date_object(args["after"], "%Y-%m-%d")
+                except Exception:
+                    return {
+                        "error": True,
+                        "message": "Wrong date format for after argument."
+                            "Expected format: 2020-01-05T13:23:10 or 2020-01-05"
+                    }, 400
+
         page_size = args["page_size"]
         only_files = args["only_files"] == "true"
         return events_service.get_last_events(

--- a/zou/app/blueprints/source/__init__.py
+++ b/zou/app/blueprints/source/__init__.py
@@ -69,6 +69,7 @@ from .csv.casting import CastingCsvImportResource
 from .kitsu import (
     ImportKitsuCommentsResource,
     ImportKitsuEntitiesResource,
+    ImportKitsuEntityLinksResource,
     ImportKitsuProjectsResource,
     ImportKitsuTasksResource
 )
@@ -114,6 +115,7 @@ routes = [
     ("/import/csv/projects/<project_id>/casting", CastingCsvImportResource),
     ("/import/kitsu/comments", ImportKitsuCommentsResource),
     ("/import/kitsu/entities", ImportKitsuEntitiesResource),
+    ("/import/kitsu/entity-links", ImportKitsuEntityLinksResource),
     ("/import/kitsu/projects", ImportKitsuProjectsResource),
     ("/import/kitsu/tasks", ImportKitsuTasksResource),
 ]

--- a/zou/app/blueprints/source/kitsu.py
+++ b/zou/app/blueprints/source/kitsu.py
@@ -2,7 +2,7 @@ from flask import request
 from flask_restful import Resource
 from flask_jwt_extended import jwt_required
 
-from zou.app.models.entity import Entity
+from zou.app.models.entity import Entity, EntityLink
 from zou.app.models.project import Project
 from zou.app.models.task import Task
 from zou.app.mixin import ArgsMixin
@@ -55,3 +55,9 @@ class ImportKitsuTasksResource(BaseImportKitsuResource):
 
     def __init__(self):
         BaseImportKitsuResource.__init__(self, Task)
+
+
+class ImportKitsuEntityLinksResource(BaseImportKitsuResource):
+
+    def __init__(self):
+        BaseImportKitsuResource.__init__(self, EntityLink)

--- a/zou/app/blueprints/source/kitsu.py
+++ b/zou/app/blueprints/source/kitsu.py
@@ -7,6 +7,7 @@ from zou.app.models.project import Project
 from zou.app.models.task import Task
 from zou.app.mixin import ArgsMixin
 from zou.app.utils import fields, permissions
+from zou.app.services.exception import WrongParameterException
 
 
 class BaseImportKitsuResource(Resource, ArgsMixin):
@@ -19,6 +20,8 @@ class BaseImportKitsuResource(Resource, ArgsMixin):
     @permissions.require_admin
     def post(self):
         kitsu_entries = request.json
+        if type(kitsu_entries) != list:
+            raise WrongParameterException("A list of entities is expected.")
         instances = []
         for entry in kitsu_entries:
             if self.pre_check_entry():


### PR DESCRIPTION
**Problem**

* Breakdown raw data are not accessible to the project members except of admins
* Import function returns a 500 error when elements sent are not inside a list
* Breakdown links cannot be imported from another Kitsu
* Event route doesn't support simple dates for `after` and `before` filters

**Solution**

* Loosen permissions on breakdown raw data
* Send a 400 errors when elements are not a list
* Add an import route for breakdown links
* Allow to use date aside of datetimes on after and before routes
