### PR TITLE
[previews] support NTSC frame rate with 3 decimal places

### DIFF
--- a/zou/app/services/preview_files_service.py
+++ b/zou/app/services/preview_files_service.py
@@ -79,7 +79,7 @@ def get_preview_file_fps(project):
     """
     fps = "25.00"
     if project.get("fps", None) is not None:
-        fps = "%.2f" % float(project["fps"].replace(",", "."))
+        fps = "%.3f" % float(project["fps"].replace(",", "."))
     return fps
 
 


### PR DESCRIPTION
**Problem**
Some users use a NTSC camera at 23.976 fps, but currently Zou rounds to 2 decimal places.

**Solution**
Increase the frame rate to 3 decimal places. 
