### PR TITLE
[qa] try to fix setuptools problem on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,10 @@ services:
 addons:
   postgresql: "9.4"
   apt:
-    packages: 
+    packages:
       - ffmpeg
-install: 
+install:
+  - "pip install -U setuptools"
   - "pip install -r requirements.txt"
 before_script:
   - psql -c 'create database zoudb;' -U postgres


### PR DESCRIPTION
**Problem**
- Python 3.8 tests on travis are broken due to a setuptools problem

**Solution**
- Try to upgrade setuptools to see if the problem is fixed
