### PR TITLE
[qa] Fix SocketIO version and set python_requires >= python 3.4

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,8 @@ classifiers =
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     Topic :: Multimedia :: Graphics
@@ -34,12 +36,7 @@ install_requires =
     flask_bcrypt==0.7.1
     flask-jwt-extended==3.25.0
     flask-migrate==2.5.2
-    flask-socketio==5.1.1; python_version > "3.5"
-    flask-socketio==5.1.0; python_version == "3.5"
-    python-engineio==4.2.1; python_version > "3.5"
-    python-engineio==4.2.0; python_version == "3.5"
-    python-socketio==5.4.0; python_version > "3.5"
-    python-socketio==5.3.0; python_version == "3.5"
+    flask-socketio==4.3.2
     flask_principal==0.4.0
     flask_caching==1.9.0
     flask_mail==0.9.1

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
 #!/usr/bin/env python
 from setuptools import setup
 
-setup()
+setup(python_requires=">=3.5")


### PR DESCRIPTION
**Problem**
Correct version of socket.io needs to be used to work with Kitsu/Gazu
**Solution**
Change version to be compatible with Kitsu and Gazu
