### PR TITLE
Fix the parameters of files and update the source of the openAPI file

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,9 +30,10 @@ jobs:
     - name: Update openapi.json
       run: |
         cd docs
-        curl --output openapi.json https://nehmath.github.io/zou-nehmat/openapi.json
+        curl --output openapi.json https://kitsu-staging.cg-wire.com/api/openapi.json
         git config --global user.email "no-reply@cg-wire.com"
         git config --global user.name "CGWire bot"
+        git add openapi.json || false
         git commit -m "Update openapi.json" || true
     - name: Push changes
       uses: ad-m/github-push-action@master

--- a/zou/app/blueprints/auth/resources.py
+++ b/zou/app/blueprints/auth/resources.py
@@ -220,20 +220,18 @@ class LoginResource(Resource):
         tags:
             - Authentication
         parameters:
-          - in: body
-            name: Credentials
-            description: The email and password of the user
-            schema:
-                type: object
-                required:
-                - email
-                - password
-                properties:
-                    email:
-                        type: string
-                        format: email
-                    password:
-                        type: string
+          - in: formData
+            name: email
+            required: True
+            type: string
+            format: email
+            x-example: admin@example.com
+          - in: formData
+            name: password
+            required: True
+            type: string
+            format: password
+            x-example: mysecretpassword
         responses:
           200:
             description: Login successful
@@ -391,30 +389,30 @@ class RegistrationResource(Resource):
         tags:
             - Authentication
         parameters:
-          - in: body
-            name: Credentials
-            description: The email, password, confirmation password, first name and last name of the user
-            schema:
-                type: object
-                required:
-                - email
-                - password
-                - password_2
-                - first_name
-                - last_name
-                properties:
-                    email:
-                        type: string
-                        format: email
-                    password:
-                        type: string
-                    password_2:
-                        type: string
-                    first_name:
-                        type: string
-                    last_name:
-                        type: string
-
+          - in: formData
+            name: email
+            required: True
+            type: string
+            format: email
+            x-example: admin@example.com
+          - in: formData
+            name: password
+            required: True
+            type: string
+            format: password
+          - in: formData
+            name: password_2
+            required: True
+            type: string
+            format: password
+          - in: formData
+            name: first_name
+            required: True
+            type: string
+          - in: formData
+            name: last_name
+            required: True
+            type: string
         responses:
           201:
             description: Registration successful
@@ -501,23 +499,21 @@ class ChangePasswordResource(Resource):
         tags:
             - Authentication
         parameters:
-          - in: body
-            name: Credentials
-            description: The old password, new password and confirmation password of the user
-            schema:
-                type: object
-                required:
-                - old_password
-                - password
-                - password_2
-                properties:
-                    old_password:
-                        type: string
-                    password:
-                        type: string
-                    password_2:
-                        type: string
-
+          - in: formData
+            name: old_password
+            required: True
+            type: string
+            format: password
+          - in: formData
+            name: password
+            required: True
+            type: string
+            format: password
+          - in: formData
+            name: password_2
+            required: True
+            type: string
+            format: password
         responses:
           200:
             description: Password changed
@@ -582,25 +578,21 @@ class ResetPasswordResource(Resource, ArgsMixin):
         tags:
             - Authentication
         parameters:
-          - in: body
-            name: Credentials
-            description: The token, new password and confirmation password of the user
-            schema:
-                type: object
-                required:
-                - token
-                - password
-                - password_2
-                properties:
-                    token:
-                        type: string
-                        format: UUID
-                        x-example: a24a6ea4-ce75-4665-a070-57453082c25
-                    password:
-                        type: string
-                    password_2:
-                        type: string
-
+          - in: formData
+            name: token
+            required: True
+            type: string
+            format: JWT token
+          - in: formData
+            name: password
+            required: True
+            type: string
+            format: password
+          - in: formData
+            name: password_2
+            required: True
+            type: string
+            format: password
         responses:
           200:
             description: Password reset
@@ -646,18 +638,12 @@ class ResetPasswordResource(Resource, ArgsMixin):
         tags:
             - Authentication
         parameters:
-          - in: body
-            name: Email
-            description: The email of the user
-            schema:
-                type: object
-                required:
-                - email
-                properties:
-                    email:
-                        type: string
-                        format: email
-
+          - in: formData
+            name: email
+            required: True
+            type: string
+            format: email
+            x-example: admin@example.com
         responses:
           200:
             description: Reset token sent

--- a/zou/app/blueprints/comments/resources.py
+++ b/zou/app/blueprints/comments/resources.py
@@ -23,6 +23,11 @@ class DownloadAttachmentResource(Resource):
         ---
         tags:
         - Comments
+        produces:
+          - multipart/form-data
+          - image/png
+          - image/gif
+          - image/jpeg
         parameters:
           - in: path
             name: attachment_file_id
@@ -38,6 +43,8 @@ class DownloadAttachmentResource(Resource):
         responses:
             200:
                 description: Attachment file downloaded
