### PR TITLE
Always save file size and add an import route for edits

### DIFF
--- a/zou/app/blueprints/previews/resources.py
+++ b/zou/app/blueprints/previews/resources.py
@@ -260,6 +260,9 @@ class CreatePreviewFilePictureResource(Resource, ArgsMixin):
         original_tmp_path = thumbnail_utils.save_file(
             tmp_folder, instance_id, uploaded_file
         )
+        file_size = fs.get_file_size(original_tmp_path)
+        preview_files_service.update_preview_file(
+            instance_id, {"file_size": file_size}, silent=True)
         return preview_files_service.save_variants(
             instance_id, original_tmp_path
         )
@@ -300,6 +303,9 @@ class CreatePreviewFilePictureResource(Resource, ArgsMixin):
         file_path = os.path.join(tmp_folder, file_name)
         uploaded_file.save(file_path)
         file_store.add_file("previews", instance_id, file_path)
+        file_size = fs.get_file_size(file_path)
+        preview_files_service.update_preview_file(
+            instance_id, {"file_size": file_size}, silent=True)
         os.remove(file_path)
         return file_path
 

--- a/zou/app/blueprints/source/__init__.py
+++ b/zou/app/blueprints/source/__init__.py
@@ -1,5 +1,5 @@
 """
-    This module is named source instead of import because import is a Python
+This module is named source instead of import because import is a Python
 keyword.
 """
 from flask import Blueprint
@@ -64,6 +64,7 @@ from .shotgun.team import (
 
 from .csv.persons import PersonsCsvImportResource
 from .csv.assets import AssetsCsvImportResource
+from .csv.edits import EditsCsvImportResource
 from .csv.shots import ShotsCsvImportResource
 from .csv.casting import CastingCsvImportResource
 from .csv.task_type_estimations import (
@@ -116,6 +117,7 @@ routes = [
     ("/import/csv/persons", PersonsCsvImportResource),
     ("/import/csv/projects/<project_id>/assets", AssetsCsvImportResource),
     ("/import/csv/projects/<project_id>/shots", ShotsCsvImportResource),
+    ("/import/csv/projects/<project_id>/edits", EditsCsvImportResource),
     ("/import/csv/projects/<project_id>/casting", CastingCsvImportResource),
     (
         "/import/csv/projects/<project_id>/task-types/<task_type_id>/estimations",

--- a/zou/app/blueprints/source/csv/edits.py
+++ b/zou/app/blueprints/source/csv/edits.py
@@ -1,0 +1,97 @@
+from zou.app.blueprints.source.csv.base import BaseCsvProjectImportResource
+from zou.app.models.project import ProjectTaskTypeLink
+from zou.app.models.task_type import TaskType
+
+from zou.app.services import edits_service, projects_service, shots_service
+from zou.app.models.entity import Entity
+from zou.app.services.tasks_service import create_tasks
+from zou.app.utils import events
+
+
+class EditsCsvImportResource(BaseCsvProjectImportResource):
+    def prepare_import(self, project_id):
+        self.episodes = {}
+        self.entity_types = {}
+        self.descriptor_fields = self.get_descriptor_field_map(
+            project_id, "Edit"
+        )
+        project = projects_service.get_project(project_id)
+        self.is_tv_show = projects_service.is_tv_show(project)
+        if self.is_tv_show:
+            episodes = shots_service.get_episodes_for_project(project_id)
+            self.episodes = {
+                episode["name"]: episode["id"] for episode in episodes
+            }
+        self.created_edits = []
+
+    def import_row(self, row, project_id):
+        asset_name = row["Name"]
+        description = row.get("Description", "")
+        episode_name = row.get("Episode", None)
+        episode_id = None
+        if episode_name is not None:
+            if episode_name not in self.episodes:
+                self.episodes[
+                    episode_name
+                ] = shots_service.get_or_create_episode(
+                    project_id, episode_name
+                )[
+                    "id"
+                ]
+            episode_id = self.episodes.get(episode_name, None)
+
+        edit_type_id = edits_service.get_edit_type()["id"]
+        entity = Entity.get_by(
+            name=asset_name,
+            project_id=project_id,
+            entity_type_id=edit_type_id,
+            source_id=episode_id,
+        )
+
+        data = {}
+        for name, field_name in self.descriptor_fields.items():
+            if name in row:
+                data[field_name] = row[name]
+            elif (
+                entity is not None
+                and entity.data is not None
+                and field_name in entity.data
+            ):
+                data[field_name] = entity.data[field_name]
+
+        if entity is None:
+            entity = Entity.create(
+                name=asset_name,
+                description=description,
+                project_id=project_id,
+                entity_type_id=edit_type_id,
+                source_id=episode_id,
+                data=data,
+            )
+            self.created_edits.append(entity.serialize())
+            events.emit(
+                "edit:new",
+                {"edit_id": str(entity.id), "episode_id": episode_id},
+                project_id=project_id,
+            )
+
+        elif self.is_update:
+            entity.update({"description": description, "data": data})
+            events.emit(
+                "edit:update",
+                {"edit_id": str(entity.id), "episode_id": episode_id},
+                project_id=project_id,
+            )
+
+        return entity.serialize()
+
+    def run_import(self, project_id, file_path):
+        entities = super().run_import(project_id, file_path)
+        task_types_in_project_for_edits = (
+            TaskType.query.join(ProjectTaskTypeLink)
+            .filter(ProjectTaskTypeLink.project_id == project_id)
+            .filter(TaskType.for_entity == "Edit")
+        )
+        for task_type in task_types_in_project_for_edits:
+            create_tasks(task_type.serialize(), self.created_edits)
+        return entities

--- a/zou/app/services/preview_files_service.py
+++ b/zou/app/services/preview_files_service.py
@@ -60,16 +60,17 @@ def get_project_from_preview_file(preview_file_id):
     return project.serialize()
 
 
-def update_preview_file(preview_file_id, data):
+def update_preview_file(preview_file_id, data, silent=False):
     preview_file = files_service.get_preview_file_raw(preview_file_id)
     preview_file.update(data)
     files_service.clear_preview_file_cache(preview_file_id)
-    task = Task.get(preview_file.task_id)
-    events.emit(
-        "preview-file:update",
-        {"preview_file_id": preview_file_id},
-        project_id=str(task.project_id),
-    )
+    if not silent:
+        task = Task.get(preview_file.task_id)
+        events.emit(
+            "preview-file:update",
+            {"preview_file_id": preview_file_id},
+            project_id=str(task.project_id),
+        )
     return preview_file.serialize()
 
 

--- a/zou/app/utils/commands.py
+++ b/zou/app/utils/commands.py
@@ -301,7 +301,6 @@ def sync_with_ldap_server():
 
             elif person is not None:
                 try:
-                    active = True
                     persons_service.update_person(
                         person["id"],
                         {


### PR DESCRIPTION
**Problem**

* The file size is not stored for non-video previews.
* There is no route to deal with the edit csv imports

**Solution**

* Always calculate and store the file size when a preview is uploaded
* Add a route similar to the asset one that allows importing edits at .csv format.
