### PR TITLE
LDAP: update query for non-AD servers

### DIFF
--- a/zou/app/utils/commands.py
+++ b/zou/app/utils/commands.py
@@ -198,7 +198,9 @@ def sync_with_ldap_server():
             ]
         else:
             attributes += ["uid", "jpegPhoto"]
-        query = "(&(objectClass=person)(!(objectClass=computer)))"
+        query = "(objectClass=person)"
+        if is_ad:
+            query = "(&(objectClass=person)(!(objectClass=computer)))"
         if len(LDAP_GROUP) > 0 and is_ad:
             query = "(&(objectClass=person)(memberOf=%s))" % LDAP_GROUP
         conn.search(LDAP_BASE_DN, query, attributes=attributes)


### PR DESCRIPTION
We can only be sure that the LDAP server has a computer type object if it's an Active Directory server

**Problem**
<!--- Explain the problem -->
According to [Plyrolith](https://github.com/Plyrolith) the previous fix breaks sync with non-AD LDAP (like openLDAP)

**Solution**
<!--- Describe the change, including rationale and design decisions -->
Avoid computer type accounts only if we are connected to an Active Directory server