+                schema:
+                    type: file
             404:
                 description: Download failed
         """
@@ -144,11 +151,12 @@ class CommentTaskResource(Resource):
                     created_at:
                         type: string
                         format: date-time
-                        example: 2022-07-12T13:00:00
+                        example: "2022-07-12T13:00:00"
                     checklist:
-                        type: array
-                        items:
-                            type: string
+                        type: object
+                        properties:
+                            item 1:
+                                type: string
         responses:
             201:
                 description: New comment created
@@ -221,6 +229,11 @@ class AddAttachmentToCommentResource(Resource):
         ---
         tags:
         - Comments
+        consumes:
+          - image/png
+          - image/gif
+          - image/jpeg
+          - multipart/form-data
         parameters:
           - in: path
             name: task_id
@@ -234,6 +247,10 @@ class AddAttachmentToCommentResource(Resource):
             type: string
             format: UUID
             x-example: a24a6ea4-ce75-4665-a070-57453082c25
+          - in: formData
+            name: files
+            type: file
+            required: True
         responses:
             201:
                 description: Given files added to the comment entry as attachments
@@ -270,6 +287,37 @@ class CommentManyTasksResource(Resource):
             type: string
             format: UUID
             x-example: a24a6ea4-ce75-4665-a070-57453082c25
+          - in: body
+            name: Comment
+            description: person ID, name, comment, revision and change status of task
+            schema:
+                type: object
+                required:
+                    - task_status_id
+                properties:
+                    task_status_id:
+                        type: string
+                        format: UUID
+                        example: a24a6ea4-ce75-4665-a070-57453082c25a4-ce75-4665-a070-57453082c25
+                    comment:
+                        type: string
+                    person_id:
+                        type: string
+                        format: UUID
+                        example: a24a6ea4-ce75-4665-a070-57453082c25a4-ce75-4665-a070-57453082c25
+                    object_id:
+                        type: string
+                        format: UUID
+                        example: a24a6ea4-ce75-4665-a070-57453082c25a4-ce75-4665-a070-57453082c25
+                    created_at:
+                        type: string
+                        format: date-time
+                        example: "2022-07-12T13:00:00"
+                    checklist:
+                        type: object
+                        properties:
+                            item 1:
+                                type: string
         responses:
             201:
                 description: Given files added to the comment entry as attachments
@@ -348,6 +396,10 @@ class ReplyCommentResource(Resource, ArgsMixin):
             type: string
             format: UUID
             x-example: a24a6ea4-ce75-4665-a070-57453082c25
+          - in: formData
+            name: text
+            type: string
+            x-example: comment
         responses:
             200:
                 description: Reply to given comment

--- a/zou/app/blueprints/edits/resources.py
+++ b/zou/app/blueprints/edits/resources.py
@@ -83,6 +83,16 @@ class EditsResource(Resource):
             type: string
             format: UUID
             x-example: a24a6ea4-ce75-4665-a070-57453082c25
+          - in: query
+            name: name
+            required: False
+            type: string
+            x-example: Name of edit
+          - in: query
+            name: force
+            required: False
+            type: boolean
+            default: False
         responses:
             200:
                 description: All edit entries
@@ -112,6 +122,16 @@ class AllEditsResource(Resource):
             type: string
             format: UUID
             x-example: a24a6ea4-ce75-4665-a070-57453082c25
+          - in: query
+            name: name
+            required: False
+            type: string
+            x-example: Name of edit
+          - in: query
+            name: force
+            required: False
+            type: boolean
+            default: False
         responses:
             200:
                 description: All edit entries
@@ -275,6 +295,16 @@ class EditsAndTasksResource(Resource):
             type: string
             format: UUID
             x-example: a24a6ea4-ce75-4665-a070-57453082c25
+          - in: query
+            name: name
+            required: False
+            type: string
+            x-example: Name of edit
+          - in: query
+            name: force
+            required: False
+            type: boolean
+            default: False
         responses:
             200:
                 description: All edits and all related tasks.
@@ -327,26 +357,20 @@ class ProjectEditsResource(Resource):
             type: string
             format: UUID
             x-example: a24a6ea4-ce75-4665-a070-57453082c25
-          - in: body
-            name: Edit
-            description: Name and description of edit, data and ID of episode.
-            schema:
-                type: object
-                required:
-                - name
-                properties:
-                    name:
-                        type: string
-                    description:
-                        type: string
-                    data:
-                        type: array
-                        items:
-                            type: string
-                    episode_id:
-                        type: string
-                        format: UUID
-                        example: a24a6ea4-ce75-4665-a070-57453082c25
+          - in: formData
+            name: name
+            required: True
+            type: string
+            x-example: Name of edit
+          - in: formData
+            name: description
+            type: string
+            x-example: Description of edit
+          - in: formData
+            name: episode_id
+            type: string
+            format: UUID
+            x-example: a24a6ea4-ce75-4665-a070-57453082c25
         responses:
             201:
                 description: Edit created for given project

--- a/zou/app/blueprints/events/resources.py
+++ b/zou/app/blueprints/events/resources.py
@@ -17,30 +17,30 @@ class EventsResource(Resource, ArgsMixin):
         tags:
           - Events
         parameters:
-          - in: body
-            name: Events
-            schema:
-                type: object
-                properties:
-                    after:
-                        type: string
-                        format: date
-                        example: 2022-07-12
-                    before:
-                        type: string
-                        format: date
-                        example: 2022-07-12
-                    only_files:
-                        type: boolean
-                        default: False
-                    page_size:
-                        type: integer
-                        default: 100
-                        example: 100
-                    project_id:
-                        type: string
-                        format: UUID
-                        example: a24a6ea4-ce75-4665-a070-57453082c25
+          - in: query
+            name: after
+            type: string
+            format: date
+            x-example: "2022-07-12"
+          - in: query
+            name: before
+            type: string
+            format: date
+            x-example: "2022-07-12"
+          - in: query
+            name: only_files
+            type: boolean
+            default: False
+          - in: query
+            name: page_size
+            type: integer
+            default: 100
+            x-example: 100
+          - in: query
+            name: project_id
+            type: string
+            format: UUID
+            x-example: a24a6ea4-ce75-4665-a070-57453082c25
         responses:
             200:
                 description: All login logs
@@ -83,18 +83,15 @@ class LoginLogsResource(Resource, ArgsMixin):
         tags:
           - Events
         parameters:
-          - in: body
-            name: Event
-            schema:
-                type: object
-                properties:
-                    before:
-                        type: string
-                        format: date-time
-                        example: 2022-07-12T00:00:00
-                    page_size:
-                        type: integer
-                        example: 100
+          - in: query
+            name: before
+            type: string
+            format: date
+            x-example: "2022-07-12T00:00:00"
+          - in: query
+            name: page_size
+            type: integer
+            x-example: 100
         responses:
             200:
                 description: All login logs

--- a/zou/app/blueprints/files/resources.py
+++ b/zou/app/blueprints/files/resources.py
@@ -105,6 +105,11 @@ class WorkingFileFileResource(Resource):
         ---
         tags:
           - Files
+        produces:
+          - image/png
+          - image/jpg
+          - image/gif
+          - multipart/form-data
         parameters:
           - in: path
             name: working_file_id
@@ -115,6 +120,8 @@ class WorkingFileFileResource(Resource):
         responses:
             200:
               description: Working file downloaded
+              schema:
+                type: file
         """
         self.check_access(working_file_id)
         return send_storage_file(working_file_id)
@@ -133,6 +140,10 @@ class WorkingFileFileResource(Resource):
             type: string
             format: UUID
             x-example: a24a6ea4-ce75-4665-a070-57453082c25
+          - in: formData
+            name: file
+            type: file
+            required: True
         responses:
             201:
               description: Working file stored
@@ -591,6 +602,11 @@ class NewWorkingFileResource(Resource):
                      It is the file the CG artist is working on.
                      It is versioned, tied to a task and a software and requires a comment each time it is created.
                      A path is generated for each file created. The path format is defined in the file tree template file.
+        produces:
+          - image/png
+          - image/jpg
+          - image/gif
+          - multipart/form-data
         parameters:
           - in: path
             name: task_id
@@ -631,6 +647,8 @@ class NewWorkingFileResource(Resource):
         responses:
             201:
                 description: New working file created
