### PR TITLE
Various fixes

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -76,7 +76,7 @@ install_requires =
     gevent-websocket==0.10.1
 
     slackclient==1.3.2
-    gazu==0.8.28
+    gazu==0.8.32
     sh==1.12.14
     pygelf==0.4.2
     matterhook==0.2

--- a/tests/auth/test_permission.py
+++ b/tests/auth/test_permission.py
@@ -46,7 +46,9 @@ class PermissionTestCase(ApiDBTestCase):
         self.generate_fixture_department()
         self.generate_fixture_task_type()
         task_type_id = self.task_type_concept.id
-        projects_service.add_task_type_setting(self.project_id, task_type_id, 1)
+        projects_service.add_task_type_setting(
+            self.project_id, task_type_id, 1
+        )
         self.log_in_cg_artist()
         user_id = str(self.user_cg_artist["id"])
         projects_service.add_team_member(self.project_id, user_id)
@@ -54,13 +56,15 @@ class PermissionTestCase(ApiDBTestCase):
 
         self.assertIsInstance(result, list)
         self.assertEqual(len(result), 1)
-        self.assertEqual(result[0]['id'], str(task_type_id))
+        self.assertEqual(result[0]["id"], str(task_type_id))
 
     def test_cg_artist_can_read_project_task_statuses(self):
         self.log_in_cg_artist()
         user_id = str(self.user_cg_artist["id"])
         projects_service.add_team_member(self.project_id, user_id)
-        self.get("data/projects/%s/settings/task-status" % self.project_id, 200)
+        self.get(
+            "data/projects/%s/settings/task-status" % self.project_id, 200
+        )
 
     def test_manager_cannot_create_person(self):
         self.log_in_manager()

--- a/tests/source/csv/test_import_assets.py
+++ b/tests/source/csv/test_import_assets.py
@@ -136,9 +136,9 @@ class ImportCsvAssetsTestCase(ApiDBTestCase):
         if type(result) != str:
             result = result.decode("utf-8")
         error = json.loads(result)
-        self.assertEqual(error["line_number"], 2)
+        self.assertEqual(error["message"], "Could not determine delimiter")
         entities = Entity.query.all()
-        self.assertEqual(len(entities), 1)
+        self.assertEqual(len(entities), 0)
 
     def test_import_assets_missing_header(self):
         # With missing columns on a given line. It should not work.

--- a/tests/tasks/test_route_tasks.py
+++ b/tests/tasks/test_route_tasks.py
@@ -529,10 +529,7 @@ class TaskRoutesTestCase(ApiDBTestCase):
         task = self.generate_fixture_task().serialize()
         preview_file = self.generate_fixture_preview_file().serialize()
         self.put(
-            "/actions/tasks/%s/set-main-preview" % preview_file["task_id"],
-            {}
+            "/actions/tasks/%s/set-main-preview" % preview_file["task_id"], {}
         )
-        entity = self.get(
-            "/data/entities/%s" % task["entity_id"]
-        )
+        entity = self.get("/data/entities/%s" % task["entity_id"])
         self.assertEqual(entity["preview_file_id"], preview_file["id"])

--- a/zou/app/blueprints/source/csv/assets.py
+++ b/zou/app/blueprints/source/csv/assets.py
@@ -189,7 +189,12 @@ class AssetsCsvImportResource(BaseCsvProjectImportResource):
             "source_id": episode_id,
         }
 
-        entity = Entity.get_by(**asset_values)
+        entity = Entity.get_by(
+            **{
+                "name": asset_values["name"],
+                "project_id": asset_values["project_id"],
+            }
+        )
 
         asset_new_values = {}
 

--- a/zou/app/services/preview_files_service.py
+++ b/zou/app/services/preview_files_service.py
@@ -504,11 +504,11 @@ def get_last_preview_file_for_task(task_id):
     Get last preview published for given task.
     """
     preview = (
-        PreviewFile.query
-        .filter(PreviewFile.task_id == task_id)
+        PreviewFile.query.filter(PreviewFile.task_id == task_id)
         .order_by(
             PreviewFile.revision.desc(),
             PreviewFile.created_at,
-        ).first()
+        )
+        .first()
     )
     return preview.serialize()


### PR DESCRIPTION
**Problem**
- When importing assets with csv it's possible to create assets with same name
- Gazu is not at the last version
- The full dialect is not guessed when parsing csv to import assets, shots etc...

**Solution**
- Stop creating assets with same name when importing csv
- Upgrade Gazu to latest version
- Guess the full dialect when parsing csv to import assets, shots etc...
