### PR TITLE
[permissions] vendor don't see every metadata descriptors

### DIFF
--- a/tests/edits/base.py
+++ b/tests/edits/base.py
@@ -27,6 +27,7 @@ class BaseEditTestCase(ApiDBTestCase):
         self.generate_fixture_assigner()
         self.generate_fixture_task_status()
         self.generate_fixture_department()
+        self.department_id = self.department.id
         self.generate_fixture_task_type()
         self.task_type_edit_dict = self.task_type_edit.serialize()
 
@@ -41,6 +42,9 @@ class BaseEditTestCase(ApiDBTestCase):
             entity_id=self.edit_id,
             task_type_id=self.task_type_edit.id,
         )
+
+        self.generate_fixture_metadata_descriptor(entity_type="Edit")
+        self.meta_descriptor_id = self.meta_descriptor.id
 
         self.maxDiff = None
 

--- a/tests/shots/test_shot_tasks.py
+++ b/tests/shots/test_shot_tasks.py
@@ -1,6 +1,11 @@
 from tests.base import ApiDBTestCase
 
-from zou.app.services import persons_service, projects_service, tasks_service
+from zou.app.services import (
+    persons_service,
+    projects_service,
+    tasks_service,
+    shots_service,
+)
 
 
 class ShotTasksTestCase(ApiDBTestCase):
@@ -19,10 +24,14 @@ class ShotTasksTestCase(ApiDBTestCase):
         self.generate_fixture_department()
         self.generate_fixture_task_type()
         self.generate_fixture_shot_task()
+        self.generate_fixture_metadata_descriptor(entity_type="Shot")
         self.person_id = str(self.person.id)
+        self.shot_id = str(self.shot.id)
+        self.meta_descriptor_id = self.meta_descriptor.id
+        self.department_id = self.department.id
 
     def test_get_tasks_for_shot(self):
-        tasks = self.get("data/shots/%s/tasks" % self.shot.id)
+        tasks = self.get("data/shots/%s/tasks" % self.shot_id)
         self.assertEqual(len(tasks), 1)
         self.assertEqual(tasks[0]["id"], str(self.shot_task.id))
 
@@ -54,8 +63,27 @@ class ShotTasksTestCase(ApiDBTestCase):
         self.assertEqual(len(shots[0]["tasks"]), 1)
         self.assertTrue(str(person_id) in shots[0]["tasks"][0]["assignees"])
 
+        shots_service.update_shot(
+            self.shot_id, {"data": {"contractor": "test"}}
+        )
+        shots = self.get("data/shots/with-tasks?project_id=%s" % project_id)
+        self.assertEqual(shots[0]["data"]["contractor"], "test")
+
+        projects_service.update_metadata_descriptor(
+            self.meta_descriptor_id, {"departments": [self.department_id]}
+        )
+        persons_service.add_to_department(str(self.department_id), person_id)
+        shots = self.get("data/shots/with-tasks?project_id=%s" % project_id)
+        self.assertEqual(shots[0]["data"]["contractor"], "test")
+
+        persons_service.remove_from_department(
+            str(self.department_id), person_id
+        )
+        shots = self.get("data/shots/with-tasks?project_id=%s" % project_id)
+        self.assertTrue("contractor" not in shots[0]["data"])
+
     def test_get_task_types_for_shot(self):