+                schema:
+                    type: file
             400:
                 description: Given working file already exists
         """
@@ -830,6 +848,11 @@ class NewEntityOutputFileResource(Resource, ArgsMixin):
                      An output type is required for better categorization (textures, caches, ...).
                      A task type can be set too to give the department related to the output file.
                      Revision is automatically set.
+        produces:
+          - image/png
+          - image/jpg
+          - image/gif
+          - multipart/form-data
         parameters:
           - in: path
             name: entity_id
@@ -888,6 +911,8 @@ class NewEntityOutputFileResource(Resource, ArgsMixin):
         responses:
             200:
                 description: New output file created
+                schema:
+                    type: file
             400:
                 description: Given output file already exists
                              Given person not found
@@ -1044,6 +1069,11 @@ class NewInstanceOutputFileResource(Resource, ArgsMixin):
                      It keeps track of the working file at the origin of the output file.
                      An output type is required for better categorization (textures, caches, ...).
                      A task type can be set too to give the department related to the output file.
+        produces:
+          - image/png
+          - image/jpg
+          - image/gif
+          - multipart/form-data
         parameters:
           - in: path
             name: asset_instance_id
@@ -1112,6 +1142,8 @@ class NewInstanceOutputFileResource(Resource, ArgsMixin):
         responses:
             200:
                 description: New output file created
+                schema:
+                    type: file
             400:
                 description: Given output file already exists
                              Given person not found

--- a/zou/app/blueprints/news/resources.py
+++ b/zou/app/blueprints/news/resources.py
@@ -21,40 +21,43 @@ class ProjectNewsResource(Resource, ArgsMixin):
             type: string
             format: UUID
             x-example: a24a6ea4-ce75-4665-a070-57453082c25
-          - in: body
-            name: Filter News
-            schema:
-                type: object
-                properties:
-                    only_preview:
-                        type: boolean
-                        default: False
-                    task_type_id:
-                        type: string
-                        format: UUID
-                        example: a24a6ea4-ce75-4665-a070-57453082c25
-                    task_status_id:
-                        type: string
-                        format: UUID
-                        example: a24a6ea4-ce75-4665-a070-57453082c25
-                    person_id:
-                        type: string
-                        format: UUID
-                        example: a24a6ea4-ce75-4665-a070-57453082c25
-                    page:
-                        type: integer
-                        example: 1
-                    page_size:
-                        type: integer
-                        example: 50
-                    after:
-                        type: string
-                        format: date
-                        example: 2022-07-12
-                    before:
-                        type: string
-                        format: date
-                        example: 2022-07-12
+          - in: query
+            name: before
+            type: string
+            format: date
+            x-example: "2022-07-12"
+          - in: query
+            name: after
+            type: string
+            format: date
+            x-example: "2022-07-12"
+          - in: query
+            name: page
+            type: integer
+            x-example: 1
+          - in: query
+            name: page_size
+            type: integer
+            x-example: 50
+          - in: query
+            name: person_id
+            type: string
+            format: UUID
+            x-example: a24a6ea4-ce75-4665-a070-57453082c25
+          - in: query
+            name: task_type_id
+            type: string
+            format: UUID
+            x-example: a24a6ea4-ce75-4665-a070-57453082c25
+          - in: query
+            name: task_status_id
+            type: string
+            format: UUID
+            x-example: a24a6ea4-ce75-4665-a070-57453082c25
+          - in: query
+            name: only_preview
+            type: boolean
+            default: False
         responses:
             200:
                 description: All news related to given project

--- a/zou/app/blueprints/persons/resources.py
+++ b/zou/app/blueprints/persons/resources.py
@@ -37,30 +37,30 @@ class NewPersonResource(Resource):
         description: Set "default" as password.
                      User role can be set but only admins can create admin users.
         parameters:
-          - in: body
-            name: User
-            description: Email, first and last name, phone, role, desktop login and department of user
-            schema:
-                type: object
-                required:
-                - email
-                - first_name
-                properties:
-                    email:
-                        type: string
-                    first_name:
-                        type: string
-                    last_name:
-                        type: string
-                    phone:
-                        type: integer
-                        example: 06 12 34 56 78
-                    role:
-                        type: string
-                    desktop_login:
-                        type: string
-                    departments:
-                        type: string
+          - in: formData
+            name: email
+            required: True
+            type: string
+            format: email
+            x-example: admin@example.com
+          - in: formData
+            name: phone
+            required: False
+            type: integer
+            x-example: 06 12 34 56 78
+          - in: formData
+            name: role
+            required: False
+            type: string
+            x-example: user
+          - in: formData
+            name: first_name
+            required: True
+            type: string
+          - in: formData
+            name: last_name
+            required: False
+            type: string
         responses:
             201:
                 description: User created
@@ -155,17 +155,12 @@ class DesktopLoginsResource(Resource):
             type: string
             format: UUID
             x-example: a24a6ea4-ce75-4665-a070-57453082c25
-          - in: body
-            name: Date
-            schema:
-                type: object
-                required:
-                - date
-                properties:
-                    date:
-                        type: string
-                        format: date
-                        example: 2022-07-12
+          - in: formDara
+            name: date
+            required: True
+            type: string
+            format: date
+            x-example: "2022-07-12"
         responses:
             201:
                 description: Desktop login logs created
@@ -209,7 +204,7 @@ class PresenceLogsResource(Resource):
             required: True
             type: string
             format: date
-            x-example: 2022-07
+            x-example: "2022-07"
         responses:
             200:
                 description: CSV file containing the presence logs based on a daily basis
@@ -246,7 +241,7 @@ class TimeSpentsResource(Resource):
             required: True
             type: string
             format: date
-            x-example: 2022-07-12
+            x-example: "2022-07-12"
         responses:
             200:
                 description: Time spents for given person and date
@@ -289,7 +284,7 @@ class DayOffResource(Resource):
             required: True
             type: string
             format: date
-            x-example: 2022-07-12
+            x-example: "2022-07-12"
         responses:
             200:
                 description: Day off object for given person and date
@@ -331,7 +326,7 @@ class PersonYearTimeSpentsResource(Resource, ArgsMixin):
             name: year
             required: True
             type: integer
-            x-example: 2022
+            x-example: "2022"
         responses:
             200:
                 description: Aggregated time spents for given person and year
@@ -371,7 +366,7 @@ class PersonMonthTimeSpentsResource(Resource, ArgsMixin):
             name: year
             required: True
             type: integer
-            x-example: 2022
+            x-example: "2022"
           - in: path
             name: month
             required: True
@@ -418,7 +413,7 @@ class PersonWeekTimeSpentsResource(Resource, ArgsMixin):
             name: year
             required: True
             type: integer
-            x-example: 2022
+            x-example: "2022"
           - in: path
             name: week
             required: True
@@ -465,7 +460,7 @@ class PersonDayTimeSpentsResource(Resource, ArgsMixin):
             name: year
             required: True
             type: integer
-            x-example: 2022
+            x-example: "2022"
           - in: path
             name: month
             required: True
@@ -519,7 +514,7 @@ class PersonMonthQuotaShotsResource(Resource, ArgsMixin):
             name: year
             required: True
             type: integer
-            x-example: 2022
+            x-example: "2022"
           - in: path
             name: month
             required: True
@@ -573,7 +568,7 @@ class PersonWeekQuotaShotsResource(Resource, ArgsMixin):
             name: year
             required: True
             type: integer
-            x-example: 2022
+            x-example: "2022"
           - in: path
             name: week
             required: True
@@ -627,7 +622,7 @@ class PersonDayQuotaShotsResource(Resource, ArgsMixin):
             name: year
             required: True
             type: integer
-            x-example: 2022
+            x-example: "2022"
           - in: path
             name: month
             required: True
@@ -684,7 +679,7 @@ class TimeSpentMonthResource(Resource, ArgsMixin):
             name: year
             required: True
             type: integer
-            x-example: 2022
+            x-example: "2022"
           - in: path
             name: month
             required: True
@@ -747,7 +742,7 @@ class TimeSpentMonthsResource(Resource, ArgsMixin):
             name: year
             required: True
             type: integer
-            x-example: 2022
+            x-example: "2022"
         responses:
             200:
                 description: Table giving time spent by user and by month for given year
@@ -778,7 +773,7 @@ class TimeSpentWeekResource(Resource, ArgsMixin):
             name: year
             required: True
             type: integer
-            x-example: 2022
+            x-example: "2022"
         responses:
             200:
                 description: Table giving time spent by user and by week for given year
@@ -837,7 +832,7 @@ class DayOffForMonthResource(Resource, ArgsMixin):
             name: year
             required: True
             type: integer
-            x-example: 2022
+            x-example: "2022"
           - in: path
             name: month
             required: True
@@ -881,7 +876,7 @@ class PersonWeekDayOffResource(Resource, ArgsMixin):
             name: year
             required: True
             type: integer
-            x-example: 2022
+            x-example: "2022"
           - in: path
             name: week
             required: True
@@ -924,7 +919,7 @@ class PersonMonthDayOffResource(Resource, ArgsMixin):
             name: year
             required: True
             type: integer
-            x-example: 2022
+            x-example: "2022"
           - in: path
             name: month
             required: True
@@ -967,7 +962,7 @@ class PersonYearDayOffResource(Resource, ArgsMixin):
             name: year
             required: True
             type: integer
-            x-example: 2022
+            x-example: "2022"
         responses:
             200:
                 description: All day off recorded for given year and person

--- a/zou/app/blueprints/playlists/resources.py
+++ b/zou/app/blueprints/playlists/resources.py
@@ -186,6 +186,8 @@ class PlaylistDownloadResource(Resource):
         ---
         tags:
         - Playlists
+        produces:
+          - multipart/form-data
         parameters:
           - in: path
             name: playlist_id
@@ -262,6 +264,8 @@ class BuildPlaylistMovieResource(Resource, ArgsMixin):
         ---
         tags:
         - Playlists
+        produces:
+          - multipart/form-data
         parameters:
           - in: path
             name: playlist_id
@@ -327,6 +331,8 @@ class PlaylistZipDownloadResource(Resource):
         ---
         tags:
         - Playlists
+        produces:
+          - multipart/form-data
         parameters:
           - in: path
             name: playlist_id
@@ -337,6 +343,8 @@ class PlaylistZipDownloadResource(Resource):
         responses:
             200:
                 description: Given playlist downloaded as zip
+                schema:
+                    type: file
         """
         playlist = playlists_service.get_playlist(playlist_id)
         project = projects_service.get_project(playlist["project_id"])

