### PR TITLE
various commits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,8 +92,8 @@ ENV/
 Vagrantfile
 .vagrant
 
-previews
-thumbnails
+/previews/
+/thumbnails/
 release.sh
 
 tmp

--- a/tests/breakdown/test_routes.py
+++ b/tests/breakdown/test_routes.py
@@ -37,14 +37,15 @@ class BreakdownServiceTestCase(ApiDBTestCase):
             {"asset_id": self.asset_id, "nb_occurences": 1},
             {"asset_id": self.asset_character_id, "nb_occurences": 3},
         ]
-        self.put("/data/projects/%s/entities/%s/casting" % (
-            self.project_id,
-            self.episode_id
-        ), new_casting)
-        casting = self.get("/data/projects/%s/entities/%s/casting" % (
-            self.project_id,
-            self.episode_id
-        ))
+        self.put(
+            "/data/projects/%s/entities/%s/casting"
+            % (self.project_id, self.episode_id),
+            new_casting,
+        )
+        casting = self.get(
+            "/data/projects/%s/entities/%s/casting"
+            % (self.project_id, self.episode_id)
+        )
         self.assertEquals(len(casting), 2)
         self.assertEquals(casting[0]["asset_name"], "Rabbit")
         self.assertEquals(casting[1]["asset_name"], "Tree")
@@ -54,23 +55,24 @@ class BreakdownServiceTestCase(ApiDBTestCase):
             {"asset_id": self.asset_id, "nb_occurences": 1},
             {"asset_id": self.asset_character_id, "nb_occurences": 3},
         ]
-        self.put("/data/projects/%s/entities/%s/casting" % (
-            self.project_id,
-            self.shot_id
-        ), new_casting)
-        casting = self.get("/data/projects/%s/entities/%s/casting" % (
-            self.project_id,
-            self.shot_id
-        ))
+        self.put(
+            "/data/projects/%s/entities/%s/casting"
+            % (self.project_id, self.shot_id),
+            new_casting,
+        )
+        casting = self.get(
+            "/data/projects/%s/entities/%s/casting"
+            % (self.project_id, self.shot_id)
+        )
         self.assertEquals(len(casting), 2)
         self.assertEquals(casting[0]["asset_name"], "Rabbit")
         self.assertEquals(casting[1]["asset_name"], "Tree")
 
         # Test automatic addition to related episode
-        casting = self.get("/data/projects/%s/entities/%s/casting" % (
-            self.project_id,
-            self.episode_id
-        ))
+        casting = self.get(
+            "/data/projects/%s/entities/%s/casting"
+            % (self.project_id, self.episode_id)
+        )
         self.assertEquals(len(casting), 2)
         self.assertEquals(casting[0]["asset_name"], "Rabbit")
         self.assertEquals(casting[1]["asset_name"], "Tree")
@@ -80,28 +82,30 @@ class BreakdownServiceTestCase(ApiDBTestCase):
             {"asset_id": self.asset_id, "nb_occurences": 1},
             {"asset_id": self.asset_character_id, "nb_occurences": 3},
         ]
-        self.put("/data/projects/%s/entities/%s/casting" % (
-            self.project_id,
-            self.shot_id
-        ), new_casting)
+        self.put(
+            "/data/projects/%s/entities/%s/casting"
+            % (self.project_id, self.shot_id),
+            new_casting,
+        )
 
         new_casting = [
             {"asset_id": self.asset_id, "nb_occurences": 1},
         ]
-        self.put("/data/projects/%s/entities/%s/casting" % (
-            self.project_id,
-            self.episode_id
-        ), new_casting)
+        self.put(
+            "/data/projects/%s/entities/%s/casting"
+            % (self.project_id, self.episode_id),
+            new_casting,
+        )
 
-        casting = self.get("/data/projects/%s/entities/%s/casting" % (
-            self.project_id,
-            self.episode_id
-        ))
+        casting = self.get(
+            "/data/projects/%s/entities/%s/casting"
+            % (self.project_id, self.episode_id)
+        )
         self.assertEquals(len(casting), 1)
