### PR TITLE
Changed working files permissions to allow non-admin users

### DIFF
--- a/zou/app/blueprints/crud/working_file.py
+++ b/zou/app/blueprints/crud/working_file.py
@@ -1,12 +1,38 @@
 from .base import BaseModelsResource, BaseModelResource
 
+from zou.app.models.entity import Entity
+from zou.app.models.project import Project
 from zou.app.models.working_file import WorkingFile
 from zou.app.services import user_service, tasks_service, files_service
+from zou.app.utils import permissions
 
 
 class WorkingFilesResource(BaseModelsResource):
     def __init__(self):
         BaseModelsResource.__init__(self, WorkingFile)
+
+    def check_read_permissions(self):
+        """
+        Overriding so that people without admin credentials can still access
+        this resource.
+        """
+        user_service.block_access_to_vendor()
+        return True
+
+    def add_project_permission_filter(self, query):
+        """
+        Filtering to keep only the files from projects available to the user's
+        team. Allows projects that are no longer open.
+        """
+        if permissions.has_admin_permissions():
+            return query
+        else:
+            query = (
+                query.join(Entity, WorkingFile.entity_id == Entity.id)
+                .join(Project)
+                .filter(user_service.build_team_filter())
+            )
+            return query
 
 
 class WorkingFileResource(BaseModelResource):


### PR DESCRIPTION
**Problem**
Querying working-files for non-admin users was too restrictive for some of our uses.

**Solution**
Allow access to all working-files of the user's projects.
