### PR TITLE
Default timezone added to config

### DIFF
--- a/zou/app/config.py
+++ b/zou/app/config.py
@@ -121,6 +121,8 @@ CRISP_TOKEN = os.getenv("CRISP_TOKEN", "")
 
 USER_LIMIT = int(os.getenv("USER_LIMIT", "100"))
 
+DEFAULT_TIMEZONE = os.getenv("DEFAULT_TIMEZONE", "Europe/Paris")
+
 # Deprecated
 DONE_TASK_STATUS = "Done"
 WIP_TASK_STATUS = "WIP"

--- a/zou/app/models/person.py
+++ b/zou/app/models/person.py
@@ -9,6 +9,7 @@ from babel import Locale
 from zou.app import db
 from zou.app.models.serializer import SerializerMixin
 from zou.app.models.base import BaseMixin
+from zou.app import config
 
 
 department_link = db.Table(
@@ -37,7 +38,8 @@ class Person(db.Model, BaseMixin, SerializerMixin):
     desktop_login = db.Column(db.String(80))
     shotgun_id = db.Column(db.Integer, unique=True)
     timezone = db.Column(
-        TimezoneType(backend="pytz"), default=pytz_timezone("Europe/Paris")
+        TimezoneType(backend="pytz"),
+        default=pytz_timezone(config.DEFAULT_TIMEZONE),
     )
     locale = db.Column(LocaleType, default=Locale("en", "US"))
     data = db.Column(JSONB)

--- a/zou/app/services/user_service.py
+++ b/zou/app/services/user_service.py
@@ -1,5 +1,6 @@
 from sqlalchemy.orm import aliased
 
+from zou.app import config
 from zou.app.models.comment import Comment
 from zou.app.models.entity import Entity
 from zou.app.models.entity_type import EntityType
@@ -753,8 +754,8 @@ def get_timezone():
     try:
         timezone = persons_service.get_current_user()["timezone"]
     except Exception:
-        timezone = "Europe/Paris"
-    return timezone or "Europe/Paris"
+        timezone = config.DEFAULT_TIMEZONE
+    return timezone or config.DEFAULT_TIMEZONE
 
 
 def get_context():


### PR DESCRIPTION
**Problem**
Previously, default time zone for users was hard coded into value "Europe/Paris"

**Solution**
Now it is moved into config, allowing administrators to change it by setting `DEFAULT_TIMEZONE` environment variable.
If not set, previous behavior is preserved.
