### PR TITLE
[tasks] Allow to delete several tasks at once

### DIFF
--- a/tests/services/test_tasks_service.py
+++ b/tests/services/test_tasks_service.py
@@ -50,7 +50,8 @@ class TaskServiceTestCase(ApiDBTestCase):
         self.generate_fixture_output_type()
         self.generate_fixture_output_file()
 
-        self.task_id = self.task.id
+        self.project_id = str(self.project.id)
+        self.task_id = str(self.task.id)
         self.open_status_id = self.task_status.id
         self.wip_status_id = self.task_status_wip.id
         self.to_review_status_id = self.task_status_to_review.id
@@ -398,6 +399,24 @@ class TaskServiceTestCase(ApiDBTestCase):
             TaskNotFoundException,
             tasks_service.get_task,
             self.task_id
+        )
+
+    def test_remove_tasks(self):
+        self.working_file.delete()
+        self.output_file.delete()
+        task_id = str(self.task_id)
+        task2_id = str(self.generate_fixture_task("main 2").id)
+        task_ids = [task_id, task2_id]
+        deletion_service.remove_tasks(self.project_id, task_ids)
+        self.assertRaises(
+            TaskNotFoundException,
+            tasks_service.get_task,
+            task_id
+        )
+        self.assertRaises(
+            TaskNotFoundException,
+            tasks_service.get_task,
+            task2_id
         )
 
     def test_remove_task_force(self):

--- a/tests/tasks/test_route_task_change.py
+++ b/tests/tasks/test_route_task_change.py
@@ -111,6 +111,32 @@ class RouteTaskChangeTestCase(ApiDBTestCase):
         task = self.get("data/tasks/%s" % task_id)
         self.assertEqual(task["retake_count"], 2)
 
+    def test_comment_many(self):
+        project_id = str(self.project.id)
+        task_id = str(self.task.id)
+        self.generate_fixture_task(name="second_task")
+        task2_id = str(self.task.id)
+        path = "/actions/projects/%s/tasks/comment-many" % project_id
+        self.post(path, [
+            {
+                "task_status_id": self.retake_status_id,
+                "comment": "retake 1",
+                "object_id": task_id
+            },
+            {
+                "task_status_id": self.retake_status_id,
+                "comment": "retake 1",
+                "object_id": task2_id
+            }
+        ])
+        self.get("data/tasks/%s" % task_id)
+        task = self.get("data/tasks/%s" % task_id)
+        self.assertEqual(task["retake_count"], 1)
+        comments = self.get("data/tasks/%s/comments" % task_id)
+        self.assertEqual(len(comments), 1)
+        comments = self.get("data/tasks/%s/comments" % task2_id)
+        self.assertEqual(len(comments), 1)
+
     def test_attachments(self):
         self.delete_test_folder()
         self.create_test_folder()

--- a/tests/tasks/test_route_tasks.py
+++ b/tests/tasks/test_route_tasks.py
@@ -397,7 +397,7 @@ class TaskRoutesTestCase(ApiDBTestCase):
         tasks = self.get("/data/persons/%s/done-tasks" % self.person.id)
         self.assertEqual(len(tasks), 1)
 
-    def test_delete_all_task_types(self):
+    def test_delete_all_tasks_for_task_type(self):
         self.generate_fixture_project_standard()
         self.generate_fixture_asset_standard()
         task_1_id = str(self.generate_fixture_task().id)
