### PR TITLE
[travis] up python versions in tests because python 3.6 will be depre…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: python
 dist: bionic
 os: linux
 python:
-  - "3.6"
+  - "3.7"
   - "3.8"
-  - "3.9"
+  - "3.10"
 services:
   - postgresql
 addons:


### PR DESCRIPTION
…cated in Zou package due to its EOL

**Problem**
- In a future release of Zou we will drop support for python 3.6 so we need to upgrade python versions tested in travis.

**Solution**
- Travis tests for python 3.7 / 3.8 / 3.10