--- a/zou/app/blueprints/previews/resources.py
+++ b/zou/app/blueprints/previews/resources.py
@@ -164,6 +164,10 @@ class CreatePreviewFilePictureResource(Resource, ArgsMixin):
         tags:
           - Previews
         description: "It stores the preview file and generates three picture files matching preview when it's possible: a square thumbnail, a rectangle thumbnail and a midsize file."
+        consumes:
+          - multipart/form-data
+          - image/png
+          - application/pdf
         parameters:
           - in: path
             name: instance_id
@@ -171,6 +175,10 @@ class CreatePreviewFilePictureResource(Resource, ArgsMixin):
             type: string
             format: UUID
             x-example: a24a6ea4-ce75-4665-a070-57453082c25
+          - in: formData
+            name: file
+            required: True
+            type: file
         responses:
             200:
                 description: Preview added
@@ -739,6 +747,10 @@ class BaseCreatePictureResource(Resource):
         ---
         tags:
           - Previews
+        consumes:
+          - multipart/form-data
+          - image/png
+          - application/pdf
         parameters:
           - in: path
             name: instance_id
@@ -746,6 +758,10 @@ class BaseCreatePictureResource(Resource):
             type: string
             format: UUID
             x-example: a24a6ea4-ce75-4665-a070-57453082c25
+          - in: formData
+            name: file
+            required: True
+            type: file
         responses:
             200:
                 description: Thumbnail created

--- a/zou/app/blueprints/projects/resources.py
+++ b/zou/app/blueprints/projects/resources.py
@@ -188,6 +188,12 @@ class ProductionAssetTypeResource(Resource, ArgsMixin):
             type: string
             format: UUID
             x-example: a24a6ea4-ce75-4665-a070-57453082c25
+          - in: formData
+            name: asset_type_id
+            required: True
+            type: string
+            format: UUID
+            x-example: a24a6ea4-ce75-4665-a070-57453082c25
         responses:
             201:
               description: Asset type added to production
@@ -280,6 +286,17 @@ class ProductionTaskTypeResource(Resource, ArgsMixin):
             type: string
             format: UUID
             x-example: a24a6ea4-ce75-4665-a070-57453082c25
+          - in: formData
+            name: task_type_id
+            required: True
+            type: string
+            format: UUID
+            x-example: a24a6ea4-ce75-4665-a070-57453082c25
+          - in: formData
+            name: priority
+            required: False
+            type: string
+            default: "None"
         responses:
             201:
               description: Asset type added to production
@@ -368,6 +385,12 @@ class ProductionTaskStatusResource(Resource, ArgsMixin):
             type: string
             format: UUID
             x-example: a24a6ea4-ce75-4665-a070-57453082c25
+          - in: formData
+            name: task_status_id
+            required: True
+            type: string
+            format: UUID
+            x-example: a24a6ea4-ce75-4665-a070-57453082c25
         responses:
             201:
               description: Task type added to production
@@ -451,6 +474,12 @@ class ProductionStatusAutomationResource(Resource, ArgsMixin):
           - in: path
             name: project_id
             required: true
+            type: string
+            format: UUID
+            x-example: a24a6ea4-ce75-4665-a070-57453082c25
+          - in: formData
+            name: status_automation_id
+            required: True
             type: string
             format: UUID
             x-example: a24a6ea4-ce75-4665-a070-57453082c25
@@ -644,6 +673,26 @@ class ProductionMetadataDescriptorResource(Resource, ArgsMixin):
             type: string
             format: UUID
             x-example: a24a6ea4-ce75-4665-a070-57453082c25
+          - in: formData
+            name: name
+            required: True
+            type: string
+            required: False
+          - in: formData
+            name: for_client
+            required: True
+            type: boolean
+            default: False
+            required: False
+          - in: formData
+            name: choices
+            required: True
+            type: array
+            required: False 
+          - in: formData
+            name: departments
+            type: array
+            required: False
         responses:
             200:
               description: Metadata descriptor updated

--- a/zou/app/blueprints/search/resources.py
+++ b/zou/app/blueprints/search/resources.py
@@ -15,14 +15,14 @@ class SearchResource(Resource, ArgsMixin):
         tags:
         - Search
         parameters:
-          - in: query
+          - in: formData
             name: query
             required: True
             type: string
-            x-example: name of asset
+            x-example: Name of asset or person
         responses:
             200:
-                description: Resource
+                description: List of assets and persons that contain the query (3 results max)
         """
         args = self.get_args([("query", "", True)])
         query = args.get("query")

--- a/zou/app/blueprints/shots/resources.py
+++ b/zou/app/blueprints/shots/resources.py
@@ -541,8 +541,7 @@ class SceneAndTasksResource(Resource):
     @jwt_required
     def get(self):
         """
-        Retrieve all scenes, adds project name and asset type name and all
-        related tasks.
+        Retrieve all scenes, adds project name and asset type name and all related tasks.
         ---
         tags:
         - Shots
