### PR TITLE
[notifications] don't send a notification when the person self reply …

### DIFF
--- a/zou/app/services/notifications_service.py
+++ b/zou/app/services/notifications_service.py
@@ -191,8 +191,9 @@ def create_notifications_for_task_and_reply(task, comment, reply):
     recipient_ids = get_notification_recipients(task, comment["replies"])
     if reply["person_id"] in recipient_ids:
         recipient_ids.remove(reply["person_id"])
-    recipient_ids.add(comment["person_id"])
     author_id = reply["person_id"]
+    if author_id != comment["person_id"]:
+        recipient_ids.add(comment["person_id"])
     task = tasks_service.get_task(comment["object_id"])
     for recipient_id in recipient_ids:
         try:


### PR DESCRIPTION
…to their comment

https://github.com/cgwire/kitsu/issues/1148 

**Problem**
- A notification is sent when a person self reply to their comment.

**Solution**
- Stop send notification when a person self reply to their comment.
