### PR TITLE
[comments] stop removing end_date when status is not a feedback request

### DIFF
--- a/zou/app/services/comments_service.py
+++ b/zou/app/services/comments_service.py
@@ -139,8 +139,6 @@ def _manage_status_change(task_status, task, comment):
 
         if task_status["is_feedback_request"]:
             new_data["end_date"] = datetime.datetime.now()
-        else:
-            new_data["end_date"] = None
 
         if (
             task_status["short_name"] == "wip"

--- a/zou/app/services/tasks_service.py
+++ b/zou/app/services/tasks_service.py
@@ -1578,8 +1578,6 @@ def reset_task_data(task_id):
 
         if task_status_is_feedback_request:
             end_date = comment.created_at
-        else:
-            end_date = None
 
         task_status_id = comment.task_status_id
         last_comment_date = comment.created_at


### PR DESCRIPTION
**Problem**
- the end_date of a task is removed when a new status that is not a feedback request is set

**Solution**
- stop removing the end_date