@@ -405,7 +405,7 @@ class TaskRoutesTestCase(ApiDBTestCase):
         task_3_id = str(self.generate_fixture_shot_task().id)
         task_4_id = str(self.generate_fixture_task_standard().id)
         self.delete(
-            "/data/projects/%s/task-types/%s/tasks" % (
+            "/actions/projects/%s/task-types/%s/delete-tasks" % (
                 self.project.id,
                 self.task_type.id
             )
@@ -414,6 +414,24 @@ class TaskRoutesTestCase(ApiDBTestCase):
         self.get("/data/tasks/%s" % task_2_id, 404)
         self.get("/data/tasks/%s" % task_3_id)
         self.get("/data/tasks/%s" % task_4_id)
+
+    def test_delete_tasks(self):
+        self.generate_fixture_project_standard()
+        self.generate_fixture_asset_standard()
+        task_1_id = str(self.generate_fixture_task().id)
+        task_2_id = str(self.generate_fixture_task(name="second task").id)
+        task_3_id = str(self.generate_fixture_shot_task().id)
+        task_4_id = str(self.generate_fixture_task_standard().id)
+        self.post(
+            "/actions/projects/%s/delete-tasks" % self.project.id,
+            [task_1_id, task_2_id],
+            code=200
+        )
+        self.get("/data/tasks/%s" % task_1_id, 404)
+        self.get("/data/tasks/%s" % task_2_id, 404)
+        self.get("/data/tasks/%s" % task_3_id)
+        self.get("/data/tasks/%s" % task_4_id)
+
 
     def test_get_tasks_permissions(self):
         self.generate_fixture_user_vendor()

--- a/zou/app/blueprints/comments/__init__.py
+++ b/zou/app/blueprints/comments/__init__.py
@@ -17,7 +17,10 @@ routes = [
         DownloadAttachmentResource
     ),
     ("/actions/tasks/<task_id>/comment", CommentTaskResource),
-    ("/actions/project/<project_id>/tasks/comment-many", CommentManyTasksResource),
+    (
+        "/actions/projects/<project_id>/tasks/comment-many",
+        CommentManyTasksResource
+    ),
 ]
 
 blueprint = Blueprint("comments", "comments")

--- a/zou/app/blueprints/comments/resources.py
+++ b/zou/app/blueprints/comments/resources.py
@@ -1,16 +1,13 @@
-import datetime
 import json
 
 from flask import abort, request, send_file as flask_send_file
 from flask_restful import Resource, reqparse
 from flask_jwt_extended import jwt_required
 
-from zou.app.utils import events, permissions
+from zou.app.utils import permissions
 
 from zou.app.services import (
     comments_service,
-    notifications_service,
-    news_service,
     persons_service,
     tasks_service,
     user_service
@@ -106,7 +103,12 @@ class CommentTaskResource(Resource):
             checklist = args["checklist"]
             checklist = json.loads(checklist)
         else:
-            parser.add_argument("checklist", type=dict, action="append", default=[])
+            parser.add_argument(
+                "checklist",
+                type=dict,
+                action="append",
+                default=[]
+            )
             args = parser.parse_args()
             checklist = args["checklist"]
 
@@ -121,6 +123,10 @@ class CommentTaskResource(Resource):
 
 class CommentManyTasksResource(Resource):
     """
+    Create several comments at once. Each comment, requires a text, a task id,
+    task_status and a person as arguments. This way, comments keep history of
+    status changes. When the comment is created, it updates the task status with
+    given task status.
     """
 
     @jwt_required

--- a/zou/app/blueprints/tasks/__init__.py
+++ b/zou/app/blueprints/tasks/__init__.py
@@ -4,6 +4,7 @@ from zou.app.utils.api import configure_api_from_blueprint
 from .resources import (
     TaskFullResource,
     TaskForEntityResource,
+    DeleteTasksResource,
     DeleteAllTasksForTaskTypeResource,
     TaskAssignResource,
     TasksAssignResource,
@@ -41,15 +42,19 @@ routes = [
         "/data/entities/<entity_id>/task-types/<task_type_id>/tasks",
         TaskForEntityResource,
     ),
-    (
-        "/data/projects/<project_id>/task-types/<task_type_id>/tasks/",
-        DeleteAllTasksForTaskTypeResource,
-    ),
     ("/data/projects/<project_id>/comments", ProjectCommentsResource),
     ("/data/projects/<project_id>/notifications", ProjectNotificationsResource),
     ("/data/projects/<project_id>/preview-files", ProjectPreviewFilesResource),
     ("/data/projects/<project_id>/subscriptions", ProjectSubscriptionsResource),
     ("/data/projects/<project_id>/tasks", ProjectTasksResource),
+    (
+        "/actions/projects/<project_id>/task-types/<task_type_id>/delete-tasks",
+        DeleteAllTasksForTaskTypeResource,
+    ),
+    (
+        "/actions/projects/<project_id>/delete-tasks",
+        DeleteTasksResource,
+    ),
     ("/actions/tasks/<task_id>/assign", TaskAssignResource),
     ("/actions/tasks/clear-assignation", ClearAssignationResource),
     ("/actions/persons/<person_id>/assign", TasksAssignResource),

--- a/zou/app/blueprints/tasks/resources.py
+++ b/zou/app/blueprints/tasks/resources.py
@@ -16,7 +16,6 @@ from zou.app.services import (
     entities_service,
     files_service,
     file_tree_service,
-    news_service,
     notifications_service,
     persons_service,
     projects_service,
@@ -547,6 +546,22 @@ class DeleteAllTasksForTaskTypeResource(Resource):
         return "", 204
 
 
+class DeleteTasksResource(Resource):
+    """
+    Delete tasks matching id list given in parameter. See it as a way to batch
+    delete tasks.
+    """
+
+    @jwt_required
+    def post(self, project_id):
+        user_service.check_manager_project_access(project_id)
+        task_ids = request.json
+        task_ids = deletion_service.remove_tasks(project_id, task_ids)
+        for task_id in task_ids:
+            tasks_service.clear_task_cache(task_id)
+        return task_ids, 200
+
+
 class ProjectSubscriptionsResource(Resource):
     """
     Retrieve all subcriptions to tasks related to given project.
@@ -554,8 +569,8 @@ class ProjectSubscriptionsResource(Resource):
     """
 
     @jwt_required
+    @permissions.require_admin
     def get(self, project_id):
-        permissions.check_admin_permissions()
         projects_service.get_project(project_id)
         return notifications_service.get_subscriptions_for_project(project_id)
 
@@ -567,8 +582,8 @@ class ProjectNotificationsResource(Resource, ArgsMixin):
     """
 
     @jwt_required
+    @permissions.require_admin
     def get(self, project_id):
-        permissions.check_admin_permissions()
         projects_service.get_project(project_id)
         page = self.get_page()
         return notifications_service.get_notifications_for_project(
@@ -583,8 +598,8 @@ class ProjectTasksResource(Resource, ArgsMixin):
     """
 
     @jwt_required
+    @permissions.require_admin
     def get(self, project_id):
-        permissions.check_admin_permissions()
         projects_service.get_project(project_id)
         page = self.get_page()
         return tasks_service.get_tasks_for_project(project_id, page)
@@ -597,8 +612,8 @@ class ProjectCommentsResource(Resource, ArgsMixin):
     """
 
     @jwt_required
+    @permissions.require_admin
     def get(self, project_id):
-        permissions.check_admin_permissions()
         projects_service.get_project(project_id)
         page = self.get_page()
         return tasks_service.get_comments_for_project(project_id, page)
@@ -611,8 +626,8 @@ class ProjectPreviewFilesResource(Resource, ArgsMixin):
     """
 
     @jwt_required
+    @permissions.require_admin
     def get(self, project_id):
-        permissions.check_admin_permissions()
         projects_service.get_project(project_id)
         page = self.get_page()
         return files_service.get_preview_files_for_project(project_id, page)

--- a/zou/app/services/deletion_service.py
+++ b/zou/app/services/deletion_service.py
@@ -23,7 +23,7 @@ from zou.app.models.task import Task
 from zou.app.models.time_spent import TimeSpent
 from zou.app.models.working_file import WorkingFile
 
-from zou.app.utils import events
+from zou.app.utils import events, fields
 from zou.app.stores import file_store
 
 from zou.app.services.exception import (
@@ -198,6 +198,24 @@ def clear_generic_files(preview_file_id):
         file_store.remove_file("previews", preview_file_id)
     except:
         pass
+
+
+def remove_tasks(project_id, task_ids):
+    """
+    Remove fully given tasks and related for given project. The project id
+    filter is there to facilitate right management.
+    """
+    task_ids = [
+        task_id for task_id in task_ids if fields.is_valid_id(task_id)
+    ]
+    tasks = (
+        Task.query
+        .filter(Project.id == project_id)
+        .filter(Task.id.in_(task_ids))
+    )
+    for task in tasks:
+        remove_task(task.id, force=True)
+    return task_ids
 
 
 def remove_tasks_for_project_and_task_type(project_id, task_type_id):


### PR DESCRIPTION
**Problem**

* It's not possible to delete tasks in a single request. That makes things very slow when a lot of deletion is needed.

**Solution**

* Add a route that expects a list of task IDs in the request body and runs deletion on all of them.
