### PR TITLE
Feature: status automations

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -7,12 +7,14 @@ import ntpath
 from mixer.backend.flask import mixer
 
 from zou.app import app
+from zou.app.models.status_automation import StatusAutomation
 from zou.app.utils import fields, auth, fs
 from zou.app.services import (
     breakdown_service,
     comments_service,
     file_tree_service,
     tasks_service,
+    projects_service
 )
 
 from zou.app.models.asset_instance import AssetInstance
@@ -534,6 +536,20 @@ class ApiDBTestCase(ApiTestCase):
             for_entity="Asset",
             department_id=self.department.id,
         )
+        self.task_type_concept = TaskType.create(
+            name="Concept",
+            short_name="cpt",
+            color="#FFFFFF",
+            for_entity="Asset",
+            department_id=self.department.id,
+        )
+        self.task_type_modeling = TaskType.create(
+            name="Modeling",
+            short_name="mdl",
+            color="#FFFFFF",
+            for_entity="Asset",
+            department_id=self.department.id,
+        )
         self.task_type_animation = TaskType.create(
             name="Animation",
             short_name="anim",
@@ -590,6 +606,30 @@ class ApiDBTestCase(ApiTestCase):
             name="Todo", short_name="todo", color="#FFFFFF"
         )
         return self.task_status_todo
+
+    def generate_fixture_status_automation_to_status(self):
+        self.status_automation_to_status = StatusAutomation.create(
+            entity_type="asset",
+            in_task_type_id = self.task_type_concept.id,
+            in_task_status_id = self.task_status_done.id,
+            out_field_type = "status",
+            out_task_type_id = self.task_type_modeling.id,
+            out_task_status_id = self.task_status_wip.id,
+        )
+        projects_service.add_status_automation_setting(self.project_id, self.status_automation_to_status.id)
+        return self.status_automation_to_status
+
+    def generate_fixture_status_automation_to_ready_for(self):
+        self.status_automation_to_ready_for = StatusAutomation.create(
+            entity_type="asset",
+            in_task_type_id = self.task_type_modeling.id,
+            in_task_status_id = self.task_status_done.id,
+            out_field_type = "ready_for",
+            out_task_type_id = self.task_type_layout.id,
+            out_task_status_id = self.task_status_wip.id,
+        )
+        projects_service.add_status_automation_setting(self.project_id, self.status_automation_to_ready_for.id)
+        return self.status_automation_to_ready_for
 
     def generate_fixture_assigner(self):
         self.assigner = Person.create(first_name="Ema", last_name="Peel")

