### PR TITLE
Add a route dedicated to annotation saving

### DIFF
--- a/zou/app/blueprints/auth/resources.py
+++ b/zou/app/blueprints/auth/resources.py
@@ -66,7 +66,7 @@ def logout():
         current_token = get_raw_jwt()
         jti = current_token["jti"]
         auth_service.revoke_tokens(app, jti)
-    except:
+    except Exception:
         pass
 
 
@@ -177,14 +177,16 @@ class LoginResource(Resource):
     Log in user by creating and registering auth tokens. Login is based
     on email and password. If no user match given email and a destkop ID,
     it looks in matching the desktop ID with the one stored in database. It is
-    useful for clients that run on desktop tools and that don't know user email.
+    useful for clients that run on desktop tools and that don't know user
+    email.
     """
 
     def post(self):
         (email, password) = self.get_arguments()
         try:
             user = auth_service.check_auth(app, email, password)
-            del user["password"]
+            if "password" in user:
+                del user["password"]
 
             if auth_service.is_default_password(app, password):
                 token = uuid.uuid4()

--- a/zou/app/blueprints/previews/__init__.py
+++ b/zou/app/blueprints/previews/__init__.py
@@ -20,6 +20,7 @@ from .resources import (
     PersonThumbnailResource,
     LegacySetMainPreviewResource,
     SetMainPreviewResource,
+    UpdateAnnotationsResource,
     UpdatePreviewPositionResource,
 )
 
@@ -97,6 +98,10 @@ routes = [
         "/actions/preview-files/<preview_file_id>/update-position",
         UpdatePreviewPositionResource,
     ),
+    (
+        "/actions/preview-files/<preview_file_id>/update-annotations",
+        UpdateAnnotationsResource,
+    )
 ]
 blueprint = Blueprint("thumbnails", "thumbnails")
 api = configure_api_from_blueprint(blueprint, routes)

--- a/zou/app/blueprints/previews/resources.py
+++ b/zou/app/blueprints/previews/resources.py
@@ -786,6 +786,24 @@ class UpdatePreviewPositionResource(Resource, ArgsMixin):
         preview_file = files_service.get_preview_file(preview_file_id)
         task = tasks_service.get_task(preview_file["task_id"])
         user_service.check_manager_project_access(task["project_id"])
+        user_service.check_entity_access(task["entity_id"])
         return preview_files_service.update_preview_file_position(
             preview_file_id, args["position"]
+        )
+
+
+class UpdateAnnotationsResource(Resource, ArgsMixin):
+    """
+    Allow to change orders of previews for a single revision.
+    """
+
+    @jwt_required
+    def put(self, preview_file_id):
+        annotations = request.json["annotations"]
+        preview_file = files_service.get_preview_file(preview_file_id)
+        task = tasks_service.get_task(preview_file["task_id"])
+        user_service.check_manager_project_access(task["project_id"])
+        user_service.check_entity_access(task["entity_id"])
+        return preview_files_service.update_preview_file_annotations(
+            task["project_id"], preview_file_id, annotations
         )

--- a/zou/app/services/preview_files_service.py
+++ b/zou/app/services/preview_files_service.py
@@ -158,7 +158,7 @@ def save_variants(preview_file_id, original_picture_path):
 def update_preview_file_position(preview_file_id, position):
     """
     Change positions for preview files of given task and revision.
-    Given position is the new position for given preview file. :q
+    Given position is the new position for given preview file.
     """
     preview_file = files_service.get_preview_file_raw(preview_file_id)
     task_id = preview_file.task_id
@@ -186,3 +186,19 @@ def get_preview_files_for_revision(task_id, revision):
         .order_by(PreviewFile.position)
     )
     return fields.serialize_models(preview_files)
+
+
+def update_preview_file_annotations(project_id, preview_file_id, annotations):
+    """
+    Update annotations for given preview file.
+    """
+    import pprint
+    pprint.pprint(annotations)
+    preview_file = files_service.get_preview_file_raw(preview_file_id)
+    preview_file.update({"annotations": annotations})
+    events.emit(
+        "preview-file:annotation-update",
+        {"preview_file_id": preview_file_id},
+        project_id=project_id,
+    )
+    return {"id": preview_file_id}


### PR DESCRIPTION
**Problem**

Annotations are treated as a classic field while they are complex to handle. 

+ unrelated minor fix related to #351 

**Solution**

* Add a route dedicated to annotation saving. It will allow later to deal with complex situations like simultaneous modifications.
* Add a new event 'preview-file:annotation-update'
