### PR TITLE
Catch exceptions for the different chats notifications when they are misconfigured

### DIFF
--- a/zou/app/services/emails_service.py
+++ b/zou/app/services/emails_service.py
@@ -43,10 +43,11 @@ def send_notification(person_id, subject, messages):
         token = organisation.get("chat_token_slack", "")
         if config.ENABLE_JOB_QUEUE:
             queue_store.job_queue.enqueue(
-                chats.send_to_slack, args=(token, userid, slack_message)
+                chats.send_to_slack,
+                args=(current_app, token, userid, slack_message),
             )
         else:
-            chats.send_to_slack(token, userid, slack_message)
+            chats.send_to_slack(current_app, token, userid, slack_message)
 
     if person["notifications_mattermost_enabled"]:
         organisation = persons_service.get_organisation()
@@ -55,10 +56,12 @@ def send_notification(person_id, subject, messages):
         if config.ENABLE_JOB_QUEUE:
             queue_store.job_queue.enqueue(
                 chats.send_to_mattermost,
-                args=(webhook, userid, mattermost_message),
+                args=(current_app, webhook, userid, mattermost_message),
             )
         else:
-            chats.send_to_mattermost(webhook, userid, discord_message)
+            chats.send_to_mattermost(
+                current_app, webhook, userid, mattermost_message
+            )
 
     if person["notifications_discord_enabled"]:
         organisation = persons_service.get_organisation()

--- a/zou/app/services/tasks_service.py
+++ b/zou/app/services/tasks_service.py
@@ -1162,7 +1162,10 @@ def is_finished(task, data):
     if "task_status_id" in data:
         task_status = get_task_status_raw(task.task_status_id)
         new_task_status = get_task_status_raw(data["task_status_id"])
-        return new_task_status.id != task_status.id and new_task_status.is_feedback_request
+        return (
+            new_task_status.id != task_status.id
+            and new_task_status.is_feedback_request
+        )
     else:
         return False
 


### PR DESCRIPTION
**Problem**
When the chats (Slack, Mattermost, Discord) are misconfigured it breaks the different requests.

**Solution**
Catch the different exceptions and log them.
