### PR TITLE
made restoration documentation more comprehensive

### DIFF
--- a/docs/backup.md
+++ b/docs/backup.md
@@ -20,13 +20,35 @@ name will follow this format: `2021-03-21-zou-db-backup.sql.gz`
 
 *Restoration*
 
-To restore the database to a new Postgres instance run
+To restore the database to a new Postgres instance make sure the source and target version 
+of the api match, otherwise the database schema may not match, if all matches run
 
 ```bash
 gunzip 2021-03-21-zou-db-backup.sql.gz
 createdb -h localhost -p 5432 -U postgres targetdb
-psql -h yourphost -p 5432 -U postgres -1 -f targetdb 2021-03-21-zou-db-backup.sql
+psql -h yourphost -p 5432 -U postgres -1 -d targetdb -f 2021-03-21-zou-db-backup.sql
 ```
+you can also just write directly to zoudb (the default database):
+```bash
+gunzip 2021-03-21-zou-db-backup.sql.gz
+psql -h yourphost -p 5432 -U postgres -1 -d zoudb -f 2021-03-21-zou-db-backup.sql
+```
+when writing to a previously created database, make sure to terminate all the connections to said 
+database by using the following statement:
+```bash
+SELECT pg_terminate_backend (pid) FROM pg_stat_activity WHERE datname = 'zoudb';
+```
+you can also change the name of a database to convert it to the default db:
+```bash
+ALTER DATABASE targetdb RENAME TO zoudb;
+```
+you can also change the database being used by using an environment variable in
+
+/etc/systemd/system/zou.service
+```bash
+Environment="DB_DATABASE=targetdb"
+```
+
 
 
 ## Backup files


### PR DESCRIPTION
-Made the documentation to restore the database more comprehensive
 -the parameter -d was missing from psql -h yourphost -p 5432 -U postgres -1 -d targetdb -f 2021-03-21-zou-db-backup.sql

**Problem**
A lot of people were having issues restoring a backed up database

**Solution**
described several options to restore a database in a more comprehensive manner
