### PR TITLE
Notification and previews

### DIFF
--- a/tests/user/test_route_context.py
+++ b/tests/user/test_route_context.py
@@ -445,7 +445,7 @@ class UserContextRoutesTestCase(ApiDBTestCase):
         self.assertEqual(len(context["task_status"]), 3)
         self.assertEqual(len(context["project_status"]), 2)
         self.assertEqual(len(context["persons"]), 3)
-        self.assertEqual(len(context["notifications"]), 0)
+        self.assertEqual(context["notification_count"], 0)
         self.assertEqual(len(context["search_filters"]), 0)
         self.assertEqual(len(context["custom_actions"]), 0)
 

--- a/zou/app/blueprints/news/resources.py
+++ b/zou/app/blueprints/news/resources.py
@@ -46,6 +46,7 @@ class ProjectNewsResource(Resource, ArgsMixin):
         result["stats"] = stats
         return result
 
+
     def get_arguments(self):
         parser = reqparse.RequestParser()
         parser.add_argument("only_preview", default=False, type=bool)

--- a/zou/app/blueprints/previews/resources.py
+++ b/zou/app/blueprints/previews/resources.py
@@ -10,6 +10,7 @@ from zou.app import config
 from zou.app.mixin import ArgsMixin
 from zou.app.stores import file_store
 from zou.app.services import (
+    assets_service,
     deletion_service,
     entities_service,
     files_service,
@@ -745,9 +746,12 @@ class SetMainPreviewResource(Resource):
         task = tasks_service.get_task(preview_file["task_id"])
         user_service.check_project_access(task["project_id"])
         user_service.check_entity_access(task["entity_id"])
-        return entities_service.update_entity_preview(
+        asset = entities_service.update_entity_preview(
             task["entity_id"], preview_file_id
         )
+        assets_service.clear_asset_cache(asset["id"])
+        shots_service.clear_shot_cache(asset["id"])
+        return asset
 
 
 class UpdatePreviewPositionResource(Resource, ArgsMixin):

--- a/zou/app/blueprints/user/resources.py
+++ b/zou/app/blueprints/user/resources.py
@@ -296,16 +296,34 @@ class DesktopLoginLogsResource(Resource):
         return parser.parse_args()
 
 
-class NotificationsResource(Resource):
+class NotificationsResource(Resource, ArgsMixin):
     """
     Return last 100 user notifications.
     """
 
     @jwt_required
     def get(self):
-        notifications = user_service.get_last_notifications()
+        (
+            after,
+            before
+        ) = self.get_arguments()
+        notifications = user_service.get_last_notifications(
+            after=after,
+            before=before
+        )
         user_service.mark_notifications_as_read()
         return notifications
+
+    def get_arguments(self):
+        parser = reqparse.RequestParser()
+        parser.add_argument("after", default=None)
+        parser.add_argument("before", default=None)
+        args = parser.parse_args()
+
+        return (
+            args["after"],
+            args["before"],
+        )
 
 
 class NotificationResource(Resource):

--- a/zou/app/services/entities_service.py
+++ b/zou/app/services/entities_service.py
@@ -15,6 +15,10 @@ from zou.app.services.exception import (
 )
 
 
+def clear_entity_cache(entity_id):
+    cache.cache.delete_memoized(get_entity, entity_id)
+
+
 def clear_entity_type_cache(entity_type_id):
     cache.cache.delete_memoized(get_entity_type, entity_type_id)
     cache.cache.delete_memoized(get_entity_type_by_name)
@@ -75,6 +79,7 @@ def update_entity_preview(entity_id, preview_file_id):
         raise PreviewFileNotFoundException
 
     entity.update({"preview_file_id": preview_file.id})
+    clear_entity_cache(str(entity.id))
     events.emit(
         "preview-file:set-main",
         {"entity_id": entity_id, "preview_file_id": preview_file_id},


### PR DESCRIPTION
**Problem**

* Set main preview route doesn't clear the cache (which leads to unexpected behaviour in Kitsu)
* Context route returns all notifications which is useless
* It's not possible to retrieve notifications preceding the last ones.

**Solution**

* Clear properly cache when a preview is set as main preview.
* Return only unread notification count in context
* Allow to filter last notifications route with °after` and `before` parameters
