### PR TITLE
new route to get all asset tasks linked to an episode

### DIFF
--- a/zou/app/blueprints/comments/__init__.py
+++ b/zou/app/blueprints/comments/__init__.py
@@ -9,6 +9,7 @@ from .resources import (
     CommentManyTasksResource,
     DownloadAttachmentResource,
     ProjectAttachmentFiles,
+    TaskAttachmentFiles,
     ReplyCommentResource,
     DeleteReplyCommentResource,
 )
@@ -33,6 +34,7 @@ routes = [
         AddAttachmentToCommentResource,
     ),
     ("/data/projects/<project_id>/attachment-files", ProjectAttachmentFiles),
+    ("/data/tasks/<task_id>/attachment-files", TaskAttachmentFiles),
     ("/actions/tasks/<task_id>/comment", CommentTaskResource),
     (
         "/actions/projects/<project_id>/tasks/comment-many",

--- a/zou/app/blueprints/comments/resources.py
+++ b/zou/app/blueprints/comments/resources.py
@@ -227,3 +227,14 @@ class ProjectAttachmentFiles(Resource):
         return comments_service.get_all_attachment_files_for_project(
             project_id
         )
+
+
+class TaskAttachmentFiles(Resource):
+    """
+    Return all attachment files related to given task.
+    """
+
+    @jwt_required
+    def get(self, task_id):
+        permissions.check_admin_permissions()
+        return comments_service.get_all_attachment_files_for_task(task_id)

--- a/zou/app/blueprints/shots/__init__.py
+++ b/zou/app/blueprints/shots/__init__.py
@@ -39,6 +39,7 @@ from .resources import (
     SequenceTasksResource,
     SequenceTaskTypesResource,
     EpisodeShotTasksResource,
+    EpisodeAssetTasksResource,
     SequenceShotTasksResource,
 )
 
@@ -67,6 +68,7 @@ routes = [
     ("/data/episodes/<episode_id>/tasks", EpisodeTasksResource),
     ("/data/episodes/<episode_id>/task-types", EpisodeTaskTypesResource),
     ("/data/episodes/<episode_id>/shot-tasks", EpisodeShotTasksResource),
+    ("/data/episodes/<episode_id>/asset-tasks", EpisodeAssetTasksResource),
     ("/data/sequences", SequencesResource),
     ("/data/sequences/with-tasks", SequenceAndTasksResource),
     ("/data/sequences/<sequence_id>", SequenceResource),

--- a/zou/app/blueprints/shots/resources.py
+++ b/zou/app/blueprints/shots/resources.py
@@ -178,7 +178,7 @@ class EpisodeShotTasksResource(Resource, ArgsMixin):
     @jwt_required
     def get(self, episode_id):
         """
-        Retrieve all tasks related to a given episode.
+        Retrieve all shots tasks related to a given episode.
         """
         episode = shots_service.get_episode(episode_id)
         user_service.check_project_access(episode["project_id"])
@@ -187,6 +187,23 @@ class EpisodeShotTasksResource(Resource, ArgsMixin):
             raise permissions.PermissionDenied
         relations = self.get_relations()
         return tasks_service.get_shot_tasks_for_episode(
+            episode_id, relations=relations
+        )
+
+
+class EpisodeAssetTasksResource(Resource, ArgsMixin):
+    @jwt_required
+    def get(self, episode_id):
+        """
+        Retrieve all assets tasks related to a given episode.
+        """
+        episode = shots_service.get_episode(episode_id)
+        user_service.check_project_access(episode["project_id"])
+        user_service.check_entity_access(episode["id"])
+        if permissions.has_vendor_permissions():
+            raise permissions.PermissionDenied
+        relations = self.get_relations()
+        return tasks_service.get_asset_tasks_for_episode(
             episode_id, relations=relations
         )
 

--- a/zou/app/services/comments_service.py
+++ b/zou/app/services/comments_service.py
@@ -257,6 +257,18 @@ def get_all_attachment_files_for_project(project_id):
     return fields.serialize_models(attachment_files)
 
 
+def get_all_attachment_files_for_task(task_id):
+    """
+    Return all attachment files listed into given task.
+    """
+    attachment_files = (
+        AttachmentFile.query.join(Comment)
+        .join(Task, Task.id == Comment.object_id)
+        .filter(Task.id == task_id)
+    )
+    return fields.serialize_models(attachment_files)
+
+
 def acknowledge_comment(comment_id):
     """
     Add current user to the list of people who acknowledged given comment.

--- a/zou/app/services/tasks_service.py
+++ b/zou/app/services/tasks_service.py
@@ -278,12 +278,24 @@ def get_shot_tasks_for_sequence(sequence_id, relations=False):
 
 def get_shot_tasks_for_episode(episode_id, relations=False):
     """
-    Get all shot tasks for given episode.
+    Get all shots tasks for given episode.
     """
     query = _get_entity_task_query()
     Sequence = aliased(Entity, name="sequence")
     query = query.join(Sequence, Entity.parent_id == Sequence.id).filter(
         Sequence.parent_id == episode_id
+    )
+    return _convert_rows_to_detailed_tasks(query.all(), relations)
+
+
+def get_asset_tasks_for_episode(episode_id, relations=False):
+    """
+    Get all assets tasks for given episode.
+    """
+    query = (
+        _get_entity_task_query()
+        .filter(assets_service.build_asset_type_filter())
+        .filter(Entity.source_id == episode_id)
     )
     return _convert_rows_to_detailed_tasks(query.all(), relations)
 


### PR DESCRIPTION
**Problem**

- There's no route to get all asset tasks linked to an episode
- There's no route to get all attachment-files for a specific task

**Solution**

- Add a route to get all asset tasks linked to an episode
- Add a route to get all attachment-files for a specific task