### PR TITLE
[playlists] Start build job sooner

### DIFF
--- a/zou/app/blueprints/playlists/resources.py
+++ b/zou/app/blueprints/playlists/resources.py
@@ -289,6 +289,7 @@ class BuildPlaylistMovieResource(Resource, ArgsMixin):
             for x in playlist["shots"]
         ]
 
+        job = playlists_service.start_build_job(playlist)
         if config.ENABLE_JOB_QUEUE:
             remote = config.ENABLE_JOB_QUEUE_REMOTE
             # remote worker can not access files local to the web app
@@ -299,6 +300,7 @@ class BuildPlaylistMovieResource(Resource, ArgsMixin):
                 playlists_service.build_playlist_job,
                 args=(
                     playlist,
+                    job,
                     shots,
                     params,
                     current_user["email"],
@@ -310,7 +312,7 @@ class BuildPlaylistMovieResource(Resource, ArgsMixin):
             return {"job": "running"}
         else:
             job = playlists_service.build_playlist_movie_file(
-                playlist, shots, params, full, remote=False
+                playlist, job, shots, params, full, remote=False
             )
             return {"job": job["status"]}
 

--- a/zou/app/services/playlists_service.py
+++ b/zou/app/services/playlists_service.py
@@ -486,11 +486,10 @@ def build_playlist_zip_file(playlist):
     return zip_file_path
 
 
-def build_playlist_movie_file(playlist, shots, params, full, remote):
+def build_playlist_movie_file(playlist, job, shots, params, full, remote):
     """
     Build a movie for all files for a given playlist into the temporary folder.
     """
-    job = start_build_job(playlist)
     success = False
     try:
         previews = playlist_previews(shots, only_movies=True)
@@ -531,6 +530,10 @@ def build_playlist_movie_file(playlist, shots, params, full, remote):
                 except Exception as exc:
                     current_app.logger.error(exc)
                     success = False
+
+    except Exception as exc:
+        current_app.logger.error(exc)
+        success = False
 
     # exception will be logged by rq
     finally:
@@ -642,7 +645,7 @@ def end_build_job(playlist, job, success):
         return {}
 
 
-def build_playlist_job(playlist, shots, params, email, full, remote):
+def build_playlist_job(playlist, job, shots, params, email, full, remote):
     """
     Build playlist file (concatenate all movie previews). This function is
     aimed at being runned as a job in a job queue.
@@ -650,7 +653,9 @@ def build_playlist_job(playlist, shots, params, email, full, remote):
     from zou.app import app, mail
 
     with app.app_context():
-        job = build_playlist_movie_file(playlist, shots, params, full, remote)
+        build_playlist_movie_file(
+            playlist, job, shots, params, full, remote
+        )
 
         # Just in case, since rq jobs which encounter an error raise an
         # exception in order to be flagged as failed.


### PR DESCRIPTION
**Problem**

When the RQ queue is busy, the job info is created late and no feedback is sent to users. 

**Solution**

Now the job info is created when the server receive the http request.
