### PR TITLE
Various fixes

### DIFF
--- a/zou/app/blueprints/previews/resources.py
+++ b/zou/app/blueprints/previews/resources.py
@@ -130,9 +130,9 @@ def send_storage_file(
     """
     file_size = None
     try:
-        if prefix in ["movies", "pictures", "previews", "originals"]:
+        if prefix in ["movies", "original"]:
             preview_file = files_service.get_preview_file(preview_file_id)
-            preview_file["file_size"]
+            file_size = preview_file["file_size"]
     except PreviewFileNotFoundException:
         pass
     file_path = fs.get_file_path_and_file(


### PR DESCRIPTION
**Problem**

* When a file is not properly cached from the object storage, it is not replaced.
* Sometimes annotations don't have IDs, which mess up their management


**Solution**

* Get the original file size from the database and download the file again if it is not present.
* On any operations, check the data stored in the database and add an ID if it is missing. Ignore operations where the annotation has no ID.
