### PR TITLE
Add route to guess an entity from a given path.

### DIFF
--- a/zou/app/blueprints/files/__init__.py
+++ b/zou/app/blueprints/files/__init__.py
@@ -26,6 +26,7 @@ from .resources import (
     SetTreeResource,
     FileResource,
     WorkingFileFileResource,
+    GuessFromPathResource,
 )
 
 routes = [
@@ -95,6 +96,7 @@ routes = [
         "/data/entities/<entity_id>/output-file-path",
         EntityOutputFilePathResource,
     ),
+    ("/data/entities/guess_from_path", GuessFromPathResource),
     (
         "/data/working-files/<working_file_id>/file",
         WorkingFileFileResource,

--- a/zou/app/blueprints/files/resources.py
+++ b/zou/app/blueprints/files/resources.py
@@ -1890,3 +1890,32 @@ class EntityWorkingFilesResource(Resource, ArgsMixin):
         return files_service.get_working_files_for_entity(
             entity_id, task_id=task_id, name=name, relations=relations
         )
+
+
+class GuessFromPathResource(Resource):
+    """
+    Get list of possible project file tree templates matching a file path
+    and data ids corresponding to template tokens.
+    """
+
+    @jwt_required
+    def post(self):
+        data = self.get_arguments()
+
+        return file_tree_service.guess_from_path(
+            project_id=data["project_id"],
+            file_path=data["file_path"],
+            sep=data["sep"],
+        )
+
+    def get_arguments(self):
+        parser = reqparse.RequestParser()
+        parser.add_argument(
+            "project_id", help="The project id is required.", required=True
+        )
+        parser.add_argument(
+            "file_path", help="The file path is required.", required=True
+        )
+        parser.add_argument("sep", default="/")
+        args = parser.parse_args()
+        return args

--- a/zou/app/models/base.py
+++ b/zou/app/models/base.py
@@ -1,12 +1,12 @@
 import datetime
 
 from sqlalchemy_utils import UUIDType
+from sqlalchemy import func
 from zou.app import db
 from zou.app.utils import fields
 
 
 class BaseMixin(object):
-
     id = db.Column(
         UUIDType(binary=False), primary_key=True, default=fields.gen_uuid
     )
@@ -46,6 +46,22 @@ class BaseMixin(object):
         element of the returned data.
         """
         return cls.query.filter_by(**kw).first()
+
+    @classmethod
+    def get_by_case_insensitive(cls, **kw):
+        """
+        Shorthand to retrieve data by using filters. It returns the first
+        element of the returned data without checking case for any String type value.
+        """
+        filters = []
+        for key, value in kw.items():
+            column = getattr(cls, key)
+            if isinstance(column.type, db.String):
+                filters.append(func.lower(column) == func.lower(value))
+            else:
+                filters.append(column == value)
+
+        return cls.query.filter(*filters).first()
 
     @classmethod
     def get_all(cls):


### PR DESCRIPTION
**Problem**
We needed a way to create output files from a file or folder, but we also wanted to avoid having the user specify which entity it was, to reduce potential errors.

**Solution**
We added this `guess_from_path` route, that allows us to guess an entity from a path.