@@ -567,8 +566,7 @@ class SequenceAndTasksResource(Resource):
     @jwt_required
     def get(self):
         """
-        Retrieve all sequences, adds project name and asset type name and all
-        related tasks.
+        Retrieve all sequences, adds project name and asset type name and all related tasks.
         ---
         tags:
         - Shots
@@ -593,8 +591,7 @@ class EpisodeAndTasksResource(Resource):
     @jwt_required
     def get(self):
         """
-        Retrieve all episodes, adds project name and asset type name and all
-        related tasks.
+        Retrieve all episodes, adds project name and asset type name and all related tasks.
         ---
         tags:
         - Shots
@@ -654,30 +651,23 @@ class ProjectShotsResource(Resource):
             type: string
             format: UUID
             x-example: a24a6ea4-ce75-4665-a070-57453082c25
-          - in: body
-            name: Shot
-            description: ID of sequence and name, description, data, number of frames and ID of asset
-            schema:
-                type: object
-                required:
-                - name
-                - description
-                - data
-                - sequence_id
-                - nb_frames
-                properties:
-                    name:
-                        type: string
-                    description:
-                        type: string
-                    data:
-                        type: string
-                    sequence_id:
-                        type: string
-                        format: UUID
-                        x-example: a24a6ea4-ce75-4665-a070-57453082c25
-                    nb_frames:
-                        type: integer
+          - in: formData
+            name: name
+            required: True
+            type: string
+            x-example: Name of shot
+          - in: formData
+            name: description
+            type: string
+            x-example: Description of shot
+          - in: formData
+            name: sequence_id
+            type: string
+            format: UUID
+            x-example: a24a6ea4-ce75-4665-a070-57453082c25
+          - in: formData
+            name: nb_frames
+            type: integer       
         responses:
             201:
                 description: Shot created for given project
@@ -758,21 +748,16 @@ class ProjectSequencesResource(Resource):
             type: string
             format: UUID
             x-example: a24a6ea4-ce75-4665-a070-57453082c25
-          - in: body
-            name: Sequence
-            description: Name and ID of episode
-            schema:
-                type: object
-                required:
-                - name
-                - episode_id
-                properties:
-                    name:
-                        type: string
-                    episode_id:
-                        type: string
-                        format: UUID
-                        x-example: a24a6ea4-ce75-4665-a070-57453082c25
+          - in: formData
+            name: name
+            required: True
+            type: string
+            x-example: Name of sequence
+          - in: formData
+            name: episode_id
+            type: string
+            format: UUID
+            x-example: a24a6ea4-ce75-4665-a070-57453082c25
         responses:
             201:
                 description: Sequence created for given project
@@ -830,16 +815,11 @@ class ProjectEpisodesResource(Resource):
             type: string
             format: UUID
             x-example: a24a6ea4-ce75-4665-a070-57453082c25
-          - in: body
-            name: Episode
-            description: Name of episode
-            schema:
-                type: object
-                required:
-                - name
-                properties:
-                    name:
-                        type: string
+          - in: formData
+            name: name
+            required: True
+            type: string
+            x-example: Name of episode
         responses:
             201:
                 description: Episode created for given project
@@ -1186,7 +1166,7 @@ class ProjectScenesResource(Resource):
     @jwt_required
     def get(self, project_id):
         """
-        Retrieve all shots related to a given project.
+        Retrieve all scenes related to a given project.
         ---
         tags:
         - Shots
@@ -1199,7 +1179,7 @@ class ProjectScenesResource(Resource):
             x-example: a24a6ea4-ce75-4665-a070-57453082c25
         responses:
             200:
-                description: All shots related to given project
+                description: All scenes related to given project
         """
         projects_service.get_project(project_id)
         user_service.check_project_access(project_id)
@@ -1208,7 +1188,7 @@ class ProjectScenesResource(Resource):
     @jwt_required
     def post(self, project_id):
         """
-        Create a shot for given project.
+        Create a scene for given project.
         ---
         tags:
         - Shots
@@ -1219,24 +1199,20 @@ class ProjectScenesResource(Resource):
             type: string
             format: UUID
             x-example: a24a6ea4-ce75-4665-a070-57453082c25
-          - in: body
-            name: Shot
-            description: Name of shot and ID of sequence
-            schema:
-                type: object
-                required:
-                - name
-                - sequence_id
-                properties:
-                    name:
-                        type: string
-                    sequence_id:
-                        type: string
-                        format: UUID
-                        x-example: a24a6ea4-ce75-4665-a070-57453082c25
+          - in: formData
+            name: name
+            required: True
+            type: string
+            x-example: Name of scene
+          - in: formData
+            name: sequence_id
+            required: True
+            type: string
+            format: UUID
+            x-example: a24a6ea4-ce75-4665-a070-57453082c25                 
         responses:
             201:
-                description: Shot created for given project
+                description: Scene created for given project
         """
         (sequence_id, name) = self.get_arguments()
         projects_service.get_project(project_id)
@@ -1362,18 +1338,11 @@ class SceneShotsResource(Resource, ArgsMixin):
             type: string
             format: UUID
             x-example: a24a6ea4-ce75-4665-a070-57453082c25
-          - in: body
-            name: Shot
-            description: ID of shot
-            schema:
-                type: object
-                required:
-                - shot_id
-                properties:
-                    shot_id:
-                        type: string
-                        format: UUID
-                        x-example: a24a6ea4-ce75-4665-a070-57453082c25
+          - in: formData
+            name: shot_id
+            type: string
+            format: UUID
+            x-example: a24a6ea4-ce75-4665-a070-57453082c25
         responses:
             200:
                 description: Given scene marked as source of given shot

--- a/zou/app/blueprints/source/csv/assets.py
+++ b/zou/app/blueprints/source/csv/assets.py
@@ -20,6 +20,8 @@ class AssetsCsvImportResource(BaseCsvProjectImportResource):
         ---
         tags:
           - Import
+        consumes:
+          - multipart/form-data
         parameters:
           - in: path
             name: project_id

--- a/zou/app/blueprints/source/csv/assets.py
+++ b/zou/app/blueprints/source/csv/assets.py
@@ -19,7 +19,7 @@ class AssetsCsvImportResource(BaseCsvProjectImportResource):
         Import project assets via a .csv file.
         ---
         tags:
-          - Source
+          - Import
         parameters:
           - in: path
             name: project_id
@@ -27,7 +27,7 @@ class AssetsCsvImportResource(BaseCsvProjectImportResource):
             type: string
             format: UUID
             x-example: a24a6ea4-ce75-4665-a070-57453082c25
-        - in: formData
+          - in: formData
             name: file
             type: file
             required: true

--- a/zou/app/blueprints/source/csv/base.py
+++ b/zou/app/blueprints/source/csv/base.py
@@ -42,6 +42,13 @@ class BaseCsvImportResource(Resource):
         ---
         tags:
           - Import
+        consumes:
+          - multipart/form-data
+        properties:
+          - in: formData
+            name: file
+            type: file
+            required: true
         responses:
             201:
                 description: Persons imported

