### PR TITLE
[metadata] add a new "taglist" type of metadata descriptor

### DIFF
--- a/zou/app/models/metadata_descriptor.py
+++ b/zou/app/models/metadata_descriptor.py
@@ -21,6 +21,7 @@ METADATA_DESCRIPTOR_TYPES = [
     ("string", "String"),
     ("number", "Number"),
     ("list", "List"),
+    ("taglist", "Taglist"),
     ("boolean", "Boolean"),
     ("checklist", "Checklist"),
 ]


### PR DESCRIPTION
**Problem**
- we need to introduce a new type of metadata in Kitsu.

**Solution**
- add "taglist" in the metadata descriptor list
