### PR TITLE
Various improvements

### DIFF
--- a/tests/services/test_preview_files_service.py
+++ b/tests/services/test_preview_files_service.py
@@ -247,3 +247,22 @@ class PlaylistTestCase(ApiDBTestCase):
         self.assertEqual(fps, "25.00")
         fps = get_preview_file_fps({"fps": None})
         self.assertEqual(fps, "25.00")
+
+    def test_get_last_preview_file_for_task(self):
+        preview_file = self.generate_fixture_preview_file()
+        preview_file = preview_files_service.get_last_preview_file_for_task(
+            self.task_id
+        )
+        self.assertEquals(preview_file["revision"], 1)
+
+        preview_file = self.generate_fixture_preview_file(revision=2)
+        preview_file = preview_files_service.get_last_preview_file_for_task(
+            self.task_id
+        )
+        self.assertEquals(preview_file["revision"], 2)
+
+        preview_file = self.generate_fixture_preview_file(revision=3)
+        preview_file = preview_files_service.get_last_preview_file_for_task(
+            self.task_id
+        )
+        self.assertEquals(preview_file["revision"], 3)

--- a/tests/tasks/test_route_tasks.py
+++ b/tests/tasks/test_route_tasks.py
@@ -524,3 +524,15 @@ class TaskRoutesTestCase(ApiDBTestCase):
         )
         self.assertEqual(ProjectTaskTypeLink.query.count(), 1)
         self.assertEqual(ProjectTaskTypeLink.query.first().priority, 3)
+
+    def test_update_entity_main_preview_from_task(self):
+        task = self.generate_fixture_task().serialize()
+        preview_file = self.generate_fixture_preview_file().serialize()
+        self.put(
+            "/actions/tasks/%s/set-main-preview" % preview_file["task_id"],
+            {}
+        )
+        entity = self.get(
+            "/data/entities/%s" % task["entity_id"]
+        )
+        self.assertEqual(entity["preview_file_id"], preview_file["id"])

--- a/zou/app/api.py
+++ b/zou/app/api.py
@@ -82,7 +82,8 @@ def register_event_handlers(app):
     except ImportError:
         # Event handlers folder is not properly configured.
         # Handlers are optional, that's why this error is ignored.
-        app.logger.info("No event handlers folder is configured.")
+        # app.logger.info("No event handlers folder is configured.")
+        pass
     return app
 
 

--- a/zou/app/blueprints/tasks/__init__.py
+++ b/zou/app/blueprints/tasks/__init__.py
@@ -29,6 +29,7 @@ from .resources import (
     GetTimeSpentResource,
     SetTimeSpentResource,
     AddTimeSpentResource,
+    SetTaskMainPreviewResource,
 )
 
 
@@ -99,6 +100,10 @@ routes = [
     (
         "/actions/projects/<project_id>/task-types/<task_type_id>/edits/create-tasks",
         CreateEditTasksResource,
+    ),
+    (
+        "/actions/tasks/<task_id>/set-main-preview",
+        SetTaskMainPreviewResource,
     ),
 ]
 

--- a/zou/app/services/preview_files_service.py
+++ b/zou/app/services/preview_files_service.py
@@ -497,3 +497,18 @@ def get_preview_files_for_entity(entity_id):
         )
     )
     return [preview_file.present() for preview_file in query.all()]
+
+
+def get_last_preview_file_for_task(task_id):
+    """
+    Get last preview published for given task.
+    """
+    preview = (
+        PreviewFile.query
+        .filter(PreviewFile.task_id == task_id)
+        .order_by(
+            PreviewFile.revision.desc(),
+            PreviewFile.created_at,
+        ).first()
+    )
+    return preview.serialize()

--- a/zou/debug.py
+++ b/zou/debug.py
@@ -1,3 +1,4 @@
+import os
 from gevent import monkey
 
 monkey.patch_all()
@@ -10,4 +11,6 @@ logging.basicConfig(level=logging.INFO, format=FORMAT)
 socketio = SocketIO(app, cors_allowed_origins=[], cors_credentials=False)
 
 if __name__ == "__main__":
-    socketio.run(app, debug=True)
+    port = int(os.getenv("DEBUG_PORT", 5000))
+    print("The Kitsu API server is listening on port %s..." % port)
+    socketio.run(app, port=port, debug=True)


### PR DESCRIPTION
**Problem**

* In debug mode, it's not possible to force the running port.
* It's not possible to set easily a task preview as the related entity main thumbnail.

**Solution**

* Get the port from `DEBUG_PORT` environment variable.
* Add a route to set the preview link to a given task as the entity preview.
