### PR TITLE
Various fixes

### DIFF
--- a/zou/app/services/assets_service.py
+++ b/zou/app/services/assets_service.py
@@ -669,6 +669,7 @@ def update_asset(asset_id, data):
         {"asset_id": asset_id, "data": data},
         project_id=str(asset.project_id),
     )
+    clear_asset_cache(asset_id)
     return asset.serialize(obj_type="Asset")
 
 

--- a/zou/app/services/playlists_service.py
+++ b/zou/app/services/playlists_service.py
@@ -215,6 +215,7 @@ def set_preview_files_for_entities(playlist_dict):
         .order_by(TaskType.priority.desc())
         .order_by(TaskType.name)
         .order_by(PreviewFile.revision.desc())
+        .order_by(PreviewFile.position)
         .order_by(PreviewFile.created_at)
         .add_column(Task.task_type_id)
         .add_column(Task.entity_id)


### PR DESCRIPTION
**Problem**

* In Kitsu after a "ready for" field is changed, the view is not updated in real time.
* The preview position is multiple previews revisions is not respected in playlists.

**Solution**

* Clear the asset cache after updating assets.
* Handle properly preview position when building the playlist information