### PR TITLE
[qa] fix import test

### DIFF
--- a/tests/source/csv/test_import_shots.py
+++ b/tests/source/csv/test_import_shots.py
@@ -53,8 +53,10 @@ class ImportCsvShotsTestCase(ApiDBTestCase):
         shot = shots[0]
         self.assertEqual(shot["data"].get("contractor", None), "contractor 1")
 
-        task = tasks[0]
-        self.assertEqual(str(task.entity_id), shot["id"])
+        self.assertEqual(
+            set(str(task.entity_id) for task in tasks),
+            set(shot["id"] for shot in shots),
+        )
 
         file_path_fixture = self.get_fixture_file_path(
             os.path.join("csv", "shots_no_metadata.csv")


### PR DESCRIPTION
**Problem**
A test was failing in the travis-CI pipeline. I'm not sure why it was failing in the first place as the test is passing locally for me, but it might be some ordering issue

**Solution**
Using `set()` instead of relying on python's ordering, this should make the test more robust.