--- a/tests/models/test_status_automation.py
+++ b/tests/models/test_status_automation.py
@@ -1,0 +1,74 @@
+from tests.base import ApiDBTestCase
+from zou.app.models.status_automation import StatusAutomation
+
+from zou.app.utils import fields
+
+
+class StatusAutomationTestCase(ApiDBTestCase):
+    def setUp(self):
+        super(StatusAutomationTestCase, self).setUp()
+        self.generate_fixture_department()
+        self.generate_fixture_task_type()
+        self.generate_fixture_task_status_done()
+        self.generate_fixture_task_status_wip()
+        self.generate_data(
+            StatusAutomation, 
+            1, 
+            entity_type="asset",
+            in_task_type_id = self.task_type_concept.id,
+            in_task_status_id = self.task_status_done.id,
+            out_field_type = "status",
+            out_task_type_id = self.task_type_modeling.id,
+            out_task_status_id = self.task_status_wip.id,
+        )
+        self.generate_data(
+            StatusAutomation, 
+            1, 
+            entity_type="asset",
+            in_task_type_id = self.task_type_modeling.id,
+            in_task_status_id = self.task_status_done.id,
+            out_field_type = "ready_for",
+            out_task_type_id = self.task_type_layout.id,
+        )
+
+    def test_get_status_automations(self):
+        status_automations = self.get("data/status-automations")
+        self.assertEqual(len(status_automations), 2)
+
+    def test_get_status_automation(self):
+        status_automation = self.get_first("data/status-automations")
+        status_automation_again = self.get("data/status-automations/%s" % status_automation["id"])
+        self.assertEqual(status_automation, status_automation_again)
+        self.get_404("data/status-automations/%s" % fields.gen_uuid())
+
+    def test_create_status_automation(self):
+        data = {
+            'entity_type': "asset",
+            'in_task_type_id': self.task_type_concept.id,
+            'in_task_status_id': self.task_status_done.id,
+            'out_field_type': "status",
+            'out_task_type_id': self.task_type_modeling.id,
+            'out_task_status_id': self.task_status_wip.id,
+        }
+        self.status_automation = self.post("data/status-automations", data)
+        self.assertIsNotNone(self.status_automation["id"])
+
+        status_automations = self.get("data/status-automations")
+        self.assertEqual(len(status_automations), 3)
+
+    def test_update_status_automation(self):
+        status_automation = self.get_first("data/status-automations")
+        data = {"out_field_type": "ready_for"}
+        self.put("data/status-automations/%s" % status_automation["id"], data)
+        status_automation_again = self.get("data/status-automations/%s" % status_automation["id"])
+        self.assertEqual(data["out_field_type"], status_automation_again["out_field_type"])
+        self.put_404("data/status-automations/%s" % fields.gen_uuid(), data)
+
+    def test_delete_status_automation(self):
+        status_automations = self.get("data/status-automations")
+        self.assertEqual(len(status_automations), 2)
+        status_automation = status_automations[0]
+        self.delete("data/status-automations/%s" % status_automation["id"])
+        status_automations = self.get("data/status-automations")
+        self.assertEqual(len(status_automations), 1)
+        self.delete_404("data/status-automations/%s" % fields.gen_uuid())

--- a/tests/services/test_status_automation_service.py
+++ b/tests/services/test_status_automation_service.py
@@ -1,0 +1,49 @@
+# -*- coding: UTF-8 -*-
+from tests.base import ApiDBTestCase
+
+from zou.app.services import (
+    comments_service,
+    status_automations_service,
+    tasks_service,
+)
+
+
+class StatusAutomationServiceTestCase(ApiDBTestCase):
+    def setUp(self):
+        super(StatusAutomationServiceTestCase, self).setUp()
+
+        self.generate_fixture_project_status()
+        self.generate_fixture_project()
+        self.generate_fixture_person()
+        self.generate_fixture_assigner()
+        self.generate_fixture_asset_type()
+        self.entity = self.generate_fixture_asset()
+        self.generate_fixture_sequence()
+        self.generate_fixture_shot()
+        self.generate_fixture_department()
+        self.generate_fixture_task_status()
+        self.generate_fixture_task_type()
+        self.generate_fixture_shot_task()
+        self.task_concept = self.generate_fixture_task(name="Concept", entity_id=self.entity.id, task_type_id=self.task_type_concept.id)
+        self.task_modeling = self.generate_fixture_task(name="Modeling", entity_id=self.entity.id, task_type_id=self.task_type_modeling.id)
+        self.generate_fixture_task_status_wip()
+        self.generate_fixture_task_status_done()
+        self.generate_fixture_status_automation_to_status()
+        self.generate_fixture_status_automation_to_ready_for()
+
+    def test_created_status_automation(self):
+        self.assertEqual(len(status_automations_service.get_status_automations()), 2)
+
+    def test_status_automation_to_status(self):
+        wip_status = tasks_service.get_wip_status()
+        comments_service.create_comment(
+            self.person.id, self.task_concept.id, str(self.task_status_done.id), "Test",
+            [], {}, None
+        )
+        self.assertEqual(str(self.task_modeling.task_status_id), wip_status["id"])
+
+    def test_status_automation_to_ready_for(self):
+        comments_service.create_comment(
+            self.person.id, self.task_modeling.id, str(self.task_status_done.id), "Test", [], {}, None
+        )
+        self.assertEqual(self.asset.ready_for, self.task_type_layout.id)

