### PR TITLE
[events] add methods to app.route

### DIFF
--- a/zou/event_stream.py
+++ b/zou/event_stream.py
@@ -21,7 +21,7 @@ def create_app(redis_url):
     app = Flask(__name__)
     app.config.from_object(config)
 
-    @app.route("/")
+    @app.route("/", methods=['GET', 'POST'])
     def index():
         return jsonify({"name": "%s Event stream" % config.APP_NAME})
 


### PR DESCRIPTION
the websocket calls returned the error code 405 (method not allowed). Adding the methods to app.route fixed the problem but I'm not sure it needs other methods too.