### PR TITLE
Update log_rotation.md

### DIFF
--- a/docs/log_rotation.md
+++ b/docs/log_rotation.md
@@ -17,7 +17,7 @@ RuntimeDirectory=zou
 Add this to the ExecStart line to create the pid file for zou
 
 ```
--p /var/run/zou/zou.pid
+-p /run/zou/zou.pid
 ```
 For example:
 > ExecStart=/opt/zou/zouenv/bin/gunicorn -p /run/zou/zou.pid  -c /etc/zou/gunicorn.conf -b 127.0.0.1:5000 zou.app:app
@@ -26,7 +26,7 @@ Edit the zou-events unit file to create the pid file for zou-events
 (`/etc/systemd/system/zou-events.service`):
 
 ```
--p /var/run/zou/zou-events.pid
+-p /run/zou/zou-events.pid
 ```
 
 PIDs are now stored in mentioned files. 


### PR DESCRIPTION
Tidying inconsistent /run directory paths

**Problem**
run directory paths were using a mix of /var/run and /run

**Solution**
removed /var from paths
