### PR TITLE
refactoring LDAP + new route for getting time-spents of a task

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ install_requires =
     flask_fs==0.6.1
     werkzeug==0.15.5
     redis==4.1.4
-    ldap3==2.8.1
+    ldap3==2.9.1
     psutil==5.8.0
     itsdangerous==2.0.1
 

--- a/zou/app/blueprints/persons/resources.py
+++ b/zou/app/blueprints/persons/resources.py
@@ -393,7 +393,7 @@ class PersonYearTimeSpentsResource(PersonDurationTimeSpentsResource):
             return time_spents_service.get_year_time_spents(
                 person_id,
                 year,
-                **self.get_project_department_arguments(person_id)
+                **self.get_project_department_arguments(person_id),
             )
         except WrongDateFormatException:
             abort(404)
@@ -441,7 +441,7 @@ class PersonMonthTimeSpentsResource(PersonDurationTimeSpentsResource):
                 person_id,
                 year,
                 month,
-                **self.get_project_department_arguments(person_id)
+                **self.get_project_department_arguments(person_id),
             )
         except WrongDateFormatException:
             abort(404)
@@ -489,7 +489,7 @@ class PersonWeekTimeSpentsResource(PersonDurationTimeSpentsResource):
                 person_id,
                 year,
                 week,
-                **self.get_project_department_arguments(person_id)
+                **self.get_project_department_arguments(person_id),
             )
         except WrongDateFormatException:
             abort(404)
@@ -545,7 +545,7 @@ class PersonDayTimeSpentsResource(PersonDurationTimeSpentsResource):
                 year,
                 month,
                 day,
-                **self.get_project_department_arguments(person_id)
+                **self.get_project_department_arguments(person_id),
             )
         except WrongDateFormatException:
             abort(404)

