### PR TITLE
various fixes

### DIFF
--- a/zou/app/services/user_service.py
+++ b/zou/app/services/user_service.py
@@ -293,14 +293,15 @@ def get_open_projects(name=None):
     """
     Get all open projects for which current user is part of the team.
     """
-    query = (
-        Project.query.join(ProjectStatus)
-        .filter(build_team_filter())
-        .filter(build_open_project_filter())
+    query = Project.query.join(ProjectStatus).filter(
+        build_open_project_filter()
     )
 
     if name is not None:
         query = query.filter(Project.name == name)
+
+    if not permissions.has_admin_permissions():
+        query = query.filter(build_team_filter())
 
     for_client = False
     vendor_departments = None


### PR DESCRIPTION
**Problem**
- In user_service.get_open_projects for an admin we need to get all opens projects like in get_context (see : https://github.com/cgwire/gazu/issues/214)
- Using playlist_service.build_playlist_movie_file in zou-rq  is missing some app.app_context
**Solution**
- In user_service.get_open_projects allow admins get all opens projects
- Set correct app.app_context in playlist_service.build_playlist_movie_file 