### PR TITLE
[qa] fix travis tests problems with setuptools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ addons:
       - ffmpeg
 install:
   - "pip install -U pip"
-  - "pip install -U "setuptools<=65.1.1""
+  - "pip install -U 'setuptools<=65.1.1'"
   - "pip install -r requirements.txt"
 before_script:
   - psql -c 'create database zoudb;' -U postgres


### PR DESCRIPTION
**Problem**
- setuptools 65.1.1 not compatible with python 3.6

**Solution**
- use <= to permit to use anterior versions and simple quotes around 
