### PR TITLE
Allow same name of task_type for different entities, cleanup tmp after preview upload

### DIFF
--- a/zou/app/services/comments_service.py
+++ b/zou/app/services/comments_service.py
@@ -1,4 +1,5 @@
 import datetime
+import os
 import re
 
 from flask import current_app
@@ -241,6 +242,7 @@ def create_attachment(comment, uploaded_file):
     size = fs.get_file_size(tmp_file_path)
     attachment_file.update({"size": size})
     file_store.add_file("attachments", attachment_file_id, tmp_file_path)
+    os.remove(tmp_file_path)
     return attachment_file.present()
 
 

--- a/zou/app/services/preview_files_service.py
+++ b/zou/app/services/preview_files_service.py
@@ -96,6 +96,7 @@ def prepare_and_store_movie(
     from zou.app import app as current_app
 
     with current_app.app_context():
+        normalized_movie_low_path = None
         try:
             project = get_project_from_preview_file(preview_file_id)
         except PreviewFileNotFoundException:
@@ -194,6 +195,8 @@ def prepare_and_store_movie(
         os.remove(uploaded_movie_path)
         if normalize:
             os.remove(normalized_movie_path)
+            if normalized_movie_low_path:
+                os.remove(normalized_movie_low_path)
         preview_file = update_preview_file(
             preview_file_id, {"status": "ready", "file_size": file_size}
         )

--- a/zou/utils/movie.py
+++ b/zou/utils/movie.py
@@ -227,6 +227,7 @@ def add_empty_soundtrack(file_path, try_count=1):
     logger.info(f"add_empty_soundtrack.sp.returncode: {sp.returncode}")
     if sp.returncode == 0:
         shutil.copyfile(tmp_file_path, file_path)
+        os.remove(tmp_file_path)
     else:
         logger.error(f"Err in soundtrack: {err}")
         logger.error(f"Err code: {sp.returncode}")


### PR DESCRIPTION
**Problem**
* Previously you couldn't add two task types with the same name but for different entities (like FX for Shot and FX for Asset) through api, while database schema definitely allow this to do so.
* Some temporary files were not properly cleaned after generating previews.

**Solution**
All of the above issues have been fixed.
