### PR TITLE
[previews] Make file download from storage more robust

### DIFF
--- a/zou/app/blueprints/playlists/resources.py
+++ b/zou/app/blueprints/playlists/resources.py
@@ -176,13 +176,13 @@ class EntityPreviewsResource(Resource):
 
 class PlaylistDownloadResource(Resource):
     """
-    Download given playlist as mp4 after given build job is finished.
+    Download given playlist as a .mp4 after given build job is finished.
     """
 
     @jwt_required
     def get(self, playlist_id, build_job_id):
         """
-        Download given playlist as mp4 after given build job is finished.
+        Download given playlist build as .mp4.
         ---
         tags:
         - Playlists
@@ -203,9 +203,9 @@ class PlaylistDownloadResource(Resource):
             x-example: a24a6ea4-ce75-4665-a070-57453082c25
         responses:
             200:
-                description: Given playlist downloaded as mp4
+                description: Given playlist build downloaded as .mp4
             400:
-                description: Build not finished
+                description: Build not finished, need to retry later
         """
         playlist = playlists_service.get_playlist(playlist_id)
         project = projects_service.get_project(playlist["project_id"])

--- a/zou/app/services/comments_service.py
+++ b/zou/app/services/comments_service.py
@@ -58,6 +58,7 @@ def get_attachment_file_path(attachment_file):
         "attachments",
         attachment_file["id"],
         attachment_file["extension"],
+        file_size=attachment_file["size"],
     )
 
 

--- a/zou/app/utils/fs.py
+++ b/zou/app/utils/fs.py
@@ -1,7 +1,12 @@
 import os
 import shutil
+import time
 
 import errno
+
+
+class DownloadFromStorageFailedException(Exception):
+    pass
 
 
 def mkdir_p(path):
@@ -29,7 +34,13 @@ def copyfile(src, dest):
 
 
 def get_file_path_and_file(
-    config, get_local_path, open_file, prefix, instance_id, extension
+    config,
+    get_local_path,
+    open_file,
+    prefix,
+    instance_id,
+    extension,
+    file_size=None
 ):
     if config.FS_BACKEND == "local":
         file_path = get_local_path(prefix, instance_id)
@@ -37,11 +48,39 @@ def get_file_path_and_file(
         file_path = os.path.join(
             config.TMP_DIR, "cache-%s-%s.%s" % (prefix, instance_id, extension)
         )
-        if not os.path.exists(file_path) or os.path.getsize(file_path) == 0:
+        if is_unvalid_file(file_path, file_size):
             with open(file_path, "wb") as tmp_file:
-                for chunk in open_file(prefix, instance_id):
-                    tmp_file.write(chunk)
+                try:
+                    for chunk in open_file(prefix, instance_id):
+                        tmp_file.write(chunk)
+                except RuntimeError:
+                    pass
+
+        if is_unvalid_file(file_path, file_size): # download failed
+            time.sleep(3)
+            with open(file_path, "wb") as tmp_file:
+                try:
+                    for chunk in open_file(prefix, instance_id):
+                        tmp_file.write(chunk)
+                except RuntimeError:
+                    pass
+
+            if is_unvalid_file(file_path, file_size): # download failed again
+                rm_file(file_path)
+                raise DownloadFromStorageFailedException
+
     return file_path
+
+
+def is_unvalid_file(file_path, file_size=None):
+    """
+    Check if file is absent, is empty or does match given size.
+    """
+    if file_size is None:
+        return not os.path.exists(file_path) or get_file_size(file_path) == 0
+    else:
+        current_size = get_file_size(file_path)
+        return not os.path.exists(file_path) or current_size != file_size
 
 
 def save_file(tmp_folder, instance_id, file_to_save):


### PR DESCRIPTION
**Problem**

Downloading files from object storage fail and is not properly detected.


**Solution**

Add a retry attempt and raise a Zou exception (500 error) when he can't download the file properly. It removes the file too (to not let empty files).
