### PR TITLE
[projects] Return first running episode as first episode

### DIFF
--- a/zou/app/services/projects_service.py
+++ b/zou/app/services/projects_service.py
@@ -109,9 +109,19 @@ def get_projects_with_extra_data(
                 Entity.query.join(EntityType)
                 .filter(EntityType.name == "Episode")
                 .filter(Entity.project_id == project.id)
+                .filter(Entity.status == "running")
                 .order_by(Entity.name)
                 .first()
             )
+            if first_episode is None:
+                first_episode = (
+                    Entity.query.join(EntityType)
+                    .filter(EntityType.name == "Episode")
+                    .filter(Entity.project_id == project.id)
+                    .order_by(Entity.name)
+                    .first()
+                )
+
             if first_episode is not None:
                 project_dict["first_episode_id"] = fields.serialize_value(
                     first_episode.id


### PR DESCRIPTION
**Problem**

The first episode id makes only sense for running projects. In the current situation, it's the first episode that is returned.

**Solution**

When returning open projects, instead of getting the first episode, get the first running episode.