### PR TITLE
Fix github action to update openAPI definition after deploying zou

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Deploy Zou to staging environment
+name: Deploy Zou to staging environment and update apidocs
 
 on:
   push:
@@ -24,3 +24,18 @@ jobs:
          sudo /opt/zou/zouenv/bin/pip install --upgrade git+https://github.com/cgwire/zou.git
          sudo -E -u zou /opt/zou/zouenv/bin/zou upgrade-db
          sudo systemctl restart zou zou-events zou-jobs
+    - uses: actions/checkout@v3
+      with:
+        ref: apidocs 
+    - name: Update openapi.json
+      run: |
+        cd docs
+        curl --output openapi.json https://nehmath.github.io/zou-nehmat/openapi.json
+        git config --global user.email "no-reply@cg-wire.com"
+        git config --global user.name "CGWire bot"
+        git commit -m "Update openapi.json" || true
+    - name: Push changes
+      uses: ad-m/github-push-action@master
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        branch: apidocs


### PR DESCRIPTION
**Problem**
- The current Github Actions does not take into consideration the openAPI definition that needs to be updated at each push on the master branch.

**Solution**
- Fix the Github Actions so that after deploying Zou to staging environment, it updates the openAPI file and replaces the old one with it.