### PR TITLE
Improve Newsfeed route

### DIFF
--- a/zou/app/blueprints/events/resources.py
+++ b/zou/app/blueprints/events/resources.py
@@ -19,37 +19,8 @@ class EventsResource(Resource, ArgsMixin):
             ("project_id", None, False),
         ])
         permissions.check_manager_permissions()
-        before = None
-        after = None
-
-        if args["before"] is not None:
-            try:
-                before = fields.get_date_object(
-                    args["before"], "%Y-%m-%dT%H:%M:%S"
-                )
-            except Exception:
-                try:
-                    before = fields.get_date_object(args["before"], "%Y-%m-%d")
-                except Exception:
-                    raise WrongParameterException(
-                        "Wrong date format for before argument."
-                        "Expected format: 2020-01-05T13:23:10 or 2020-01-05"
-                    )
-
-        if args["after"] is not None:
-            try:
-                after = fields.get_date_object(
-                    args["after"], "%Y-%m-%dT%H:%M:%S"
-                )
-            except Exception:
-                try:
-                    after = fields.get_date_object(args["after"], "%Y-%m-%d")
-                except Exception:
-                    raise WrongParameterException(
-                        "Wrong date format for after argument."
-                        "Expected format: 2020-01-05T13:23:10 or 2020-01-05"
-                    )
-
+        before = self.parse_date_parameter(args["before"])
+        after = self.parse_date_parameter(args["after"])
         page_size = args["page_size"]
         only_files = args["only_files"] == "true"
         project_id = args.get("project_id", None)

--- a/zou/app/blueprints/news/resources.py
+++ b/zou/app/blueprints/news/resources.py
@@ -1,10 +1,11 @@
 from flask_restful import Resource, reqparse
 from flask_jwt_extended import jwt_required
 
+from zou.app.mixin import ArgsMixin
 from zou.app.services import news_service, projects_service, user_service
 
 
-class ProjectNewsResource(Resource):
+class ProjectNewsResource(Resource, ArgsMixin):
     @jwt_required
     def get(self, project_id):
         (
@@ -14,10 +15,14 @@ class ProjectNewsResource(Resource):
             person_id,
             page,
             page_size,
+            after,
+            before
         ) = self.get_arguments()
         projects_service.get_project(project_id)
         user_service.check_project_access(project_id)
         user_service.block_access_to_vendor()
+        after = self.parse_date_parameter(after)
+        before = self.parse_date_parameter(before)
         return news_service.get_last_news_for_project(
             project_id,
             only_preview=only_preview,
@@ -26,6 +31,8 @@ class ProjectNewsResource(Resource):
             author_id=person_id,
             page=page,
             page_size=page_size,
+            after=after,
+            before=before,
         )
 
     def get_arguments(self):
@@ -36,6 +43,8 @@ class ProjectNewsResource(Resource):
         parser.add_argument("person_id", default=None)
         parser.add_argument("page", default=1, type=int)
         parser.add_argument("page_size", default=50, type=int)
+        parser.add_argument("after", default=None)
+        parser.add_argument("before", default=None)
         args = parser.parse_args()
 
         return (
@@ -45,6 +54,8 @@ class ProjectNewsResource(Resource):
             args["person_id"],
             args["page"],
             args["page_size"],
+            args["after"],
+            args["before"],
         )
 
 

--- a/zou/app/blueprints/news/resources.py
+++ b/zou/app/blueprints/news/resources.py
@@ -23,7 +23,7 @@ class ProjectNewsResource(Resource, ArgsMixin):
         user_service.block_access_to_vendor()
         after = self.parse_date_parameter(after)
         before = self.parse_date_parameter(before)
-        return news_service.get_last_news_for_project(
+        result = news_service.get_last_news_for_project(
             project_id,
             only_preview=only_preview,
             task_type_id=task_type_id,
@@ -34,6 +34,16 @@ class ProjectNewsResource(Resource, ArgsMixin):
             after=after,
             before=before,
         )
+        stats = news_service.get_news_stats_for_project(
+            project_id,
+            task_type_id=task_type_id,
+            task_status_id=task_status_id,
+            author_id=person_id,
+            after=after,
+            before=before,
+        )
+        result["stats"] = stats
+        return result
 
     def get_arguments(self):
         parser = reqparse.RequestParser()

--- a/zou/app/blueprints/persons/resources.py
+++ b/zou/app/blueprints/persons/resources.py
@@ -38,9 +38,7 @@ class NewPersonResource(Resource):
         parser.add_argument(
             "first_name", help="The first name is required.", required=True
         )
-        parser.add_argument(
-            "last_name", help="The last name is required.", required=True
-        )
+        parser.add_argument("last_name", default="")
         parser.add_argument("phone", default="")
         parser.add_argument("role", default="user")
         parser.add_argument("desktop_login", default="")

--- a/zou/app/mixin.py
+++ b/zou/app/mixin.py
@@ -1,6 +1,9 @@
 from flask_restful import reqparse
 from flask import request
 
+from zou.app.utils import fields
+from zou.app.services.exception import WrongParameterException
+
 
 class ArgsMixin(object):
     """
@@ -59,3 +62,19 @@ class ArgsMixin(object):
         """
         options = request.args
         return options.get("episode_id", None)
+
+    def parse_date_parameter(self, param):
+        date = None
+        if param is None:
+            return date
+        try:
+            date = fields.get_date_object(param, "%Y-%m-%dT%H:%M:%S")
+        except Exception:
+            try:
+                date = fields.get_date_object(param, "%Y-%m-%d")
+            except Exception:
+                raise WrongParameterException(
+                    "Wrong date format for before argument."
+                    "Expected format: 2020-01-05T13:23:10 or 2020-01-05"
+                )
+        return date


### PR DESCRIPTION
**Problem**

* It's not possible to filters news list with dates
* News route don't return full statistics about the query

**Solution**

* Allow to give `before` and `after` parameter to the news route
* Return a paginated result, news list is stored in the `data` field. Page and total information are returned alongside the result.
* Add a `stats` field to the result giving numbers of status change by status for current list
