### PR TITLE
[requirements] upgrade pillow to 8.4.0 it's possible since we don't c…

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -55,7 +55,7 @@ install_requires =
     python-slugify==3.0.2
     boto3
 
-    pillow==7.2.0
+    pillow==8.4.0
     pytz==2020.4
     babel==2.7.0
     isoweek==1.3.3


### PR DESCRIPTION
…ontinue to support Python 3.6

**Problem**
There's no whl for Python 3.9/3.10 for pillow 7.2.0 so it's needed to build from sources 

**Solution**
Upgrade pillow to 8.4.0
