### PR TITLE
Add start service line to jobs documentation

### DIFF
--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -12,7 +12,7 @@ is required.
 
 ## Enabling job queue
 
-Set `ENABLE_JOB_QUEUE` environment variable to `True` in the main service file.
+Set `ENABLE_JOB_QUEUE` environment variable to `True` in the main service file (zou.service).
 
 
 ## Setting up RQ, the job manager
@@ -38,4 +38,9 @@ ExecStart=/opt/zou/zouenv/bin/rq worker -c zou.job_settings
 
 [Install]
 WantedBy=multi-user.target
+```
+
+Start the service:
+```
+sudo service zou-jobs start
 ```


### PR DESCRIPTION
add information missing on zou jobs page about Setting up RQ (start service after creting file, specify which is the main service file)

**Problem**
information missing on zou jobs page about Setting up RQ

**Solution**
add this documentation, (start service, specify which is the main service file)
