### PR TITLE
Add limit parameter to requests in zou to specify the number of entries per page

### DIFF
--- a/zou/app/blueprints/crud/base.py
+++ b/zou/app/blueprints/crud/base.py
@@ -26,9 +26,9 @@ class BaseModelsResource(Resource):
 
         return self.model.serialize_list(query.all(), relations=relations)
 
-    def paginated_entries(self, query, page, relations=False):
+    def paginated_entries(self, query, page, limit=None, relations=False):
         total = query.count()
-        limit = current_app.config["NB_RECORDS_PER_PAGE"]
+        limit = limit or current_app.config["NB_RECORDS_PER_PAGE"]
         offset = (page - 1) * limit
 
         nb_pages = int(math.ceil(total / float(limit)))
@@ -154,12 +154,13 @@ class BaseModelsResource(Resource):
                 query = self.apply_filters(query, options)
                 query = self.add_project_permission_filter(query)
                 page = int(options.get("page", "-1"))
+                limit = int(options.get("limit", 0))
                 relations = options.get("relations", "false") == "true"
                 is_paginated = page > -1
 
                 if is_paginated:
                     return self.paginated_entries(
-                        query, page, relations=relations
+                        query, page, limit=limit, relations=relations
                     )
                 else:
                     return self.all_entries(query, relations=relations)


### PR DESCRIPTION
**Problem**
We wanted to be able to specify the number of entries that we wanted per page from the client, so as to be more flexible.

**Solution**
We added a `limit` parameter, that can be used like so : `gazu.client.fetch_all("working-files", params={"page": 2, "limit": 10})`