-        casting = self.get("/data/projects/%s/entities/%s/casting" % (
-            self.project_id,
-            self.shot_id
-        ))
+        casting = self.get(
+            "/data/projects/%s/entities/%s/casting"
+            % (self.project_id, self.shot_id)
+        )
         self.assertEquals(len(casting), 1)
         self.assertEquals(casting[0]["asset_name"], "Tree")
 
@@ -110,10 +114,11 @@ class BreakdownServiceTestCase(ApiDBTestCase):
             {"asset_id": self.asset_id, "nb_occurences": 1},
             {"asset_id": self.asset_character_id, "nb_occurences": 3},
         ]
-        self.put("/data/projects/%s/entities/%s/casting" % (
-            self.project_id,
-            self.shot_id
-        ), new_casting)
+        self.put(
+            "/data/projects/%s/entities/%s/casting"
+            % (self.project_id, self.shot_id),
+            new_casting,
+        )
         assets = self.get("/data/assets?episode_id=%s" % self.episode_id)
         assets = sorted(assets, key=lambda a: a["name"])
         self.assertEquals(len(assets), 2)

--- a/tests/source/csv/test_import_casting.py
+++ b/tests/source/csv/test_import_casting.py
@@ -88,7 +88,7 @@ class ImportCsvCastingTestCase(ApiDBTestCase):
         self.assertEqual(len(links), 18)
         link = EntityLink.get_by(
             entity_in_id=self.e01seq01sh01_id,
-            entity_out_id=self.asset_victor_id
+            entity_out_id=self.asset_victor_id,
         )
         self.assertEqual(link.label, "fixed")
         self.assertEqual(get_shot(self.e01seq01sh01_id)["nb_entities_out"], 2)

--- a/zou/app/blueprints/crud/base.py
+++ b/zou/app/blueprints/crud/base.py
@@ -275,16 +275,16 @@ class BaseModelResource(Resource):
         return result, 200
 
     def pre_update(self, instance_dict, data):
-        pass
+        return data
 
     def post_update(self, instance_dict):
-        pass
+        return instance_dict
 
     def post_delete(self, instance_dict):
-        pass
+        return instance_dict
 
     def pre_delete(self, instance_dict):
-        pass
+        return instance_dict
 
     @jwt_required
     def put(self, instance_id):

--- a/zou/app/blueprints/crud/comments.py
+++ b/zou/app/blueprints/crud/comments.py
@@ -67,6 +67,7 @@ class CommentResource(BaseModelResource):
         if instance_dict["task_status_id"] != data.get("task_status_id", None):
             self.task_status_change = True
             self.previous_task_status_id = instance_dict["task_status_id"]
+        return data
 
     def post_update(self, instance_dict):
         comment = comments_service.reset_mentions(instance_dict)

--- a/zou/app/blueprints/crud/department.py
+++ b/zou/app/blueprints/crud/department.py
@@ -45,6 +45,8 @@ class DepartmentResource(BaseModelResource):
 
     def post_update(self, instance_dict):
         tasks_service.clear_department_cache(instance_dict["id"])
+        return instance_dict
 
     def post_delete(self, instance_dict):
         tasks_service.clear_department_cache(instance_dict["id"])
+        return instance_dict

--- a/zou/app/blueprints/crud/entity_type.py
+++ b/zou/app/blueprints/crud/entity_type.py
@@ -40,7 +40,9 @@ class EntityTypeResource(BaseModelResource):
     def post_update(self, instance_dict):
         entities_service.clear_entity_type_cache(instance_dict["id"])
         assets_service.clear_asset_type_cache()
+        return instance_dict
 
     def post_delete(self, instance_dict):
         entities_service.clear_entity_type_cache(instance_dict["id"])
         assets_service.clear_asset_type_cache()
+        return instance_dict

