### PR TITLE
[filters] Add missing group argument on update filter route

### DIFF
--- a/zou/app/blueprints/user/resources.py
+++ b/zou/app/blueprints/user/resources.py
@@ -612,6 +612,7 @@ class FilterResource(Resource, ArgsMixin):
             [
                 ("name", None, False),
                 ("search_query", None, False),
+                ("search_filter_group_id", None, False),
             ]
         )
         data = self.clear_empty_fields(data)


### PR DESCRIPTION
**Problem**
- The endpoint for updating a filter fails to save the group id.

**Solution**
- Add the missing argument to the route declaration.
