### PR TITLE
Fix boolean envvar check for LDAP sync

### DIFF
--- a/zou/app/utils/commands.py
+++ b/zou/app/utils/commands.py
@@ -155,11 +155,11 @@ def sync_with_ldap_server():
     LDAP_DOMAIN = os.getenv("LDAP_DOMAIN", "")
     LDAP_USER = os.getenv("LDAP_USER", "")
     LDAP_GROUP = os.getenv("LDAP_GROUP", "")
-    LDAP_SSL = os.getenv("LDAP_SSL", False) == "true"
+    LDAP_SSL = os.getenv("LDAP_SSL", "False").lower() == "true"
     EMAIL_DOMAIN = os.getenv("EMAIL_DOMAIN", "studio.local")
     LDAP_EXCLUDED_ACCOUNTS = os.getenv("LDAP_EXCLUDED_ACCOUNTS", "")
-    LDAP_IS_AD = os.getenv("LDAP_IS_AD", False) == "true"
-    LDAP_IS_AD_SIMPLE = os.getenv("LDAP_IS_AD_SIMPLE", False) == "true"
+    LDAP_IS_AD = os.getenv("LDAP_IS_AD", "False").lower() == "true"
+    LDAP_IS_AD_SIMPLE = os.getenv("LDAP_IS_AD_SIMPLE", "False").lower() == "true"
 
     def clean_value(value):
         cleaned_value = str(value)


### PR DESCRIPTION
**Problem**

The introduction of SSL for LDAP ( cgwire/zou@31ffd14 ) broke the boolean check for LDAP_IS_AD and LDAP_IS_AD_SIMPLE


**Solution**

Use the same code used in config.py https://github.com/cgwire/zou/blob/959e842bca02d721590c96675e33b807d886acbe/zou/app/config.py#L104-L105