--- a/zou/app/blueprints/tasks/__init__.py
+++ b/zou/app/blueprints/tasks/__init__.py
@@ -27,6 +27,7 @@ from .resources import (
     CreateAssetTasksResource,
     CreateEditTasksResource,
     CreateEntityTasksResource,
+    GetTimeSpentDateResource,
     GetTimeSpentResource,
     SetTimeSpentResource,
     AddTimeSpentResource,
@@ -71,7 +72,8 @@ routes = [
     ("/actions/tasks/<task_id>/assign", TaskAssignResource),
     ("/actions/tasks/clear-assignation", ClearAssignationResource),
     ("/actions/persons/<person_id>/assign", TasksAssignResource),
-    ("/actions/tasks/<task_id>/time-spents/<date>", GetTimeSpentResource),
+    ("/actions/tasks/<task_id>/time-spents/<date>", GetTimeSpentDateResource),
+    ("/actions/tasks/<task_id>/time-spents", GetTimeSpentResource),
     (
         "/actions/tasks/<task_id>/time-spents/<date>/persons/<person_id>",
         SetTimeSpentResource,

--- a/zou/app/blueprints/tasks/resources.py
+++ b/zou/app/blueprints/tasks/resources.py
@@ -481,7 +481,6 @@ class CreateShotTasksResource(Resource):
 
 
 class CreateEntityTasksResource(Resource):
-
     @jwt_required
     def post(self, project_id, entity_type, task_type_id):
         """
@@ -515,10 +514,11 @@ class CreateEntityTasksResource(Resource):
         """
         user_service.check_manager_project_access(project_id)
         task_type = tasks_service.get_task_type(task_type_id)
-        entity_type_dict = \
+        entity_type_dict = (
             entities_service.get_entity_type_by_name_or_not_found(
                 entity_type.capitalize()
             )
+        )
 
         entity_ids = request.json
         entities = []
@@ -1149,6 +1149,37 @@ class AddTimeSpentResource(Resource):
 
 
 class GetTimeSpentResource(Resource):
+    """
+    Get time spent on a given task.
+    """
+
+    @jwt_required
+    def get(self, task_id):
+        """
+        Get time spent on a given task.
+        ---
+        tags:
+        - Tasks
+        parameters:
+          - in: path
+            name: task_id
+            required: True
+            type: string
+            format: UUID
+            x-example: a24a6ea4-ce75-4665-a070-57453082c25
+        responses:
+            200:
+                description: Time spent on given task
+            404:
+                description: Wrong date format
+        """
+        task = tasks_service.get_task(task_id)
+        user_service.check_project_access(task["project_id"])
+        user_service.check_entity_access(task["entity_id"])
+        return tasks_service.get_time_spents(task_id)
+
+
+class GetTimeSpentDateResource(Resource):
     """
     Get time spent on a given task and date.
     """

--- a/zou/app/config.py
+++ b/zou/app/config.py
@@ -3,10 +3,11 @@ import datetime
 import tempfile
 
 from zou.app.utils import dbhelpers
+from zou.app.utils.string import strtobool
 
 PROPAGATE_EXCEPTIONS = True
 RESTFUL_JSON = {"ensure_ascii": False}
-DEBUG = os.getenv("DEBUG", 0)
+DEBUG = strtobool(os.getenv("DEBUG", False))
 DEBUG_PORT = int(os.getenv("DEBUG_PORT", 5000))
 
 APP_NAME = "Zou"
@@ -66,14 +67,14 @@ EVENT_HANDLERS_FOLDER = os.getenv(
     "EVENT_HANDLERS_FOLDER", os.path.join(os.getcwd(), "event_handlers")
 )
 
-MAIL_ENABLED = os.getenv("MAIL_ENABLED", "True").lower() == "true"
+MAIL_ENABLED = strtobool(os.getenv("MAIL_ENABLED", True))
 MAIL_SERVER = os.getenv("MAIL_SERVER", "localhost")
 MAIL_PORT = os.getenv("MAIL_PORT", 25)
 MAIL_USERNAME = os.getenv("MAIL_USERNAME", "")
 MAIL_PASSWORD = os.getenv("MAIL_PASSWORD", "")
-MAIL_DEBUG = os.getenv("MAIL_DEBUG", 0) != 0
-MAIL_USE_TLS = os.getenv("MAIL_USE_TLS", "False").lower() == "true"
-MAIL_USE_SSL = os.getenv("MAIL_USE_SSL", "False").lower() == "true"
+MAIL_DEBUG = strtobool(os.getenv("MAIL_DEBUG", False))
+MAIL_USE_TLS = strtobool(os.getenv("MAIL_USE_TLS", False))
+MAIL_USE_SSL = strtobool(os.getenv("MAIL_USE_SSL", False))
 MAIL_DEFAULT_SENDER = os.getenv(
     "MAIL_DEFAULT_SENDER", "no-reply@your-studio.com"
 )
@@ -97,9 +98,9 @@ FS_S3_ENDPOINT = os.getenv("FS_S3_ENDPOINT")
 FS_S3_ACCESS_KEY = os.getenv("FS_S3_ACCESS_KEY")
 FS_S3_SECRET_KEY = os.getenv("FS_S3_SECRET_KEY")
 
-ENABLE_JOB_QUEUE = os.getenv("ENABLE_JOB_QUEUE", "False").lower() == "true"
-ENABLE_JOB_QUEUE_REMOTE = (
-    os.getenv("ENABLE_JOB_QUEUE_REMOTE", "False").lower() == "true"
+ENABLE_JOB_QUEUE = strtobool(os.getenv("ENABLE_JOB_QUEUE", False))
+ENABLE_JOB_QUEUE_REMOTE = strtobool(
+    os.getenv("ENABLE_JOB_QUEUE_REMOTE", False)
 )
 JOB_QUEUE_NOMAD_PLAYLIST_JOB = os.getenv(
     "JOB_QUEUE_NOMAD_PLAYLIST_JOB", "zou-playlist"
@@ -114,10 +115,10 @@ LDAP_PORT = os.getenv("LDAP_PORT", "389")
 LDAP_BASE_DN = os.getenv("LDAP_BASE_DN", "cn=Users,dc=zou,dc=local")
 LDAP_GROUP = os.getenv("LDAP_GROUP", "")
 LDAP_DOMAIN = os.getenv("LDAP_DOMAIN", "zou.local")
-LDAP_FALLBACK = os.getenv("LDAP_FALLBACK", "False").lower() == "true"
-LDAP_IS_AD = os.getenv("LDAP_IS_AD", "False").lower() == "true"
-LDAP_IS_AD_SIMPLE = os.getenv("LDAP_IS_AD_SIMPLE", "False").lower() == "true"
-LDAP_SSL = os.getenv("LDAP_SSL", "False").lower() == "true"
+LDAP_FALLBACK = strtobool(os.getenv("LDAP_FALLBACK", False))
+LDAP_IS_AD = strtobool(os.getenv("LDAP_IS_AD", False))
+LDAP_IS_AD_SIMPLE = strtobool(os.getenv("LDAP_IS_AD_SIMPLE", False))
+LDAP_SSL = strtobool(os.getenv("LDAP_SSL", False))
 
 
 LOGS_MODE = os.getenv("LOGS_MODE", "default")

--- a/zou/app/services/auth_service.py
+++ b/zou/app/services/auth_service.py
@@ -116,7 +116,6 @@ def ldap_auth_strategy(person, password, app):
                     person["full_name"],
                     app.config["LDAP_BASE_DN"],
                 )
-                SSL = True
                 authentication = SIMPLE
             elif app.config["LDAP_IS_AD"]:
                 user = "%s\%s" % (

--- a/zou/app/services/entities_service.py
+++ b/zou/app/services/entities_service.py
@@ -231,22 +231,24 @@ def get_entities_and_tasks(criterions={}):
         if task_id is not None:
 
             if task_id not in task_map:
-                task_dict = fields.serialize_dict({
-                    "id": str(task_id),
-                    "entity_id": entity_id,
-                    "task_status_id": str(task_status_id),
-                    "task_type_id": str(task_type_id),
-                    "priority": task_priority or 0,
-                    "estimation": task_estimation,
-                    "duration": task_duration,
-                    "retake_count": task_retake_count,
-                    "real_start_date": task_real_start_date,
-                    "end_date": task_end_date,
-                    "start_date": task_start_date,
-                    "due_date": task_due_date,
-                    "last_comment_date": task_last_comment_date,
-                    "assignees": [],
-                })
+                task_dict = fields.serialize_dict(
+                    {
+                        "id": str(task_id),
+                        "entity_id": entity_id,
+                        "task_status_id": str(task_status_id),
+                        "task_type_id": str(task_type_id),
+                        "priority": task_priority or 0,
+                        "estimation": task_estimation,
+                        "duration": task_duration,
+                        "retake_count": task_retake_count,
+                        "real_start_date": task_real_start_date,
+                        "end_date": task_end_date,
+                        "start_date": task_start_date,
+                        "due_date": task_due_date,
+                        "last_comment_date": task_last_comment_date,
+                        "assignees": [],
+                    }
+                )
                 task_map[task_id] = task_dict
                 entity_dict = entity_map[entity_id]
                 entity_dict["tasks"].append(task_dict)

--- a/zou/app/services/tasks_service.py
+++ b/zou/app/services/tasks_service.py
@@ -465,14 +465,16 @@ def get_next_position(task_id, revision):
     return len(preview_files) + 1
 
 
-def get_time_spents(task_id, date):
+def get_time_spents(task_id, date=None):
     """
     Return time spents for given task.
     """
     result = collections.defaultdict(list)
     result["total"] = 0
-    time_spents = TimeSpent.query.filter_by(task_id=task_id, date=date).all()
-    for time_spent in time_spents:
+    time_spents = TimeSpent.query.filter_by(task_id=task_id)
+    if date is not None:
+        time_spents = time_spents.filter_by(date=date)
+    for time_spent in time_spents.all():
         result[str(time_spent.person_id)].append(time_spent.serialize())
         result["total"] += time_spent.duration
     return result

--- a/zou/app/utils/string.py
+++ b/zou/app/utils/string.py
@@ -1,0 +1,9 @@
+def strtobool(val):
+    if isinstance(val, bool):
+        return val
+    elif val.lower() in ("y", "yes", "t", "true", "on", "1"):
+        return True
+    elif val.lower() in ("n", "no", "f", "false", "off", "0"):
+        return False
+    else:
+        raise ValueError


### PR DESCRIPTION
**Problem**
- LDAP code can be refactored.
- LDAP accounts that are not present anymore have to be disabled.
- There's no route to get time spents of a specific task without specifying the date. 
- Black formater.

**Solution**
- refactoring of LDAP code to be simpler.
- LDAP accounts that are not present anymore will be disabled.
- Add new route to get time-spents of a specific task without specifying the date : /actions/tasks/<task_id>/time-spents
- Black formater.