--- a/zou/app/blueprints/crud/person.py
+++ b/zou/app/blueprints/crud/person.py
@@ -88,6 +88,7 @@ class PersonResource(BaseModelResource, ArgsMixin):
             and persons_service.is_user_limit_reached()
         ):
             raise WrongParameterException("User limit reached.")
+        return data
 
     def post_update(self, instance_dict):
         persons_service.clear_person_cache()

--- a/zou/app/blueprints/crud/person.py
+++ b/zou/app/blueprints/crud/person.py
@@ -88,7 +88,6 @@ class PersonResource(BaseModelResource, ArgsMixin):
             and persons_service.is_user_limit_reached()
         ):
             raise WrongParameterException("User limit reached.")
-        return instance_dict
 
     def post_update(self, instance_dict):
         persons_service.clear_person_cache()

--- a/zou/app/blueprints/crud/playlist.py
+++ b/zou/app/blueprints/crud/playlist.py
@@ -48,7 +48,6 @@ class PlaylistResource(BaseModelResource):
                 if "preview_file_id" in shot
             ]
             data["shots"] = shots
-        return data
 
     def delete(self, instance_id):
         playlists_service.remove_playlist(instance_id)

--- a/zou/app/blueprints/crud/playlist.py
+++ b/zou/app/blueprints/crud/playlist.py
@@ -48,6 +48,7 @@ class PlaylistResource(BaseModelResource):
                 if "preview_file_id" in shot
             ]
             data["shots"] = shots
+        return data
 
     def delete(self, instance_id):
         playlists_service.remove_playlist(instance_id)

--- a/zou/app/blueprints/crud/project.py
+++ b/zou/app/blueprints/crud/project.py
@@ -114,7 +114,6 @@ class ProjectResource(BaseModelResource):
                 )
                 for task_type_id in data["status_automations"]
             ]
-        return project_dict
 
     def post_update(self, project_dict):
         if project_dict["production_type"] == "tvshow":

--- a/zou/app/blueprints/crud/project.py
+++ b/zou/app/blueprints/crud/project.py
@@ -114,6 +114,7 @@ class ProjectResource(BaseModelResource):
                 )
                 for task_type_id in data["status_automations"]
             ]
+        return data
 
     def post_update(self, project_dict):
         if project_dict["production_type"] == "tvshow":
@@ -133,6 +134,7 @@ class ProjectResource(BaseModelResource):
 
     def post_delete(self, project_dict):
         projects_service.clear_project_cache(project_dict["id"])
+        return project_dict
 
     @jwt_required
     def delete(self, instance_id):

--- a/zou/app/blueprints/crud/project.py
+++ b/zou/app/blueprints/crud/project.py
@@ -10,6 +10,10 @@ from zou.app.services import (
     projects_service,
     shots_service,
     user_service,
+    persons_service,
+    assets_service,
+    tasks_service,
+    status_automations_service,
 )
 from zou.app.utils import events, permissions, fields
 
@@ -33,6 +37,33 @@ class ProjectsResource(BaseModelsResource):
         open_status = projects_service.get_or_create_open_status()
         if "project_status_id" not in data:
             data["project_status_id"] = open_status["id"]
+        if "team" in data:
+            data["team"] = [
+                persons_service.get_person_raw(person_id)
+                for person_id in data["team"]
+            ]
+        if "asset_types" in data:
+            data["asset_types"] = [
+                assets_service.get_asset_type_raw(asset_type_id)
+                for asset_type_id in data["asset_types"]
+            ]
+        if "task_statuses" in data:
+            data["task_statuses"] = [
+                tasks_service.get_task_status_raw(task_status_id)
+                for task_status_id in data["task_statuses"]
+            ]
+        if "task_types" in data:
+            data["task_types"] = [
+                tasks_service.get_task_type_raw(task_type_id)
+                for task_type_id in data["task_types"]
+            ]
+        if "status_automations" in data:
+            data["status_automations"] = [
+                status_automations_service.get_status_automation_raw(
+                    task_type_id
+                )
+                for task_type_id in data["status_automations"]
+            ]
         return data
 
     def post_creation(self, project):