--- a/zou/app/blueprints/source/csv/base.py
+++ b/zou/app/blueprints/source/csv/base.py
@@ -41,7 +41,7 @@ class BaseCsvImportResource(Resource):
         Import persons as csv.
         ---
         tags:
-          - Source
+          - Import
         responses:
             201:
                 description: Persons imported

--- a/zou/app/blueprints/source/csv/casting.py
+++ b/zou/app/blueprints/source/csv/casting.py
@@ -18,7 +18,7 @@ class CastingCsvImportResource(BaseCsvProjectImportResource):
         Import project casting links via a .csv file.
         ---
         tags:
-          - Source
+          - Import
         parameters:
           - in: path
             name: project_id

--- a/zou/app/blueprints/source/csv/casting.py
+++ b/zou/app/blueprints/source/csv/casting.py
@@ -19,6 +19,8 @@ class CastingCsvImportResource(BaseCsvProjectImportResource):
         ---
         tags:
           - Import
+        consumes:
+          - multipart/form-data
         parameters:
           - in: path
             name: project_id

--- a/zou/app/blueprints/source/csv/edits.py
+++ b/zou/app/blueprints/source/csv/edits.py
@@ -27,7 +27,13 @@ class EditsCsvImportResource(BaseCsvProjectImportResource):
         ---
         tags:
           - Import
+        consumes:
+          - multipart/form-data
         parameters:
+          - in: formData
+            name: file
+            type: file
+            required: true
           - in: path
             name: project_id
             required: True

--- a/zou/app/blueprints/source/csv/edits.py
+++ b/zou/app/blueprints/source/csv/edits.py
@@ -26,7 +26,7 @@ class EditsCsvImportResource(BaseCsvProjectImportResource):
         Import project edits.
         ---
         tags:
-          - Source
+          - Import
         parameters:
           - in: path
             name: project_id
@@ -40,7 +40,7 @@ class EditsCsvImportResource(BaseCsvProjectImportResource):
             400:
                 description: Format error
         """
-        super().post(project_id, **kwargs)
+        return super().post(project_id, **kwargs)
 
     def prepare_import(self, project_id):
         self.episodes = {}

--- a/zou/app/blueprints/source/csv/persons.py
+++ b/zou/app/blueprints/source/csv/persons.py
@@ -14,6 +14,8 @@ class PersonsCsvImportResource(BaseCsvImportResource):
         ---
         tags:
             - Import
+        consumes:
+          - multipart/form-data
         parameters:
           - in: formData
             name: file

--- a/zou/app/blueprints/source/csv/persons.py
+++ b/zou/app/blueprints/source/csv/persons.py
@@ -13,9 +13,9 @@ class PersonsCsvImportResource(BaseCsvImportResource):
         Import persons via a .csv file.
         ---
         tags:
-            - Source
+            - Import
         parameters:
-        - in: formData
+          - in: formData
             name: file
             type: file
             required: true

--- a/zou/app/blueprints/source/csv/shots.py
+++ b/zou/app/blueprints/source/csv/shots.py
@@ -27,6 +27,8 @@ class ShotsCsvImportResource(BaseCsvProjectImportResource):
         ---
         tags:
           - Import
+        consumes:
+          - multipart/form-data
         parameters:
           - in: path
             name: project_id

--- a/zou/app/blueprints/source/csv/shots.py
+++ b/zou/app/blueprints/source/csv/shots.py
@@ -26,7 +26,7 @@ class ShotsCsvImportResource(BaseCsvProjectImportResource):
         Import project shots via a .csv file.
         ---
         tags:
-          - Source
+          - Import
         parameters:
           - in: path
             name: project_id

--- a/zou/app/blueprints/source/csv/task_type_estimations.py
+++ b/zou/app/blueprints/source/csv/task_type_estimations.py
@@ -19,7 +19,7 @@ class TaskTypeEstimationsCsvImportResource(BaseCsvProjectImportResource):
         Import the estimations of task-types for given project.
         ---
         tags:
-          - Source
+          - Import
         parameters:
           - in: path
             name: project_id
@@ -127,7 +127,7 @@ class TaskTypeEstimationsEpisodeCsvImportResource(
         Import the estimations of task-types for given episode of given project.
         ---
         tags:
-          - Source
+          - Import
         parameters:
           - in: path
             name: project_id

--- a/zou/app/blueprints/source/csv/task_type_estimations.py
+++ b/zou/app/blueprints/source/csv/task_type_estimations.py
@@ -20,7 +20,13 @@ class TaskTypeEstimationsCsvImportResource(BaseCsvProjectImportResource):
         ---
         tags:
           - Import
+        consumes:
+          - multipart/form-data
         parameters:
+          - in: formData
+            name: file
+            type: file
+            required: true
           - in: path
             name: project_id
             required: True
@@ -128,7 +134,13 @@ class TaskTypeEstimationsEpisodeCsvImportResource(
         ---
         tags:
           - Import
+        consumes:
+          - multipart/form-data
         parameters:
+          - in: formData
+            name: file
+            type: file
+            required: true
           - in: path
             name: project_id
             required: True

--- a/zou/app/blueprints/source/kitsu.py
+++ b/zou/app/blueprints/source/kitsu.py
@@ -26,10 +26,10 @@ class BaseImportKitsuResource(Resource, ArgsMixin):
     @jwt_required
     def post(self):
         """
-        Import Kistu resource.
+        Import Kitsu resource.
         ---
         tags:
-          - Source
+          - Import
         responses:
             200:
                 description: Resource imported

--- a/zou/app/blueprints/source/kitsu.py
+++ b/zou/app/blueprints/source/kitsu.py
@@ -30,6 +30,17 @@ class BaseImportKitsuResource(Resource, ArgsMixin):
         ---
         tags:
           - Import
+        parameters:
+          - in: body
+            name: entries
+            required: True
+            schema:
+                type: array
+                items:
+                    type: object
+                    properties:
+                        id:
+                            type: string
         responses:
             200:
                 description: Resource imported

--- a/zou/app/blueprints/source/shotgun/base.py
+++ b/zou/app/blueprints/source/shotgun/base.py
@@ -32,6 +32,17 @@ class BaseImportShotgunResource(Resource):
         ---
         tags:
           - Import
+        parameters:
+          - in: body
+            name: sg_entries
+            required: True
+            schema:
+                type: array
+                items:
+                    type: object
+                    properties:
+                        id:
+                            type: string
         responses:
             200:
                 description: Resource imported
@@ -163,7 +174,7 @@ class ImportRemoveShotgunBaseResource(Resource):
         tags:
           - Import
         responses:
