### PR TITLE
[requirements] use psycopg[binary] instead of the pure python version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -58,7 +58,7 @@ install_requires =
     OpenTimelineIO==0.15.0
     pillow==10.0.0
     psutil==5.9.5
-    psycopg==3.1.10
+    psycopg[binary]==3.1.10
     pygelf==0.4.2
     pyotp==2.9.0
     python-nomad==2.0.0


### PR DESCRIPTION
**Problem**
- We use the pure python implementation of psycopg that is slower to the binary one (see [here](https://www.psycopg.org/psycopg3/docs/api/pq.html#pq-module-implementations))

**Solution**
- Use the binary implementation
