### PR TITLE
Fix breakdown import

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -444,7 +444,7 @@ class ApiDBTestCase(ApiTestCase):
             first_name="John",
             last_name="Did",
             role="admin",
-            email=u"john.did@gmail.com",
+            email="john.did@gmail.com",
             password=auth.encrypt_password("mypassword"),
         ).serialize()
         return self.user
@@ -454,7 +454,7 @@ class ApiDBTestCase(ApiTestCase):
             first_name="John",
             last_name="Did2",
             role="manager",
-            email=u"john.did.manager@gmail.com",
+            email="john.did.manager@gmail.com",
             password=auth.encrypt_password("mypassword"),
         ).serialize()
         return self.user_manager
@@ -463,7 +463,7 @@ class ApiDBTestCase(ApiTestCase):
         self.user_cg_artist = Person.create(
             first_name="John",
             last_name="Did3",
-            email=u"john.did.cg.artist@gmail.com",
+            email="john.did.cg.artist@gmail.com",
             role="user",
             password=auth.encrypt_password("mypassword"),
         ).serialize(relations=True)
@@ -474,7 +474,7 @@ class ApiDBTestCase(ApiTestCase):
             first_name="John",
             last_name="Did4",
             role="client",
-            email=u"john.did.client@gmail.com",
+            email="john.did.client@gmail.com",
             password=auth.encrypt_password("mypassword"),
         ).serialize()
         return self.user_client
@@ -484,7 +484,7 @@ class ApiDBTestCase(ApiTestCase):
             first_name="John",
             last_name="Did5",
             role="vendor",
-            email=u"john.did.vendor@gmail.com",
+            email="john.did.vendor@gmail.com",
             password=auth.encrypt_password("mypassword"),
         ).serialize()
         return self.user_vendor

--- a/tests/export/test_casting_to_csv.py
+++ b/tests/export/test_casting_to_csv.py
@@ -6,6 +6,7 @@ class CastingCsvExportTestCase(ApiDBTestCase):
         super(CastingCsvExportTestCase, self).setUp()
         self.generate_fixture_project_status()
         self.generate_fixture_project()
+        self.project.update({"production_type": "tvshow"})
         self.generate_fixture_asset_type()
         self.generate_fixture_asset_types()
 

--- a/tests/misc/test_special_chars.py
+++ b/tests/misc/test_special_chars.py
@@ -9,12 +9,12 @@ class SpecialCharTestCase(ApiDBTestCase):
         self.generate_fixture_project()
 
     def test_repr(self):
-        self.project.name = u"Battle 360°"
+        self.project.name = "Battle 360°"
         self.project.save()
-        self.assertEqual(self.project.name, u"Battle 360°")
+        self.assertEqual(self.project.name, "Battle 360°")
 
     def test_get_special_char(self):
-        self.project.name = u"Battle 360°"
+        self.project.name = "Battle 360°"
         self.project.save()
         projects = self.get("data/projects")
-        self.assertEqual(projects[0]["name"], u"Battle 360°")
+        self.assertEqual(projects[0]["name"], "Battle 360°")

--- a/tests/models/test_person.py
+++ b/tests/models/test_person.py
@@ -25,7 +25,7 @@ class PersonTestCase(ApiDBTestCase):
 
     def test_repr(self):
         self.assertEqual(str(self.person), "<Person John Doe>")
-        self.person.first_name = u"Léon"
+        self.person.first_name = "Léon"
         self.assertEqual(str(self.person), "<Person Léon Doe>")
 
     def test_get_persons(self):

--- a/tests/services/test_tasks_service.py
+++ b/tests/services/test_tasks_service.py
@@ -263,8 +263,8 @@ class TaskServiceTestCase(ApiDBTestCase):
 
         tasks = tasks_service.get_task_dicts_for_entity(self.asset.id)
         self.assertEqual(len(tasks), 1)
-        self.assertEqual(tasks[0]["name"], u"Première Tâche")
-        self.assertEqual(tasks[0]["task_type_name"], u"Modélisation")
+        self.assertEqual(tasks[0]["name"], "Première Tâche")
+        self.assertEqual(tasks[0]["task_type_name"], "Modélisation")
 
     def test_get_or_create_time_spents(self):
         person_id = self.person.id

--- a/tests/source/csv/test_import_casting.py
+++ b/tests/source/csv/test_import_casting.py
@@ -8,6 +8,7 @@ class ImportCsvCastingTestCase(ApiDBTestCase):
         super(ImportCsvCastingTestCase, self).setUp()
         self.generate_fixture_project_status()
         self.generate_fixture_project()
