### PR TITLE
Fix issue #540

### DIFF
--- a/zou/app/services/auth_service.py
+++ b/zou/app/services/auth_service.py
@@ -118,7 +118,7 @@ def ldap_auth_strategy(email, password, app):
         SSL = app.config["LDAP_SSL"]
         if app.config["LDAP_IS_AD_SIMPLE"]:
             user = "CN=%s,%s" % (
-                person["full_name"],
+                person["desktop_login"],
                 app.config["LDAP_BASE_DN"],
             )
             SSL = True


### PR DESCRIPTION
Replaces unpopulated attribute 'full_name' with 'desktop_login'

**Problem**
`full_name` does not exist in the `person` object, this leads to bad data being sent to the LDAP server

**Solution**
Change `full_name` to `desktop_login`