### PR TITLE
:bug: fixed malformed dict key

### DIFF
--- a/zou/app/services/tasks_service.py
+++ b/zou/app/services/tasks_service.py
@@ -866,7 +866,7 @@ def get_person_tasks(person_id, projects, is_done=None):
                 "episode_name": episode_name,
                 "task_estimation": task.estimation,
                 "task_duration": task.duration,
-                "task_start_ðate": fields.serialize_value(task.start_date),
+                "task_start_date": fields.serialize_value(task.start_date),
                 "task_due_date": fields.serialize_value(task.due_date),
                 "task_type_name": task_type_name,
                 "task_status_name": task_status_name,


### PR DESCRIPTION
**Problem**
"task" dictionaries returned with 'task_start_ðate' key containing unwanted special character.

**Solution**
Changed special character to regular 'd'.
