### PR TITLE
Various fixes

### DIFF
--- a/zou/app/blueprints/comments/resources.py
+++ b/zou/app/blueprints/comments/resources.py
@@ -195,6 +195,10 @@ class DeleteReplyCommentResource(Resource):
         task = tasks_service.get_task(task_id)
         user_service.check_project_access(task["project_id"])
         user_service.check_entity_access(task["entity_id"])
+        reply = comments_service.get_reply(comment_id, reply_id)
+        current_user = persons_service.get_current_user()
+        if reply["person_id"] != current_user["id"]:
+            permissions.check_admin_permissions()
         return comments_service.delete_reply(comment_id, reply_id)
 
 

--- a/zou/app/services/comments_service.py
+++ b/zou/app/services/comments_service.py
@@ -321,6 +321,15 @@ def reply_comment(comment_id, text):
     return reply
 
 
+def get_reply(comment_id, reply_id):
+    comment = tasks_service.get_comment_raw(comment_id)
+    reply = next(
+        reply for reply in comment.replies
+        if reply["id"] == reply_id
+    )
+    return reply
+
+
 def delete_reply(comment_id, reply_id):
     comment = tasks_service.get_comment_raw(comment_id)
     task = tasks_service.get_task(comment.object_id)

--- a/zou/app/services/comments_service.py
+++ b/zou/app/services/comments_service.py
@@ -5,6 +5,7 @@ from flask import current_app
 
 from zou.app.models.attachment_file import AttachmentFile
 from zou.app.models.comment import Comment
+from zou.app.models.notification import Notification
 from zou.app.models.project import Project
 from zou.app.models.task import Task
 
@@ -291,6 +292,10 @@ def _send_ack_event(project_id, comment, user_id, name="acknowledge"):
 
 
 def reply_comment(comment_id, text):
+    """
+    Add a reply entry to the JSONB field of given comment model. Create
+    notifications needed for this.
+    """
     person = persons_service.get_current_user()
     comment = tasks_service.get_comment_raw(comment_id)
     task = tasks_service.get_task(comment.object_id, relations=True)
@@ -340,6 +345,7 @@ def delete_reply(comment_id, reply_id):
         if reply["id"] != reply_id
     ]
     comment.save()
+    Notification.delete_all_by(reply_id=reply_id)
     events.emit(
         "comment:delete-reply",
         {

--- a/zou/app/services/notifications_service.py
+++ b/zou/app/services/notifications_service.py
@@ -158,6 +158,7 @@ def create_notifications_for_task_and_reply(task, comment, reply):
     recipient_ids = get_notification_recipients(task, comment["replies"])
     if reply["person_id"] in recipient_ids:
         recipient_ids.remove(reply["person_id"])
+    recipient_ids.add(comment["person_id"])
     author_id = reply["person_id"]
     task = tasks_service.get_task(comment["object_id"])
     for recipient_id in recipient_ids:

--- a/zou/app/utils/commands.py
+++ b/zou/app/utils/commands.py
@@ -289,6 +289,7 @@ def sync_with_ldap_server():
 
             elif person is not None:
                 try:
+                    active = True
                     persons_service.update_person(
                         person["id"],
                         {


### PR DESCRIPTION
**Problem**

* During LDAP synchronization, if the user is inactive on Kitsu it can be reactivated.
* Replies can be deleted by anyone.
* Comment author doesn't get any notification when a reply is posted
* When a reply is deleted, related notifications stay

**Solution**

* Activate user only on creation.
* Allow only the reply author and admins to delete a reply.
* Creates a notification for the comment author when the reply is created.
* Delete related notifications when a reply is deleted.