-        task_types = self.get("/data/shots/%s/task-types" % self.shot.id)
+        task_types = self.get("/data/shots/%s/task-types" % self.shot_id)
         self.assertEqual(len(task_types), 1)
         self.assertDictEqual(
             task_types[0], self.task_type_animation.serialize()

--- a/zou/app/blueprints/assets/resources.py
+++ b/zou/app/blueprints/assets/resources.py
@@ -139,9 +139,10 @@ class AssetsAndTasksResource(Resource):
             criterions["assigned_to"] = persons_service.get_current_user()[
                 "id"
             ]
-            criterions[
-                "vendor_departments"
-            ] = persons_service.get_current_user(relations=True)["departments"]
+            criterions["vendor_departments"] = [
+                str(department.id)
+                for department in persons_service.get_current_user_raw().departments
+            ]
         return assets_service.get_assets_and_tasks(criterions, page)
 
 

--- a/zou/app/blueprints/assets/resources.py
+++ b/zou/app/blueprints/assets/resources.py
@@ -139,6 +139,9 @@ class AssetsAndTasksResource(Resource):
             criterions["assigned_to"] = persons_service.get_current_user()[
                 "id"
             ]
+            criterions[
+                "vendor_departments"
+            ] = persons_service.get_current_user(relations=True)["departments"]
         return assets_service.get_assets_and_tasks(criterions, page)
 
 

--- a/zou/app/blueprints/edits/resources.py
+++ b/zou/app/blueprints/edits/resources.py
@@ -315,6 +315,9 @@ class EditsAndTasksResource(Resource):
             criterions["assigned_to"] = persons_service.get_current_user()[
                 "id"
             ]
+            criterions[
+                "vendor_departments"
+            ] = persons_service.get_current_user(relations=True)["departments"]
         return edits_service.get_edits_and_tasks(criterions)
 
 

--- a/zou/app/blueprints/edits/resources.py
+++ b/zou/app/blueprints/edits/resources.py
@@ -315,9 +315,10 @@ class EditsAndTasksResource(Resource):
             criterions["assigned_to"] = persons_service.get_current_user()[
                 "id"
             ]
-            criterions[
-                "vendor_departments"
-            ] = persons_service.get_current_user(relations=True)["departments"]
+            criterions["vendor_departments"] = [
+                str(department.id)
+                for department in persons_service.get_current_user_raw().departments
+            ]
         return edits_service.get_edits_and_tasks(criterions)
 
 

--- a/zou/app/blueprints/projects/resources.py
+++ b/zou/app/blueprints/projects/resources.py
@@ -33,14 +33,10 @@ class OpenProjectsResource(Resource):
               description: All running projects
         """
         name = request.args.get("name", None)
-        try:
-            permissions.check_admin_permissions()
-            for_client = permissions.has_client_permissions()
-            return projects_service.open_projects(
-                name=name, for_client=for_client
-            )
-        except permissions.PermissionDenied:
-            return user_service.get_open_projects(name=name)
+        if permissions.has_admin_permissions():
+            return projects_service.open_projects(name)
+        else:
+            return user_service.get_open_projects(name)
 
 
 class AllProjectsResource(Resource):

--- a/zou/app/blueprints/shots/resources.py
+++ b/zou/app/blueprints/shots/resources.py
@@ -534,9 +534,10 @@ class ShotsAndTasksResource(Resource):
             criterions["assigned_to"] = persons_service.get_current_user()[
                 "id"
             ]
-            criterions[
-                "vendor_departments"
-            ] = persons_service.get_current_user(relations=True)["departments"]
+            criterions["vendor_departments"] = [
+                str(department.id)
+                for department in persons_service.get_current_user_raw().departments
+            ]
         return shots_service.get_shots_and_tasks(criterions)
 
 

--- a/zou/app/blueprints/shots/resources.py
+++ b/zou/app/blueprints/shots/resources.py
@@ -534,6 +534,9 @@ class ShotsAndTasksResource(Resource):
             criterions["assigned_to"] = persons_service.get_current_user()[
                 "id"
             ]
+            criterions[
+                "vendor_departments"
+            ] = persons_service.get_current_user(relations=True)["departments"]
         return shots_service.get_shots_and_tasks(criterions)
 
 

--- a/zou/app/services/assets_service.py
+++ b/zou/app/services/assets_service.py
@@ -21,6 +21,7 @@ from zou.app.services import (
     projects_service,
     shots_service,
     user_service,
+    entities_service,
 )
 
 from zou.app.services.exception import (
@@ -258,6 +259,15 @@ def get_assets_and_tasks(criterions={}, page=1, with_episode_ids=False):
                 str(link.entity_in_id)
             )
 
+    query_result = tasks_query.all()
+
+    if "vendor_departments" in criterions:
+        not_allowed_descriptors_field_names = entities_service.get_not_allowed_descriptors_fields_for_entity_type_and_departments(
+            "Asset",
+            criterions["vendor_departments"],
+            set(asset[0].project_id for asset in query_result),
+        )
+
     for (
         asset,
         entity_type_name,
@@ -274,7 +284,7 @@ def get_assets_and_tasks(criterions={}, page=1, with_episode_ids=False):
         task_due_date,
         task_last_comment_date,
         person_id,
-    ) in tasks_query.all():
+    ) in query_result:
 
         if asset.source_id is None:
             source_id = ""
@@ -284,6 +294,12 @@ def get_assets_and_tasks(criterions={}, page=1, with_episode_ids=False):
         asset_id = str(asset.id)
 
         if asset_id not in asset_map:
+            data = fields.serialize_value(asset.data or {})
+            if "vendor_departments" in criterions:
+                data = entities_service.remove_not_allowed_descriptors_fields_from_metadata(
+                    not_allowed_descriptors_field_names[asset.project_id], data
+                )
+
             asset_map[asset_id] = {
                 "id": asset_id,
                 "name": asset.name,
@@ -296,7 +312,7 @@ def get_assets_and_tasks(criterions={}, page=1, with_episode_ids=False):
                 "episode_id": source_id,
                 "casting_episode_ids": cast_in_episode_ids.get(asset_id, []),
                 "is_casting_standby": asset.is_casting_standby,
-                "data": fields.serialize_value(asset.data),
+                "data": data,
                 "tasks": [],
             }
 

--- a/zou/app/services/assets_service.py
+++ b/zou/app/services/assets_service.py
@@ -262,10 +262,12 @@ def get_assets_and_tasks(criterions={}, page=1, with_episode_ids=False):
     query_result = tasks_query.all()
 
     if "vendor_departments" in criterions:
-        not_allowed_descriptors_field_names = entities_service.get_not_allowed_descriptors_fields_for_entity_type_and_departments(
-            "Asset",
-            criterions["vendor_departments"],
-            set(asset[0].project_id for asset in query_result),
+        not_allowed_descriptors_field_names = (
+            entities_service.get_not_allowed_descriptors_fields_for_vendor(
+                "Asset",
+                criterions["vendor_departments"],
+                set(asset[0].project_id for asset in query_result),
+            )
         )
 
     for (
@@ -296,8 +298,11 @@ def get_assets_and_tasks(criterions={}, page=1, with_episode_ids=False):
         if asset_id not in asset_map:
             data = fields.serialize_value(asset.data or {})
             if "vendor_departments" in criterions:
-                data = entities_service.remove_not_allowed_descriptors_fields_from_metadata(
-                    not_allowed_descriptors_field_names[asset.project_id], data
+                data = (
+                    entities_service.remove_not_allowed_fields_from_metadata(
+                        not_allowed_descriptors_field_names[asset.project_id],
+                        data,
+                    )
                 )
 
             asset_map[asset_id] = {

--- a/zou/app/services/edits_service.py
+++ b/zou/app/services/edits_service.py
@@ -121,10 +121,12 @@ def get_edits_and_tasks(criterions={}):
     query_result = query.all()
 
     if "vendor_departments" in criterions:
-        not_allowed_descriptors_field_names = entities_service.get_not_allowed_descriptors_fields_for_entity_type_and_departments(
-            "Edit",
-            criterions["vendor_departments"],
-            set(edit[0].project_id for edit in query_result),
+        not_allowed_descriptors_field_names = (
+            entities_service.get_not_allowed_descriptors_fields_for_vendor(
+                "Edit",
+                criterions["vendor_departments"],
+                set(edit[0].project_id for edit in query_result),
+            )
         )
 
     for (
@@ -153,8 +155,11 @@ def get_edits_and_tasks(criterions={}):
         if edit_id not in edit_map:
             data = fields.serialize_value(edit.data or {})
             if "vendor_departments" in criterions:
-                data = entities_service.remove_not_allowed_descriptors_fields_from_metadata(
-                    not_allowed_descriptors_field_names[edit.project_id], data
+                data = (
+                    entities_service.remove_not_allowed_fields_from_metadata(
+                        not_allowed_descriptors_field_names[edit.project_id],
+                        data,
+                    )
                 )
 
             edit_map[edit_id] = fields.serialize_dict(

--- a/zou/app/services/edits_service.py
+++ b/zou/app/services/edits_service.py
@@ -165,7 +165,7 @@ def get_edits_and_tasks(criterions={}):
             edit_map[edit_id] = fields.serialize_dict(
                 {
                     "canceled": edit.canceled,
-                    "data": edit.data,
+                    "data": data,
                     "description": edit.description,
                     "entity_type_id": edit.entity_type_id,
                     "episode_id": episode_id,

--- a/zou/app/services/entities_service.py
+++ b/zou/app/services/entities_service.py
@@ -243,7 +243,7 @@ def remove_entity_link(link_id):
         raise EntityLinkNotFoundException
 
 
-def get_not_allowed_descriptors_fields_for_entity_type_and_departments(
+def get_not_allowed_descriptors_fields_for_vendor(
     entity_type="Asset", departments=[], projects_ids=[]
 ):
     not_allowed_descriptors_field_names = {}
@@ -262,7 +262,7 @@ def get_not_allowed_descriptors_fields_for_entity_type_and_departments(
     return not_allowed_descriptors_field_names
 
 
-def remove_not_allowed_descriptors_fields_from_metadata(
+def remove_not_allowed_fields_from_metadata(
     not_allowed_descriptors_field_names=[], data={}
 ):
     return {

--- a/zou/app/services/entities_service.py
+++ b/zou/app/services/entities_service.py
@@ -65,7 +65,6 @@ def get_entity_type_by_name_or_not_found(name):
     return entity_type.serialize()
 
 
-
 def get_entity_raw(entity_id):
     """
     Return an entity type matching given id, as an active record. Raises an
@@ -254,10 +253,8 @@ def get_not_allowed_descriptors_fields_for_vendor(
                 project_id
             )
             if descriptor["entity_type"] == entity_type
-            and not (
-                descriptor["departments"] == []
-                or len(set(departments) & set(descriptor["departments"])) > 0
-            )
+            and descriptor["departments"] != []
+            and len(set(departments) & set(descriptor["departments"])) == 0
         ]
     return not_allowed_descriptors_field_names
 

