### PR TITLE
Add desktop_login to present_minimal

### DIFF
--- a/zou/app/models/person.py
+++ b/zou/app/models/person.py
@@ -132,6 +132,7 @@ class Person(db.Model, BaseMixin, SerializerMixin):
             "active": data["active"],
             "departments": data.get("departments", []),
             "role": data["role"],
+            "desktop_login": data["desktop_login"],
         }
 
     def set_departments(self, department_ids):


### PR DESCRIPTION
**Problem**
We needed regular users to be able to access the `desktop_login` of a queried users.

**Solution**
We added `desktop_login` to the keys returned by `Person.present_minimal`.
