### PR TITLE
Add route to query all timespents for a user and a month

### DIFF
--- a/zou/app/blueprints/persons/__init__.py
+++ b/zou/app/blueprints/persons/__init__.py
@@ -11,6 +11,7 @@ from .resources import (
     PersonWeekQuotaShotsResource,
     PersonDayQuotaShotsResource,
     PersonMonthTimeSpentsResource,
+    PersonMonthAllTimeSpentsResource,
     PersonWeekTimeSpentsResource,
     PersonDayTimeSpentsResource,
     PersonWeekDayOffResource,
@@ -42,6 +43,10 @@ routes = [
     (
         "/data/persons/<person_id>/time-spents/month/<year>/<month>",
         PersonMonthTimeSpentsResource,
+    ),
+    (
+        "/data/persons/<person_id>/time-spents/month/all/<year>/<month>",
+        PersonMonthAllTimeSpentsResource,
     ),
     (
         "/data/persons/<person_id>/time-spents/week/<year>/<week>",

--- a/zou/app/blueprints/persons/resources.py
+++ b/zou/app/blueprints/persons/resources.py
@@ -15,7 +15,7 @@ from zou.app.services import (
     shots_service,
     user_service,
 )
-from zou.app.utils import permissions, csv_utils, auth, emails
+from zou.app.utils import permissions, csv_utils, auth, emails, fields
 from zou.app.services.exception import (
     DepartmentNotFoundException,
     WrongDateFormatException,
@@ -447,6 +447,23 @@ class PersonMonthTimeSpentsResource(PersonDurationTimeSpentsResource):
                 month,
                 **self.get_project_department_arguments(person_id),
             )
+        except WrongDateFormatException:
+            abort(404)
+
+
+class PersonMonthAllTimeSpentsResource(Resource):
+    """
+    Get all time spents for a given person and month.
+    """
+
+    @jwt_required
+    def get(self, person_id, year, month):
+        user_service.check_person_access(person_id)
+        try:
+            timespents = time_spents_service.get_time_spents_for_month(
+                year, month, person_id=person_id
+            )
+            return fields.serialize_list(timespents)
         except WrongDateFormatException:
             abort(404)
 


### PR DESCRIPTION
**Problem**
We needed a route to get the full list of timespents for a given person and month, and the existing route `"/data/persons/<person_id>/time-spents/month/<year>/<month>"` gave only an aggregated result (the sum of time spent for each task for the month + user).

**Solution**
We added a route to get all the timespents rather than an aggregated list.

**Note**
This is the kind of thing that would stay on our side with the plugins system you are planning on implementing, so if you feel no one else benefits from this route, we can absolutely keep this on our side while waiting for the plugins system.