### PR TITLE
Edits entity and task type

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -512,6 +512,7 @@ class ApiDBTestCase(ApiTestCase):
         self.sequence_type = EntityType.create(name="Sequence")
         self.episode_type = EntityType.create(name="Episode")
         self.scene_type = EntityType.create(name="Scene")
+        self.edit_type = EntityType.create(name="Edit")
 
     def generate_fixture_asset_types(self):
         self.asset_type_character = EntityType.create(name="Character")
@@ -545,6 +546,13 @@ class ApiDBTestCase(ApiTestCase):
             color="#FFFFFF",
             for_shots=True,
             department_id=self.department_animation.id,
+        )
+        self.task_type_edit = TaskType.create(
+            name="Edit",
+            short_name="edit",
+            color="#FFFFFF",
+            for_shots=False,
+            for_entity="Edit",
         )
 
     def generate_fixture_task_status(self):
@@ -656,6 +664,23 @@ class ApiDBTestCase(ApiTestCase):
         self.project.team.append(self.person)
         self.project.save()
         return self.shot_task
+
+    def generate_fixture_edit_task(self, name="Edit", task_type_id=None):
+        if task_type_id is None:
+            task_type_id = self.task_type_edit.id
+
+        self.edit_task = Task.create(
+            name=name,
+            project_id=self.project.id,
+            task_type_id=task_type_id,
+            task_status_id=self.task_status.id,
+            entity_id=self.edit.id,
+            assignees=[self.person],
+            assigner_id=self.assigner.id,
+        )
+        self.project.team.append(self.person)
+        self.project.save()
+        return self.edit_task
 
     def generate_fixture_episode_task(self, name="Master"):
         self.episode_task = Task.create(
@@ -928,6 +953,16 @@ class ApiDBTestCase(ApiTestCase):
             person_id = self.person.id
         self.day_off = DayOff.create(date=date, person_id=person_id)
         return self.day_off.serialize()
+
+    def generate_fixture_edit(self, name="Edit", parent_id=None):
+        self.edit = Entity.create(
+            name=name,
+            description="Description of the Edit",
+            project_id=self.project.id,
+            entity_type_id=self.edit_type.id,
+            parent_id=parent_id,
+        )
+        return self.edit
 
     def generate_base_context(self):
         self.generate_fixture_project_status()

--- a/tests/edits/base.py
+++ b/tests/edits/base.py
@@ -15,6 +15,7 @@ class BaseEditTestCase(ApiDBTestCase):
 
         episode = self.generate_fixture_episode()
         self.episode_id = str(episode.id)
+        self.episode_name = episode.name
 
         self.generate_fixture_edit(parent_id=episode.id)
         self.edit_id = self.edit.id
@@ -27,11 +28,19 @@ class BaseEditTestCase(ApiDBTestCase):
         self.generate_fixture_task_status()
         self.generate_fixture_department()
         self.generate_fixture_task_type()
-        self.task_type_dict = self.task_type.serialize()
+        self.task_type_edit_dict = self.task_type_edit.serialize()
 
         self.generate_fixture_task()
-        self.generate_fixture_task(name="Edit", entity_id=self.edit_id)
-        self.generate_fixture_task(name="DCP", entity_id=self.edit_id)
+        self.generate_fixture_task(
+            name="Edit",
+            entity_id=self.edit_id,
+            task_type_id=self.task_type_edit.id,
+        )
+        self.generate_fixture_task(
+            name="DCP",
+            entity_id=self.edit_id,
+            task_type_id=self.task_type_edit.id,
+        )
 
         self.maxDiff = None
 

--- a/tests/edits/base.py
+++ b/tests/edits/base.py
@@ -1,0 +1,39 @@
+from tests.base import ApiDBTestCase
+
+from zou.app.utils import events
+
+
+class BaseEditTestCase(ApiDBTestCase):
+    def setUp(self):
+        super(BaseEditTestCase, self).setUp()
+        self.generate_fixture_project_status()
+        project = self.generate_fixture_project()
+        self.project_name = project.name
+
+        self.generate_fixture_asset_type()
+        self.generate_fixture_asset()
+
+        episode = self.generate_fixture_episode()
+        self.episode_id = str(episode.id)
+
+        self.generate_fixture_edit(parent_id=episode.id)
+        self.edit_id = self.edit.id
+        self.edit_dict = self.edit.serialize(obj_type="Edit")
+
+        self.generate_fixture_person()
+        self.person_id = str(self.person.id)
+
+        self.generate_fixture_assigner()
+        self.generate_fixture_task_status()
+        self.generate_fixture_department()
+        self.generate_fixture_task_type()
+        self.task_type_dict = self.task_type.serialize()
+
+        self.generate_fixture_task()
+        self.generate_fixture_task(name="Edit", entity_id=self.edit_id)
+        self.generate_fixture_task(name="DCP", entity_id=self.edit_id)
+
+        self.maxDiff = None
+
+        self.is_event_fired = False
+        events.unregister_all()

--- a/tests/edits/test_edit_tasks.py
+++ b/tests/edits/test_edit_tasks.py
@@ -1,0 +1,46 @@
+from .base import BaseEditTestCase
+from zou.app.services import projects_service, tasks_service
+
+
+class EditTasksTestCase(BaseEditTestCase):
+    def test_get_tasks_for_edit(self):
+        tasks = self.get("data/edits/%s/tasks" % self.edit.id)
+        self.assertEqual(len(tasks), 2)
+        self.assertEqual(tasks[0]["id"], str(self.task.id))
+
+    def test_get_edits_and_tasks(self):
+        self.generate_fixture_task(name="Secondary", entity_id=self.edit_id)
+        edits = self.get("data/edits/with-tasks")
+        self.assertEqual(len(edits), 1)
+        self.assertEqual(len(edits[0]["tasks"]), 3)
+        self.assertEqual(
+            edits[0]["tasks"][0]["assignees"][0], str(self.person_id)
+        )
+
+    def test_get_edits_and_tasks_vendor(self):
+        self.generate_fixture_task(name="Secondary", entity_id=self.edit_id)
+        self.generate_fixture_user_vendor()
+        task_id = self.task.id
+        project_id = self.project.id
+        person_id = self.user_vendor["id"]
+        self.log_in_vendor()
+        edits = self.get(
+            "data/edits/with-tasks?project_id=%s" % project_id, 403
+        )
+        projects_service.add_team_member(project_id, person_id)
+        projects_service.clear_project_cache(str(project_id))
+        edits = self.get("data/edits/with-tasks?project_id=%s" % project_id)
+        self.assertEqual(len(edits), 0)
+        tasks_service.assign_task(task_id, person_id)
+        edits = self.get("data/edits/with-tasks?project_id=%s" % project_id)
+        self.assertEqual(len(edits), 1)
+        self.assertEqual(len(edits[0]["tasks"]), 1)
+        self.assertTrue(str(person_id) in edits[0]["tasks"][0]["assignees"])
+
+    def test_get_task_types_for_edit(self):
+        task_types = self.get("data/edits/%s/task-types" % self.edit_id)
+        self.assertEqual(len(task_types), 1)
+        self.assertDictEqual(task_types[0], self.task_type_dict)
+
+    def test_get_task_types_for_edit_not_found(self):
+        self.get("data/edits/no-edit/task-types", 404)

--- a/tests/edits/test_edit_tasks.py
+++ b/tests/edits/test_edit_tasks.py
@@ -40,7 +40,7 @@ class EditTasksTestCase(BaseEditTestCase):
     def test_get_task_types_for_edit(self):
         task_types = self.get("data/edits/%s/task-types" % self.edit_id)
         self.assertEqual(len(task_types), 1)
-        self.assertDictEqual(task_types[0], self.task_type_dict)
+        self.assertDictEqual(task_types[0], self.task_type_edit_dict)
 
     def test_get_task_types_for_edit_not_found(self):
         self.get("data/edits/no-edit/task-types", 404)

--- a/tests/edits/test_edits.py
+++ b/tests/edits/test_edits.py
@@ -21,6 +21,8 @@ class EditsTestCase(BaseEditTestCase):
         self.assertEqual(edit["name"], "Edit")
         self.assertEqual(edit["project_name"], self.project_name)
         self.assertEqual(edit["parent_id"], self.episode_id)
+        self.assertEqual(edit["episode_id"], self.episode_id)
+        self.assertEqual(edit["episode_name"], self.episode_name)
         self.assertEqual(len(edit["tasks"]), 2)
 
     def test_get_edit_by_name(self):
@@ -29,12 +31,14 @@ class EditsTestCase(BaseEditTestCase):
         self.assertEqual(edits[0]["id"], str(self.edit.id))
         self.assertEqual(edits[0]["type"], "Edit")
         self.assertEqual(edits[0]["name"], "Edit")
+        self.assertEqual(edits[0]["parent_id"], self.episode_id)
 
     def test_get_project_edits(self):
         edits = self.get("data/projects/%s/edits" % self.project.id)
         self.assertEqual(len(edits), 1)
         self.assertEqual(edits[0]["type"], "Edit")
         self.assertEqual(edits[0]["name"], "Edit")
+        self.assertEqual(edits[0]["parent_id"], self.episode_id)
 
     def test_create_edit(self):
         events.register("edit:new", "handle_event", self)

--- a/tests/edits/test_edits.py
+++ b/tests/edits/test_edits.py
@@ -1,0 +1,106 @@
+from .base import BaseEditTestCase
+from zou.app.services import edits_service
+from zou.app.utils import events
+
+
+class EditsTestCase(BaseEditTestCase):
+    def handle_event(self, data):
+        self.is_event_fired = True
+
+    def test_get_edits(self):
+        edits = self.get("data/edits/all")
+
+        self.assertEqual(len(edits), 1)
+        self.assertEqual(edits[0]["name"], self.edit_dict["name"])
+
+    def test_get_edit(self):
+        edit = self.get("data/edits/%s" % self.edit.id)
+
+        self.assertEqual(edit["id"], str(self.edit.id))
+        self.assertEqual(edit["type"], "Edit")
+        self.assertEqual(edit["name"], "Edit")
+        self.assertEqual(edit["project_name"], self.project_name)
+        self.assertEqual(edit["parent_id"], self.episode_id)
+        self.assertEqual(len(edit["tasks"]), 2)
+
+    def test_get_edit_by_name(self):
+        edits = self.get("data/edits/all?name=%s" % self.edit.name.lower())
+
+        self.assertEqual(edits[0]["id"], str(self.edit.id))
+        self.assertEqual(edits[0]["type"], "Edit")
+        self.assertEqual(edits[0]["name"], "Edit")
+
+    def test_get_project_edits(self):
+        edits = self.get("data/projects/%s/edits" % self.project.id)
+        self.assertEqual(len(edits), 1)
+        self.assertEqual(edits[0]["type"], "Edit")
+        self.assertEqual(edits[0]["name"], "Edit")
+
+    def test_create_edit(self):
+        events.register("edit:new", "handle_event", self)
+        new_edit_data = {
+            "name": "Director's Cut",
+            "description": "Test Edit description",
+            "data": {"extra": "test extra"},
+        }
+        path = "data/projects/%s/edits" % (self.project.id,)
+
+        edit = self.post(path, new_edit_data)
+
+        edits = edits_service.get_edits()
+        self.assertIsNotNone(edit.get("id", None))
+        self.assertEqual(len(edits), 2)
+        self.assertEqual(
+            {edit["name"] for edit in edits},
+            {self.edit_dict["name"], new_edit_data["name"]},
+        )
+        self.assertEqual(edit["name"], new_edit_data["name"])
+        self.assertIsNone(edit["parent_id"])
+        self.assertEqual(edit["type"], "Edit")
+        self.assertEqual(edit["description"], new_edit_data["description"])
+        self.assertDictEqual(edit["data"], new_edit_data["data"])
+
+    def test_remove_edit(self):
+        edit = self.generate_fixture_edit()
+        edits = edits_service.get_edits()
+        self.assertEqual(len(edits), 2)
+        path = "data/edits/%s" % edit.id
+
+        self.delete(path)
+
+        edits = edits_service.get_edits()
+        self.assertEqual(len(edits), 1)
+        self.get(path, 404)
+
+    def test_remove_edit_force(self):
+        edit = self.generate_fixture_edit()
+        self.assertEqual(len(edits_service.get_edits()), 2)
+        path = "data/edits/%s?force=true" % edit.id
+
+        self.delete(path)
+
+        self.assertEqual(len(edits_service.get_edits()), 1)
+        self.get(path, 404)
+
+    def test_remove_edit_with_tasks(self):
+        edits = edits_service.get_edits()
+        self.assertEqual(len(edits), 1)
+        path = "data/edits/%s" % self.edit_dict["id"]
+
+        self.delete(path)
+
+        edits = edits_service.get_edits()
+        self.assertEqual(len(edits), 1)
+        self.assertEqual(edits[0]["canceled"], True)
+        self.get(path, 200)
+
+    def test_remove_edit_with_tasks_force(self):
+        edits = edits_service.get_edits()
+        self.assertEqual(len(edits), 1)
+        path = "data/edits/%s?force=true" % self.edit_dict["id"]
+
+        self.delete(path)
+
+        edits = edits_service.get_edits()
+        self.assertEqual(len(edits), 0)
+        self.get(path, 404)

--- a/tests/export/test_edits_to_csv.py
+++ b/tests/export/test_edits_to_csv.py
@@ -1,0 +1,35 @@
+from zou.app.models.metadata_descriptor import MetadataDescriptor
+
+from tests.edits.base import BaseEditTestCase
+
+
+class EditCsvExportTestCase(BaseEditTestCase):
+    def test_export(self):
+        csv_edits = self.get_raw(
+            "/export/csv/projects/%s/edits.csv" % self.project.id
+        )
+        expected_result = """Project;Episode;Name;Description;Time Spent;Edit\r
+Cosmos Landromat;E01;Edit;Description of the Edit;0.21;opn\r\n"""
+        self.assertEqual(csv_edits, expected_result)
+
+    def test_export_with_metadata(self):
+        MetadataDescriptor.create(
+            project_id=self.project.id,
+            name="Start frame",
+            field_name="start_frame",
+            choices=["0", "100"],
+            entity_type="Edit",
+        )
+        self.edit.update(
+            {
+                "data": {
+                    "start_frame": "100",
+                }
+            }
+        )
+        csv_edits = self.get_raw(
+            "/export/csv/projects/%s/edits.csv" % self.project.id
+        )
+        expected_result = """Project;Episode;Name;Description;Time Spent;Start frame;Edit\r
+Cosmos Landromat;E01;Edit;Description of the Edit;0.21;100;opn\r\n"""
+        self.assertEqual(csv_edits, expected_result)

--- a/tests/misc/test_commands.py
+++ b/tests/misc/test_commands.py
@@ -85,6 +85,6 @@ class CommandsTestCase(ApiDBTestCase):
     def test_init_data(self):
         commands.init_data()
         task_types = TaskType.get_all()
-        asset_types = EntityType.get_all()
-        self.assertEqual(len(task_types), 11)
-        self.assertEqual(len(asset_types), 7)
+        entity_types = EntityType.get_all()
+        self.assertEqual(len(task_types), 12)
+        self.assertEqual(len(entity_types), 8)

--- a/tests/services/test_edits_service.py
+++ b/tests/services/test_edits_service.py
@@ -1,0 +1,106 @@
+import pytest
+
+from tests.base import ApiDBTestCase
+
+from zou.app.services import edits_service, shots_service
+from zou.app.services.exception import EditNotFoundException
+
+
+class EditUtilsTestCase(ApiDBTestCase):
+    def setUp(self):
+        super(EditUtilsTestCase, self).setUp()
+
+        self.generate_fixture_project_status()
+        self.generate_fixture_project()
+        self.generate_fixture_asset_type()
+        self.generate_fixture_episode()
+        self.generate_fixture_edit()
+        self.generate_fixture_asset()
+
+    def test_get_edit_type(self):
+        edit_type = edits_service.get_edit_type()
+        self.assertEqual(edit_type["name"], "Edit")
+
+    def test_get_edits(self):
+        edits = edits_service.get_edits()
+        self.edit_dict = self.edit.serialize(obj_type="Edit")
+        self.edit_dict["project_name"] = self.project.name
+        self.assertDictEqual(edits[0], self.edit_dict)
+
+    def test_get_edits_and_tasks(self):
+        self.generate_fixture_person()
+        self.generate_fixture_assigner()
+        self.generate_fixture_department()
+        self.generate_fixture_task_status()
+        self.generate_fixture_task_type()
+        self.generate_fixture_edit_task()
+        self.generate_fixture_edit_task(name="Secondary")
+        self.generate_fixture_edit("P02")
+
+        edits = edits_service.get_edits_and_tasks()
+        edits = sorted(edits, key=lambda s: s["name"])
+        self.assertEqual(len(edits), 2)
+        self.assertEqual(len(edits[0]["tasks"]), 2)
+        self.assertEqual(len(edits[1]["tasks"]), 0)
+        self.assertEqual(edits[0]["episode_id"], str(self.episode.id))
+        self.assertEqual(
+            edits[0]["tasks"][0]["assignees"][0], str(self.person.id)
+        )
+        self.assertEqual(
+            edits[0]["tasks"][0]["task_status_id"],
+            str(self.edit_task.task_status_id),
+        )
+        self.assertEqual(
+            edits[0]["tasks"][0]["task_type_id"],
+            str(self.edit_task.task_type_id),
+        )
+
+    def test_get_edit(self):
+        self.assertEqual(
+            str(self.edit.id), edits_service.get_edit(self.edit.id)["id"]
+        )
+
+    def test_get_full_edit(self):
+        self.generate_fixture_person()
+        self.generate_fixture_assigner()
+        self.generate_fixture_department()
+        self.generate_fixture_task_status()
+        self.generate_fixture_task_type()
+        self.generate_fixture_edit_task()
+
+        edit = edits_service.get_full_edit(self.edit.id)
+        self.assertEqual(edit["id"], str(self.edit.id))
+        self.assertEqual(edit["episode_name"], str(self.episode.name))
+        self.assertEqual(len(edit["tasks"]), 1)
+
+    def test_get_episode(self):
+        self.assertEqual(
+            str(self.episode.id),
+            shots_service.get_episode(self.episode.id)["id"],
+        )
+
+    def test_is_edit(self):
+        self.assertTrue(edits_service.is_edit(self.edit.serialize()))
+        self.assertFalse(edits_service.is_edit(self.asset.serialize()))
+
+    def test_get_episode_from_edit(self):
+        episode = shots_service.get_episode(self.edit.parent_id)
+        self.assertEqual(episode["name"], "E01")
+
+    def test_create_edit(self):
+        edit_name = "Editor's Cut"
+        parent_id = str(self.episode.id)
+        edit = edits_service.create_edit(
+            self.project.id, edit_name, parent_id=parent_id
+        )
+        self.assertEqual(edit["name"], edit_name)
+        self.assertEqual(edit["parent_id"], parent_id)
+
+    def test_remove_edit(self):
+        edit_id = str(self.edit.id)
+        self.assertIsNotNone(edit_id)
+        edits_service.get_edit(edit_id)
+
+        edits_service.remove_edit(edit_id)
+        with pytest.raises(EditNotFoundException):
+            edits_service.get_edit(edit_id)

--- a/tests/services/test_edits_service.py
+++ b/tests/services/test_edits_service.py
@@ -14,7 +14,7 @@ class EditUtilsTestCase(ApiDBTestCase):
         self.generate_fixture_project()
         self.generate_fixture_asset_type()
         self.generate_fixture_episode()
-        self.generate_fixture_edit()
+        self.generate_fixture_edit(parent_id=self.episode.id)
         self.generate_fixture_asset()
 
     def test_get_edit_type(self):
@@ -70,7 +70,8 @@ class EditUtilsTestCase(ApiDBTestCase):
 
         edit = edits_service.get_full_edit(self.edit.id)
         self.assertEqual(edit["id"], str(self.edit.id))
-        self.assertEqual(edit["episode_name"], str(self.episode.name))
+        self.assertEqual(edit["episode_id"], str(self.episode.id))
+        self.assertEqual(edit["episode_name"], self.episode.name)
         self.assertEqual(len(edit["tasks"]), 1)
 
     def test_get_episode(self):

--- a/tests/source/csv/test_import_assets.py
+++ b/tests/source/csv/test_import_assets.py
@@ -24,7 +24,7 @@ class ImportCsvAssetsTestCase(ApiDBTestCase):
     def test_import_assets(self):
         self.assertEqual(len(Task.query.all()), 0)
         number_of_task_per_entity_to_create = len(
-            TaskType.query.filter_by(for_shots=False).all()
+            TaskType.query.filter_by(for_shots=False, for_entity='Asset').all()
         )
         db.session.add(
             ProjectTaskTypeLink(

--- a/tests/user/test_route_context.py
+++ b/tests/user/test_route_context.py
@@ -442,7 +442,7 @@ class UserContextRoutesTestCase(ApiDBTestCase):
         self.assertEqual(len(context["projects"]), 1)
         self.assertEqual(len(context["asset_types"]), 1)
         self.assertEqual(len(context["departments"]), 2)
-        self.assertEqual(len(context["task_types"]), 3)
+        self.assertEqual(len(context["task_types"]), 4)
         self.assertEqual(len(context["task_status"]), 3)
         self.assertEqual(len(context["project_status"]), 2)
         self.assertEqual(len(context["persons"]), 3)

--- a/zou/app/api.py
+++ b/zou/app/api.py
@@ -23,6 +23,7 @@ from .blueprints.source import blueprint as import_blueprint
 from .blueprints.shots import blueprint as shots_blueprint
 from .blueprints.tasks import blueprint as tasks_blueprint
 from .blueprints.user import blueprint as user_blueprint
+from .blueprints.edits import blueprint as edits_blueprint
 
 
 def configure(app):
@@ -60,6 +61,7 @@ def configure_api_routes(app):
     app.register_blueprint(tasks_blueprint)
     app.register_blueprint(previews_blueprint)
     app.register_blueprint(user_blueprint)
+    app.register_blueprint(edits_blueprint)
     return app
 
 

--- a/zou/app/blueprints/edits/__init__.py
+++ b/zou/app/blueprints/edits/__init__.py
@@ -1,0 +1,34 @@
+from flask import Blueprint
+from zou.app.utils.api import configure_api_from_blueprint
+
+from .resources import (
+    EditResource,
+    EditsResource,
+    AllEditsResource,
+    EditsAndTasksResource,
+    EditPreviewsResource,
+    EditTaskTypesResource,
+    EditTasksResource,
+    EditVersionsResource,
+    ProjectEditsResource,
+    EpisodeEditsResource,
+    EpisodeEditTasksResource,
+)
+
+routes = [
+    ("/data/edits", AllEditsResource),
+    ("/data/edits/all", EditsResource),
+    ("/data/edits/with-tasks", EditsAndTasksResource),
+    ("/data/edits/<edit_id>", EditResource),
+    ("/data/edits/<edit_id>/task-types", EditTaskTypesResource),
+    ("/data/edits/<edit_id>/tasks", EditTasksResource),
+    ("/data/edits/<edit_id>/preview-files", EditPreviewsResource),
+    ("/data/edits/<edit_id>/versions", EditVersionsResource),
+    ("/data/episodes/<episode_id>/edits", EpisodeEditsResource),
+    ("/data/episodes/<episode_id>/edit-tasks", EpisodeEditTasksResource),
+    ("/data/projects/<project_id>/edits", ProjectEditsResource),
+]
+
+
+blueprint = Blueprint("edits", "edits")
+api = configure_api_from_blueprint(blueprint, routes)

--- a/zou/app/blueprints/edits/resources.py
+++ b/zou/app/blueprints/edits/resources.py
@@ -1,0 +1,217 @@
+from flask import request
+from flask_restful import Resource, reqparse
+from flask_jwt_extended import jwt_required
+
+from zou.app.services import (
+    persons_service,
+    projects_service,
+    playlists_service,
+    edits_service,
+    tasks_service,
+    user_service,
+)
+
+from zou.app.mixin import ArgsMixin
+from zou.app.utils import permissions, query
+
+
+class EditResource(Resource, ArgsMixin):
+    @jwt_required
+    def get(self, edit_id):
+        """
+        Retrieve given edit.
+        """
+        edit = edits_service.get_full_edit(edit_id)
+        if edit is None:
+            edits_service.clear_edit_cache(edit_id)
+            edit = edits_service.get_full_edit(edit_id)
+        user_service.check_project_access(edit["project_id"])
+        user_service.check_entity_access(edit["id"])
+        return edit
+
+    @jwt_required
+    def delete(self, edit_id):
+        """
+        Delete given edit.
+        """
+        force = self.get_force()
+        edit = edits_service.get_edit(edit_id)
+        user_service.check_manager_project_access(edit["project_id"])
+        edits_service.remove_edit(edit_id, force=force)
+        return "", 204
+
+
+class EditsResource(Resource):
+    @jwt_required
+    def get(self):
+        """
+        Retrieve all edit entries. Filters can be specified in the query string.
+        """
+        criterions = query.get_query_criterions_from_request(request)
+        user_service.check_project_access(criterions.get("project_id", None))
+        if permissions.has_vendor_permissions():
+            criterions["assigned_to"] = persons_service.get_current_user()[
+                "id"
+            ]
+        return edits_service.get_edits(criterions)
+
+
+class AllEditsResource(Resource):
+    @jwt_required
+    def get(self):
+        """
+        Retrieve all edit entries. Filters can be specified in the query string.
+        """
+        criterions = query.get_query_criterions_from_request(request)
+        if permissions.has_vendor_permissions():
+            criterions["assigned_to"] = persons_service.get_current_user()[
+                "id"
+            ]
+        user_service.check_project_access(criterions.get("project_id", None))
+        return edits_service.get_edits(criterions)
+
+
+class EditTaskTypesResource(Resource):
+    @jwt_required
+    def get(self, edit_id):
+        """
+        Retrieve all task types related to a given edit.
+        """
+        edit = edits_service.get_edit(edit_id)
+        user_service.check_project_access(edit["project_id"])
+        user_service.check_entity_access(edit["id"])
+        return tasks_service.get_task_types_for_edit(edit_id)
+
+
+class EditTasksResource(Resource, ArgsMixin):
+    @jwt_required
+    def get(self, edit_id):
+        """
+        Retrieve all tasks related to a given edit.
+        """
+        edit = edits_service.get_edit(edit_id)
+        user_service.check_project_access(edit["project_id"])
+        user_service.check_entity_access(edit["id"])
+        relations = self.get_relations()
+        return tasks_service.get_tasks_for_edit(edit_id, relations=relations)
+
+
+class EpisodeEditTasksResource(Resource, ArgsMixin):
+    @jwt_required
+    def get(self, episode_id):
+        """
+        Retrieve all tasks related to a given episode.
+        """
+        episode = edits_service.get_episode(episode_id)
+        user_service.check_project_access(episode["project_id"])
+        user_service.check_entity_access(episode["id"])
+        if permissions.has_vendor_permissions():
+            raise permissions.PermissionDenied
+        relations = self.get_relations()
+        return tasks_service.get_edit_tasks_for_episode(
+            episode_id, relations=relations
+        )
+
+
+class EpisodeEditsResource(Resource, ArgsMixin):
+    @jwt_required
+    def get(self, episode_id):
+        """
+        Retrieve all edits related to a given episode.
+        """
+        episode = edits_service.get_episode(episode_id)
+        user_service.check_project_access(episode["project_id"])
+        user_service.check_entity_access(episode["id"])
+        relations = self.get_relations()
+        return edits_service.get_edits_for_episode(
+            episode_id, relations=relations
+        )
+
+
+class EditPreviewsResource(Resource):
+    @jwt_required
+    def get(self, edit_id):
+        """
+        Retrieve all previews related to a given edit. It sends them
+        as a dict. Keys are related task type ids and values are arrays
+        of preview for this task type.
+        """
+        edit = edits_service.get_edit(edit_id)
+        user_service.check_project_access(edit["project_id"])
+        user_service.check_entity_access(edit["id"])
+        return playlists_service.get_preview_files_for_entity(edit_id)
+
+
+class EditsAndTasksResource(Resource):
+    @jwt_required
+    def get(self):
+        """
+        Retrieve all edits, adds project name and all related tasks.
+        """
+        criterions = query.get_query_criterions_from_request(request)
+        user_service.check_project_access(criterions.get("project_id", None))
+        if permissions.has_vendor_permissions():
+            criterions["assigned_to"] = persons_service.get_current_user()[
+                "id"
+            ]
+        return edits_service.get_edits_and_tasks(criterions)
+
+
+class ProjectEditsResource(Resource):
+    @jwt_required
+    def get(self, project_id):
+        """
+        Retrieve all edits related to a given project.
+        """
+        projects_service.get_project(project_id)
+        user_service.check_project_access(project_id)
+        return edits_service.get_edits_for_project(
+            project_id, only_assigned=permissions.has_vendor_permissions()
+        )
+
+    @jwt_required
+    def post(self, project_id):
+        """
+        Create a edit for given project.
+        """
+        (name, description, data, parent_id) = self.get_arguments()
+        projects_service.get_project(project_id)
+        user_service.check_manager_project_access(project_id)
+
+        edit = edits_service.create_edit(
+            project_id,
+            name,
+            data=data,
+            description=description,
+            parent_id=parent_id,
+        )
+        return edit, 201
+
+    def get_arguments(self):
+        parser = reqparse.RequestParser()
+        parser.add_argument(
+            "name", help="The edit name is required.", required=True
+        )
+        parser.add_argument("description")
+        parser.add_argument("data", type=dict)
+        parser.add_argument("episode_id", default=None)
+        args = parser.parse_args()
+        return (
+            args["name"],
+            args.get("description", ""),
+            args["data"],
+            args["episode_id"],
+        )
+
+
+class EditVersionsResource(Resource):
+    """
+    Retrieve data versions of given edit.
+    """
+
+    @jwt_required
+    def get(self, edit_id):
+        edit = edits_service.get_edit(edit_id)
+        user_service.check_project_access(edit["project_id"])
+        user_service.check_entity_access(edit["id"])
+        return edits_service.get_edit_versions(edit_id)

--- a/zou/app/blueprints/export/__init__.py
+++ b/zou/app/blueprints/export/__init__.py
@@ -14,11 +14,13 @@ from .csv.playlists import PlaylistCsvExport
 from .csv.task_types import TaskTypesCsvExport
 from .csv.tasks import TasksCsvExport
 from .csv.time_spents import TimeSpentsCsvExport
+from .csv.edits import EditsCsvExport
 
 routes = [
     ("/export/csv/projects/<project_id>/assets.csv", AssetsCsvExport),
     ("/export/csv/projects/<project_id>/shots.csv", ShotsCsvExport),
     ("/export/csv/projects/<project_id>/casting.csv", CastingCsvExport),
+    ("/export/csv/projects/<project_id>/edits.csv", EditsCsvExport),
     ("/export/csv/playlists/<playlist_id>", PlaylistCsvExport),
     ("/export/csv/persons.csv", PersonsCsvExport),
     ("/export/csv/projects.csv", ProjectsCsvExport),

--- a/zou/app/blueprints/export/csv/edits.py
+++ b/zou/app/blueprints/export/csv/edits.py
@@ -1,0 +1,130 @@
+from flask_restful import Resource
+from flask_jwt_extended import jwt_required
+from slugify import slugify
+
+from zou.app.services import (
+    edits_service,
+    projects_service,
+    user_service,
+    tasks_service,
+)
+from zou.app.utils import csv_utils
+
+
+class EditsCsvExport(Resource):
+    @jwt_required
+    def get(self, project_id):
+        self.task_type_map = tasks_service.get_task_type_map()
+        self.task_status_map = tasks_service.get_task_status_map()
+
+        project = projects_service.get_project(project_id)
+        self.check_permissions(project["id"])
+
+        csv_content = []
+        results = self.get_edits_data(project_id)
+        metadata_infos = self.get_metadata_infos(project_id)
+        validation_columns = self.get_validation_columns(results)
+        headers = self.build_headers(metadata_infos, validation_columns)
+        csv_content.append(headers)
+
+        for result in results:
+            result["project_name"] = project["name"]
+            csv_content.append(
+                self.build_row(result, metadata_infos, validation_columns)
+            )
+
+        file_name = "%s edits" % project["name"]
+        return csv_utils.build_csv_response(csv_content, slugify(file_name))
+
+    def check_permissions(self, project_id):
+        user_service.check_project_access(project_id)
+        user_service.block_access_to_vendor()
+
+    def build_headers(self, metadata_infos, validation_headers):
+        headers = ["Project", "Episode", "Name", "Description", "Time Spent"]
+
+        metadata_headers = [name for (name, field_name) in metadata_infos]
+
+        return headers + metadata_headers + validation_headers
+
+    def build_row(self, result, metadata_infos, validation_columns):
+        row = [
+            result["project_name"],
+            result["episode_name"],
+            result["name"],
+            result["description"],
+            self.get_time_spent(result),
+        ]
+        task_map = {}
+
+        for task in result["tasks"]:
+            task_status = self.task_status_map[task["task_status_id"]]
+            task_type = self.task_type_map[task["task_type_id"]]
+            task_map[task_type["name"]] = task_status["short_name"]
+
+        for (_, field_name) in metadata_infos:
+            result_metadata = result.get("data", {}) or {}
+            row.append(result_metadata.get(field_name, ""))
+
+        for column in validation_columns:
+            row.append(task_map.get(column, ""))
+
+        return row
+
+    def get_edits_data(self, project_id):
+        results = edits_service.get_edits_and_tasks({"project_id": project_id})
+        return sorted(
+            results,
+            key=lambda edit: (edit["episode_name"], edit["name"]),
+        )
+
+    def get_validation_columns(self, results):
+        task_type_map = {}
+
+        for result in results:
+            for task in result["tasks"]:
+                task_type = self.task_type_map[task["task_type_id"]]
+                task_type_map[task_type["name"]] = {
+                    "name": task_type["name"],
+                    "priority": task_type["priority"],
+                }
+
+        validation_columns = [
+            task_type["name"]
+            for task_type in sorted(
+                task_type_map.values(),
+                key=lambda task_type: (
+                    task_type["priority"],
+                    task_type["name"],
+                ),
+            )
+        ]
+
+        return validation_columns
+
+    def get_metadata_infos(self, project_id):
+        descriptors = [
+            descriptor
+            for descriptor in projects_service.get_metadata_descriptors(
+                project_id
+            )
+            if descriptor["entity_type"] == "Edit"
+        ]
+
+        columns = [
+            (descriptor["name"], descriptor["field_name"])
+            for descriptor in descriptors
+        ]
+
+        return columns
+
+    def get_time_spent(self, result):
+        time_spent = 0
+        for task in result["tasks"]:
+            if task["duration"] is not None:
+                time_spent += task["duration"]
+
+        if time_spent > 0:
+            time_spent = time_spent / 8.0 / 60.0
+
+        return "%.2f" % time_spent

--- a/zou/app/blueprints/projects/resources.py
+++ b/zou/app/blueprints/projects/resources.py
@@ -216,9 +216,9 @@ class ProductionMetadataDescriptorsResource(Resource, ArgsMixin):
 
         args["for_client"] = args["for_client"] == "True"
 
-        if args["entity_type"] not in ["Asset", "Shot"]:
+        if args["entity_type"] not in ["Asset", "Shot", "Edit"]:
             raise WrongParameterException(
-                "Wrong entity type. Please select Asset or Shot."
+                "Wrong entity type. Please select Asset, Shot or Edit."
             )
 
         if len(args["name"]) == 0:

--- a/zou/app/blueprints/tasks/__init__.py
+++ b/zou/app/blueprints/tasks/__init__.py
@@ -26,6 +26,7 @@ from .resources import (
     ProjectTasksResource,
     CreateShotTasksResource,
     CreateAssetTasksResource,
+    CreateEditTasksResource,
     GetTimeSpentResource,
     SetTimeSpentResource,
     AddTimeSpentResource,
@@ -96,6 +97,10 @@ routes = [
     (
         "/actions/projects/<project_id>/task-types/<task_type_id>/assets/create-tasks",
         CreateAssetTasksResource,
+    ),
+    (
+        "/actions/projects/<project_id>/task-types/<task_type_id>/edits/create-tasks",
+        CreateEditTasksResource,
     ),
 ]
 

--- a/zou/app/blueprints/tasks/resources.py
+++ b/zou/app/blueprints/tasks/resources.py
@@ -13,6 +13,7 @@ from zou.app.services.exception import (
 from zou.app.services import (
     assets_service,
     deletion_service,
+    edits_service,
     entities_service,
     files_service,
     file_tree_service,
@@ -255,6 +256,32 @@ class CreateAssetTasksResource(Resource):
         return tasks, 201
 
 
+class CreateEditTasksResource(Resource):
+    """
+    Create a new task for given edit and task type.
+    """
+
+    @jwt_required
+    def post(self, project_id, task_type_id):
+        user_service.check_manager_project_access(project_id)
+        task_type = tasks_service.get_task_type(task_type_id)
+
+        edit_ids = request.json
+        edits = []
+        if type(edit_ids) == list and len(edit_ids) > 0:
+            for edit_id in edit_ids:
+                edit = edits_service.get_edit(edit_id)
+                if edit["project_id"] == project_id:
+                    edits.append(edit)
+        else:
+            criterions = query.get_query_criterions_from_request(request)
+            criterions["project_id"] = project_id
+            edits = edits_service.get_edits(criterions)
+
+        tasks = tasks_service.create_tasks(task_type, edits)
+        return tasks, 201
+
+
 class ToReviewResource(Resource):
     """
     Change a task status to "to review". It creates a new preview file entry
@@ -368,8 +395,7 @@ class TasksAssignResource(Resource):
         for task_id in task_ids:
             try:
                 user_service.check_project_departement_access(
-                    task_id,
-                    person_id
+                    task_id, person_id
                 )
                 task = self.assign_task(task_id, person_id)
                 author = persons_service.get_current_user()

--- a/zou/app/models/entity.py
+++ b/zou/app/models/entity.py
@@ -221,7 +221,7 @@ class Entity(db.Model, BaseMixin, SerializerMixin):
             if field in data:
                 del data[field]
 
-        if model_type in ["Shot", "Sequence", "Episode"]:
+        if model_type in ["Shot", "Sequence", "Episode", "Edit"]:
             entity_type = EntityType.get_by(name=model_type)
             data["entity_type_id"] = entity_type.id
 

--- a/zou/app/services/assets_service.py
+++ b/zou/app/services/assets_service.py
@@ -13,6 +13,7 @@ from zou.app.models.task import assignees_table
 from zou.app.services import (
     base_service,
     deletion_service,
+    edits_service,
     projects_service,
     shots_service,
     user_service,
@@ -56,7 +57,17 @@ def get_temporal_type_ids():
         cache.cache.delete_memoized(shots_service.get_episode_type)
         episode_type = shots_service.get_episode_type()
 
-    ids_to_exclude = [shot_type["id"], sequence_type["id"], episode_type["id"]]
+    edit_type = edits_service.get_edit_type()
+    if edit_type is None:
+        cache.cache.delete_memoized(edits_service.get_edit_type)
+        edit_type = edits_service.get_edit_type()
+
+    ids_to_exclude = [
+        shot_type["id"],
+        sequence_type["id"],
+        episode_type["id"],
+        edit_type["id"],
+    ]
     if scene_type is not None:
         ids_to_exclude.append(scene_type["id"])
 

--- a/zou/app/services/edits_service.py
+++ b/zou/app/services/edits_service.py
@@ -1,0 +1,356 @@
+from sqlalchemy.exc import StatementError
+
+from zou.app.utils import cache, events, fields, query as query_utils
+
+from zou.app.models.entity import Entity, EntityLink, EntityVersion
+from zou.app.models.project import Project
+from zou.app.models.subscription import Subscription
+from zou.app.models.task import Task
+from zou.app.models.task import assignees_table
+
+from zou.app.services import (
+    deletion_service,
+    entities_service,
+    user_service,
+)
+from zou.app.services.exception import (
+    EditNotFoundException,
+    WrongIdFormatException,
+)
+
+
+def clear_edit_cache(edit_id):
+    cache.cache.delete_memoized(get_edit, edit_id)
+    cache.cache.delete_memoized(get_edit_with_relations, edit_id)
+    cache.cache.delete_memoized(get_full_edit, edit_id)
+
+
+@cache.memoize_function(1200)
+def get_edit_type():
+    return entities_service.get_temporal_entity_type_by_name("Edit")
+
+
+def get_edits(criterions={}):
+    """
+    Get all edits for given criterions.
+    """
+    edit_type = get_edit_type()
+    criterions["entity_type_id"] = edit_type["id"]
+    is_only_assignation = "assigned_to" in criterions
+    if is_only_assignation:
+        del criterions["assigned_to"]
+
+    query = Entity.query
+    query = query_utils.apply_criterions_to_db_query(Entity, query, criterions)
+    query = query.join(Project).add_columns(Project.name).order_by(Entity.name)
+
+    if is_only_assignation:
+        query = query.outerjoin(Task, Task.entity_id == Entity.id)
+        query = query.filter(user_service.build_assignee_filter())
+
+    try:
+        data = query.all()
+    except StatementError:  # Occurs when an id is not properly formatted
+        raise WrongIdFormatException
+
+    edits = []
+    for (edit_model, project_name) in data:
+        edit = edit_model.serialize(obj_type="Edit")
+        edit["project_name"] = project_name
+        edits.append(edit)
+
+    return edits
+
+
+def get_edits_and_tasks(criterions={}):
+    """
+    Get all edits for given criterions with related tasks for each edit.
+    """
+    edit_type = get_edit_type()
+    edit_map = {}
+    task_map = {}
+
+    query = (
+        Entity.query.join(Project)
+        .outerjoin(Task, Task.entity_id == Entity.id)
+        .outerjoin(assignees_table)
+        .add_columns(
+            Task.id,
+            Task.task_type_id,
+            Task.task_status_id,
+            Task.priority,
+            Task.estimation,
+            Task.duration,
+            Task.retake_count,
+            Task.real_start_date,
+            Task.end_date,
+            Task.start_date,
+            Task.due_date,
+            Task.last_comment_date,
+            Task.nb_assets_ready,
+            assignees_table.columns.person,
+            Project.id,
+            Project.name,
+        )
+        .filter(Entity.entity_type_id == edit_type["id"])
+    )
+    if "id" in criterions:
+        query = query.filter(Entity.id == criterions["id"])
+
+    if "project_id" in criterions:
+        query = query.filter(Entity.project_id == criterions["project_id"])
+
+    if "episode_id" in criterions:
+        query = query.filter(Entity.parent_id == criterions["episode_id"])
+
+    if "assigned_to" in criterions:
+        query = query.filter(user_service.build_assignee_filter())
+        del criterions["assigned_to"]
+
+    for (
+        edit,
+        task_id,
+        task_type_id,
+        task_status_id,
+        task_priority,
+        task_estimation,
+        task_duration,
+        task_retake_count,
+        task_real_start_date,
+        task_end_date,
+        task_start_date,
+        task_due_date,
+        task_last_comment_date,
+        task_nb_assets_ready,
+        person_id,
+        project_id,
+        project_name,
+    ) in query.all():
+        edit_id = str(edit.id)
+
+        edit.data = edit.data or {}
+
+        if edit_id not in edit_map:
+
+            edit_map[edit_id] = fields.serialize_dict(
+                {
+                    "canceled": edit.canceled,
+                    "data": edit.data,
+                    "description": edit.description,
+                    "entity_type_id": edit.entity_type_id,
+                    "id": edit.id,
+                    "name": edit.name,
+                    "parent_id": edit.parent_id,
+                    "preview_file_id": edit.preview_file_id or None,
+                    "project_id": project_id,
+                    "project_name": project_name,
+                    "source_id": edit.source_id,
+                    "nb_entities_out": edit.nb_entities_out,
+                    "tasks": [],
+                    "type": "Edit",
+                }
+            )
+
+        if task_id is not None:
+            if task_id not in task_map:
+                task_dict = fields.serialize_dict(
+                    {
+                        "id": task_id,
+                        "entity_id": edit_id,
+                        "task_status_id": task_status_id,
+                        "task_type_id": task_type_id,
+                        "priority": task_priority or 0,
+                        "estimation": task_estimation,
+                        "duration": task_duration,
+                        "retake_count": task_retake_count,
+                        "real_start_date": task_real_start_date,
+                        "end_date": task_end_date,
+                        "start_date": task_start_date,
+                        "due_date": task_due_date,
+                        "last_comment_date": task_last_comment_date,
+                        "nb_assets_ready": task_nb_assets_ready,
+                        "assignees": [],
+                    }
+                )
+                task_map[task_id] = task_dict
+                edit_dict = edit_map[edit_id]
+                edit_dict["tasks"].append(task_dict)
+
+            if person_id:
+                task_map[task_id]["assignees"].append(str(person_id))
+
+    return list(edit_map.values())
+
+
+def get_edit_raw(edit_id):
+    """
+    Return given edit as an active record.
+    """
+    edit_type = get_edit_type()
+    try:
+        edit = Entity.get_by(entity_type_id=edit_type["id"], id=edit_id)
+    except StatementError:
+        raise EditNotFoundException
+
+    if edit is None:
+        raise EditNotFoundException
+
+    return edit
+
+
+@cache.memoize_function(120)
+def get_edit(edit_id):
+    """
+    Return given edit as a dictionary.
+    """
+    return get_edit_raw(edit_id).serialize(obj_type="Edit")
+
+
+@cache.memoize_function(120)
+def get_edit_with_relations(edit_id):
+    """
+    Return given edit as a dictionary.
+    """
+    return get_edit_raw(edit_id).serialize(obj_type="Edit", relations=True)
+
+
+@cache.memoize_function(120)
+def get_full_edit(edit_id):
+    """
+    Return given edit as a dictionary with extra data like project.
+    """
+    edits = get_edits_and_tasks({"id": edit_id})
+    if len(edits) > 0:
+        return edits[0]
+    else:
+        raise EditNotFoundException
+
+
+def is_edit(entity):
+    """
+    Returns True if given entity has 'Edit' as entity type
+    """
+    edit_type = get_edit_type()
+    return str(entity["entity_type_id"]) == edit_type["id"]
+
+
+def get_edits_for_project(project_id, only_assigned=False):
+    """
+    Retrieve all edits related to given project.
+    """
+    return entities_service.get_entities_for_project(
+        project_id, get_edit_type()["id"], "Edit", only_assigned=only_assigned
+    )
+
+
+def get_edits_for_episode(episode_id, relations=False):
+    """
+    Get all edits for given episode.
+    """
+    edit_type_id = get_edit_type()["id"]
+    result = (
+        Entity.query.filter(Entity.entity_type_id == edit_type_id).filter(
+            Entity.parent_id == episode_id
+        )
+    ).all()
+    return Entity.serialize_list(result, "Edit", relations=relations)
+
+
+def remove_edit(edit_id, force=False):
+    """
+    Remove given edit from database. If it has tasks linked to it, it marks
+    the edit as canceled. Deletion can be forced.
+    """
+    edit = get_edit_raw(edit_id)
+    is_tasks_related = Task.query.filter_by(entity_id=edit_id).count() > 0
+
+    if is_tasks_related and not force:
+        edit.update({"canceled": True})
+        clear_edit_cache(edit_id)
+        events.emit(
+            "edit:update",
+            {"edit_id": edit_id},
+            project_id=str(edit.project_id),
+        )
+    else:
+        from zou.app.services import tasks_service
+
+        tasks = Task.query.filter_by(entity_id=edit_id).all()
+        for task in tasks:
+            deletion_service.remove_task(task.id, force=True)
+            tasks_service.clear_task_cache(str(task.id))
+
+        EntityVersion.delete_all_by(entity_id=edit_id)
+        Subscription.delete_all_by(entity_id=edit_id)
+        EntityLink.delete_all_by(entity_in_id=edit_id)
+        edit.delete()
+        clear_edit_cache(edit_id)
+        events.emit(
+            "edit:delete",
+            {"edit_id": edit_id},
+            project_id=str(edit.project_id),
+        )
+
+    deleted_edit = edit.serialize(obj_type="Edit")
+    return deleted_edit
+
+
+def create_edit(project_id, name, data={}, description="", parent_id=None):
+    """
+    Create edit for given project and episode.
+    """
+    edit_type = get_edit_type()
+
+    if parent_id is not None and len(parent_id) < 36:
+        parent_id = None
+
+    edit = Entity.get_by(
+        entity_type_id=edit_type["id"],
+        parent_id=parent_id,
+        project_id=project_id,
+        name=name,
+    )
+    if edit is None:
+        edit = Entity.create(
+            entity_type_id=edit_type["id"],
+            project_id=project_id,
+            parent_id=parent_id,
+            name=name,
+            data=data,
+            description=description,
+        )
+    events.emit(
+        "edit:new",
+        {
+            "edit_id": edit.id,
+            "parent_id": parent_id,
+        },
+        project_id=project_id,
+    )
+    return edit.serialize(obj_type="Edit")
+
+
+def update_edit(edit_id, data_dict):
+    """
+    Update fields of an edit with a given edit_id with data given data_dict.
+    """
+    edit = get_edit_raw(edit_id)
+    edit.update(data_dict)
+    clear_edit_cache(edit_id)
+    events.emit(
+        "edit:update", {"edit_id": edit_id}, project_id=str(edit.project_id)
+    )
+    return edit.serialize()
+
+
+def get_edit_versions(edit_id):
+    """
+    Edit metadata changes are versioned. This function returns all versions
+    of a given edit.
+    """
+    versions = (
+        EntityVersion.query.filter_by(entity_id=edit_id)
+        .order_by(EntityVersion.created_at.desc())
+        .all()
+    )
+    return EntityVersion.serialize_list(versions, obj_type="EditVersion")

--- a/zou/app/services/entities_service.py
+++ b/zou/app/services/entities_service.py
@@ -24,6 +24,14 @@ def clear_entity_type_cache(entity_type_id):
     cache.cache.delete_memoized(get_entity_type_by_name)
 
 
+def get_temporal_entity_type_by_name(name):
+    entity_type = get_entity_type_by_name(name)
+    if entity_type is None:
+        cache.cache.delete_memoized(get_entity_type_by_name, name)
+        entity_type = get_entity_type_by_name(name)
+    return entity_type
+
+
 @cache.memoize_function(240)
 def get_entity_type(entity_type_id):
     """

--- a/zou/app/services/exception.py
+++ b/zou/app/services/exception.py
@@ -175,3 +175,7 @@ class WrongParameterException(Exception):
 
 class ModelWithRelationsDeletionException(Exception):
     pass
+
+
+class EditNotFoundException(NotFound):
+    pass

--- a/zou/app/services/shots_service.py
+++ b/zou/app/services/shots_service.py
@@ -43,34 +43,24 @@ def clear_episode_cache(episode_id):
     cache.cache.delete_memoized(get_episode, episode_id)
 
 
-def get_temporal_entity_type_by_name(name):
-    entity_type = entities_service.get_entity_type_by_name(name)
-    if entity_type is None:
-        cache.cache.delete_memoized(
-            entities_service.get_entity_type_by_name, name
-        )
-        entity_type = entities_service.get_entity_type_by_name(name)
-    return entity_type
-
-
 @cache.memoize_function(1200)
 def get_episode_type():
-    return get_temporal_entity_type_by_name("Episode")
+    return entities_service.get_temporal_entity_type_by_name("Episode")
 
 
 @cache.memoize_function(1200)
 def get_sequence_type():
-    return get_temporal_entity_type_by_name("Sequence")
+    return entities_service.get_temporal_entity_type_by_name("Sequence")
 
 
 @cache.memoize_function(1200)
 def get_shot_type():
-    return get_temporal_entity_type_by_name("Shot")
+    return entities_service.get_temporal_entity_type_by_name("Shot")
 
 
 @cache.memoize_function(1200)
 def get_scene_type():
-    return get_temporal_entity_type_by_name("Scene")
+    return entities_service.get_temporal_entity_type_by_name("Scene")
 
 
 @cache.memoize_function(1200)

--- a/zou/app/utils/commands.py
+++ b/zou/app/utils/commands.py
@@ -12,6 +12,7 @@ from zou.app.services import (
     assets_service,
     backup_service,
     deletion_service,
+    edits_service,
     persons_service,
     projects_service,
     shots_service,
@@ -68,6 +69,9 @@ def init_data():
     shots_service.get_sequence_type()
     shots_service.get_shot_type()
     print("Shot types initialized.")
+
+    edits_service.get_edit_type()
+    print("Edit type initialized.")
 
     modeling = tasks_service.get_or_create_department("Modeling")
     animation = tasks_service.get_or_create_department("Animation")
@@ -131,6 +135,14 @@ def init_data():
         priority=7,
         for_shots=True,
         for_entity="Shot",
+    )
+    tasks_service.get_or_create_task_type(
+        compositing,
+        "Edit",
+        "#9b298c",
+        priority=8,
+        for_shots=False,
+        for_entity="Edit",
     )
     print("Task types initialized.")
 


### PR DESCRIPTION
These are the back-end changes necessary for adding Edits, see the discussion here: /cgwire/kitsu/discussions/801

In the context of this PR, an edit is a final result of the whole production: an edit of a film or an edit of an episode, revisioned/versioned in the same manner Shots a revisioned.

This PR adds a new Edit entity and a task type Edit, as well as respective API endpoints.
The API and data structure of Edit are similar to those of Assets or Shots, which the main difference being that Edits are parented to episodes directly.

https://user-images.githubusercontent.com/176934/150321649-765b13a3-ecb7-48a3-ab96-639a58b6771c.mp4

https://user-images.githubusercontent.com/176934/150321543-b99bfe37-99b2-4e76-a772-239b60f6fe09.mp4