### PR TITLE
Less opinionated root path

### DIFF
--- a/zou/app/services/file_tree_service.py
+++ b/zou/app/services/file_tree_service.py
@@ -399,7 +399,10 @@ def get_root_path(tree, mode, sep):
         raise MalformedFileTreeException(
             "Can't find given mode (%s) in given tree." % mode
         )
-    return "%s%s%s%s" % (mountpoint, sep, root, sep)
+    if root:
+        return "%s%s%s%s" % (mountpoint, sep, root, sep)
+    else:
+        return "%s%s" % (mountpoint, sep)
 
 
 def update_variable(


### PR DESCRIPTION
**Problem**
If a studio didn't want to use a `mountpoint` or `root` in their file tree and they set the values to empty strings `get_root_path()` would still return a string with separators.

**Solution**
 Check if  `root` is an empty string. If there isn't a `root` provided we can get rid of a separator. This change allows a studio to pass empty string for either mountpoint, root, or both and still get a valid path.
