### PR TITLE
various improvements

### DIFF
--- a/zou/app/services/backup_service.py
+++ b/zou/app/services/backup_service.py
@@ -27,12 +27,10 @@ local_file = LocalBackend(
 )
 
 
-def generate_db_backup(host, port, user, password, database):
+def generate_db_backup(host, port, user, password, database, filename):
     """
     Generate a Postgres dump file from the database.
     """
-    now = datetime.datetime.now().strftime("%Y-%m-%d")
-    filename = "%s-zou-db-backup.sql.gz" % now
     cmd = ["pg_dump", "-h", host, "-p", port, "-U", user, database]
     with gzip.open(filename, "wb") as f:
         popen = subprocess.Popen(
@@ -48,11 +46,10 @@ def generate_db_backup(host, port, user, password, database):
         popen.stdout.close()
         popen.wait()
 
-    print(f"Postgres dump created ({filename}).")
     return filename
 
 
-def store_db_backup(filename):
+def store_db_backup(filename, path):
     """
     Store given file located in the same directory, inside the files bucket
     using the `dbbackup` prefix.
@@ -60,7 +57,7 @@ def store_db_backup(filename):
     from zou.app import app
 
     with app.app_context():
-        file_store.add_file("dbbackup", filename, filename)
+        file_store.add_file("dbbackup", filename, path)
 
 
 def upload_preview_files_to_storage(days=None):

--- a/zou/app/utils/date_helpers.py
+++ b/zou/app/utils/date_helpers.py
@@ -66,7 +66,7 @@ def get_year_interval(year):
     Get a tuple containing start date and end date for given year.
     """
     year = int(year)
-    if year > datetime.now().year or year < 2010:
+    if year > datetime.utcnow().year or year < 2010:
         raise WrongDateFormatException
 
     start = datetime(year, 1, 1)
@@ -80,7 +80,7 @@ def get_month_interval(year, month):
     """
     year = int(year)
     month = int(month)
-    if year > datetime.now().year or year < 2010 or month < 1 or month > 12:
+    if year > datetime.utcnow().year or year < 2010 or month < 1 or month > 12:
         raise WrongDateFormatException
 
     start = datetime(year, month, 1)
@@ -94,7 +94,7 @@ def get_week_interval(year, week):
     """
     year = int(year)
     week = int(week)
-    if year > datetime.now().year or year < 2010 or week < 1 or week > 52:
+    if year > datetime.utcnow().year or year < 2010 or week < 1 or week > 52:
         raise WrongDateFormatException
     start = isoweek.Week(year, week).monday()
     end = start + relativedelta.relativedelta(days=7)
@@ -109,7 +109,7 @@ def get_day_interval(year, month, day):
     month = int(month)
     day = int(day)
     if (
-        year > datetime.now().year
+        year > datetime.utcnow().year
         or year < 2010
         or month < 1
         or month > 12

--- a/zou/cli.py
+++ b/zou/cli.py
@@ -395,12 +395,13 @@ def download_storage_files():
 
 
 @cli.command()
-def dump_database():
+@click.option("--store", is_flag=True)
+def dump_database(store=False):
     """
     Dump database described in Zou environment variables and save it to
     configured object storage.
     """
-    commands.dump_database()
+    commands.dump_database(store)
 
 
 @cli.command()


### PR DESCRIPTION
**Problem**
- for cli command dump_database it create two files one in current directory and one in the preview folder. See here : https://github.com/cgwire/zou/issues/654
- we need to use utc() instead of utcnow().

**Solution**
- for cli command dump_database add a flag to store in the preview folder (or not if flag is missing).
- use utc() instead of utcnow()
