### PR TITLE
Upgrade Flask-SocketIO to last version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,9 +34,12 @@ install_requires =
     flask_bcrypt==0.7.1
     flask-jwt-extended==3.25.0
     flask-migrate==2.5.2
-    flask-socketio==4.1.0
-    python-engineio==3.8.2.post1
-    python-socketio==4.2.0
+    flask-socketio==5.1.1; python_version > "3.5"
+    flask-socketio==5.1.0; python_version == "3.5"
+    python-engineio==4.2.1; python_version > "3.5"
+    python-engineio==4.2.0; python_version == "3.5"
+    python-socketio==5.4.0; python_version > "3.5"
+    python-socketio==5.3.0; python_version == "3.5"
     flask_principal==0.4.0
     flask_caching==1.9.0
     flask_mail==0.9.1
@@ -49,7 +52,7 @@ install_requires =
     email_validator==1.0.4
 
     sqlalchemy==1.3.20
-    sqlalchemy_utils==0.36.8
+    sqlalchemy_utils==0.37.8
     psycopg2-binary==2.8.6
 
     python-slugify==3.0.2
@@ -70,7 +73,8 @@ install_requires =
     six==1.15.0
 
     gunicorn==20.0.4
-    gevent==20.9.0
+    gevent==21.8.0; python_version > "3.5"
+    gevent==21.1.2; python_version == "3.5"
     gevent-websocket==0.10.1
 
     slackclient==1.3.2

--- a/zou/app/stores/publisher_store.py
+++ b/zou/app/stores/publisher_store.py
@@ -30,7 +30,11 @@ def init():
             host=host, port=port, db=redis_db, decode_responses=True
         )
         publisher_store.get("test")
-        socketio = SocketIO(message_queue=redis_url)
+        socketio = SocketIO(
+            message_queue=redis_url,
+            cors_allowed_origins=[],
+            cors_credentials=False,
+        )
     except redis.ConnectionError:
         pass
 

--- a/zou/debug.py
+++ b/zou/debug.py
@@ -1,10 +1,13 @@
+from gevent import monkey
+
+monkey.patch_all()
 import logging
 from flask_socketio import SocketIO
 from zou.app import app
 
 FORMAT = "%(message)s"
 logging.basicConfig(level=logging.INFO, format=FORMAT)
-socketio = SocketIO(app)
+socketio = SocketIO(app, cors_allowed_origins=[], cors_credentials=False)
 
 if __name__ == "__main__":
     socketio.run(app, debug=True)

--- a/zou/event_stream.py
+++ b/zou/event_stream.py
@@ -16,7 +16,9 @@ def get_redis_url():
 
 
 def create_app(redis_url):
-    socketio = SocketIO(logger=True)
+    socketio = SocketIO(
+        logger=True, cors_allowed_origins=[], cors_credentials=False
+    )
 
     app = Flask(__name__)
     app.config.from_object(config)


### PR DESCRIPTION
**Problem**
- SocketIO in zou are not in the last version.
- Current version of sqlalchemy_utils is yanked

**Solution**
- Upgrade Flask-SocketIO to last version (upgrade flask-socketio, python-engineio, python-socketio, gevent)
- Enable monkey patch when debugging
- Upgrade sqlalchemy_utils because the previous version tagged is yanked
- Disable CORS for socketIO maybe to reenable after
- Needs this PR to be accepted to work with Kitsu : https://github.com/cgwire/vue-websocket/pull/1