### PR TITLE
[entities] create tasks only for current project

### DIFF
--- a/tests/source/csv/test_import_assets.py
+++ b/tests/source/csv/test_import_assets.py
@@ -2,9 +2,11 @@ import os
 import json
 
 from tests.base import ApiDBTestCase
+from zou.app import db
 
 from zou.app.models.entity import Entity
 from zou.app.models.entity_type import EntityType
+from zou.app.models.project import ProjectTaskTypeLink
 from zou.app.models.task import Task
 from zou.app.models.task_type import TaskType
 
@@ -24,6 +26,17 @@ class ImportCsvAssetsTestCase(ApiDBTestCase):
         number_of_task_per_entity_to_create = len(
             TaskType.query.filter_by(for_shots=False).all()
         )
+        db.session.add(ProjectTaskTypeLink(
+            project_id=self.project_id, task_type_id=self.task_type.id
+        ))
+        db.session.add(ProjectTaskTypeLink(
+            project_id=self.project_id, task_type_id=self.task_type_layout.id
+        ))
+        db.session.add(ProjectTaskTypeLink(
+            project_id=self.project_id,
+            task_type_id=self.task_type_animation.id,
+        ))
+        db.session.commit()
         self.assertEqual(number_of_task_per_entity_to_create, 1)
         path = "/import/csv/projects/%s/assets" % self.project.id
 

--- a/tests/source/csv/test_import_shots.py
+++ b/tests/source/csv/test_import_shots.py
@@ -1,8 +1,10 @@
 import os
 
 from tests.base import ApiDBTestCase
+from zou.app import db
 
 from zou.app.models.entity_type import EntityType
+from zou.app.models.project import ProjectTaskTypeLink
 from zou.app.models.task import Task
 from zou.app.models.task_type import TaskType
 from zou.app.services import shots_service
@@ -20,10 +22,12 @@ class ImportCsvShotsTestCase(ApiDBTestCase):
 
     def test_import_shots(self):
         self.assertEqual(len(Task.query.all()), 0)
-        number_of_task_per_entity_to_create = len(
-            TaskType.query.filter_by(for_shots=True).all()
-        )
-        self.assertEqual(number_of_task_per_entity_to_create, 2)
+        db.session.add(ProjectTaskTypeLink(
+            project_id=self.project_id, task_type_id=self.task_type.id
+        ))
+        db.session.add(ProjectTaskTypeLink(
+            project_id=self.project_id, task_type_id=self.task_type_layout.id
+        ))
         path = "/import/csv/projects/%s/shots" % self.project.id
         self.project.update({"production_type": "tvshow"})
 
@@ -43,7 +47,7 @@ class ImportCsvShotsTestCase(ApiDBTestCase):
         tasks = Task.query.all()
         self.assertEqual(
             len(tasks),
-            number_of_task_per_entity_to_create * len(shots),
+            len(shots),
         )
 
         shot = shots[0]

--- a/zou/app/blueprints/source/csv/assets.py
+++ b/zou/app/blueprints/source/csv/assets.py
@@ -1,4 +1,5 @@
 from zou.app.blueprints.source.csv.base import BaseCsvProjectImportResource
+from zou.app.models.project import ProjectTaskTypeLink
 from zou.app.models.task import Task
 from zou.app.models.task_type import TaskType
 
@@ -96,6 +97,13 @@ class AssetsCsvImportResource(BaseCsvProjectImportResource):
 
     def run_import(self, project_id, file_path):
         entities = super().run_import(project_id, file_path)
-        for task_type in TaskType.query.filter_by(for_shots=False):
+        task_types_in_project_for_assets = TaskType.query.join(
+            ProjectTaskTypeLink
+        ).filter(
+            ProjectTaskTypeLink.project_id == project_id
+        ).filter(
+            TaskType.for_shots == False
+        )
+        for task_type in task_types_in_project_for_assets:
             create_tasks(task_type.serialize(), self.created_assets)
         return entities

--- a/zou/app/blueprints/source/csv/shots.py
+++ b/zou/app/blueprints/source/csv/shots.py
@@ -1,6 +1,7 @@
 from zou.app.blueprints.source.csv.base import BaseCsvProjectImportResource
 
 from zou.app.models.entity import Entity
+from zou.app.models.project import ProjectTaskTypeLink
 from zou.app.models.task_type import TaskType
 from zou.app.services import shots_service, projects_service
 from zou.app.services.tasks_service import create_tasks
@@ -125,6 +126,13 @@ class ShotsCsvImportResource(BaseCsvProjectImportResource):
 
     def run_import(self, project_id, file_path):
         entities = super().run_import(project_id, file_path)
-        for task_type in TaskType.query.filter_by(for_shots=True):
+        task_types_in_project_for_shots = TaskType.query.join(
+            ProjectTaskTypeLink
+        ).filter(
+            ProjectTaskTypeLink.project_id == project_id
+        ).filter(
+            TaskType.for_shots == True
+        )
+        for task_type in task_types_in_project_for_shots:
             create_tasks(task_type.serialize(), self.created_shots)
         return entities


### PR DESCRIPTION
**Problem**
When importing assets/shots we were creating tasks based on the existing task statuses. But we were creating tasks regardless if the task status was linked to the project we added the asset/shot on.

**Solution**
Now when we import assets/shots, the tasks created are based on the existing task statuses in the current project