### PR TITLE
[jwt] JWT_COOKIE_SAMESITE set on Lax

### DIFF
--- a/zou/app/config.py
+++ b/zou/app/config.py
@@ -30,6 +30,7 @@ JWT_TOKEN_LOCATION = ["cookies", "headers"]
 JWT_REFRESH_COOKIE_PATH = "/auth/refresh-token"
 JWT_COOKIE_CSRF_PROTECT = False
 JWT_SESSION_COOKIE = False
+JWT_COOKIE_SAMESITE = "Lax"
 
 DATABASE = {
     "drivername": os.getenv("DB_DRIVER", "postgresql"),


### PR DESCRIPTION
**Problem**
SameSite attribute was set by default by flask-jwt-extended to None. We have to set it explicitly to Lax rather than relying on browsers to apply SameSite=Lax automatically to avoid warnings. 
https://github.com/cgwire/zou/issues/385

**Solution**
Set JWT_COOKIE_SAMESITE to Lax