-            200:
+            204:
                 description: Instance removed
         """
         sg_model = request.json

--- a/zou/app/blueprints/source/shotgun/base.py
+++ b/zou/app/blueprints/source/shotgun/base.py
@@ -31,7 +31,7 @@ class BaseImportShotgunResource(Resource):
         Import shotgun resource.
         ---
         tags:
-          - Source
+          - Import
         responses:
             200:
                 description: Resource imported
@@ -161,7 +161,7 @@ class ImportRemoveShotgunBaseResource(Resource):
         Import remove instance.
         ---
         tags:
-          - Source
+          - Import
         responses:
             200:
                 description: Instance removed

--- a/zou/app/blueprints/source/shotgun/import_errors.py
+++ b/zou/app/blueprints/source/shotgun/import_errors.py
@@ -17,7 +17,7 @@ class ShotgunImportErrorsResource(Resource):
         Import shotgun error resource.
         ---
         tags:
-          - Source
+          - Import
         responses:
             200:
                 description: Resource imported
@@ -32,7 +32,7 @@ class ShotgunImportErrorsResource(Resource):
         Serialize shotgun error resource.
         ---
         tags:
-          - Source
+          - Import
         responses:
             200:
                 description: Resource serialized
@@ -52,7 +52,7 @@ class ShotgunImportErrorResource(Resource):
         Delete error.
         ---
         tags:
-          - Source
+          - Import
         parameters:
           - in: path
             name: error_id

--- a/zou/app/blueprints/source/shotgun/import_errors.py
+++ b/zou/app/blueprints/source/shotgun/import_errors.py
@@ -61,7 +61,7 @@ class ShotgunImportErrorResource(Resource):
             format: UUID
             x-example: a24a6ea4-ce75-4665-a070-57453082c25
         responses:
-            200:
+            204:
                 description: Error deleted
             404:
                 description: Error non-existant or Statement error

--- a/zou/app/blueprints/tasks/resources.py
+++ b/zou/app/blueprints/tasks/resources.py
@@ -55,6 +55,10 @@ class AddPreviewResource(Resource):
             type: string
             format: UUID
             x-example: a24a6ea4-ce75-4665-a070-57453082c25
+          - in: formData
+            name: file
+            type: file
+            required: True
         responses:
             201:
                 description: Preview added to given task
@@ -103,6 +107,10 @@ class AddExtraPreviewResource(Resource):
             type: string
             format: UUID
             x-example: a24a6ea4-ce75-4665-a070-57453082c25
+          - in: formData
+            name: file
+            type: file
+            required: True
         responses:
             201:
                 description: Preview added to given comment
@@ -967,7 +975,7 @@ class SetTimeSpentResource(Resource):
             required: True
             type: string
             format: date
-            x-example: 2022-07-12
+            x-example: "2022-07-12"
           - in: path
             name: person_id
             required: True
@@ -1037,7 +1045,7 @@ class AddTimeSpentResource(Resource):
             required: True
             type: string
             format: date
-            x-example: 2022-07-12
+            x-example: "2022-07-12"
           - in: path
             name: person_id
             required: True
@@ -1105,7 +1113,7 @@ class GetTimeSpentResource(Resource):
             required: True
             type: string
             format: date
-            x-example: 2022-07-12
+            x-example: "2022-07-12"
         responses:
             200:
                 description: Time spent on given task by given person

--- a/zou/app/blueprints/user/resources.py
+++ b/zou/app/blueprints/user/resources.py
@@ -497,28 +497,29 @@ class FiltersResource(Resource, ArgsMixin):
         tags:
         - User
         parameters:
-          - in: body
-            name: Filter
-            description: Name, query, list type, project id and entity type
-            schema:
-                type: object
-                required:
-                    - name
-                    - query
-                    - list_type
-                properties:
-                    name:
-                        type: string
-                    query:
-                        type: string
-                    list_type:
-                        type: string
-                    project_id:
-                        type: string
-                        format: UUID
-                        example: a24a6ea4-ce75-4665-a070-57453082c25
-                    entity_type:
-                        type: string
+          - in: formData
+            name: name
+            required: True
+            type: string
+            x-example: Name of filter
+          - in: formData
+            name: query
+            required: True
+            type: string
+          - in: formData
+            name: list_type
+            required: True
+            type: string
+          - in: formData
+            name: entity_type
+            required: False
+            type: string
+          - in: formData
+            name: project_id
+            required: True
+            type: string
+            format: UUID
+            example: a24a6ea4-ce75-4665-a070-57453082c25
         responses:
             201:
                 description: Filter for current user and only for open projects created
@@ -632,15 +633,11 @@ class DesktopLoginLogsResource(Resource):
         - User
         description: Desktop login logs can only be created by current user.
         parameters:
-          - in: body
-            name: Date
-            schema:
-                type: object
-                properties:
-                    date:
-                        type: string
-                        format: date
-                        example: 2022-07-12
+          - in: formData
+            name: date
+            type: string
+            format: date
+            x-example: "2022-07-12"
         responses:
             201:
                 description: Desktop login logs created
@@ -665,33 +662,18 @@ class NotificationsResource(Resource, ArgsMixin):
         Return last 100 user notifications filtered by given parameters.
         ---
         tags:
-        - User
+          - User
         parameters:
-          - in: query
+          - in: formData
             name: after
             type: string
             format: date
-            x-example: 2022-07-12
-          - in: query
+            x-example: "2022-07-12"
+          - in: formData
             name: before
             type: string
             format: date
-            x-example: 2022-08-12
-          - in: query
-            name: task_type_id
-            type: string
-            format: UUID
-            x-example: a24a6ea4-ce75-4665-a070-57453082c25
-          - in: query
-            name: task_status_id
-            type: string
-            format: UUID
-            x-example: a24a6ea4-ce75-4665-a070-57453082c25
-          - in: query
-            name: type
-            type: string
-            format: UUID
-            x-example: mention, comment, assignation or reply
+            x-example: "2022-07-12"
         responses:
             200:
                 description: 100 last user notifications
@@ -1011,7 +993,7 @@ class TaskTimeSpentResource(Resource):
             required: True
             type: string
             format: date
-            x-example: 2022-07-12
+            x-example: "2022-07-12"
         responses:
             200:
                 description:  Time spents for current user and given date
@@ -1045,7 +1027,7 @@ class DayOffResource(Resource):
             required: True
             type: string
             format: date
-            x-example: 2022-07-12
+            x-example: "2022-07-12"
         responses:
             200:
                 description:  Day off object for current user and given date
@@ -1070,8 +1052,7 @@ class ContextResource(Resource):
           - User
         responses:
             200:
-                description: Context to properly run a full app connected to
-                the API
+                description: Context to properly run a full app connected to the API
         """
         return user_service.get_context()
 
@@ -1087,7 +1068,7 @@ class ClearAvatarResource(Resource):
           - User
         responses:
             204:
