### PR TITLE
[playlists] Allow to filter the playlists by task type

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -849,6 +849,7 @@ class ApiDBTestCase(ApiTestCase):
         for_entity="shot",
         for_client=False,
         is_for_all=False,
+        task_type_id=None,
     ):
         if project_id is None:
             project_id = self.project.id
@@ -859,6 +860,7 @@ class ApiDBTestCase(ApiTestCase):
             for_entity=for_entity,
             is_for_all=is_for_all,
             for_client=for_client,
+            task_type_id=task_type_id,
             shots=[],
         )
         return self.playlist.serialize()

--- a/tests/playlists/test_playlists.py
+++ b/tests/playlists/test_playlists.py
@@ -30,6 +30,28 @@ class PlaylistTestCase(ApiDBTestCase):
         playlists = self.get("data/projects/%s/playlists" % self.project_id)
         self.assertEqual(len(playlists), 1)
 
+    def test_get_playlists_by_task_type(self):
+        self.generate_fixture_department()
+        self.generate_fixture_task_type()
+        self.generate_fixture_playlist(
+            "Playlist 1", task_type_id=self.task_type_layout.id
+        )
+        self.generate_fixture_playlist(
+            "Playlist 2", task_type_id=self.task_type_animation.id
+        )
+        self.generate_fixture_playlist(
+            "Playlist 3", task_type_id=self.task_type_animation.id
+        )
+        playlists = self.get(
+            "data/projects/%s/playlists?task_type_id=%s" % (
+                self.project_id,
+                self.task_type_animation.id
+            )
+        )
+        self.assertEqual(len(playlists), 2)
+        self.assertEqual(playlists[0]["name"], "Playlist 3")
+        self.assertEqual(playlists[1]["name"], "Playlist 2")
+
     def test_delete_playlist(self):
         self.generate_fixture_playlist("Playlist 1")
         playlists = self.get("data/projects/%s/playlists" % self.project_id)

--- a/zou/app/blueprints/playlists/resources.py
+++ b/zou/app/blueprints/playlists/resources.py
@@ -34,11 +34,13 @@ class ProjectPlaylistsResource(Resource, ArgsMixin):
         user_service.check_project_access(project_id)
         page = self.get_page()
         sort_by = self.get_sort_by()
+        task_type_id = self.get_text_parameter("task_type_id")
         return playlists_service.all_playlists_for_project(
             project_id,
             for_client=permissions.has_client_permissions(),
             page=page,
             sort_by=sort_by,
+            task_type_id=task_type_id
         )
 
 
@@ -53,6 +55,7 @@ class EpisodePlaylistsResource(Resource, ArgsMixin):
         user_service.block_access_to_vendor()
         user_service.check_project_access(project_id)
         sort_by = self.get_sort_by()
+        task_type_id = self.get_text_parameter("task_type_id")
         if episode_id not in ["main", "all"]:
             shots_service.get_episode(episode_id)
         return playlists_service.all_playlists_for_episode(
@@ -60,6 +63,7 @@ class EpisodePlaylistsResource(Resource, ArgsMixin):
             episode_id,
             permissions.has_client_permissions(),
             sort_by=sort_by,
+            task_type_id=task_type_id,
         )
 
 
@@ -145,7 +149,6 @@ class BuildPlaylistMovieResource(Resource):
             project
         )
         fps = preview_files_service.get_preview_file_fps(project)
-
         params = EncodingParameters(width=width, height=height, fps=fps)
 
         shots = [

--- a/zou/app/services/playlists_service.py
+++ b/zou/app/services/playlists_service.py
@@ -50,7 +50,11 @@ logger = logging.getLogger(__name__)
 
 
 def all_playlists_for_project(
-    project_id, for_client=False, page=1, sort_by="updated_at"
+    project_id,
+    for_client=False,
+    page=1,
+    sort_by="updated_at",
+    task_type_id=None
 ):
     """
     Return all playlists created for given project.
@@ -59,6 +63,9 @@ def all_playlists_for_project(
     query = Playlist.query.filter(Playlist.project_id == project_id)
     if for_client:
         query = query.filter(Playlist.for_client)
+
+    if task_type_id is not None and len(task_type_id) > 0:
+        query = query.filter(Playlist.task_type_id == task_type_id)
 
     query = query_utils.apply_sort_by(Playlist, query, sort_by)
     if page < 1:
@@ -75,7 +82,11 @@ def all_playlists_for_project(
 
 
 def all_playlists_for_episode(
-    project_id, episode_id, for_client=False, sort_by="updated_at"
+    project_id,
+    episode_id,
+    for_client=False,
+    sort_by="updated_at",
+    task_type_id=None
 ):
     """
     Return all playlists created for given episode.
@@ -85,12 +96,15 @@ def all_playlists_for_episode(
     if for_client:
         query = query.filter(Playlist.for_client)
 
+    if task_type_id is not None and len(task_type_id) > 0:
+        query = query.filter(Playlist.task_type_id == task_type_id)
+
     if episode_id == "main":
         query = (
             query.filter(Playlist.episode_id == None)
             .filter(Playlist.project_id == project_id)
             .filter(
-                or_(Playlist.is_for_all == None, Playlist.is_for_all == False)
+                or_(Playlist.is_for_all is None, Playlist.is_for_all == False)
             )
         )
     elif episode_id == "all":


### PR DESCRIPTION
**Problem**

It is not possible to filter playlists by task type.

**Solution**

Add a parameter to the playlist route to filter playlists by task type ID.
