### PR TITLE
Invalid file: Check for file existence first, avoiding size check of inexistent file

### DIFF
--- a/zou/app/utils/fs.py
+++ b/zou/app/utils/fs.py
@@ -76,11 +76,13 @@ def is_unvalid_file(file_path, file_size=None):
     """
     Check if file is absent, is empty or does match given size.
     """
-    if file_size is None:
-        return not os.path.exists(file_path) or get_file_size(file_path) == 0
+    if not os.path.exists(file_path):
+        return True
+    elif file_size is None:
+        return get_file_size(file_path) == 0
     else:
         current_size = get_file_size(file_path)
-        return not os.path.exists(file_path) or current_size != file_size
+        return current_size != file_size
 
 
 def save_file(tmp_folder, instance_id, file_to_save):


### PR DESCRIPTION
# Problem
https://github.com/cgwire/zou/blob/59fd95ccabf594daabe4961143d0e3faff722782/zou/app/utils/fs.py#L75
`is_invalid_file` tried to check the size of non-existing files, which specifically affected attachment files on remote storage (e.g. S3).

## Exception
> Trying to open an attachment in Kitsu:
```python
Traceback (most recent call last):
  File \"/usr/local/lib/python3.7/site-packages/flask/app.py\", line 1949, in full_dispatch_request
    rv = self.dispatch_request()
  File \"/usr/local/lib/python3.7/site-packages/flask/app.py\", line 1935, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File \"/usr/local/lib/python3.7/site-packages/flask_restful/__init__.py\", line 468, in wrapper
    resp = resource(*args, **kwargs)
  File \"/usr/local/lib/python3.7/site-packages/flask/views.py\", line 89, in view
    return self.dispatch_request(*args, **kwargs)
  File \"/usr/local/lib/python3.7/site-packages/flask_restful/__init__.py\", line 583, in dispatch_request
    resp = meth(*args, **kwargs)
  File \"/usr/local/lib/python3.7/site-packages/flask_jwt_extended/view_decorators.py\", line 108, in wrapper
    return fn(*args, **kwargs)
  File \"/usr/local/lib/python3.7/site-packages/zou/app/blueprints/comments/resources.py\", line 59, in get
    file_path = comments_service.get_attachment_file_path(attachment_file)
  File \"/usr/local/lib/python3.7/site-packages/zou/app/services/comments_service.py\", line 61, in get_attachment_file_path
    file_size=attachment_file[\"size\"],
  File \"/usr/local/lib/python3.7/site-packages/zou/app/utils/fs.py\", line 51, in get_file_path_and_file
    if is_unvalid_file(file_path, file_size):
  File \"/usr/local/lib/python3.7/site-packages/zou/app/utils/fs.py\", line 82, in is_unvalid_file
    current_size = get_file_size(file_path)
  File \"/usr/local/lib/python3.7/site-packages/zou/app/utils/fs.py\", line 109, in get_file_size
    return os.path.getsize(file_path)
  File \"/usr/local/lib/python3.7/genericpath.py\", line 50, in getsize
    return os.stat(filename).st_size
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/zou/cache-attachments-48221646-5bf0-4e60-8723-e5a3cefd2b14.png'
```

# Solution
`os.path.exists` needs to be performed/returned **before** `os.path.getsize`.

```python
def is_unvalid_file(file_path, file_size=None):
    """
    Check if file is absent, is empty or does match given size.
    """
    if not os.path.exists(file_path):
        return True
    elif file_size is None:
        return get_file_size(file_path) == 0
    else:
        current_size = get_file_size(file_path)
        return current_size != file_size
```