### PR TITLE
Allow to compute the quotas the old way

### DIFF
--- a/zou/app/blueprints/persons/resources.py
+++ b/zou/app/blueprints/persons/resources.py
@@ -232,6 +232,7 @@ class PersonMonthQuotaShotsResource(Resource, ArgsMixin):
         project_id = self.get_project_id()
         task_type_id = self.get_task_type_id()
         user_service.check_person_access(person_id)
+        weighted = self.get_bool_parameter("weighted", default="true")
         try:
             return shots_service.get_month_quota_shots(
                 person_id,
@@ -239,6 +240,7 @@ class PersonMonthQuotaShotsResource(Resource, ArgsMixin):
                 month,
                 project_id=project_id,
                 task_type_id=task_type_id,
+                weighted=weighted,
             )
         except WrongDateFormatException:
             abort(404)
@@ -254,6 +256,7 @@ class PersonWeekQuotaShotsResource(Resource, ArgsMixin):
         project_id = self.get_project_id()
         task_type_id = self.get_task_type_id()
         user_service.check_person_access(person_id)
+        weighted = self.get_bool_parameter("weighted", default="true")
         try:
             return shots_service.get_week_quota_shots(
                 person_id,
@@ -261,6 +264,7 @@ class PersonWeekQuotaShotsResource(Resource, ArgsMixin):
                 week,
                 project_id=project_id,
                 task_type_id=task_type_id,
+                weighted=weighted,
             )
         except WrongDateFormatException:
             abort(404)
@@ -276,6 +280,7 @@ class PersonDayQuotaShotsResource(Resource, ArgsMixin):
         project_id = self.get_project_id()
         task_type_id = self.get_task_type_id()
         user_service.check_person_access(person_id)
+        weighted = self.get_bool_parameter("weighted", default="true")
         try:
             return shots_service.get_day_quota_shots(
                 person_id,
@@ -284,6 +289,7 @@ class PersonDayQuotaShotsResource(Resource, ArgsMixin):
                 day,
                 project_id=project_id,
                 task_type_id=task_type_id,
+                weighted=weighted,
             )
         except WrongDateFormatException:
             abort(404)

--- a/zou/app/blueprints/shots/resources.py
+++ b/zou/app/blueprints/shots/resources.py
@@ -693,7 +693,19 @@ class ProjectQuotasResource(Resource, ArgsMixin):
 
     @jwt_required
     def get(self, project_id, task_type_id):
-        project = projects_service.get_project(project_id)
+        projects_service.get_project(project_id)
         user_service.check_project_access(project_id)
         detail_level = self.get_text_parameter("detail")
-        return shots_service.get_quotas(project_id, task_type_id, detail_level)
+        weighted = self.get_bool_parameter("weighted", default="true")
+        if weighted:
+            return shots_service.get_weighted_quotas(
+                project_id,
+                task_type_id,
+                detail_level
+            )
+        else:
+            return shots_service.get_raw_quotas(
+                project_id,
+                task_type_id,
+                detail_level
+            )

--- a/zou/app/mixin.py
+++ b/zou/app/mixin.py
@@ -95,9 +95,9 @@ class ArgsMixin(object):
         options = request.args
         return options.get(field_name, None)
 
-    def get_bool_parameter(self, field_name):
+    def get_bool_parameter(self, field_name, default="false"):
         options = request.args
-        return options.get(field_name, "false") == "true"
+        return options.get(field_name, default) == "true"
 
     def get_date_parameter(self, field_name):
         self.parse_date_parameter(self.get_text_parameter(field_name))


### PR DESCRIPTION
**Problem**

Some studios rely heavily on the old way to compute quotas.

**Solution**

Add a `weighted` flag set to true by default to the quota route. If it's set to false, it computes the quotas the old way by counting frames on real end date (feedback date).
