### PR TITLE
[csv][shots] allow to set nb_frames to null

### DIFF
--- a/zou/app/blueprints/source/csv/shots.py
+++ b/zou/app/blueprints/source/csv/shots.py
@@ -201,7 +201,9 @@ class ShotsCsvImportResource(BaseCsvProjectImportResource):
 
         nb_frames = row.get("Nb Frames", None) or row.get("Frames", None)
         if nb_frames is not None:
-            shot_new_values["nb_frames"] = nb_frames
+            shot_new_values["nb_frames"] = (
+                nb_frames if nb_frames != "" else None
+            )
 
         if entity is None or not entity.data:
             shot_new_values["data"] = {}


### PR DESCRIPTION
**Problem**
- when importing a csv of shots there's a bug if a column Frames or nb_frames have an empty value

**Solution**
- when there's an empty value set nb_frames to null