-                description:
+                description: Avatar file deleted
         """
         user = persons_service.get_current_user()
         persons_service.clear_avatar(user["id"])

--- a/zou/app/swagger.py
+++ b/zou/app/swagger.py
@@ -16,23 +16,26 @@ swagger_config = {
     "specs_route": "/apidocs/",
 }
 
+curl = 'curl -X POST <server_address>/api/auth/login -d \"email=<youremail>&password=<yourpassword>{\"login\": true", "access_token\": \"eyJ0e...\", ...}'
 
 swagger_template = {
     "swagger": "2.0",
     "info": {
         "title": "Kitsu API",
-        "description": f"## Welcome to Kitsu API specification. \n```Version: {__version__}``` \n\n The Kitsu API allows to store and manage the data of your animation/VFX production. Through it you can link all the tools of your pipeline and make sure they are all synchronized. \n\n [Read the install documentation](https://zou.cg-wire.com) \n\n[OpenAPI definition](/openapi.json)",
+        "description": f"## Welcome to Kitsu API specification \n```Version: {__version__}``` \n\n The Kitsu API allows to store and manage the data of your animation/VFX production. Through it you can link all the tools of your pipeline and make sure they are all synchronized. \n\n## Authentication\n\n<div class=\"auth\"><p>Before you can use any of the endpoints outline below, you will have to get a JWT to authorize your requests.\n\nYou can get a authorization token using a (form-encoded) POST request to ```/auth/login```. With curl this would look something like ```curl -X POST <server_address>/auth/login -d \"email=<youremail>&password=<yourpassword>```.\n\nThe response is a JSON object, specifically you'll need to provide the ```access_token``` for your future requests.\n\nHere is a complete authentication process as an example (again using curl):\n\n```\n$ {curl}\n\n$ jwt=eyJ0e...  # Store the access token for easier use\n\n$ curl -H \"Authorization: Bearer $jwt\" <server_address>/api/data/projects\n[{{...}},\n {{...}}]\n ``` \n\n [OpenAPI definition](/openapi.json)\n",
         "contact": {
             "name": "CGWire",
-            "email": "support@cg-wire.com",
             "url": "https://www.cg-wire.com",
         },
-        "termsOfService": "https://www.cg-wire.com/terms.html",
         "version": __version__,
         "license": {
             "name": "AGPL 3.0",
             "url": "https://www.gnu.org/licenses/agpl-3.0.en.html",
         },
+    },
+    "externalDocs": {
+        "description": "Read the installation documentation",
+        "url": "https://zou.cg-wire.com"
     },
     "host": "localhost:8080",
     "basePath": "/api",
@@ -57,6 +60,7 @@ swagger_template = {
         {"name": "Events"},
         {"name": "Export"},
         {"name": "Files"},
+        {"name": "Import"},
         {"name": "Index"},
         {"name": "News"},
         {"name": "Persons"},
@@ -65,7 +69,6 @@ swagger_template = {
         {"name": "Projects"},
         {"name": "Search"},
         {"name": "Shots"},
-        {"name": "Source"},
         {"name": "Tasks"},
         {"name": "User"},
     ],
@@ -139,7 +142,7 @@ swagger_template = {
                 },
             },
         },
-        "Asset instance": {
+        "AssetInstance": {
             "type": "object",
             "properties": {
                 "asset_id": {
@@ -168,11 +171,11 @@ swagger_template = {
                 },
             },
         },
-        "Asset type": {
+        "AssetType": {
             "type": "object",
             "properties": {"name": {"type": "string"}},
         },
-        "Attachment file": {
+        "AttachmentFile": {
             "type": "object",
             "properties": {
                 "name": {
@@ -195,7 +198,7 @@ swagger_template = {
                 },
             },
         },
-        "Build job": {
+        "BuildJob": {
             "type": "object",
             "properties": {
                 "status": {
@@ -260,7 +263,7 @@ swagger_template = {
                 },
             },
         },
-        "Custom action": {
+        "CustomAction": {
             "type": "object",
             "properties": {
                 "name": {
@@ -276,7 +279,7 @@ swagger_template = {
                 },
             },
         },
-        "Data import error": {
+        "DataImportError": {
             "type": "object",
             "properties": {
                 "event_data": {
@@ -290,7 +293,7 @@ swagger_template = {
                 },
             },
         },
-        "Day off": {
+        "DayOff": {
             "type": "object",
             "properties": {
                 "date": {"type": "string", "format": "date"},
@@ -314,7 +317,7 @@ swagger_template = {
                 },
             },
         },
-        "Desktop login log": {
+        "DesktopLoginLog": {
             "type": "object",
             "properties": {
                 "date": {"type": "string", "format": "date"},
@@ -389,14 +392,14 @@ swagger_template = {
                 },
             },
         },
-        "File status": {
+        "FileStatus": {
             "type": "object",
             "properties": {
                 "name": {"type": "string"},
                 "color": {"type": "string"},
             },
         },
-        "Login log": {
+        "LoginLog": {
             "type": "object",
             "properties": {
                 "origin": {"type": "string", "description": "web, script"},
@@ -557,7 +560,7 @@ swagger_template = {
                 "chat_token_discord": {"type": "string"},
             },
         },
-        "Output file": {
+        "OutputFile": {
             "type": "object",
             "properties": {
                 "shotgun_id": {
@@ -659,7 +662,7 @@ swagger_template = {
                 },
             },
         },
-        "Output type": {
+        "OutputType": {
             "type": "object",
             "properties": {
                 "name": {"type": "string"},
@@ -756,7 +759,7 @@ swagger_template = {
                 },
             },
         },
-        "Preview file": {
+        "PreviewFile": {
             "type": "object",
             "properties": {
                 "shotgun_id": {
@@ -929,14 +932,14 @@ swagger_template = {
                 },
             },
         },
-        "Project status": {
+        "ProjectStatus": {
             "type": "object",
             "properties": {
                 "name": {"type": "string"},
                 "color": {"type": "string"},
             },
         },
-        "Schedule item": {
+        "ScheduleItem": {
             "type": "object",
             "properties": {
                 "start_date": {"type": "string", "format": "date"},
@@ -959,7 +962,7 @@ swagger_template = {
                 },
             },
         },
-        "Search filter": {
+        "SearchFilter": {
             "type": "object",
             "properties": {
                 "list_type": {"type": "string", "description": "Type of list"},
@@ -1101,7 +1104,7 @@ swagger_template = {
                 },
             },
         },
-        "Status automation": {
+        "StatusAutomation": {
             "type": "object",
             "properties": {
                 "entity_type": {"type": "string", "default": "asset"},
@@ -1131,7 +1134,7 @@ swagger_template = {
                 },
             },
         },
-        "Subscription to notifications": {
+        "SubscriptionToNotifications": {
             "type": "object",
             "properties": {
                 "person_id": {
@@ -1237,7 +1240,7 @@ swagger_template = {
                 },
             },
         },
-        "Task status": {
+        "TaskStatus": {
             "type": "object",
             "properties": {
                 "name": {
@@ -1285,7 +1288,7 @@ swagger_template = {
                 },
             },
         },
-        "Task type": {
+        "TaskType": {
             "type": "object",
             "properties": {
                 "name": {"type": "string", "description": "Name of task type"},
@@ -1316,7 +1319,7 @@ swagger_template = {
                 },
             },
         },
-        "Time spent": {
+        "TimeSpent": {
             "type": "object",
             "properties": {
                 "duration": {"type": "integer"},
@@ -1333,7 +1336,7 @@ swagger_template = {
                 },
             },
         },
-        "Working file": {
+        "WorkingFile": {
             "type": "object",
             "properties": {
                 "shotgun_id": {


### PR DESCRIPTION
**Problem**
- There is no parameters for file input in most of the endpoints.
- The openAPI file used in the Github Actions comes from a site not controlled by CGWire.
- The models were written with no specific naming conventions.

**Solution**

- Add file parameters in all endpoints.
- Update the openAPI file based on a testing instance called kitsu-staging that is updated and modified by CGWire.
- Use CamelCase as a naming convention for all models.