### PR TITLE
[qa] Fix itsdangerous dependency issue

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -45,6 +45,7 @@ install_requires =
     redis==3.5.3
     ldap3==2.8.1
     psutil==5.8.0
+    itsdangerous==2.0.1
 
     email_validator==1.0.4
 


### PR DESCRIPTION

**Problem**

While deploying Zou, there is an issue with recent Python versions related to the latest version of the `itsdangerous` package grabbed by the `flask` package.

**Solution**

Force `itsdangerous` version to a prior version that works (compatible with our version of Flask).
