### PR TITLE
Improve movie quality + fix

### DIFF
--- a/zou/app/blueprints/tasks/resources.py
+++ b/zou/app/blueprints/tasks/resources.py
@@ -1477,8 +1477,9 @@ class SetTaskMainPreviewResource(Resource):
         preview_file = preview_files_service.get_last_preview_file_for_task(
             task_id
         )
+        entity = entities_service.get_entity(task["entity_id"])
         if preview_file is not None:
-            entity = entities_service.update_entity_preview(
+            entities_service.update_entity_preview(
                 task["entity_id"], preview_file["id"]
             )
             assets_service.clear_asset_cache(entity["id"])

--- a/zou/utils/movie.py
+++ b/zou/utils/movie.py
@@ -168,7 +168,7 @@ def normalize_encoding(
         color_trc=1,
         colorspace=1,
         movflags="+faststart",
-        x264opts="keyint=3:scenecut=0",
+        x264opts="keyint=1:scenecut=0",
         s="%sx%s" % (width, height),
     )
     try:
@@ -232,7 +232,7 @@ def normalize_movie(movie_path, fps, width, height):
         "Compute low def version",
         low_file_target_path,
         fps,
-        "2M",
+        "5M",
         low_width,
         low_height,
     )


### PR DESCRIPTION
**Problem**

* It's too slow to scrub into the High Def movies
* Lowdef is too pixelated
* Setting a thumbnail from a task with no preview leads to 500 errors.

**Solution**

* Set every frame as a keyframe
* Change low-def  bitrate from 2M to 6M
* Assign the entity before the number of preview condition