@@ -56,11 +87,33 @@ class ProjectResource(BaseModelResource):
         user_service.check_project_access(project["id"])
 
     def pre_update(self, project_dict, data):
-        data.pop("team", [])
-        data.pop("asset_types", [])
-        data.pop("task_statuses", [])
-        data.pop("task_types", [])
-        data.pop("status_automations", [])
+        if "team" in data:
+            data["team"] = [
+                persons_service.get_person_raw(person_id)
+                for person_id in data["team"]
+            ]
+        if "asset_types" in data:
+            data["asset_types"] = [
+                assets_service.get_asset_type_raw(asset_type_id)
+                for asset_type_id in data["asset_types"]
+            ]
+        if "task_statuses" in data:
+            data["task_statuses"] = [
+                tasks_service.get_task_status_raw(task_status_id)
+                for task_status_id in data["task_statuses"]
+            ]
+        if "task_types" in data:
+            data["task_types"] = [
+                tasks_service.get_task_type_raw(task_type_id)
+                for task_type_id in data["task_types"]
+            ]
+        if "status_automations" in data:
+            data["status_automations"] = [
+                status_automations_service.get_status_automation_raw(
+                    task_type_id
+                )
+                for task_type_id in data["status_automations"]
+            ]
         return project_dict
 
     def post_update(self, project_dict):

--- a/zou/app/blueprints/crud/task.py
+++ b/zou/app/blueprints/crud/task.py
@@ -83,6 +83,7 @@ class TaskResource(BaseModelResource):
 
     def post_update(self, instance_dict):
         tasks_service.clear_task_cache(instance_dict["id"])
+        return instance_dict
 
     def pre_update(self, instance_dict, data):
         if "assignees" in data:
@@ -90,6 +91,7 @@ class TaskResource(BaseModelResource):
                 persons_service.get_person_raw(assignee)
                 for assignee in data["assignees"]
             ]
+        return data
 
     @jwt_required
     def delete(self, instance_id):

--- a/zou/app/blueprints/crud/task.py
+++ b/zou/app/blueprints/crud/task.py
@@ -8,7 +8,12 @@ from zou.app.models.person import Person
 from zou.app.models.project import Project
 from zou.app.models.task import Task
 
-from zou.app.services import user_service, tasks_service, deletion_service
+from zou.app.services import (
+    user_service,
+    tasks_service,
+    deletion_service,
+    persons_service,
+)
 from zou.app.utils import permissions
 
 from .base import BaseModelsResource, BaseModelResource
@@ -78,6 +83,13 @@ class TaskResource(BaseModelResource):
 
     def post_update(self, instance_dict):
         tasks_service.clear_task_cache(instance_dict["id"])
+
+    def pre_update(self, instance_dict, data):
+        if "assignees" in data:
+            data["assignees"] = [
+                persons_service.get_person_raw(assignee)
+                for assignee in data["assignees"]
+            ]
 
     @jwt_required
     def delete(self, instance_id):

--- a/zou/app/blueprints/crud/task_status.py
+++ b/zou/app/blueprints/crud/task_status.py
@@ -24,6 +24,8 @@ class TaskStatusResource(BaseModelResource):
 
     def post_update(self, instance_dict):
         tasks_service.clear_task_status_cache(instance_dict["id"])
+        return instance_dict
 
     def post_delete(self, instance_dict):
         tasks_service.clear_task_status_cache(instance_dict["id"])
+        return instance_dict

--- a/zou/app/blueprints/crud/task_type.py
+++ b/zou/app/blueprints/crud/task_type.py
@@ -47,6 +47,8 @@ class TaskTypeResource(BaseModelResource):
 
     def post_update(self, instance_dict):
         tasks_service.clear_task_type_cache(instance_dict["id"])
