### PR TITLE
[cli] add new task status "Ready To Start" to init-data

### DIFF
--- a/zou/app/utils/commands.py
+++ b/zou/app/utils/commands.py
@@ -159,6 +159,7 @@ def init_data():
         "Retake", "retake", "#ff3860", is_retake=True
     )
     tasks_service.get_or_create_status("Done", "done", "#22d160", is_done=True)
+    tasks_service.get_or_create_status("Ready To Start", "ready", "#fbc02d")
 
     print("Task status initialized.")
 


### PR DESCRIPTION
**Problem**
we need a new task status "ready to start" when initializing Zou 
**Solution**
add new task status "Ready To Start" to init-data
