### PR TITLE
Use value coming from configuration for redis connection

### DIFF
--- a/zou/event_stream.py
+++ b/zou/event_stream.py
@@ -81,7 +81,8 @@ def _update_room_playing_status(data, room):
 def get_redis_url():
     redis_host = config.KEY_VALUE_STORE["host"]
     redis_port = config.KEY_VALUE_STORE["port"]
-    return "redis://%s:%s/2" % (redis_host, redis_port)
+    db_index = config.KV_EVENTS_DB_INDEX
+    return "redis://%s:%s/%s" % (redis_host, redis_port, db_index)
 
 
 # Routes


### PR DESCRIPTION
**Problem**
`get_redis_url()` did not use the database index from the configuration.

**Solution**
We use the database index from the configuration.
