### PR TITLE
Various fixes

### DIFF
--- a/tests/projects/test_route_metadata.py
+++ b/tests/projects/test_route_metadata.py
@@ -44,6 +44,7 @@ class ProjectMetadataRouteTestCase(ApiDBTestCase):
         self.assertEqual(descriptors[0]["id"], descriptor["id"])
         self.assertEqual(descriptors[0]["field_name"], "contractor")
         self.assertEqual(descriptors[1]["field_name"], "environment_type")
+        self.assertEqual(descriptors[1]["choices"], ["indoor", "outdoor"])
 
         projects = self.get("data/projects/open/")
         self.assertEqual(len(projects), 1)

--- a/zou/app/blueprints/crud/event.py
+++ b/zou/app/blueprints/crud/event.py
@@ -7,6 +7,15 @@ class EventsResource(BaseModelsResource):
     def __init__(self):
         BaseModelsResource.__init__(self, ApiEvent)
 
+    def all_entries(self, query=None, relations=False):
+        if query is None:
+            query = self.model.query
+
+        return self.model.serialize_list(
+            query.limit(1000).all(),
+            relations=relations
+        )
+
 
 class EventResource(BaseModelResource):
     def __init__(self):

--- a/zou/app/blueprints/projects/resources.py
+++ b/zou/app/blueprints/projects/resources.py
@@ -108,7 +108,7 @@ class ProductionTeamResource(Resource, ArgsMixin):
     @jwt_required()
     def post(self, project_id):
         """
-        Manage the people listed in a production team.
+        Add a person to a production team.
         ---
         tags:
           - Projects
@@ -119,9 +119,15 @@ class ProductionTeamResource(Resource, ArgsMixin):
             type: string
             format: UUID
             x-example: a24a6ea4-ce75-4665-a070-57453082c25
+          - in: formData
+            name: person_id
+            required: True
+            type: string
+            format: UUID
+            x-example: a24a6ea4-ce75-4665-a070-57453082c25
         responses:
             201:
-              description: Person added to production team
+              description: Person added to the production team
         """
         args = self.get_args([("person_id", "", True)])
 

--- a/zou/app/blueprints/projects/resources.py
+++ b/zou/app/blueprints/projects/resources.py
@@ -100,7 +100,7 @@ class ProductionTeamResource(Resource, ArgsMixin):
         persons = []
         for person in project.team:
             if permissions.has_manager_permissions():
-                persons.append(person.serialize_safe())
+                persons.append(person.serialize_safe(relations=True))
             else:
                 persons.append(person.present_minimal())
         return persons
@@ -593,8 +593,8 @@ class ProductionMetadataDescriptorsResource(Resource, ArgsMixin):
                 ("entity_type", "Asset", False),
                 ("name", "", True),
                 ("for_client", "False", False),
-                ("choices", [], False, list, "append"),
-                ("departments", [], False, list, "append"),
+                ("choices", [], False, str, "append"),
+                ("departments", [], False, str, "append"),
             ]
         )
 
@@ -714,8 +714,8 @@ class ProductionMetadataDescriptorResource(Resource, ArgsMixin):
             [
                 ("name", "", False),
                 ("for_client", "False", False),
-                ("choices", [], False, list, "append"),
-                ("departments", [], False, list, "append"),
+                ("choices", [], False, str, "append"),
+                ("departments", [], False, str, "append"),
             ]
         )
         user_service.check_all_departments_access(

--- a/zou/app/services/breakdown_service.py
+++ b/zou/app/services/breakdown_service.py
@@ -242,7 +242,7 @@ def update_casting(entity_id, casting):
         assets = _extract_removal(entity_dict, casting)
         for asset_id in assets:
             _remove_asset_from_episode_shots(asset_id, entity_id)
-    entity.update({"entities_out": [], "entities_out_length": 0})
+    entity.update({"entities_out": [], "nb_entities_out": 0})
     for cast in casting:
         if "asset_id" in cast and "nb_occurences" in cast:
             create_casting_link(
@@ -734,7 +734,6 @@ def refresh_shot_casting_stats(shot, priority_map=None):
     For all tasks related to given shot, it computes how many assets are
     available for this task and saves the result on the task level.
     """
-
     if priority_map is None:
         priority_map = _get_task_type_priority_map(shot["project_id"])
     casting = get_entity_casting(shot["id"])


### PR DESCRIPTION
**Problem**

* Getting all events from the CRUD events route can flood the API.
* The team person list doesn't return the departments.
* The casting update starts by resetting the casting but doesn't properly update the casting count.
* Metadata choices were not properly parsed at creation and update.

**Solution**

* Limit the number of events returned to 1000
* Add relations to returned persons in the person team list route
* Reset the number of entities when updating the breakdown
* Parse with the right type choices data
