### PR TITLE
Change permissions for preview retrieving

### DIFF
--- a/zou/app/blueprints/crud/preview_file.py
+++ b/zou/app/blueprints/crud/preview_file.py
@@ -8,6 +8,9 @@ class PreviewFilesResource(BaseModelsResource):
     def __init__(self):
         BaseModelsResource.__init__(self, PreviewFile)
 
+    def check_read_permissions(self):
+        return True
+
 
 class PreviewFileResource(BaseModelResource):
     def __init__(self):

--- a/zou/app/utils/permissions.py
+++ b/zou/app/utils/permissions.py
@@ -21,7 +21,7 @@ def has_manager_permissions():
 
 def has_admin_permissions():
     """
-    Return True if user is admin or manager.
+    Return True if user is admin.
     """
     return admin_permission.can()
 


### PR DESCRIPTION
**Problem**

Users with the role "Artist" can't use the gazu function [get_all_preview_files_for_task(task)](https://gazu.cg-wire.com/specs.html?highlight=get_all_previe#gazu.files.get_all_preview_files_for_task).
It seems to be a permission issue from zou, related to the fact that artists can't access the following route : api/data/preview-files

Artist :

![preview2](https://user-images.githubusercontent.com/32680314/110663425-b8457700-81c6-11eb-86e9-caf2067d28c5.jpg)

Studio manager :

![preview](https://user-images.githubusercontent.com/32680314/110663364-a237b680-81c6-11eb-80e7-9de99ccd1aeb.jpg)


**Solution**

I think the problem could be solved if the appropriate permission were added in zou here : https://github.com/cgwire/zou/blob/d33ba7393aa4435694253e17cb00a633f6c06281/zou/app/blueprints/crud/preview_file.py#L7
Since the permission function [`check_read_permissions`](https://github.com/cgwire/zou/blob/d33ba7393aa4435694253e17cb00a633f6c06281/zou/app/blueprints/crud/base.py#L111)
 was not reimplemented, I think the default behaviour was to check for admin permissions, which is maybe a little bit too much (artists can see preview files, they should be able to get them). With the proposed changes, the route would be exposed to everyone, artists and admins.
I'm still learning zou, so maybe the changes I propose are not appropriate, please let me know if there's any issue with py proposition