--- a/zou/app/services/shots_service.py
+++ b/zou/app/services/shots_service.py
@@ -253,6 +253,15 @@ def get_shots_and_tasks(criterions={}):
         query = query.filter(user_service.build_assignee_filter())
         del criterions["assigned_to"]
 
+    query_result = query.all()
+
+    if "vendor_departments" in criterions:
+        not_allowed_descriptors_field_names = entities_service.get_not_allowed_descriptors_fields_for_entity_type_and_departments(
+            "Shot",
+            criterions["vendor_departments"],
+            set(shot[0].project_id for shot in query_result),
+        )
+
     for (
         shot,
         episode_name,
@@ -275,17 +284,20 @@ def get_shots_and_tasks(criterions={}):
         person_id,
         project_id,
         project_name,
-    ) in query.all():
+    ) in query_result:
         shot_id = str(shot.id)
 
-        shot.data = shot.data or {}
-
         if shot_id not in shot_map:
+            data = fields.serialize_value(shot.data or {})
+            if "vendor_departments" in criterions:
+                data = entities_service.remove_not_allowed_descriptors_fields_from_metadata(
+                    not_allowed_descriptors_field_names[shot.project_id], data
+                )
 
             shot_map[shot_id] = fields.serialize_dict(
                 {
                     "canceled": shot.canceled,
-                    "data": shot.data,
+                    "data": data,
                     "description": shot.description,
                     "entity_type_id": shot.entity_type_id,
                     "episode_id": episode_id,

--- a/zou/app/services/shots_service.py
+++ b/zou/app/services/shots_service.py
@@ -256,10 +256,12 @@ def get_shots_and_tasks(criterions={}):
     query_result = query.all()
 
     if "vendor_departments" in criterions:
-        not_allowed_descriptors_field_names = entities_service.get_not_allowed_descriptors_fields_for_entity_type_and_departments(
-            "Shot",
-            criterions["vendor_departments"],
-            set(shot[0].project_id for shot in query_result),
+        not_allowed_descriptors_field_names = (
+            entities_service.get_not_allowed_descriptors_fields_for_vendor(
+                "Shot",
+                criterions["vendor_departments"],
+                set(shot[0].project_id for shot in query_result),
+            )
         )
 
     for (
@@ -290,8 +292,11 @@ def get_shots_and_tasks(criterions={}):
         if shot_id not in shot_map:
             data = fields.serialize_value(shot.data or {})
             if "vendor_departments" in criterions:
-                data = entities_service.remove_not_allowed_descriptors_fields_from_metadata(
-                    not_allowed_descriptors_field_names[shot.project_id], data
+                data = (
+                    entities_service.remove_not_allowed_fields_from_metadata(
+                        not_allowed_descriptors_field_names[shot.project_id],
+                        data,
+                    )
                 )
 
             shot_map[shot_id] = fields.serialize_dict(

--- a/zou/app/services/user_service.py
+++ b/zou/app/services/user_service.py
@@ -267,7 +267,7 @@ def get_scenes_for_sequence(sequence_id):
     return Entity.serialize_list(query.all(), obj_type="Scene")
 
 
-def get_open_projects(name=None, for_client=False):
+def get_open_projects(name=None):
     """
     Get all open projects for which current user has a task assigned.
     """
@@ -280,9 +280,18 @@ def get_open_projects(name=None, for_client=False):
     if name is not None:
         query = query.filter(Project.name == name)
 
-    for_client = permissions.has_client_permissions()
+    for_client = False
+    vendor_departments = None
+    if permissions.has_client_permissions():
+        for_client = True
+    elif permissions.has_vendor_permissions():
+        vendor_departments = persons_service.get_current_user(True)[
+            "departments"
+        ]
 
-    return projects_service.get_projects_with_extra_data(query, for_client)
+    return projects_service.get_projects_with_extra_data(
+        query, for_client, vendor_departments
+    )
 
 
 def get_projects(name=None):


### PR DESCRIPTION
**Problem**
- vendors see every metadata descriptors and every data information

**Solution**
- vendor don't see every metadata descriptors, they see only metadata descriptors with no departments or metadata descriptors corresponding to their departments, the same for data in entity

