### PR TITLE
clients can see other clients comments

### DIFF
--- a/zou/app/blueprints/tasks/resources.py
+++ b/zou/app/blueprints/tasks/resources.py
@@ -119,11 +119,7 @@ class TaskCommentResource(Resource):
         Get comment corresponding at given ID.
         """
         comment = tasks_service.get_comment(comment_id)
-        task = tasks_service.get_task(comment["object_id"])
-        if permissions.has_manager_permissions():
-            user_service.check_project_access(task["project_id"])
-        else:
-            user_service.check_person_access(comment["person_id"])
+        user_service.check_comment_access(comment)
         return comment
 
     def pre_delete(self, comment):

--- a/zou/app/services/tasks_service.py
+++ b/zou/app/services/tasks_service.py
@@ -504,9 +504,8 @@ def get_comments(task_id, is_client=False, is_manager=False):
     if is_client:
         tmp_comments = []
         for comment in comments:
-            person = persons_service.get_person(comment["person_id"])
             current_user = persons_service.get_current_user()
-            is_author = person["id"] == current_user["id"]
+            is_author = comment["person_id"] == current_user["id"]
             if len(comment["previews"]) > 0:
                 comment["text"] = ""
                 comment["attachment_files"] = []

--- a/zou/app/services/tasks_service.py
+++ b/zou/app/services/tasks_service.py
@@ -505,13 +505,15 @@ def get_comments(task_id, is_client=False, is_manager=False):
         tmp_comments = []
         for comment in comments:
             person = persons_service.get_person(comment["person_id"])
-            is_author_client = person["role"] == "client"
-            if len(comment["previews"]) > 0 or is_author_client:
-                tmp_comments.append(comment)
-            if not is_author_client:
+            current_user = persons_service.get_current_user()
+            is_author = person["id"] == current_user["id"]
+            if len(comment["previews"]) > 0:
                 comment["text"] = ""
                 comment["attachment_files"] = []
                 comment["checklist"] = []
+                tmp_comments.append(comment)
+            if is_author:
+                tmp_comments.append(comment)
         comments = tmp_comments
     return comments
 


### PR DESCRIPTION
**Problem**
- we want that a client can't see comments of other clients
- problems with permissions when getting a comment (for example an artist can get a client comment)

**Solution**
- only allow to get comments from itself or comments with previews for a client
- fix permissions for getting a single comment
