### PR TITLE
Update the "Development environment" section

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -62,7 +62,7 @@ pip install -r requirements.txt
 
 ## Init data
 
-Create a database in postgres named `zou` with user `postgres` and password
+Create a database in postgres named `zoudb` with user `postgres` and password
 `mysecretpassword`. Then init db:
 
 ```bash

--- a/docs/development.md
+++ b/docs/development.md
@@ -92,7 +92,7 @@ To run the Server Events server used to update the web GUI in realtime, use the
 following command.
 
 ```bash
-gunicorn --worker-class geventwebsocket.gunicorn.workers.GeventWebSocketWorker -b 127.0.0.1:5001 -w 3 zou.event_stream:app
+gunicorn --worker-class geventwebsocket.gunicorn.workers.GeventWebSocketWorker -b 127.0.0.1:5001 -w 1 zou.event_stream:app
 ```
 
 ## Tests

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,7 +1,7 @@
 # Development environment
 
 To start with developing on Zou you need Python 3 installed and a
-Postgres database instance. 
+Postgres database instance.
 
 ## Database
 
@@ -31,7 +31,7 @@ sudo docker run \
 
 ## FFMPEG
 
-For video operations, it is required to have FFMPEG installed. For that, simply install it through your OS package manager: 
+For video operations, it is required to have FFMPEG installed. For that, simply install it through your OS package manager:
 
 ```
 sudo apt-get install ffmpeg
@@ -57,7 +57,7 @@ workon zou
 Install dependencies:
 
 ```bash
-pip install -r requirements.txt 
+pip install -r requirements.txt
 ```
 
 ## Init data

--- a/docs/development.md
+++ b/docs/development.md
@@ -92,7 +92,7 @@ To run the Server Events server used to update the web GUI in realtime, use the
 following command.
 
 ```bash
-gunicorn --worker-class gevent -b 127.0.0.1:5001 -w 3 zou.event_stream:app
+gunicorn --worker-class geventwebsocket.gunicorn.workers.GeventWebSocketWorker -b 127.0.0.1:5001 -w 3 zou.event_stream:app
 ```
 
 ## Tests


### PR DESCRIPTION
Synchronize the `Development environment` section with the `install` section:
* database: use `zoudb` instead of `zou`
* gunicorn:
  * use `GeventWebSocketWorker` worker class in order to support WebSocket.
  * follow `flask-socketio` [recommendation](https://flask-socketio.readthedocs.io/en/latest/#gunicorn-web-server): use only one worker process
* remove trailing spaces