### PR TITLE
[cli] reset-db: clear-db and stamp to first revision before, clear-db…

### DIFF
--- a/zou/cli.py
+++ b/zou/cli.py
@@ -73,12 +73,12 @@ def clear_db():
     with app.app_context():
         import zou
 
-        directory = os.path.join(os.path.dirname(zou.__file__), "migrations")
-        flask_migrate.stamp(directory=directory, revision="base")
-
         print("Deleting database and tables...")
         dbhelpers.drop_all()
         print("Database and tables deleted.")
+
+        directory = os.path.join(os.path.dirname(zou.__file__), "migrations")
+        flask_migrate.stamp(directory=directory, revision="base")
 
 
 @cli.command()
@@ -90,12 +90,12 @@ def reset_db():
     with app.app_context():
         import zou
 
-        directory = os.path.join(os.path.dirname(zou.__file__), "migrations")
-        flask_migrate.stamp(directory=directory, revision="base")
-
         print("Deleting database and tables...")
         dbhelpers.drop_all()
         print("Database and tables deleted.")
+
+        directory = os.path.join(os.path.dirname(zou.__file__), "migrations")
+        flask_migrate.stamp(directory=directory, revision="base")
 
         flask_migrate.upgrade(directory=directory)
         print("Database and tables created.")

--- a/zou/cli.py
+++ b/zou/cli.py
@@ -68,17 +68,37 @@ def downgrade_db(revision):
 def clear_db():
     "Drop all tables from database"
 
-    print("Deleting database and tables...")
-    dbhelpers.drop_all()
-    print("Database and tables deleted.")
+    from zou.app import app
+
+    with app.app_context():
+        import zou
+
+        directory = os.path.join(os.path.dirname(zou.__file__), "migrations")
+        flask_migrate.stamp(directory=directory, revision="base")
+
+        print("Deleting database and tables...")
+        dbhelpers.drop_all()
+        print("Database and tables deleted.")
 
 
 @cli.command()
 def reset_db():
     "Drop all tables then recreates them."
 
-    clear_db()
-    dbhelpers.create_all()
+    from zou.app import app
+
+    with app.app_context():
+        import zou
+
+        directory = os.path.join(os.path.dirname(zou.__file__), "migrations")
+        flask_migrate.stamp(directory=directory, revision="base")
+
+        print("Deleting database and tables...")
+        dbhelpers.drop_all()
+        print("Database and tables deleted.")
+
+        flask_migrate.upgrade(directory=directory)
+        print("Database and tables created.")
 
 
 @cli.command()


### PR DESCRIPTION
…: stamp to first revision before

**Problem**
Command clear-db : we don't set the db revision to first one when we clear the db, so when we do init-db it's not working (see https://github.com/cgwire/zou/issues/405)
Command reset-db is not working because it calls clear-db and we need to set the db revision to first one

**Solution**
For clear-db / reset-db : set the db revision to first one
For reset-db : remove the call to clear-db copy the code instead

