### PR TITLE
Fix person serialization

### DIFF
--- a/tests/models/test_person.py
+++ b/tests/models/test_person.py
@@ -33,6 +33,14 @@ class PersonTestCase(ApiDBTestCase):
         self.assertEqual(len(persons), 4)
         self.assertEqual(persons[0]["type"], "Person")
 
+    def test_present(self):
+        person = self.get_first("data/persons")
+        person_model = Person.get(person["id"])
+        person_dict = person_model.present_minimal()
+        self.assertEquals(person_dict["departments"], [])
+        person_dict = person_model.present_minimal(relations=True)
+        self.assertEquals(person_dict["departments"], [])
+
     def test_get_person(self):
         person = self.get_first("data/persons")
         person_again = self.get("data/persons/%s" % person["id"])

--- a/zou/app/models/person.py
+++ b/zou/app/models/person.py
@@ -85,7 +85,7 @@ class Person(db.Model, BaseMixin, SerializerMixin):
             "full_name": self.full_name(),
             "has_avatar": data["has_avatar"],
             "active": data["active"],
-            "departments": data["departments"],
+            "departments": data.get("departments", [])
         }
 
     def set_departments(self, department_ids):


### PR DESCRIPTION
**Problem**

When relations were not retrieved, the departments were not included while the serialization was expecting of them.

**Solution**

Handle the case where the departments are not there by setting an array as default value.