+        self.project.update({"production_type": "tvshow"})
         self.generate_fixture_asset_type()
         self.generate_fixture_asset_types()
         for (name, asset_type_id) in [

--- a/tests/source/csv/test_import_casting.py
+++ b/tests/source/csv/test_import_casting.py
@@ -2,6 +2,8 @@ from tests.base import ApiDBTestCase
 
 from zou.app.models.entity import EntityLink
 
+from zou.app.services.shots_service import get_shot
+
 
 class ImportCsvCastingTestCase(ApiDBTestCase):
     def setUp(self):
@@ -76,9 +78,11 @@ class ImportCsvCastingTestCase(ApiDBTestCase):
         self.upload_csv(path, "casting")
         links = EntityLink.query.all()
         self.assertEqual(len(links), 12)
+        self.assertEqual(get_shot(self.e01seq01sh01_id)["nb_entities_out"], 2)
 
         path = "/import/csv/projects/%s/casting" % self.project_id
         self.upload_csv(path, "casting_02")
         links = EntityLink.query.all()
         self.assertEqual(len(links), 12)
         self.assertEqual(links[0].label, "fixed")
+        self.assertEqual(get_shot(self.e01seq01sh01_id)["nb_entities_out"], 2)

--- a/zou/app/blueprints/source/csv/casting.py
+++ b/zou/app/blueprints/source/csv/casting.py
@@ -89,7 +89,9 @@ class CastingCsvImportResource(BaseCsvProjectImportResource):
                 link.update({"nb_occurences": occurences, "label": label})
             entity_id = str(entity.id)
             if shots_service.is_shot(entity.serialize()):
-                breakdown_service.refresh_shot_casting_stats(entity.serialize())
+                breakdown_service.refresh_shot_casting_stats(
+                    entity.serialize()
+                )
                 events.emit(
                     "shot:casting-update",
                     {

--- a/zou/app/blueprints/source/csv/casting.py
+++ b/zou/app/blueprints/source/csv/casting.py
@@ -87,9 +87,9 @@ class CastingCsvImportResource(BaseCsvProjectImportResource):
                 entity.update({"nb_entities_out": entity.nb_entities_out + 1})
             else:
                 link.update({"nb_occurences": occurences, "label": label})
-            breakdown_service.refresh_shot_casting_stats(entity.serialize())
             entity_id = str(entity.id)
             if shots_service.is_shot(entity.serialize()):
+                breakdown_service.refresh_shot_casting_stats(entity.serialize())
                 events.emit(
                     "shot:casting-update",
                     {

--- a/zou/app/services/auth_service.py
+++ b/zou/app/services/auth_service.py
@@ -63,7 +63,7 @@ def check_credentials(email, password, app=None):
             raise WrongPasswordException()
 
     try:
-        password_hash = person["password"] or u""
+        password_hash = person["password"] or ""
 
         if bcrypt.check_password_hash(password_hash, password):
             return person

--- a/zou/app/services/breakdown_service.py
+++ b/zou/app/services/breakdown_service.py
@@ -169,8 +169,8 @@ def update_casting(entity_id, casting):
     entity_id = str(entity.id)
     nb_entities_out = len(casting)
     entity.update({"nb_entities_out": nb_entities_out})
-    refresh_shot_casting_stats(entity.serialize())
     if shots_service.is_shot(entity.serialize()):
+        refresh_shot_casting_stats(entity.serialize())
         events.emit(
             "shot:casting-update",
             {"shot_id": entity_id, "nb_entities_out": nb_entities_out},

--- a/zou/app/services/file_tree_service.py
+++ b/zou/app/services/file_tree_service.py
@@ -114,7 +114,7 @@ def get_working_file_name(
         revision=revision,
     )
 
-    return u"%s" % file_name
+    return "%s" % file_name
 
 
 def get_output_file_name(
@@ -144,7 +144,7 @@ def get_output_file_name(
     if nb_elements > 1:
         file_name += "_[1-%s]" % nb_elements
 
-    return u"%s" % file_name
+    return "%s" % file_name
 
 
 def get_instance_file_name(
@@ -176,7 +176,7 @@ def get_instance_file_name(
     if nb_elements > 1:
         file_name += "_[1-%s]" % nb_elements
 
-    return u"%s" % file_name
+    return "%s" % file_name
 
 
 def get_working_folder_path(


### PR DESCRIPTION
**Problem**
- when we upload a csv for breakdown/casting it's always needed to have an "episode" column even though it's not a tv show
- the casting stats are not correctly upgraded

**Solution**
- "episode" column not needed if it's not a tv show 
- correctly refresh casting stats 

This PR is related to this one : https://github.com/cgwire/kitsu/pull/865