### PR TITLE
Fix rq problem with click 8.1.3

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -66,7 +66,7 @@ install_requires =
     requests==2.27.1
     ffmpeg-python==0.2.0
 
-    rq==1.10.0
+    rq==1.11.1
     python-nomad==1.2.1
     six==1.15.0
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     Topic :: Multimedia :: Graphics


### PR DESCRIPTION
**Problem**
- When upgrading click to 8.1.3 there's a problem with rq library.
- In pypi it's not shown that python 3.11 is supported.

**Solution**
- Upgrade rq library (to 1.11.1) to fix that problem. 
- Show that python 3.11 is supported in pypi.
