### PR TITLE
Various fixes

### DIFF
--- a/tests/tasks/test_route_tasks.py
+++ b/tests/tasks/test_route_tasks.py
@@ -418,6 +418,21 @@ class TaskRoutesTestCase(ApiDBTestCase):
         tasks = self.get("/data/persons/%s/done-tasks" % self.person.id)
         self.assertEqual(len(tasks), 1)
 
+    def test_get_related_tasks_for_person(self):
+        task_type_id = str(self.task_type_animation.id)
+        self.generate_fixture_task()
+        task = self.generate_fixture_task(task_type_id=task_type_id)
+        task.assignees = []
+        task.save()
+        tasks = self.get(
+            "/data/persons/%s/related-tasks/%s" % (
+                self.person.id,
+                task_type_id
+            )
+        )
+        self.assertEqual(len(tasks), 1)
+        self.assertEqual(tasks[0]["task_type_id"], task_type_id)
+
     def test_delete_all_tasks_for_task_type(self):
         self.generate_fixture_project_standard()
         self.generate_fixture_asset_standard()

--- a/zou/app/blueprints/crud/entity.py
+++ b/zou/app/blueprints/crud/entity.py
@@ -113,7 +113,7 @@ class EntityResource(BaseModelResource, EntityEventMixin):
             if data.get("source_id", None) == "null":
                 data["source_id"] = None
             entity.update(data)
-            entity_dict = entity.serialize()
+            entity_dict = self.serialize_instance(entity)
 
             if shots_service.is_shot(entity_dict):
                 shots_service.clear_shot_cache(entity_dict["id"])

--- a/zou/app/blueprints/crud/playlist.py
+++ b/zou/app/blueprints/crud/playlist.py
@@ -32,6 +32,18 @@ class PlaylistResource(BaseModelResource):
         user_service.check_project_access(playlist["project_id"])
         user_service.block_access_to_vendor()
 
+    def pre_update(self, instance_dict, data):
+        if "shots" in data:
+            shots = [
+                {
+                    "entity_id": shot["entity_id"],
+                    "preview_file_id": shot["preview_file_id"],
+                }
+                for shot in data["shots"]
+            ]
+            data["shots"] = shots
+        return data
+
     def delete(self, instance_id):
         playlists_service.remove_playlist(instance_id)
         return "", 204

--- a/zou/app/blueprints/playlists/resources.py
+++ b/zou/app/blueprints/playlists/resources.py
@@ -22,25 +22,44 @@ from zou.app.utils import fs
 from zou.utils.movie import EncodingParameters
 
 
-class ProjectPlaylistsResource(Resource):
+class ProjectPlaylistsResource(Resource, ArgsMixin):
+    """
+    Retrieve all playlists related to given project. Result is paginated and
+    can be sorted.
+    """
+
     @jwt_required
     def get(self, project_id):
         user_service.block_access_to_vendor()
         user_service.check_project_access(project_id)
+        page = self.get_page()
+        sort_by = self.get_sort_by()
         return playlists_service.all_playlists_for_project(
-            project_id, permissions.has_client_permissions()
+            project_id,
+            for_client=permissions.has_client_permissions(),
+            page=page,
+            sort_by=sort_by
         )
 
 
 class EpisodePlaylistsResource(Resource):
+    """
+    Retrieve all playlists related to given episode. The full list is returned
+    because the number of playlists in an episode is not that big.
+    """
+
     @jwt_required
     def get(self, project_id, episode_id):
         user_service.block_access_to_vendor()
         user_service.check_project_access(project_id)
+        sort_by = self.get_sort_by()
         if episode_id not in ["main", "all"]:
             shots_service.get_episode(episode_id)
         return playlists_service.all_playlists_for_episode(
-            project_id, episode_id, permissions.has_client_permissions()
+            project_id,
+            episode_id,
+            permissions.has_client_permissions(),
+            sort_by=sort_by
         )
 
 

