### PR TITLE
Fix 'cannot import name 'escape' from 'jinja2'

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -80,6 +80,8 @@ install_requires =
     matterhook==0.2
     discord.py==1.7.3
 
+    Jinja2==3.0.3
+
 [options.package_data]
 * = app/file_trees/*.json,migrations/*,migrations/versions/*.py
 


### PR DESCRIPTION
**Problem**
We have an error `Fix 'cannot import name 'escape' from 'jinja2'` with a fresh install.

**Solution**
Pin `Jinja2` in previous version (`3.0.3`).

Link to https://github.com/pallets/jinja/issues/1633