### PR TITLE
[qa] Fix _run_status_automation in_priority can be None so the compar…

### DIFF
--- a/zou/app/services/comments_service.py
+++ b/zou/app/services/comments_service.py
@@ -159,7 +159,7 @@ def _run_status_automation(automation, task, person_id):
     priorities = projects_service.get_task_type_priority_map(
         task["project_id"], automation["entity_type"].capitalize()
     )
-    in_priority = priorities.get(automation["in_task_type_id"], 0)
+    in_priority = priorities.get(automation["in_task_type_id"], 0) or 0
     out_priority = priorities.get(automation["out_task_type_id"], 0) or 0
     is_rollback = (
         priorities is not None


### PR DESCRIPTION
…ison is not possible

**Problem**
Some status automation are not working correctly and there's an error when we change the status of a task
```
  File "/mnt/DATA/DEV/zou/zou/app/blueprints/comments/resources.py", line 81, in post
    comment = comments_service.create_comment(
  File "/mnt/DATA/DEV/zou/zou/app/services/comments_service.py", line 90, in create_comment
    _run_status_automation(automation, task, person_id)
  File "/mnt/DATA/DEV/zou/zou/app/services/comments_service.py", line 167, in _run_status_automation
    and in_priority > out_priority
TypeError: '>' not supported between instances of 'NoneType' and 'int'
```

**Solution**
in_priority has to be always a number