### PR TITLE
AD users may have complex flags combination in userAccountControl

### DIFF
--- a/zou/app/utils/commands.py
+++ b/zou/app/utils/commands.py
@@ -198,7 +198,7 @@ def sync_with_ldap_server():
                 "email": clean_value(entry.mail),
                 "desktop_login": clean_value(entry.sAMAccountName),
                 "thumbnail": entry.thumbnailPhoto.raw_values,
-                "active": bool(int(clean_value(entry.userAccountControl)) & 2) is False,
+                "active": bool(entry.userAccountControl.value & 2) is False,
             }
             for entry in conn.entries
             if clean_value(entry.sAMAccountName) not in excluded_accounts

--- a/zou/app/utils/commands.py
+++ b/zou/app/utils/commands.py
@@ -198,8 +198,7 @@ def sync_with_ldap_server():
                 "email": clean_value(entry.mail),
                 "desktop_login": clean_value(entry.sAMAccountName),
                 "thumbnail": entry.thumbnailPhoto.raw_values,
-                "active": clean_value(entry.userAccountControl)
-                in ["512", "66048"],
+                "active": bool(int(clean_value(entry.userAccountControl)) & 2) is False,
             }
             for entry in conn.entries
             if clean_value(entry.sAMAccountName) not in excluded_accounts


### PR DESCRIPTION

**Problem**

The userAccountControl flag may contain a complex combination of flag. Some users end up disabled despite the absence of the ACCOUNT_DISABLED flag.

**Solution**

Check the absence of the ACCOUNT_DISABLED flag (2) instead of predefined flags combination