### PR TITLE
[sync] increase the speed of cli sync_full_files by allowing multithr…

### DIFF
--- a/zou/app/utils/commands.py
+++ b/zou/app/utils/commands.py
@@ -471,14 +471,30 @@ def import_last_file_changes_from_another_instance(
         print("Last files syncing ended.")
 
 
-def import_files_from_another_instance(target, login, password, project=None):
+def import_files_from_another_instance(
+    target,
+    login,
+    password,
+    project=None,
+    multithreaded=False,
+    number_workers=30,
+):
     """
     Retrieve and save all the data related most recent events from another API
     instance. It doesn't change the IDs.
     """
     with app.app_context():
+        if multithreaded:
+            # allow poolsize in swift client HTTPSession to allow more than 10 simultaneous connections.
+            from requests import adapters
+
+            adapters.DEFAULT_POOLSIZE = number_workers
         sync_service.init(target, login, password)
-        sync_service.download_files_from_another_instance(project=project)
+        sync_service.download_files_from_another_instance(
+            project=project,
+            multithreaded=multithreaded,
+            number_workers=number_workers,
+        )
 
 
 def download_file_from_storage():

--- a/zou/cli.py
+++ b/zou/cli.py
@@ -287,9 +287,13 @@ def sync_full(
 
 
 @cli.command()
-@click.option("--target", default="http://localhost:5000")
+@click.option("--target", default="http://localhost:5000", show_default=True)
+@click.option(
+    "--multithreaded", is_flag=True, show_default=True, default=False
+)
+@click.option("--number_workers", default=30, show_default=True)
 @click.option("--project")
-def sync_full_files(target, project=None):
+def sync_full_files(target, multithreaded, number_workers, project=None):
     """
     Retrieve all files from target instance. It expects that credentials to
     connect to target instance are given through SYNC_LOGIN and SYNC_PASSWORD
@@ -299,7 +303,12 @@ def sync_full_files(target, project=None):
     login = os.getenv("SYNC_LOGIN")
     password = os.getenv("SYNC_PASSWORD")
     commands.import_files_from_another_instance(
-        target, login, password, project=project
+        target,
+        login,
+        password,
+        project=project,
+        multithreaded=multithreaded,
+        number_workers=number_workers,
     )
     print("Syncing ended.")
 


### PR DESCRIPTION
…eading

**Problem**
- sync_full_files is too slow when there's a lot of files

**Solution**
- increase the speed (up to 24X) by allowing mutlithreading
