### PR TITLE
Various fixes

### DIFF
--- a/zou/app/blueprints/auth/resources.py
+++ b/zou/app/blueprints/auth/resources.py
@@ -302,10 +302,10 @@ class LoginResource(Resource):
             return response
         except WrongUserException:
             current_app.logger.info("User %s is not registered." % email)
-            return {"login": False}, 401
+            return {"login": False}, 400
         except WrongPasswordException:
             current_app.logger.info("User %s gave a wrong password." % email)
-            return {"login": False}, 401
+            return {"login": False}, 400
         except NoAuthStrategyConfigured:
             current_app.logger.info(
                 "Authentication strategy is not properly configured."
@@ -315,7 +315,7 @@ class LoginResource(Resource):
             current_app.logger.info(
                 "User %s can't login due to no fallback from LDAP." % email
             )
-            return {"login": False}, 401
+            return {"login": False}, 400
         except TimeoutError:
             current_app.logger.info("Timeout occurs while logging in.")
             return {"login": False}, 400
@@ -326,7 +326,7 @@ class LoginResource(Resource):
                     "login": False,
                     "message": "User is inactive, he cannot log in.",
                 },
-                401,
+                400,
             )
         except TooMuchLoginFailedAttemps:
             return (
@@ -335,7 +335,7 @@ class LoginResource(Resource):
                     "login": False,
                     "too_many_failed_login_attemps": True,
                 },
-                401,
+                400,
             )
         except OperationalError as exception:
             current_app.logger.error(exception, exc_info=1)

--- a/zou/app/blueprints/previews/resources.py
+++ b/zou/app/blueprints/previews/resources.py
@@ -136,8 +136,13 @@ def send_storage_file(
     except PreviewFileNotFoundException:
         pass
     file_path = fs.get_file_path_and_file(
-        config, get_local_path, open_file, prefix, preview_file_id, extension,
-        file_size=file_size
+        config,
+        get_local_path,
+        open_file,
+        prefix,
+        preview_file_id,
+        extension,
+        file_size=file_size,
     )
 
     attachment_filename = ""
@@ -212,8 +217,8 @@ class CreatePreviewFilePictureResource(Resource, ArgsMixin):
                 {
                     "extension": "png",
                     "original_name": original_file_name,
-                    "status": "ready"
-                }
+                    "status": "ready",
+                },
             )
             self.emit_app_preview_event(instance_id)
             return preview_file, 201
@@ -231,10 +236,7 @@ class CreatePreviewFilePictureResource(Resource, ArgsMixin):
                 abort(400, "Normalization failed.")
             preview_file = preview_files_service.update_preview_file(
                 instance_id,
-                {
-                    "extension": "mp4",
-                    "original_name": original_file_name
-                },
+                {"extension": "mp4", "original_name": original_file_name},
             )
             self.emit_app_preview_event(instance_id)
             return preview_file, 201

--- a/zou/app/config.py
+++ b/zou/app/config.py
@@ -3,11 +3,11 @@ import datetime
 import tempfile
 
 from zou.app.utils import dbhelpers
-from zou.app.utils.string import strtobool
+from zou.app.utils.env import envtobool
 
 PROPAGATE_EXCEPTIONS = True
 RESTFUL_JSON = {"ensure_ascii": False}
-DEBUG = strtobool(os.getenv("DEBUG", False))
+DEBUG = envtobool("DEBUG", False)
 DEBUG_PORT = int(os.getenv("DEBUG_PORT", 5000))
 
 APP_NAME = "Zou"
@@ -67,14 +67,14 @@ EVENT_HANDLERS_FOLDER = os.getenv(
     "EVENT_HANDLERS_FOLDER", os.path.join(os.getcwd(), "event_handlers")
 )
 
-MAIL_ENABLED = strtobool(os.getenv("MAIL_ENABLED", True))
+MAIL_ENABLED = envtobool("MAIL_ENABLED", True)
 MAIL_SERVER = os.getenv("MAIL_SERVER", "localhost")
 MAIL_PORT = os.getenv("MAIL_PORT", 25)
 MAIL_USERNAME = os.getenv("MAIL_USERNAME", "")
 MAIL_PASSWORD = os.getenv("MAIL_PASSWORD", "")
-MAIL_DEBUG = strtobool(os.getenv("MAIL_DEBUG", False))
-MAIL_USE_TLS = strtobool(os.getenv("MAIL_USE_TLS", False))
-MAIL_USE_SSL = strtobool(os.getenv("MAIL_USE_SSL", False))
+MAIL_DEBUG = envtobool("MAIL_DEBUG", False)
+MAIL_USE_TLS = envtobool("MAIL_USE_TLS", False)
+MAIL_USE_SSL = envtobool("MAIL_USE_SSL", False)
 MAIL_DEFAULT_SENDER = os.getenv(
     "MAIL_DEFAULT_SENDER", "no-reply@your-studio.com"
 )