--- a/zou/app/blueprints/tasks/__init__.py
+++ b/zou/app/blueprints/tasks/__init__.py
@@ -9,6 +9,7 @@ from .resources import (
     TaskAssignResource,
     TasksAssignResource,
     ClearAssignationResource,
+    PersonRelatedTasksResource,
     PersonTasksResource,
     PersonDoneTasksResource,
     TaskStartResource,
@@ -37,6 +38,10 @@ routes = [
     ("/data/tasks/<task_id>/previews", TaskPreviewsResource),
     ("/data/tasks/<task_id>/full", TaskFullResource),
     ("/data/persons/<person_id>/tasks", PersonTasksResource),
+    (
+        "/data/persons/<person_id>/related-tasks/<task_type_id>",
+        PersonRelatedTasksResource
+    ),
     ("/data/persons/<person_id>/done-tasks", PersonDoneTasksResource),
     (
         "/data/entities/<entity_id>/task-types/<task_type_id>/tasks",

--- a/zou/app/blueprints/tasks/resources.py
+++ b/zou/app/blueprints/tasks/resources.py
@@ -168,6 +168,22 @@ class PersonTasksResource(Resource):
         return tasks_service.get_person_tasks(person_id, projects)
 
 
+class PersonRelatedTasksResource(Resource):
+    """
+    For all entities assigned to given person (that have at least one task
+    assigned to given person), returns all tasks for given task type.
+    """
+
+    @jwt_required
+    def get(self, person_id, task_type_id):
+        user = persons_service.get_current_user()
+        if person_id != user["id"]:
+            permissions.check_admin_permissions()
+        projects = projects_service.open_projects()
+        return tasks_service.get_person_related_tasks(person_id, task_type_id)
+
+
+
 class PersonDoneTasksResource(Resource):
     """
     Return task assigned to given user of which status has is_done flag sets

--- a/zou/app/mixin.py
+++ b/zou/app/mixin.py
@@ -42,6 +42,12 @@ class ArgsMixin(object):
         options = request.args
         return int(options.get("page", "-1"))
 
+    def get_sort_by(self):
+        """
+        Returns sort by option value
+        """
+        return self.get_text_parameter("sort_by")
+
     def get_force(self):
         """
         Returns force parameter.
@@ -55,7 +61,6 @@ class ArgsMixin(object):
         """
         options = request.args
         return options.get("relations", "false") == "true"
-
 
     def get_project_id(self):
         """
@@ -77,6 +82,13 @@ class ArgsMixin(object):
         """
         options = request.args
         return options.get("no_job", "false") == "true"
+
+    def get_text_parameter(self, field_name):
+        options = request.args
+        return options.get(field_name, None)
+
+    def get_date_parameter(self, field_name):
+        self.parse_date_parameter(self.get_text_parameter(field_name))
 
     def parse_date_parameter(self, param):
         date = None

--- a/zou/app/services/tasks_service.py
+++ b/zou/app/services/tasks_service.py
@@ -350,6 +350,18 @@ def get_task_types_for_sequence(sequence_id):
     """
     Return all task types for which there is a task related to given sequence.
     """
+    Sequence = aliased(Entity, name="sequence")
+    task_types = (
+        TaskType.query
+        .join(Task, Entity)
+        .join(Sequence, Sequence.id == Entity.parent_id)
+        .filter(Sequence.id == sequence_id)
+        .group_by(TaskType.id)
+        .all()
+    )
+    return fields.serialize_models(task_types)
+
+
     return get_task_types_for_entity(sequence_id)
 
 
@@ -364,7 +376,18 @@ def get_task_types_for_episode(episode_id):
     """
     Return all task types for which there is a task related to given episode.
     """
-    return get_task_types_for_entity(episode_id)
+    Sequence = aliased(Entity, name="sequence")
+    Episode = aliased(Entity, name="episode")
+    task_types = (
+        TaskType.query
+        .join(Task, Entity)
+        .join(Sequence, Sequence.id == Entity.parent_id)
+        .join(Episode, Episode.id == Sequence.parent_id)
+        .filter(Episode.id == episode_id)
+        .group_by(TaskType.id)
+        .all()
+    )
+    return fields.serialize_models(task_types)
 
 
 def get_task_types_for_entity(entity_id):

--- a/zou/app/utils/query.py
+++ b/zou/app/utils/query.py
@@ -72,3 +72,16 @@ def get_paginated_results(query, page, relations=False):
                 "page": page,
             }
         return result
+
+
+def apply_sort_by(model, query, sort_by):
+    """
+    Apply an order by clause to a sqlalchemy query from a string parameter.
+    """
+    if sort_by in model.__table__.columns.keys():
+        sort_field = model.__table__.columns[sort_by]
+        if sort_by in ["created_at", "updated_at"]:
+            sort_field = sort_field.desc()
+    else:
+        sort_field = model.updated_at.desc()
+    return query.order_by(sort_field)


### PR DESCRIPTION
**Problem**

* Playlists are not paginated, which leads to slowness when browsing feature film playlists
* Playlists cannot be sorted
* Entity update doesn't return a proper serialized entity because the type is not descriptive enough
* Asset filtering is not allowed to artists if only the episode_id is given
* Task types are empty for episode/sequence task type routes

**Solution**

* Add a limit to project playlist requests and allow to give a page parameter. Episode playlists are not paginated.
* Allow to sort the playlist list on a given field, convert the string to a SQL Alchemy field
* Add type to serialization after entity update.
* Get the project from the given episode and give access rights if the artist is part of the project team.
* Change the rules, do not retrieve task types that match tasks linked to episode or sequence. Instead grab the task types related to the shots
