### PR TITLE
Task types permission fix

### DIFF
--- a/tests/auth/test_permission.py
+++ b/tests/auth/test_permission.py
@@ -42,6 +42,26 @@ class PermissionTestCase(ApiDBTestCase):
         self.log_in_cg_artist()
         self.get("data/projects/open")
 
+    def test_cg_artist_can_read_project_task_types(self):
+        self.generate_fixture_department()
+        self.generate_fixture_task_type()
+        task_type_id = self.task_type_concept.id
+        projects_service.add_task_type_setting(self.project_id, task_type_id, 1)
+        self.log_in_cg_artist()
+        user_id = str(self.user_cg_artist["id"])
+        projects_service.add_team_member(self.project_id, user_id)
+        result = self.get("data/projects/%s/task-types" % self.project_id, 200)
+
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]['id'], str(task_type_id))
+
+    def test_cg_artist_can_read_project_task_statuses(self):
+        self.log_in_cg_artist()
+        user_id = str(self.user_cg_artist["id"])
+        projects_service.add_team_member(self.project_id, user_id)
+        self.get("data/projects/%s/settings/task-status" % self.project_id, 200)
+
     def test_manager_cannot_create_person(self):
         self.log_in_manager()
         data = {

--- a/zou/app/blueprints/projects/resources.py
+++ b/zou/app/blueprints/projects/resources.py
@@ -263,7 +263,7 @@ class ProductionTaskTypesResource(Resource, ArgsMixin):
             200:
               description: Task types linked to the production
         """
-        user_service.check_manager_project_access(project_id)
+        user_service.check_project_access(project_id)
         return projects_service.get_project_task_types(project_id)
 
 


### PR DESCRIPTION
**Problem**
<!--- Explain the problem -->
Currently the task types linked to a project require manager permissions to list.
It requires `gazu` to list them through `/data/task-types` and filter them with the task type id's listed in the project. 

**Solution**
<!--- Describe the change, including rationale and design decisions -->
Changed the permissions to match the behaviour of `task-status` by only requiring project access.