### PR TITLE
Add route to extract a frame from a preview

### DIFF
--- a/zou/app/blueprints/previews/__init__.py
+++ b/zou/app/blueprints/previews/__init__.py
@@ -23,6 +23,7 @@ from zou.app.blueprints.previews.resources import (
     SetMainPreviewResource,
     UpdateAnnotationsResource,
     UpdatePreviewPositionResource,
+    ExtractFrameFromPreview,
 )
 
 routes = [
@@ -98,6 +99,10 @@ routes = [
     (
         "/actions/preview-files/<preview_file_id>/set-main-preview",
         SetMainPreviewResource,
+    ),
+    (
+        "/data/preview-files/<preview_file_id>/extract-frame",
+        ExtractFrameFromPreview,
     ),
     (
         "/actions/preview-files/<preview_file_id>/update-position",

--- a/zou/app/services/preview_files_service.py
+++ b/zou/app/services/preview_files_service.py
@@ -543,3 +543,28 @@ def get_last_preview_file_for_task(task_id):
         return None
     else:
         return preview.serialize()
+
+
+def extract_frame_from_preview_file(preview_file, frame_number):
+    try:
+        project = get_project_from_preview_file(preview_file["id"])
+    except PreviewFileNotFoundException:
+        raise PreviewFileNotFoundException
+
+    if preview_file["extension"] == "mp4":
+        preview_file_path = fs.get_file_path_and_file(
+            config,
+            file_store.get_local_movie_path,
+            file_store.open_movie,
+            "previews",
+            preview_file["id"],
+            "mp4",
+        )
+    # exception ou renvoyer image si png ?
+
+    fps = get_preview_file_fps(project)
+    extracted_frame_path = movie.extract_frame_from_movie(
+        preview_file_path, frame_number, fps
+    )
+
+    return extracted_frame_path


### PR DESCRIPTION
**Problem**

There is no way to get given from a given preview. While it's an interesting feature to build thumbnails.

**Solution**

Add a route with a preview ID and a frame as parameters that returns the frame as a `.png` file.
