### PR TITLE
Fix relations argument evaluated with wrong type

### DIFF
--- a/zou/app/blueprints/crud/base.py
+++ b/zou/app/blueprints/crud/base.py
@@ -155,7 +155,7 @@ class BaseModelsResource(Resource):
                 query = self.add_project_permission_filter(query)
                 page = int(options.get("page", "-1"))
                 limit = int(options.get("limit", 0))
-                relations = options.get("relations", "false") == "true"
+                relations = options.get("relations", "false").lower() == "true"
                 is_paginated = page > -1
 
                 if is_paginated:

--- a/zou/app/blueprints/crud/base.py
+++ b/zou/app/blueprints/crud/base.py
@@ -104,7 +104,7 @@ class BaseModelsResource(Resource):
         for id_filter in in_filter:
             query = query.filter(id_filter)
 
-        for (key, value) in many_join_filter:
+        for key, value in many_join_filter:
             query = query.filter(getattr(self.model, key).any(id=value))
 
         return query

--- a/zou/app/blueprints/files/resources.py
+++ b/zou/app/blueprints/files/resources.py
@@ -1880,7 +1880,7 @@ class EntityWorkingFilesResource(Resource):
         """
         task_id = request.args.get("task_id", None)
         name = request.args.get("name", None)
-        relations = request.args.get("relations", False)
+        relations = request.args.get("relations", "false").lower() == "true"
 
         entity = entities_service.get_entity(entity_id)
         user_service.check_project_access(entity["project_id"])


### PR DESCRIPTION
**Problem**
The `relation` argument is not automatically converted to boolean, which causes problems sometimes.

**Solution**
We compare the lowercase string to `"true"` instead, to ensure it works in all cases, such as when the user passed `params={"relations": True}` (with `True` as a boolean) to the client function.
