### PR TITLE
[auth/person] Add feature to protect(hide) some fields on serializer

### DIFF
--- a/zou/app/blueprints/auth/resources.py
+++ b/zou/app/blueprints/auth/resources.py
@@ -135,7 +135,6 @@ class AuthenticatedResource(Resource):
     def get(self):
         try:
             person = persons_service.get_person_by_email(get_jwt_identity())
-            del person["password"]
             organisation = persons_service.get_organisation()
             return {
                 "authenticated": True,
@@ -185,7 +184,6 @@ class LoginResource(Resource):
         (email, password) = self.get_arguments()
         try:
             user = auth_service.check_auth(app, email, password)
-            del user["password"]
 
             if auth_service.is_default_password(app, password):
                 token = uuid.uuid4()

--- a/zou/app/models/base.py
+++ b/zou/app/models/base.py
@@ -19,6 +19,9 @@ class BaseMixin(object):
         onupdate=datetime.datetime.utcnow,
     )
 
+    class Meta:
+        exclude_serializes = ()
+
     def __repr__(self):
         """
         String representation based on type and name by default.

--- a/zou/app/models/person.py
+++ b/zou/app/models/person.py
@@ -50,6 +50,9 @@ class Person(db.Model, BaseMixin, SerializerMixin):
 
     skills = db.relationship("Department", secondary=department_link)
 
+    class Meta:
+        exclude_serializes = ('password',)
+
     def __repr__(self):
         if sys.version_info[0] < 3:
             return "<Person %s>" % self.full_name().encode("utf-8")
@@ -67,7 +70,6 @@ class Person(db.Model, BaseMixin, SerializerMixin):
     def serialize_safe(self, relations=False):
         data = SerializerMixin.serialize(self, "Person", relations=relations)
         data["full_name"] = self.full_name()
-        del data["password"]
         return data
 
     def present_minimal(self, relations=False):

--- a/zou/app/models/serializer.py
+++ b/zou/app/models/serializer.py
@@ -15,7 +15,11 @@ class SerializerMixin(object):
         )
 
     def serialize(self, obj_type=None, relations=False):
-        attrs = inspect(self).attrs.keys()
+        exclude_fields = self.__class__.Meta.exclude_serializes
+        attrs = filter(lambda attr: attr not in exclude_fields, inspect(self).attrs.keys())
+        if not isinstance(attrs, list):
+            attrs = list(attrs)
+
         if relations:
             obj_dict = {
                 attr: serialize_value(getattr(self, attr)) for attr in attrs

--- a/zou/app/services/auth_service.py
+++ b/zou/app/services/auth_service.py
@@ -53,29 +53,29 @@ def check_credentials(email, password, app=None):
     Password hash comparison is based on BCrypt.
     """
     try:
-        person = persons_service.get_person_by_email(email)
+        person = persons_service.get_person_by_email_raw(email)
     except PersonNotFoundException:
         try:
-            person = persons_service.get_person_by_desktop_login(email)
+            person = persons_service.get_person_by_desktop_login_raw(email)
         except PersonNotFoundException:
             if app is not None:
                 app.logger.error("Person not found: %s" % (email))
             raise WrongPasswordException()
 
     try:
-        password_hash = person["password"] or u""
+        password_hash = person.password or u""
 
         if bcrypt.check_password_hash(password_hash, password):
-            return person
+            return person.serialize()
         else:
             if app is not None:
                 app.logger.error(
-                    "Wrong password for person: %s" % person["full_name"]
+                    "Wrong password for person: %s" % person.full_name
                 )
             raise WrongPasswordException()
     except ValueError:
         if app is not None:
-            app.logger.error("Wrong password for: %s" % person["full_name"])
+            app.logger.error("Wrong password for: %s" % person.full_name)
         raise WrongPasswordException()
 
 

--- a/zou/app/services/persons_service.py
+++ b/zou/app/services/persons_service.py
@@ -118,11 +118,9 @@ def get_person_by_email(email):
     return person.serialize()
 
 
-@cache.memoize_function(120)
-def get_person_by_desktop_login(desktop_login):
+def get_person_by_desktop_login_raw(desktop_login):
     """
-    Return person that matches given desktop login as a dictionary. It is useful
-    to authenticate user from their desktop session login.
+    Return person that matches given desktop_login as an active record.
     """
     try:
         person = Person.get_by(desktop_login=desktop_login)
@@ -131,6 +129,16 @@ def get_person_by_desktop_login(desktop_login):
 
     if person is None:
         raise PersonNotFoundException()
+    return person
+
+
+@cache.memoize_function(120)
+def get_person_by_desktop_login(desktop_login):
+    """
+    Return person that matches given desktop login as a dictionary. It is useful
+    to authenticate user from their desktop session login.
+    """
+    person = get_person_by_desktop_login_raw(desktop_login)
     return person.serialize()
 
 


### PR DESCRIPTION
**Problem**

Related issue: [Encrypted password shown on comment api response #614](https://github.com/cgwire/kitsu/issues/614)

**Solution**

Create `Meta` class on base models and put `exclude_serializes` on its property. The `exclude_serializes` used to protect/hide some fields like `password` field on person models. Then the protected fields are not serialized and not returned in any api/json response.