### PR TITLE
Add project_id data field for episode sequence delete events

### DIFF
--- a/zou/app/services/deletion_service.py
+++ b/zou/app/services/deletion_service.py
@@ -381,7 +381,7 @@ def remove_episode(episode_id, force=False):
         episode.delete()
         events.emit(
             "episode:delete",
-            {"episode_id": episode_id},
+            {"episode_id": episode_id, "project_id": episode.project_id},
             project_id=str(episode.project_id),
         )
     except IntegrityError:

--- a/zou/app/services/shots_service.py
+++ b/zou/app/services/shots_service.py
@@ -819,7 +819,7 @@ def remove_shot(shot_id, force=False):
         clear_shot_cache(shot_id)
         events.emit(
             "shot:delete",
-            {"shot_id": shot_id},
+            {"shot_id": shot_id, "project_id": shot.project_id},
             project_id=str(shot.project_id),
         )
 
@@ -860,7 +860,7 @@ def remove_sequence(sequence_id, force=False):
         sequence.delete()
         events.emit(
             "sequence:delete",
-            {"sequence_id": sequence_id},
+            {"sequence_id": sequence_id, "project_id": sequence.project_id},
             project_id=str(sequence.project_id),
         )
     except IntegrityError:


### PR DESCRIPTION
## Problem
When adding **gazu** event listeners `episode:delete` and `sequence:delete`,  data don't provide `project_id` field as `asset:delete` or `shot:delete`

### Solution
- Just adding project_id with `events.emit` in the data argument.

### Additional note
Not sure about this **PR** because when `asset:delete` events are emitted we have `project_id` in data with **gazu** listeners but seems not provided in **zou** `assets_service.py`

https://github.com/cgwire/zou/blob/ad7895b5c3e005302310ac1f553ffc7d77c6dc18/zou/app/services/assets_service.py#L669

Resolve: #464