### PR TITLE
Improve previews

### DIFF
--- a/zou/app/blueprints/persons/resources.py
+++ b/zou/app/blueprints/persons/resources.py
@@ -302,8 +302,13 @@ class DayOffForMonthResource(Resource, ArgsMixin):
 
     @jwt_required
     def get(self, year, month):
-        permissions.check_admin_permissions()
-        return time_spents_service.get_day_offs_for_month(year, month)
+        if permissions.has_admin_permissions():
+            return time_spents_service.get_day_offs_for_month(year, month)
+        else:
+            person_id = persons_service.get_current_user()["id"]
+            return time_spents_service.get_person_day_offs_for_month(
+                person_id, year, month
+            )
 
 
 class PersonWeekDayOffResource(Resource, ArgsMixin):
@@ -313,7 +318,9 @@ class PersonWeekDayOffResource(Resource, ArgsMixin):
 
     @jwt_required
     def get(self, person_id, year, week):
-        permissions.check_admin_permissions()
+        user_id = persons_service.get_current_user()["id"]
+        if person_id != user_id:
+            permissions.check_admin_permissions()
         return time_spents_service.get_person_day_offs_for_week(
             person_id, year, week
         )
@@ -326,7 +333,9 @@ class PersonMonthDayOffResource(Resource, ArgsMixin):
 
     @jwt_required
     def get(self, person_id, year, month):
-        permissions.check_admin_permissions()
+        user_id = persons_service.get_current_user()["id"]
+        if person_id != user_id:
+            permissions.check_admin_permissions()
         return time_spents_service.get_person_day_offs_for_month(
             person_id, year, month
         )
@@ -339,7 +348,9 @@ class PersonYearDayOffResource(Resource, ArgsMixin):
 
     @jwt_required
     def get(self, person_id, year):
-        permissions.check_admin_permissions()
+        user_id = persons_service.get_current_user()["id"]
+        if person_id != user_id:
+            permissions.check_admin_permissions()
         return time_spents_service.get_person_day_offs_for_year(person_id, year)
 
 

--- a/zou/app/blueprints/previews/resources.py
+++ b/zou/app/blueprints/previews/resources.py
@@ -166,23 +166,7 @@ def send_storage_file(
         )
     except IOError as e:
         current_app.logger.error(e)
-        return (
-            {
-                "error": True,
-                "message": "File not found for: %s %s"
-                % (prefix, preview_file_id),
-            },
-            404,
-        )
-    except FileNotFound:
-        return (
-            {
-                "error": True,
-                "message": "File not found for: %s %s"
-                % (prefix, preview_file_id),
-            },
-            404,
-        )
+        raise FileNotFound
 
 
 class CreatePreviewFilePictureResource(Resource, ArgsMixin):
@@ -399,12 +383,14 @@ class PreviewFileLowMovieResource(PreviewFileMovieResource):
 
         try:
             return send_movie_file(instance_id, lowdef=True)
-        except FileNotFound:
-            current_app.logger.error(
-                "Movie file was not found for: %s" % instance_id
-            )
-            abort(404)
-
+        except Exception as e:
+            try:
+                return send_movie_file(instance_id)
+            except FileNotFound:
+                current_app.logger.error(
+                    "Movie file was not found for: %s" % instance_id
+                )
+                abort(404)
 
 
 class PreviewFileMovieDownloadResource(PreviewFileMovieResource):
@@ -420,7 +406,9 @@ class PreviewFileMovieDownloadResource(PreviewFileMovieResource):
         try:
             return send_movie_file(instance_id, as_attachment=True)
         except FileNotFound:
-            current_app.logger.error("Movie file was not found for: %s" % instance_id)
+            current_app.logger.error(
+                "Movie file was not found for: %s" % instance_id
+            )
             abort(404)
 
 

--- a/zou/utils/movie.py
+++ b/zou/utils/movie.py
@@ -98,9 +98,12 @@ def normalize_movie(movie_path, fps, width, height):
         format="mp4",
         r=fps,
         b="28M",
-        preset="medium",
+        preset="slow",
         vcodec="libx264",
-        vsync="passthrough",
+        color_primaries=1,
+        color_trc=1,
+        colorspace=1,
+        movflags="+faststart",
         s="%sx%s" % (width, height),
     )
     stream.run(quiet=False, capture_stderr=True)
@@ -118,10 +121,13 @@ def normalize_movie(movie_path, fps, width, height):
         pix_fmt="yuv420p",
         format="mp4",
         r=fps,
-        b="14M",
-        preset="medium",
+        b="1M",
+        preset="slow",
         vcodec="libx264",
-        vsync="passthrough",
+        color_primaries=1,
+        color_trc=1,
+        colorspace=1,
+        movflags="+faststart",
         s="%sx%s" % (low_width, low_height),
     )
     stream.run(quiet=False, capture_stderr=True)


### PR DESCRIPTION
**Problem**

* When low def version is not there, it returns a 404, which is a problem for legacy videos.
* Parameters for videos can be improved
* Day off routes are not allowed to artists

**Solution**

* If the lowdef version is absent, returns the high def version (original).
* Remove ambiguous parameter vsync and add some web friendly parameters, use slow mode to perform the conversion
* Allow day off routes to artists but return only their information.
