### PR TITLE
Allow to limit the number of user per instance

### DIFF
--- a/tests/services/test_persons_service.py
+++ b/tests/services/test_persons_service.py
@@ -112,3 +112,12 @@ class PersonServiceTestCase(ApiDBTestCase):
         self.assertEqual(len(logs), 2)
         self.assertEqual(logs[0]["person_id"], person["id"])
         self.assertEqual(logs[0]["date"], date_2)
+
+    def test_is_user_limit_reached(self):
+        is_reached = persons_service.is_user_limit_reached()
+        self.assertEqual(is_reached, False)
+        from zou.app import config
+        config.USER_LIMIT = 2
+        is_reached = persons_service.is_user_limit_reached()
+        self.assertEqual(is_reached, True)
+        config.USER_LIMIT = 100

--- a/zou/app/blueprints/crud/person.py
+++ b/zou/app/blueprints/crud/person.py
@@ -9,6 +9,8 @@ from .base import BaseModelsResource, BaseModelResource
 
 from zou.app.mixin import ArgsMixin
 
+from zou.app.services.exception import WrongParameterException
+
 
 class PersonsResource(BaseModelsResource):
     def __init__(self):
@@ -65,6 +67,13 @@ class PersonResource(BaseModelResource, ArgsMixin):
             return instance.serialize_safe()
         else:
             return instance.present_minimal()
+
+    def pre_update(self, instance_dict, data):
+        if data.get("active", False) \
+           and not instance_dict.get("active", False) \
+           and persons_service.is_user_limit_reached():
+            raise WrongParameterException("User limit reached.")
+        return instance_dict
 
     def post_update(self, instance_dict):
         persons_service.clear_person_cache()

--- a/zou/app/blueprints/persons/resources.py
+++ b/zou/app/blueprints/persons/resources.py
@@ -8,6 +8,8 @@ from zou.app.services import persons_service, user_service, time_spents_service
 from zou.app.utils import auth, permissions, csv_utils
 from zou.app.services.exception import WrongDateFormatException
 
+from zou.app import config
+
 
 class NewPersonResource(Resource):
     """
@@ -19,15 +21,23 @@ class NewPersonResource(Resource):
     def post(self):
         permissions.check_admin_permissions()
         data = self.get_arguments()
-        person = persons_service.create_person(
-            data["email"],
-            auth.encrypt_password("default"),
-            data["first_name"],
-            data["last_name"],
-            data["phone"],
-            role=data["role"],
-            desktop_login=data["desktop_login"],
-        )
+
+        if persons_service.is_user_limit_reached():
+            return {
+                "error": True,
+                "message": "User limit reached.",
+                "limit": config.USER_LIMIT,
+            }, 400
+        else:
+            person = persons_service.create_person(
+                data["email"],
+                auth.encrypt_password("default"),
+                data["first_name"],
+                data["last_name"],
+                data["phone"],
+                role=data["role"],
+                desktop_login=data["desktop_login"],
+            )
         return person, 201
 
     def get_arguments(self):

--- a/zou/app/config.py
+++ b/zou/app/config.py
@@ -101,6 +101,8 @@ LOGS_TOKEN = os.getenv("LOGS_TOKEN")
 
 CRISP_TOKEN = os.getenv("CRISP_TOKEN", "")
 
+USER_LIMIT = int(os.getenv("USER_LIMIT", "100"))
+
 # Deprecated
 DONE_TASK_STATUS = "Done"
 WIP_TASK_STATUS = "WIP"

--- a/zou/app/services/persons_service.py
+++ b/zou/app/services/persons_service.py
@@ -356,3 +356,12 @@ def update_organisation(organisation_id, data):
     organisation.update(data)
     events.emit("organisation:update", {"organisation_id": organisation_id})
     return organisation.present()
+
+
+def is_user_limit_reached():
+    """
+    Returns true if the number of active users is equal and superior to the
+    user limit set in the configuration.
+    """
+    nb_active_users = Person.query.filter(Person.active).count()
+    return nb_active_users >= config.USER_LIMIT


### PR DESCRIPTION
**Problem**

Our customers creates often too many accounts. When we ask them to upgrade their plan it felt weird for them. Allowing to limit an instance number of seats would allow a saner workflow.

**Solution**

Add an env variable to limit the number of users (100 by default).
