### PR TITLE
Allow to create tasks for an entity list and a task type

### DIFF
--- a/tests/services/test_tasks_service.py
+++ b/tests/services/test_tasks_service.py
@@ -100,6 +100,20 @@ class TaskServiceTestCase(ApiDBTestCase):
         self.assertEqual(task["project_id"], shot["project_id"])
         self.assertEqual(task["task_status_id"], status["id"])
 
+    def test_create_tasks(self):
+        shot = self.shot.serialize()
+        shot_2 = self.generate_fixture_shot("S02").serialize()
+        task_type = self.task_type.serialize()
+        status = tasks_service.get_todo_status()
+        tasks = tasks_service.create_tasks(task_type, [shot, shot_2])
+        self.assertEqual(len(tasks), 2)
+        task = tasks[0]
+        task = tasks_service.get_task(task["id"])
+        self.assertEqual(task["entity_id"], shot["id"])
+        self.assertEqual(task["task_type_id"], task_type["id"])
+        self.assertEqual(task["project_id"], shot["project_id"])
+        self.assertEqual(task["task_status_id"], status["id"])
+
     def test_status_to_wip(self):
         events.register(
             "task:start",

--- a/tests/tasks/test_route_tasks.py
+++ b/tests/tasks/test_route_tasks.py
@@ -41,11 +41,30 @@ class TaskRoutesTestCase(ApiDBTestCase):
         self.person_id = self.person.id
 
     def test_create_asset_tasks(self):
-        path = "/actions/task-types/%s/assets/create-tasks" % self.task_type_id
-        path += "?project_id=%s" % self.project.id
+        self.generate_fixture_asset_types()
+        self.generate_fixture_asset_character()
+        path = "/actions/projects/%s/task-types/%s/assets/create-tasks" % (
+            self.project.id,
+            self.task_type_id
+        )
         tasks = self.post(path, {})
-        self.assertEqual(len(tasks), 1)
+        self.assertEqual(len(tasks), 2)
 
+        tasks = self.get("/data/tasks")
+        self.assertEqual(len(tasks), 2)
+        task = tasks[0]
+        self.assertEqual(task["name"], "main")
+        self.assertEqual(task["task_type_id"], self.task_type_id)
+
+    def test_create_asset_tasks_from_list(self):
+        self.generate_fixture_asset_types()
+        self.generate_fixture_asset_character()
+        path = "/actions/projects/%s/task-types/%s/assets/create-tasks" % (
+            self.project.id,
+            self.task_type_id,
+        )
+        tasks = self.post(path, [self.asset_id])
+        self.assertEqual(len(tasks), 1)
         tasks = self.get("/data/tasks")
         self.assertEqual(len(tasks), 1)
         task = tasks[0]
@@ -54,8 +73,10 @@ class TaskRoutesTestCase(ApiDBTestCase):
         self.assertEqual(task["entity_id"], self.asset_id)
 
     def test_create_shot_tasks(self):
-        path = "/actions/task-types/%s/shots/create-tasks" % self.task_type_id
-        path += "?project_id=%s" % self.project.id
+        path = "/actions/projects/%s/task-types/%s/shots/create-tasks" % (
+            self.project.id,
+            self.task_type_id
+        )
         tasks = self.post(path, {})
         self.assertEqual(len(tasks), 1)
 

--- a/zou/app/blueprints/tasks/__init__.py
+++ b/zou/app/blueprints/tasks/__init__.py
@@ -79,11 +79,11 @@ routes = [
     ),
     ("/actions/tasks/<task_id>/to-review", ToReviewResource),
     (
-        "/actions/task-types/<task_type_id>/shots/create-tasks",
+        "/actions/projects/<project_id>/task-types/<task_type_id>/shots/create-tasks",
         CreateShotTasksResource,
     ),
     (
-        "/actions/task-types/<task_type_id>/assets/create-tasks",
+        "/actions/projects/<project_id>/task-types/<task_type_id>/assets/create-tasks",
         CreateAssetTasksResource,
     ),
 ]

--- a/zou/app/blueprints/tasks/resources.py
+++ b/zou/app/blueprints/tasks/resources.py
@@ -192,15 +192,24 @@ class CreateShotTasksResource(Resource):
     """
 
     @jwt_required
-    def post(self, task_type_id):
-        criterions = query.get_query_criterions_from_request(request)
-        if "project_id" not in criterions:
-            return {"error": True, "message": "Project ID is missing"}, 400
-
-        user_service.check_manager_project_access(criterions["project_id"])
-        shots = shots_service.get_shots(criterions)
+    def post(self, project_id, task_type_id):
+        user_service.check_manager_project_access(project_id)
         task_type = tasks_service.get_task_type(task_type_id)
-        tasks = [tasks_service.create_task(task_type, shot) for shot in shots]
+
+        shot_ids = request.json
+        shots = []
+        if type(shot_ids) == list and len(shot_ids) > 0:
+            for shot_id in shot_ids:
+                shot = shots_service.get_shot(shot_id)
+                if shot["project_id"] == project_id:
+                    shots.append(shot)
+        else:
+            criterions = query.get_query_criterions_from_request(request)
+            criterions["project_id"] = project_id
+            shots = shots_service.get_shots(criterions)
+
+        task_type = tasks_service.get_task_type(task_type_id)
+        tasks = tasks_service.create_tasks(task_type, shots)
         return tasks, 201
 
 
@@ -210,17 +219,23 @@ class CreateAssetTasksResource(Resource):
     """
 
     @jwt_required
-    def post(self, task_type_id):
-        criterions = query.get_query_criterions_from_request(request)
-        if "project_id" not in criterions:
-            return {"error": True, "message": "Project ID is missing"}, 400
-
-        user_service.check_manager_project_access(criterions["project_id"])
-        assets = assets_service.get_assets(criterions)
+    def post(self, project_id, task_type_id):
+        user_service.check_manager_project_access(project_id)
         task_type = tasks_service.get_task_type(task_type_id)
-        tasks = [
-            tasks_service.create_task(task_type, asset) for asset in assets
-        ]
+
+        asset_ids = request.json
+        assets = []
+        if type(asset_ids) == list and len(asset_ids) > 0:
+            for asset_id in asset_ids:
+                asset = assets_service.get_asset(asset_id)
+                if asset["project_id"] == project_id:
+                    assets.append(asset)
+        else:
+            criterions = query.get_query_criterions_from_request(request)
+            criterions["project_id"] = project_id
+            assets = assets_service.get_assets(criterions)
+
+        tasks = tasks_service.create_tasks(task_type, assets)
         return tasks, 201
 
 

--- a/zou/app/services/comments_service.py
+++ b/zou/app/services/comments_service.py
@@ -258,7 +258,7 @@ def acknowledge_comment(comment_id):
 def _ack_comment(project_id, comment, user):
     user_id = str(user.id)
     comment.acknowledgements.append(user)
-    _send_ack_event(comment, user_id, "acknowledge")
+    _send_ack_event(project_id, comment, user_id, "acknowledge")
 
 
 def _unack_comment(project_id, comment, user):


### PR DESCRIPTION
**Problem**

It is not possible to create tasks for an entity task list and a given task type. In the Kitsu UX, it results in complex actions to create tasks: you have to create many tasks and remove the unwanted task after.

**Solution**

Allow to send a list of entity IDS in the create-tasks route to create tasks only for this selection.
It was the opportunity too, to improve performances a little bit.