@@ -98,10 +98,8 @@ FS_S3_ENDPOINT = os.getenv("FS_S3_ENDPOINT")
 FS_S3_ACCESS_KEY = os.getenv("FS_S3_ACCESS_KEY")
 FS_S3_SECRET_KEY = os.getenv("FS_S3_SECRET_KEY")
 
-ENABLE_JOB_QUEUE = strtobool(os.getenv("ENABLE_JOB_QUEUE", False))
-ENABLE_JOB_QUEUE_REMOTE = strtobool(
-    os.getenv("ENABLE_JOB_QUEUE_REMOTE", False)
-)
+ENABLE_JOB_QUEUE = envtobool("ENABLE_JOB_QUEUE", False)
+ENABLE_JOB_QUEUE_REMOTE = envtobool("ENABLE_JOB_QUEUE_REMOTE", False)
 JOB_QUEUE_NOMAD_PLAYLIST_JOB = os.getenv(
     "JOB_QUEUE_NOMAD_PLAYLIST_JOB", "zou-playlist"
 )
@@ -115,10 +113,10 @@ LDAP_PORT = os.getenv("LDAP_PORT", "389")
 LDAP_BASE_DN = os.getenv("LDAP_BASE_DN", "cn=Users,dc=zou,dc=local")
 LDAP_GROUP = os.getenv("LDAP_GROUP", "")
 LDAP_DOMAIN = os.getenv("LDAP_DOMAIN", "zou.local")
-LDAP_FALLBACK = strtobool(os.getenv("LDAP_FALLBACK", False))
-LDAP_IS_AD = strtobool(os.getenv("LDAP_IS_AD", False))
-LDAP_IS_AD_SIMPLE = strtobool(os.getenv("LDAP_IS_AD_SIMPLE", False))
-LDAP_SSL = strtobool(os.getenv("LDAP_SSL", False))
+LDAP_FALLBACK = envtobool("LDAP_FALLBACK", False)
+LDAP_IS_AD = envtobool("LDAP_IS_AD", False)
+LDAP_IS_AD_SIMPLE = envtobool("LDAP_IS_AD_SIMPLE", False)
+LDAP_SSL = envtobool("LDAP_SSL", False)
 
 
 LOGS_MODE = os.getenv("LOGS_MODE", "default")

--- a/zou/app/utils/env.py
+++ b/zou/app/utils/env.py
@@ -1,0 +1,12 @@
+import os
+from zou.app.utils.string import strtobool
+
+def envtobool(key, default=False):
+    """
+    Convert an environment variable to a boolean value.
+    If environment variable can't be converted raise ValueError.
+    """
+    try:
+        return strtobool(os.getenv(key, default))
+    except ValueError:
+        raise ValueError(f"Environment variable {key} cannot be converted to a boolean value.")

--- a/zou/app/utils/env.py
+++ b/zou/app/utils/env.py
@@ -1,6 +1,7 @@
 import os
 from zou.app.utils.string import strtobool
 
+
 def envtobool(key, default=False):
     """
     Convert an environment variable to a boolean value.
@@ -9,4 +10,6 @@ def envtobool(key, default=False):
     try:
         return strtobool(os.getenv(key, default))
     except ValueError:
-        raise ValueError(f"Environment variable {key} cannot be converted to a boolean value.")
+        raise ValueError(
+            f"Environment variable {key} cannot be converted to a boolean value."
+        )

--- a/zou/app/utils/fs.py
+++ b/zou/app/utils/fs.py
@@ -40,7 +40,7 @@ def get_file_path_and_file(
     prefix,
     instance_id,
     extension,
-    file_size=None
+    file_size=None,
 ):
     if config.FS_BACKEND == "local":
         file_path = get_local_path(prefix, instance_id)
@@ -56,7 +56,7 @@ def get_file_path_and_file(
                 except RuntimeError:
                     pass
 
-        if is_unvalid_file(file_path, file_size): # download failed
+        if is_unvalid_file(file_path, file_size):  # download failed
             time.sleep(3)
             with open(file_path, "wb") as tmp_file:
                 try:
@@ -65,7 +65,7 @@ def get_file_path_and_file(
                 except RuntimeError:
                     pass
 
-            if is_unvalid_file(file_path, file_size): # download failed again
+            if is_unvalid_file(file_path, file_size):  # download failed again
                 rm_file(file_path)
                 raise DownloadFromStorageFailedException
 

--- a/zou/app/utils/string.py
+++ b/zou/app/utils/string.py
@@ -1,4 +1,9 @@
 def strtobool(val):
+    """
+    Convert a string (val) to a boolean value.
+    If val is already a boolean return val.
+    Else raise ValueError.
+    """
     if isinstance(val, bool):
         return val
     elif val.lower() in ("y", "yes", "t", "true", "on", "1"):


### PR DESCRIPTION
**Problem**
- When converting environment variable to boolean value we don't know which specific environment variable fails.
- We need to go back to 400 as status code when login fails for retro compatibility.
- Black 

**Solution**
- Show better exceptions when converting environment variables to boolean values (show which one is involved).
- Go back to 400 as status code when login fails for retro compatibility.
- Black
