### PR TITLE
Get department from task AND task_type

### DIFF
--- a/zou/app/services/file_tree_service.py
+++ b/zou/app/services/file_tree_service.py
@@ -479,7 +479,7 @@ def get_folder_from_datatype(
     elif datatype == "TaskType":
         folder = get_folder_from_task_type(task, task_type, field)
     elif datatype == "Department":
-        folder = get_folder_from_department(task, field)
+        folder = get_folder_from_department(task, task_type, field)
     elif datatype == "Shot":
         folder = get_folder_from_shot(entity)
     elif datatype == "TemporalEntity":
@@ -540,10 +540,14 @@ def get_folder_from_output_type(output_type, field="name"):
     return output_type[field].lower()
 
 
-def get_folder_from_department(task, field="name"):
+def get_folder_from_department(task, task_type, field="name"):
     folder = ""
-    department = tasks_service.get_department_from_task(task["id"])
-    folder = department[field]
+    if task_type is None and task is not None:
+        department = tasks_service.get_department_from_task(task["id"])
+        folder = department[field]
+    elif task_type is not None:
+        department = tasks_service.get_department_from_task_type(task_type["id"])
+        folder = department[field]
     return folder
 
 

--- a/zou/app/services/tasks_service.py
+++ b/zou/app/services/tasks_service.py
@@ -147,13 +147,20 @@ def get_department(department_id):
     return department.serialize()
 
 
+def get_department_from_task_type(task_type_id):
+    """
+    Get department of given task type as dictionary
+    """
+    task_type = get_task_type_raw(task_type_id)
+    return get_department(task_type.department_id)
+
+
 def get_department_from_task(task_id):
     """
     Get department of given task as dictionary
     """
     task = get_task_raw(task_id)
-    task_type = get_task_type_raw(task.task_type_id)
-    return get_department(task_type.department_id)
+    return get_department_from_task_type(task.task_type_id)
 
 
 def get_task_type_raw(task_type_id):


### PR DESCRIPTION
\<Department> file tree variable was not working for output files, since the department id lookup only happened for tasks and not for task types.
<!--- Explain the problem -->

**Solution**
Added **get_department_from_task_type** function.
For more streamlining, the existing **get_department_from_task** will now also use this function as a base, since it already looked up the task's task type.
**get_folder_from_department** now includes both functions and takes *task_type* as an additional parameter.
<!--- Describe the change, including rationale and design decisions -->