--- a/zou/app/blueprints/crud/__init__.py
+++ b/zou/app/blueprints/crud/__init__.py
@@ -6,6 +6,7 @@ from .asset_instance import AssetInstanceResource, AssetInstancesResource
 from .attachment_file import AttachmentFilesResource, AttachmentFileResource
 from .comments import CommentsResource, CommentResource
 from .custom_action import CustomActionsResource, CustomActionResource
+from .status_automation import StatusAutomationsResource, StatusAutomationResource
 from .day_off import DayOffsResource, DayOffResource
 from .department import DepartmentsResource, DepartmentResource
 from .entity import EntityResource, EntitiesResource
@@ -87,6 +88,8 @@ routes = [
     ("/data/day-offs/<instance_id>", DayOffResource),
     ("/data/custom-actions/", CustomActionsResource),
     ("/data/custom-actions/<instance_id>", CustomActionResource),
+    ("/data/status-automations/", StatusAutomationsResource),
+    ("/data/status-automations/<instance_id>", StatusAutomationResource),
     ("/data/asset-instances/", AssetInstancesResource),
     ("/data/asset-instances/<instance_id>", AssetInstanceResource),
     ("/data/playlists/", PlaylistsResource),

--- a/zou/app/blueprints/crud/project.py
+++ b/zou/app/blueprints/crud/project.py
@@ -60,6 +60,7 @@ class ProjectResource(BaseModelResource):
         data.pop("asset_types", [])
         data.pop("task_statuses", [])
         data.pop("task_types", [])
+        data.pop("status_automations", [])
         return project_dict
 
     def post_update(self, project_dict):

--- a/zou/app/blueprints/crud/status_automation.py
+++ b/zou/app/blueprints/crud/status_automation.py
@@ -1,0 +1,30 @@
+from zou.app.models.status_automation import StatusAutomation
+
+from .base import BaseModelsResource, BaseModelResource
+
+from zou.app.services import status_automations_service, user_service
+
+class StatusAutomationsResource(BaseModelsResource):
+    def __init__(self):
+        BaseModelsResource.__init__(self, StatusAutomation)
+
+    def check_read_permissions(self):
+        user_service.block_access_to_vendor()
+        return True
+
+    def post_creation(self, status_automation):
+        status_automations_service.clear_status_automation_cache()
+        return status_automation.serialize()
+
+
+class StatusAutomationResource(BaseModelResource):
+    def __init__(self):
+        BaseModelResource.__init__(self, StatusAutomation)
+
+    def post_update(self, status_automation):
+        status_automations_service.clear_status_automation_cache()
+        return status_automation
+
+    def post_delete(self, status_automation):
+        status_automations_service.clear_status_automation_cache()
+        return status_automation

--- a/zou/app/blueprints/projects/__init__.py
+++ b/zou/app/blueprints/projects/__init__.py
@@ -13,6 +13,8 @@ from .resources import (
     ProductionTaskTypesResource,
     ProductionTaskStatusResource,
     ProductionTaskStatusRemoveResource,
+    ProductionStatusAutomationResource,
+    ProductionStatusAutomationRemoveResource,
     ProductionMetadataDescriptorResource,
     ProductionMetadataDescriptorsResource,
     ProductionMilestonesResource,
@@ -59,6 +61,14 @@ routes = [
     (
         "/data/projects/<project_id>/settings/task-status/<task_status_id>",
         ProductionTaskStatusRemoveResource,
+    ),
+    (
+        "/data/projects/<project_id>/settings/status-automations",
+        ProductionStatusAutomationResource,
+    ),
+    (
+        "/data/projects/<project_id>/settings/status-automations/<status_automation_id>",
+        ProductionStatusAutomationRemoveResource,
     ),
     (
         "/data/projects/<project_id>/metadata-descriptors",

--- a/zou/app/blueprints/projects/resources.py
+++ b/zou/app/blueprints/projects/resources.py
@@ -193,6 +193,35 @@ class ProductionTaskStatusRemoveResource(Resource):
         return "", 204
 
 
+class ProductionStatusAutomationResource(Resource, ArgsMixin):
+    """
+    Allow to add a status automation linked to a production.
+    """
+
+    @jwt_required
+    def post(self, project_id):
+        args = self.get_args(
+            [("status_automation_id", "", True)]
+        )
+        user_service.check_manager_project_access(project_id)
+        project = projects_service.add_status_automation_setting(
+            project_id, args["status_automation_id"]
+        )
+        return project, 201
+
+
+class ProductionStatusAutomationRemoveResource(Resource):
+    """
+    Allow to remove an status automation linked to a production.
+    """
+
+    @jwt_required
+    def delete(self, project_id, status_automation_id):
+        user_service.check_manager_project_access(project_id)
+        projects_service.remove_status_automation_setting(project_id, status_automation_id)
+        return "", 204
+
+
 class ProductionMetadataDescriptorsResource(Resource, ArgsMixin):
     """
     Resource to get and create metadata descriptors. It serves to describe

--- a/zou/app/blueprints/projects/resources.py
+++ b/zou/app/blueprints/projects/resources.py
@@ -199,6 +199,11 @@ class ProductionStatusAutomationResource(Resource, ArgsMixin):
     """
 
     @jwt_required
+    def get(self, project_id):
+        user_service.check_manager_project_access(project_id)
+        return projects_service.get_project_status_automations(project_id)
+
+    @jwt_required
     def post(self, project_id):
         args = self.get_args(
             [("status_automation_id", "", True)]

--- a/zou/app/models/project.py
+++ b/zou/app/models/project.py
@@ -57,6 +57,16 @@ class ProjectAssetTypeLink(db.Model):
         primary_key=True,
     )
 
+class ProjectStatusAutomationLink(db.Model):
+    __tablename__ = "project_status_automation_link"
+    project_id = db.Column(
+        UUIDType(binary=False), db.ForeignKey("project.id"), primary_key=True
+    )
+    status_automation_id = db.Column(
+        UUIDType(binary=False),
+        db.ForeignKey("status_automation.id"),
+        primary_key=True,
+    )
 
 class Project(db.Model, BaseMixin, SerializerMixin):
     """
@@ -94,6 +104,9 @@ class Project(db.Model, BaseMixin, SerializerMixin):
     task_types = db.relationship(
         "TaskType", secondary="project_task_type_link"
     )
+    status_automations = db.relationship(
+        "StatusAutomation", secondary="project_status_automation_link"
+    )
 
     def set_team(self, person_ids):
         for person_id in person_ids:
@@ -125,6 +138,11 @@ class Project(db.Model, BaseMixin, SerializerMixin):
             asset_type_ids, ProjectAssetTypeLink, "project_id", "asset_type_id"
         )
 
+    def set_status_automations(self, status_automation_ids):
+        return self.set_links(
+            status_automation_ids, ProjectStatusAutomationLink, "project_id", "status_automation_id"
+        )
+
     @classmethod
     def create_from_import(cls, data):
         is_update = False
@@ -136,6 +154,7 @@ class Project(db.Model, BaseMixin, SerializerMixin):
         task_type_ids = data.pop("task_types", None)
         task_status_ids = data.pop("task_statuses", None)
         asset_type_ids = data.pop("asset_types", None)
+        status_automation_ids = data.pop("status_automations", None)
 
         if previous_project is None:
             previous_project = cls.create(**data)
@@ -156,5 +175,8 @@ class Project(db.Model, BaseMixin, SerializerMixin):
 
         if asset_type_ids is not None:
             previous_project.set_asset_types(asset_type_ids)
+
+        if status_automation_ids is not None:
+            previous_project.set_status_automations(status_automation_ids)
 
         return (previous_project, is_update)

--- a/zou/app/models/status_automation.py
+++ b/zou/app/models/status_automation.py
@@ -1,0 +1,27 @@
+from sqlalchemy_utils import UUIDType
+from zou.app import db
+from zou.app.models.serializer import SerializerMixin
+from zou.app.models.base import BaseMixin
+
+class StatusAutomation(db.Model, BaseMixin, SerializerMixin):
+    """
+    Status automations are status changes automations.
+    They allow supervisors to TODO
+    """
+    entity_type = db.Column(db.String(40), default="asset")
+
+    in_field_type = db.Column(db.String(40), default="status")
+    in_task_type_id = db.Column(
+        UUIDType(binary=False), db.ForeignKey("task_type.id"), index=True
+    )
+    in_task_status_id = db.Column(
+        UUIDType(binary=False), db.ForeignKey("task_status.id"), index=True
+    )
+
+    out_field_type = db.Column(db.String(40), default="status")
+    out_task_type_id = db.Column(
+        UUIDType(binary=False), db.ForeignKey("task_type.id"), index=True
+    )
+    out_task_status_id = db.Column(
+        UUIDType(binary=False), db.ForeignKey("task_status.id"), index=True
+    )

--- a/zou/app/models/status_automation.py
+++ b/zou/app/models/status_automation.py
@@ -6,11 +6,12 @@ from zou.app.models.base import BaseMixin
 class StatusAutomation(db.Model, BaseMixin, SerializerMixin):
     """
     Status automations are status changes automations.
-    They allow supervisors to TODO
+    They allow supervisors to automate status changes or `ready for` set when 
+    a status of a task is changed.
     """
     entity_type = db.Column(db.String(40), default="asset")
 
-    in_field_type = db.Column(db.String(40), default="status")
+    in_field_type = db.Column(db.String(40), default="status")  # TODO maybe to delete
     in_task_type_id = db.Column(
         UUIDType(binary=False), db.ForeignKey("task_type.id"), index=True
     )
@@ -23,5 +24,5 @@ class StatusAutomation(db.Model, BaseMixin, SerializerMixin):
         UUIDType(binary=False), db.ForeignKey("task_type.id"), index=True
     )
     out_task_status_id = db.Column(
-        UUIDType(binary=False), db.ForeignKey("task_status.id"), index=True
+        UUIDType(binary=False), db.ForeignKey("task_status.id"), index=True, nullable=True
     )

--- a/zou/app/services/comments_service.py
+++ b/zou/app/services/comments_service.py
@@ -12,6 +12,7 @@ from zou.app.models.task import Task
 from zou.app.services import (
     assets_service,
     base_service,
+    breakdown_service,
     news_service,
     notifications_service,
     persons_service,
@@ -109,7 +110,10 @@ def create_comment(
             
             # Output is `ready_for` field, can be performed only on assets
             elif automation["out_field_type"] == "ready_for":
-                assets_service.update_asset(task["entity_id"], {"ready_for": automation["out_task_type_id"]})
+                asset = assets_service.update_asset(task["entity_id"], {"ready_for": automation["out_task_type_id"]})
+                
+                # Refresh after ready_for
+                breakdown_service.refresh_casting_stats(asset)
         
     return comment
 

--- a/zou/app/services/comments_service.py
+++ b/zou/app/services/comments_service.py
@@ -83,7 +83,7 @@ def create_comment(
     status_automations = projects_service.get_project_status_automations(task["project_id"])
     for automation in status_automations:
         # Match IN status and type
-        if task_status_id == automation["in_task_status_id"] and str(task["task_type_id"]) == automation["in_task_type_id"]:
+        if task_status_id == automation["in_task_status_id"] and task["task_type_id"] == automation["in_task_type_id"]:
             # Sentinel for project task types which OUT priority is higher than IN's
             project_task_types_priority = { # TODO shall we make it a function? Used in projects_service.py too
                 str(task_type_link.task_type_id): task_type_link.priority
@@ -91,7 +91,7 @@ def create_comment(
                     project_id=task["project_id"]
                 )
             }
-            if automation["out_field_type"] != "ready_for" and project_task_types_priority[automation["in_task_type_id"]] > project_task_types_priority[automation["out_task_type_id"]]:
+            if automation["out_field_type"] != "ready_for" and project_task_types_priority and project_task_types_priority[automation["in_task_type_id"]] > project_task_types_priority[automation["out_task_type_id"]]:
                 continue
 
             # Output is `status` field

--- a/zou/app/services/projects_service.py
+++ b/zou/app/services/projects_service.py
@@ -6,6 +6,7 @@ from zou.app.models.metadata_descriptor import MetadataDescriptor
 from zou.app.models.person import Person
 from zou.app.models.project import Project, ProjectTaskTypeLink
 from zou.app.models.project_status import ProjectStatus
+from zou.app.models.status_automation import StatusAutomation
 from zou.app.models.task_type import TaskType
 from zou.app.models.task_status import TaskStatus
 from zou.app.services import base_service
@@ -312,6 +313,21 @@ def remove_task_status_setting(project_id, task_status_id):
         project_id, TaskStatus, task_status_id, "task_statuses"
     )
 
+def add_status_automation_setting(project_id, status_automation_id):
+    """
+    Add a status automation listed in database to the project status automations.
+    """
+    return _add_to_list_attr(
+        project_id, StatusAutomation, status_automation_id, "status_automations"
+    )
+
+def remove_status_automation_setting(project_id, status_automation_id):
+    """
+    Remove a status automation listed in database from the project status automations.
+    """
+    return _remove_from_list_attr(
+        project_id, StatusAutomation, status_automation_id, "status_automations"
+    )
 
 def _add_to_list_attr(project_id, model_class, model_id, list_attr):
     project = get_project_raw(project_id)
@@ -476,6 +492,9 @@ def get_project_task_statuses(project_id):
     project = get_project_raw(project_id)
     return Project.serialize_list(project.task_statuses)
 
+def get_project_status_automations(project_id):
+    project = get_project_raw(project_id)
+    return Project.serialize_list(project.status_automations)
 
 def get_project_fps(project_id):
     """

--- a/zou/app/services/status_automations_service.py
+++ b/zou/app/services/status_automations_service.py
@@ -1,0 +1,11 @@
+from zou.app.models.status_automation import StatusAutomation
+from zou.app.utils import cache, fields
+
+
+def clear_status_automation_cache():
+    cache.cache.delete_memoized(get_status_automations)
+
+
+@cache.memoize_function(120)
+def get_status_automations():
+    return fields.serialize_models(StatusAutomation.get_all())

--- a/zou/app/services/tasks_service.py
+++ b/zou/app/services/tasks_service.py
@@ -48,7 +48,6 @@ from zou.app.services import (
     shots_service,
     entities_service,
     edits_service,
-    status_automations_service,
 )
 
 
@@ -1015,21 +1014,6 @@ def update_task(task_id, data):
 
     if is_finished(task, data):
         data["end_date"] = datetime.datetime.now()
-
-    # Run status automations
-    status_automations = projects_service.get_project_status_automations(task.project_id)
-    for automation in status_automations:
-        # Match IN status and type
-        if data["task_status_id"] == automation["in_task_status_id"] and str(task.task_type_id) == automation["in_task_type_id"]:
-            # Output is `status` field
-            if automation["out_field_type"] == "status":
-                task_to_update = get_tasks_for_entity_and_task_type(task.entity_id, automation["out_task_type_id"])
-                if task_to_update:
-                    update_task(task_to_update[0]["id"], {"task_status_id": automation["out_task_status_id"]})
-            
-            # Output is `ready_for` field, can be performed only on assets
-            elif automation["out_field_type"] == "ready_for":
-                assets_service.update_asset(task.entity_id, {"ready_for": automation["out_task_type_id"]})
 
     task.update(data)
     clear_task_cache(task_id)

--- a/zou/app/services/tasks_service.py
+++ b/zou/app/services/tasks_service.py
@@ -48,6 +48,7 @@ from zou.app.services import (
     shots_service,
     entities_service,
     edits_service,
+    status_automations_service,
 )
 
 
@@ -1014,6 +1015,15 @@ def update_task(task_id, data):
 
     if is_finished(task, data):
         data["end_date"] = datetime.datetime.now()
+
+    # Run status automations
+    status_automations = status_automations_service.get_status_automations()
+    for automation in status_automations:
+        # Match status and type
+        if data["task_status_id"] == automation["in_task_status_id"] and str(task.task_type_id) == automation["in_task_type_id"]:
+            task_to_update = get_tasks_for_entity_and_task_type(task.entity_id, automation["out_task_type_id"])
+            if task_to_update:
+                update_task(task_to_update[0]["id"], {"task_status_id": automation["out_task_status_id"]})
 
     task.update(data)
     clear_task_cache(task_id)

--- a/zou/app/services/tasks_service.py
+++ b/zou/app/services/tasks_service.py
@@ -1019,11 +1019,19 @@ def update_task(task_id, data):
     # Run status automations
     status_automations = status_automations_service.get_status_automations()
     for automation in status_automations:
-        # Match status and type
+        # Match IN status and type
         if data["task_status_id"] == automation["in_task_status_id"] and str(task.task_type_id) == automation["in_task_type_id"]:
-            task_to_update = get_tasks_for_entity_and_task_type(task.entity_id, automation["out_task_type_id"])
-            if task_to_update:
-                update_task(task_to_update[0]["id"], {"task_status_id": automation["out_task_status_id"]})
+            # Output is `status` field
+            if automation["out_field_type"] == "status":
+                task_to_update = get_tasks_for_entity_and_task_type(task.entity_id, automation["out_task_type_id"])
+                if task_to_update:
+                    update_task(task_to_update[0]["id"], {"task_status_id": automation["out_task_status_id"]})
+            
+            # Output is `ready_for` field, can be performed only on assets
+            elif automation["out_field_type"] == "ready_for":
+                assets_service.update_asset(task.entity_id, {"ready_for": automation["out_task_type_id"]})
+
+            # TODO 'Ready for' change event must be added
 
     task.update(data)
     clear_task_cache(task_id)

--- a/zou/app/services/tasks_service.py
+++ b/zou/app/services/tasks_service.py
@@ -1017,7 +1017,7 @@ def update_task(task_id, data):
         data["end_date"] = datetime.datetime.now()
 
     # Run status automations
-    status_automations = status_automations_service.get_status_automations()
+    status_automations = projects_service.get_project_status_automations(task.project_id)
     for automation in status_automations:
         # Match IN status and type
         if data["task_status_id"] == automation["in_task_status_id"] and str(task.task_type_id) == automation["in_task_type_id"]:
@@ -1030,8 +1030,6 @@ def update_task(task_id, data):
             # Output is `ready_for` field, can be performed only on assets
             elif automation["out_field_type"] == "ready_for":
                 assets_service.update_asset(task.entity_id, {"ready_for": automation["out_task_type_id"]})
-
-            # TODO 'Ready for' change event must be added
 
     task.update(data)
     clear_task_cache(task_id)

--- a/zou/app/services/user_service.py
+++ b/zou/app/services/user_service.py
@@ -19,6 +19,7 @@ from zou.app.services import (
     persons_service,
     projects_service,
     shots_service,
+    status_automations_service,
     tasks_service,
 )
 from zou.app.services.exception import (
@@ -766,6 +767,7 @@ def get_context():
 
     asset_types = assets_service.get_asset_types()
     custom_actions = custom_actions_service.get_custom_actions()
+    status_automations = status_automations_service.get_status_automations()
     persons = persons_service.get_persons(
         minimal=not permissions.has_manager_permissions()
     )
@@ -779,6 +781,7 @@ def get_context():
     return {
         "asset_types": asset_types,
         "custom_actions": custom_actions,
+        "status_automations": status_automations,
         "departments": departments,
         "notification_count": notification_count,
         "persons": persons,


### PR DESCRIPTION
**Problem**
Zou implementation for this issue: https://github.com/cgwire/kitsu/issues/828

**Solution**
Implemented it following `TaskStatus` implementation.

The automation is run in `create_comment`, and a status automation changes the status of the OUT task by creating a comment with a default message.