+        return instance_dict
 
     def post_delete(self, instance_dict):
         tasks_service.clear_task_type_cache(instance_dict["id"])
+        return instance_dict

--- a/zou/app/blueprints/previews/__init__.py
+++ b/zou/app/blueprints/previews/__init__.py
@@ -27,7 +27,10 @@ from .resources import (
 
 routes = [
     ("/data/playlists/preview-files/running", RunningPreviewFiles),
-    ("/pictures/preview-files/<instance_id>", CreatePreviewFilePictureResource),
+    (
+        "/pictures/preview-files/<instance_id>",
+        CreatePreviewFilePictureResource,
+    ),
     (
         "/movies/originals/preview-files/<instance_id>.mp4",
         PreviewFileMovieResource,
@@ -78,7 +81,7 @@ routes = [
     ),
     (
         "/pictures/thumbnails/persons/<instance_id>.png",
-        PersonThumbnailResource
+        PersonThumbnailResource,
     ),
     (
         "/pictures/thumbnails/projects/<instance_id>",
@@ -103,7 +106,7 @@ routes = [
     (
         "/actions/preview-files/<preview_file_id>/update-annotations",
         UpdateAnnotationsResource,
-    )
+    ),
 ]
 blueprint = Blueprint("thumbnails", "thumbnails")
 api = configure_api_from_blueprint(blueprint, routes)

--- a/zou/app/blueprints/previews/resources.py
+++ b/zou/app/blueprints/previews/resources.py
@@ -232,16 +232,14 @@ class CreatePreviewFilePictureResource(Resource, ArgsMixin):
         )
         file_size = fs.get_file_size(original_tmp_path)
         preview_files_service.update_preview_file(
-            instance_id, {"file_size": file_size}, silent=True)
+            instance_id, {"file_size": file_size}, silent=True
+        )
         return preview_files_service.save_variants(
             instance_id, original_tmp_path
         )
 
     def save_movie_preview(
-        self,
-        preview_file_id,
-        uploaded_file,
-        normalize=True
+        self, preview_file_id, uploaded_file, normalize=True
     ):
         """
         Get uploaded movie, normalize it then build thumbnails then save
@@ -275,7 +273,8 @@ class CreatePreviewFilePictureResource(Resource, ArgsMixin):
         file_store.add_file("previews", instance_id, file_path)
         file_size = fs.get_file_size(file_path)
         preview_files_service.update_preview_file(
-            instance_id, {"file_size": file_size}, silent=True)
+            instance_id, {"file_size": file_size}, silent=True
+        )
         os.remove(file_path)
         return file_path
 
@@ -586,7 +585,8 @@ class BaseCreatePictureResource(Resource):
     def emit_event(self, instance_id):
         model_name = self.data_type[:-1]
         events.emit(
-            "%s:set-thumbnail" % model_name, {"%s_id" % model_name: instance_id}
+            "%s:set-thumbnail" % model_name,
+            {"%s_id" % model_name: instance_id},
         )
 
     @jwt_required
@@ -815,7 +815,7 @@ class UpdateAnnotationsResource(Resource, ArgsMixin):
             preview_file_id,
             additions=additions,
             updates=updates,
-            deletions=deletions
+            deletions=deletions,
         )
 
 

--- a/zou/app/blueprints/previews/resources.py
+++ b/zou/app/blueprints/previews/resources.py
@@ -32,7 +32,7 @@ from zou.app.utils import (
 )
 
 
-ALLOWED_PICTURE_EXTENSION = [".png", ".jpg", ".jpeg", ".PNG", ".JPG", ".JPEG"]
+ALLOWED_PICTURE_EXTENSION = [".png", ".jpg", ".jpeg", ".jpe"]
 ALLOWED_MOVIE_EXTENSION = [
     ".avi",
     ".mp4",
@@ -40,12 +40,6 @@ ALLOWED_MOVIE_EXTENSION = [
     ".mkv",
     ".mov",
     ".wmv",
-    ".AVI",
-    ".MP4",
-    ".MOV",
-    ".WMV",
-    ".M4V",
-    ".MKV",
 ]
 ALLOWED_FILE_EXTENSION = [
     ".ae",
@@ -72,30 +66,6 @@ ALLOWED_FILE_EXTENSION = [
     ".wav",
     ".glb",
     ".gltf",
-    ".AE",
-    ".AI",
-    ".BLEND",
-    ".COMP",
-    ".EXR",
-    ".FBX",
-    ".FLA",
-    ".FLV",
-    ".GIF",
-    ".HIP",
-    ".MA",
-    ".MB",
-    ".OBJ",
-    ".PDF",
-    ".PSD",
-    ".RAR",
-    ".SBBKP",
-    ".SVG",
-    ".SWF",
-    ".ZIP",
-    ".MP3",
-    ".WAV",
-    ".GLB",
-    ".GLTF",
 ]
 
 

--- a/zou/app/services/assets_service.py
+++ b/zou/app/services/assets_service.py
@@ -118,8 +118,9 @@ def get_assets(criterions={}):
         result = query.all()
         # Filter based on episode casting.
         query = (
-            Entity.query
-            .join(EntityLink, EntityLink.entity_out_id == Entity.id)
+            Entity.query.join(
+                EntityLink, EntityLink.entity_out_id == Entity.id
+            )
             .filter(EntityLink.entity_in_id == episode_id)
             .filter(build_asset_type_filter())
         )
@@ -176,8 +177,7 @@ def get_assets_and_tasks(criterions={}, page=1):
     Shot = aliased(Entity, name="shot")
 
     query = (
-        Entity.query
-        .filter(build_asset_type_filter())
+        Entity.query.filter(build_asset_type_filter())
         .join(EntityType, Entity.entity_type_id == EntityType.id)
         .outerjoin(Task)
         .outerjoin(assignees_table)
@@ -206,7 +206,9 @@ def get_assets_and_tasks(criterions={}, page=1):
         tasks_query = tasks_query.filter(Entity.id == criterions["id"])
 
     if "project_id" in criterions:
-        tasks_query = tasks_query.filter(Entity.project_id == criterions["project_id"])
+        tasks_query = tasks_query.filter(
+            Entity.project_id == criterions["project_id"]
+        )
 
     if "episode_id" in criterions:
         episode_id = criterions["episode_id"]
@@ -216,7 +218,7 @@ def get_assets_and_tasks(criterions={}, page=1):
             tasks_query = tasks_query.filter(
                 or_(
                     Entity.source_id == episode_id,
-                    EntityLink.entity_in_id == episode_id
+                    EntityLink.entity_in_id == episode_id,
                 )
             )
 
@@ -227,9 +229,9 @@ def get_assets_and_tasks(criterions={}, page=1):
     cast_in_episode_ids = {}
     if "project_id" in criterions:
         episode_links_query = (
-            EntityLink
-            .query
-            .join(Episode, EntityLink.entity_in_id == Episode.id)
+            EntityLink.query.join(
+                Episode, EntityLink.entity_in_id == Episode.id
+            )
             .join(EntityType, EntityType.id == Episode.entity_type_id)
             .filter(EntityType.name == "Episode")
             .filter(Episode.project_id == criterions["project_id"])
@@ -238,8 +240,9 @@ def get_assets_and_tasks(criterions={}, page=1):
         for link in episode_links_query.all():
             if str(link.entity_out_id) not in cast_in_episode_ids:
                 cast_in_episode_ids[str(link.entity_out_id)] = []
-            cast_in_episode_ids[str(link.entity_out_id)] \
-                .append(str(link.entity_in_id))
+            cast_in_episode_ids[str(link.entity_out_id)].append(
+                str(link.entity_in_id)
+            )
 
     for (
         asset,

--- a/zou/app/services/breakdown_service.py
+++ b/zou/app/services/breakdown_service.py
@@ -290,11 +290,9 @@ def _extract_removal(entity, casting):
 def _remove_asset_from_episode_shots(asset_id, episode_id):
     shots = shots_service.get_shots_for_episode(episode_id)
     shot_ids = [shot["id"] for shot in shots]
-    links = (
-        EntityLink.query
-        .filter(EntityLink.entity_in_id.in_(shot_ids))
-        .filter(EntityLink.entity_out_id == asset_id)
-    )
+    links = EntityLink.query.filter(
+        EntityLink.entity_in_id.in_(shot_ids)
+    ).filter(EntityLink.entity_out_id == asset_id)
     for link in links:
         shot = shots_service.get_shot_raw(str(link.entity_in_id))
         shot.update({"nb_entities_out": shot.nb_entities_out - 1})
@@ -308,9 +306,7 @@ def _remove_asset_from_episode_shots(asset_id, episode_id):
     return shots
 
 
-def _create_episode_casting_link(
-    entity, asset_id, nb_occurences=1, label=""
-):
+def _create_episode_casting_link(entity, asset_id, nb_occurences=1, label=""):
     """
     When an asset is casted in a shot, the asset is automatically casted in
     the episode.
@@ -319,8 +315,7 @@ def _create_episode_casting_link(
         sequence = shots_service.get_sequence(entity["parent_id"])
         if sequence["parent_id"] is not None:
             link = EntityLink.get_by(
-                entity_in_id=sequence["parent_id"],
-                entity_out_id=asset_id
+                entity_in_id=sequence["parent_id"], entity_out_id=asset_id
             )
             if link is None:
                 link = EntityLink.create(
@@ -712,8 +707,7 @@ def refresh_shot_casting_stats(shot, priority_map=None):
 
 def _get_task_type_priority_map(project_id):
     task_types = (
-        ProjectTaskTypeLink.query
-        .join(TaskType)
+        ProjectTaskTypeLink.query.join(TaskType)
         .filter(ProjectTaskTypeLink.project_id == project_id)
         .filter(TaskType.for_entity == "Shot")
         .all()

--- a/zou/app/services/exception.py
+++ b/zou/app/services/exception.py
@@ -179,3 +179,7 @@ class ModelWithRelationsDeletionException(Exception):
 
 class EditNotFoundException(NotFound):
     pass
+
+
+class StatusAutomationNotFoundException(NotFound):
+    pass

--- a/zou/app/services/status_automations_service.py
+++ b/zou/app/services/status_automations_service.py
@@ -1,5 +1,7 @@
 from zou.app.models.status_automation import StatusAutomation
 from zou.app.utils import cache, fields
+from zou.app.services import base_service
+from zou.app.services.exception import StatusAutomationNotFoundException
 
 
 def clear_status_automation_cache():
@@ -9,3 +11,14 @@ def clear_status_automation_cache():
 @cache.memoize_function(120)
 def get_status_automations():
     return fields.serialize_models(StatusAutomation.get_all())
+
+
+def get_status_automation_raw(status_automation_id):
+    """
+    Get status automation matching given id as an active record.
+    """
+    return base_service.get_instance(
+        StatusAutomation,
+        status_automation_id,
+        StatusAutomationNotFoundException,
+    )


### PR DESCRIPTION
**Problem**
- in .gitignore previews and thumbnails are ignored but not only the directories at the root of the project (for example /zou/app/blueprints/previews/ is ignored)
- .jpe extension for preview pictures are not allowed 
- we can't set team/asset-types/task_statuses/task_types/status_automations directly when we create/update a project
- we can't update with assignees links https://github.com/cgwire/gazu/issues/241  

**Solution**
- ignore only the directories at the root of the project
- allow .jpe extension for preview pictures + refactoring (remove all the extensions in uppercase, the extension calculated is in lowercase every time so it's not usefull) 
- we can now set team/asset-types/task_statuses/task_types/status_automations directly when we create/update a project
- when we update a task we can update assignees too