### PR TITLE
Various fixes

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -464,7 +464,7 @@ class ApiDBTestCase(ApiTestCase):
             email=u"john.did.cg.artist@gmail.com",
             role="user",
             password=auth.encrypt_password("mypassword"),
-        ).serialize()
+        ).serialize(relations=True)
         return self.user_cg_artist
 
     def generate_fixture_user_client(self):

--- a/tests/source/csv/test_import_casting.py
+++ b/tests/source/csv/test_import_casting.py
@@ -73,6 +73,11 @@ class ImportCsvCastingTestCase(ApiDBTestCase):
         self.upload_csv(path, "casting")
         path = "/import/csv/projects/%s/casting" % self.project_id
         self.upload_csv(path, "casting")
-
         links = EntityLink.query.all()
         self.assertEqual(len(links), 12)
+
+        path = "/import/csv/projects/%s/casting" % self.project_id
+        self.upload_csv(path, "casting_02")
+        links = EntityLink.query.all()
+        self.assertEqual(len(links), 12)
+        self.assertEqual(links[0].label, "fixed")

--- a/tests/tasks/test_route_tasks.py
+++ b/tests/tasks/test_route_tasks.py
@@ -129,6 +129,29 @@ class TaskRoutesTestCase(ApiDBTestCase):
         notifications = notifications_service.get_last_notifications()
         self.assertEqual(len(notifications), 2)
 
+    def test_multiple_task_assign_artist(self):
+        self.generate_fixture_task()
+        self.generate_fixture_shot_task()
+        self.generate_fixture_user_cg_artist()
+        task_id = str(self.task.id)
+        shot_task_id = str(self.shot_task.id)
+        person_id = str(self.user_cg_artist["id"])
+        department_id = str(self.department.id)
+        data = {"task_ids": [task_id, shot_task_id]}
+        self.put("/actions/tasks/clear-assignation", data)
+        self.log_in_cg_artist()
+        self.put("/actions/persons/%s/assign" % person_id, data)
+        task = tasks_service.get_task_with_relations(task_id)
+        self.assertEqual(len(task["assignees"]), 0)
+        task = tasks_service.get_task_with_relations(shot_task_id)
+        self.assertEqual(len(task["assignees"]), 0)
+        persons_service.add_to_department(department_id, person_id)
+        self.put("/actions/persons/%s/assign" % person_id, data)
+        task = tasks_service.get_task_with_relations(task_id)
+        self.assertEqual(len(task["assignees"]), 0)
+        task = tasks_service.get_task_with_relations(shot_task_id)
+        self.assertEqual(len(task["assignees"]), 0)
+
     def test_clear_assignation(self):
         self.generate_fixture_task()
         self.generate_fixture_shot_task()

--- a/zou/app/blueprints/auth/resources.py
+++ b/zou/app/blueprints/auth/resources.py
@@ -134,7 +134,10 @@ class AuthenticatedResource(Resource):
     @jwt_required
     def get(self):
         try:
-            person = persons_service.get_person_by_email(get_jwt_identity())
+            person = persons_service.get_person_by_email(
+                get_jwt_identity(),
+                relations=True
+            )
             organisation = persons_service.get_organisation()
             return {
                 "authenticated": True,

--- a/zou/app/blueprints/export/csv/casting.py
+++ b/zou/app/blueprints/export/csv/casting.py
@@ -36,7 +36,7 @@ class CastingCsvExport(Resource, ArgsMixin):
 
     def build_headers(self, episode_id=None):
         headers = [
-            "Parent/Type",
+            "Parent",
             "Name",
             "Asset Type",
             "Asset",

--- a/zou/app/blueprints/source/csv/casting.py
+++ b/zou/app/blueprints/source/csv/casting.py
@@ -59,19 +59,21 @@ class CastingCsvImportResource(BaseCsvProjectImportResource):
         occurences = 1
         if len(row["Occurences"]) > 0:
             occurences = int(row["Occurences"])
-        label = slugify(row["Label"])
 
         asset_id = self.asset_map.get(asset_key, None)
         target_id = self.shot_map.get(target_key, None)
-        print(asset_key, target_key)
+        label = slugify(row.get("Label", "fixed"))
         if target_id is None:
             target_id = self.asset_map.get(target_key, None)
-        print(asset_key, target_key, asset_id, target_id)
-        print(self.asset_map)
 
         if asset_id is not None and target_id is not None:
-            link = breakdown_service.get_entity_link(target_id, asset_id)
+            link = breakdown_service.get_entity_link_raw(target_id, asset_id)
             if link is None:
                 breakdown_service.create_casting_link(
                     target_id, asset_id, occurences, label
                 )
+            else:
+                link.update({
+                    "nb_occurences": occurences,
+                    "label": label
+                })

--- a/zou/app/blueprints/tasks/resources.py
+++ b/zou/app/blueprints/tasks/resources.py
@@ -363,14 +363,16 @@ class TasksAssignResource(Resource):
     @jwt_required
     def put(self, person_id):
         (task_ids) = self.get_arguments()
-
-        if len(task_ids) > 0:
-            task = tasks_service.get_task(task_ids[0])
-            user_service.check_manager_project_access(task["project_id"])
+        print("ok")
 
         tasks = []
         for task_id in task_ids:
             try:
+                user_service.check_project_departement_access(
+                    task_id,
+                    person_id
+                )
+                print("hyey")
                 task = self.assign_task(task_id, person_id)
                 author = persons_service.get_current_user()
                 notifications_service.create_assignation_notification(
@@ -379,9 +381,10 @@ class TasksAssignResource(Resource):
                 tasks.append(task)
             except TaskNotFoundException:
                 pass
+            except permissions.PermissionDenied:
+                pass
             except PersonNotFoundException:
                 return {"error": "Assignee doesn't exist in database."}, 400
-
         if len(tasks) > 0:
             projects_service.add_team_member(tasks[0]["project_id"], person_id)
 

--- a/zou/app/services/breakdown_service.py
+++ b/zou/app/services/breakdown_service.py
@@ -521,13 +521,22 @@ def get_entity_casting(entity_id):
     return Entity.serialize_list(entity.entities_out, obj_type="Asset")
 
 
-def get_entity_link(entity_in_id, entity_out_id):
+
+def get_entity_link_raw(entity_in_id, entity_out_id):
     """
     Get link matching given entities.
     """
     link = EntityLink.get_by(
         entity_in_id=entity_in_id, entity_out_id=entity_out_id
     )
+    return link
+
+
+def get_entity_link(entity_in_id, entity_out_id):
+    """
+    Get link matching given entities.
+    """
+    link = get_entity_link_raw(entity_in_id, entity_out_id)
     if link:
         return link.serialize()
     else:

--- a/zou/app/services/files_service.py
+++ b/zou/app/services/files_service.py
@@ -8,7 +8,6 @@ from zou.app.models.working_file import WorkingFile
 from zou.app.models.output_file import OutputFile
 from zou.app.models.output_type import OutputType
 from zou.app.models.preview_file import PreviewFile
-from zou.app.models.project import Project
 from zou.app.models.software import Software
 from zou.app.models.task import Task
 
@@ -699,7 +698,7 @@ def get_preview_files_for_task(task_id):
     """
     Get all preview files for given task.
     """
-    previews = PreviewFile.filter_by(task_id=task_id).order_by(
+    previews = PreviewFile.query.filter_by(task_id=task_id).order_by(
         PreviewFile.revision.desc()
     )
     return fields.serialize_models(previews)

--- a/zou/app/services/persons_service.py
+++ b/zou/app/services/persons_service.py
@@ -141,12 +141,12 @@ def get_person_by_desktop_login(desktop_login):
     return person.serialize()
 
 
-def get_current_user():
+def get_current_user(relations=False):
     """
     Return person from its auth token (the one that does the request) as a
     dictionary.
     """
-    return get_person_by_email(get_jwt_identity())
+    return get_person_by_email(get_jwt_identity(), relations=relations)
 
 
 def get_current_user_raw():

--- a/zou/app/services/persons_service.py
+++ b/zou/app/services/persons_service.py
@@ -114,15 +114,15 @@ def get_person_by_email_raw(email):
 
 
 @cache.memoize_function(120)
-def get_person_by_email(email, unsafe=False):
+def get_person_by_email(email, unsafe=False, relations=False):
     """
     Return person that matches given email as a dictionary.
     """
     person = get_person_by_email_raw(email)
     if unsafe:
-        return person.serialize()
+        return person.serialize(relations=relations)
     else:
-        return person.serialize_safe()
+        return person.serialize_safe(relations=relations)
 
 
 @cache.memoize_function(120)


### PR DESCRIPTION
**Problem**

* Preview file route is broken
* Casting CSV import doesn't handle updates
* Sometimes users want to upload their own videos as previews and don't want normalization
* When requesting is-authenticated route, the user departments are not given. This route is use to build the kitsu context. So it's a problem to not have the user departments at that time.
* Artists can't assign tasks to themselves

**Solution**

* Fix sqlachemy usage error
* Update nb of occurrences and label on CSV import
* Allow uploading a video without running the normalization. In that case, low def and high def videos are similar.
* Add department route to user infos returned by is-authenticated route.
* Allow artists to assign themselves tasks if they belong to the task department.
