### PR TITLE
Various fixes

### DIFF
--- a/zou/app/blueprints/breakdown/resources.py
+++ b/zou/app/blueprints/breakdown/resources.py
@@ -372,7 +372,7 @@ class SceneCameraInstancesResource(Resource):
         return breakdown_service.get_camera_instances_for_scene(scene_id)
 
 
-class ProjectEntityLinksResource(Resource):
+class ProjectEntityLinksResource(Resource, ArgsMixin):
     @jwt_required()
     def get(self, project_id):
         """
@@ -394,7 +394,11 @@ class ProjectEntityLinksResource(Resource):
         """
         user_service.check_manager_project_access(project_id)
         projects_service.get_project(project_id)
-        return entities_service.get_entity_links_for_project(project_id)
+        page = self.get_page()
+        limit = self.get_limit()
+        return entities_service.get_entity_links_for_project(
+            project_id, page, limit
+        )
 
 
 class ProjectEntityLinkResource(Resource):

--- a/zou/app/blueprints/crud/project.py
+++ b/zou/app/blueprints/crud/project.py
@@ -1,4 +1,5 @@
 from flask_jwt_extended import jwt_required
+
 from flask_restful import Resource
 
 
@@ -96,7 +97,10 @@ class ProjectResource(BaseModelResource, ArgsMixin):
         self.protected_fields.append("team")
 
     def check_read_permissions(self, project):
-        user_service.check_project_access(project["id"])
+        return user_service.check_project_access(project["id"])
+
+    def check_update_permissions(self, project, data):
+        return user_service.check_manager_project_access(project["id"])
 
     def pre_update(self, project_dict, data):
         if "team" in data:

--- a/zou/app/mixin.py
+++ b/zou/app/mixin.py
@@ -67,10 +67,17 @@ class ArgsMixin(object):
 
     def get_page(self):
         """
-        Returns page requested by the user.
+        Returns page requested by the user as an integer.
         """
         options = request.args
         return int(options.get("page", "-1"))
+
+    def get_limit(self):
+        """
+        Returns limit requested by the user as an integer.
+        """
+        options = request.args
+        return int(options.get("limit", "-1"))
 
     def get_sort_by(self):
         """
@@ -115,14 +122,23 @@ class ArgsMixin(object):
         return self.get_bool_parameter("no_job")
 
     def get_text_parameter(self, field_name):
+        """
+        Returns text parameter value matching `field_name`.
+        """
         options = request.args
         return options.get(field_name, None)
 
     def get_bool_parameter(self, field_name, default="false"):
+        """
+        Returns bool parameter value matching `field_name`.
+        """
         options = request.args
         return options.get(field_name, default).lower() == "true"
 
     def get_date_parameter(self, field_name):
+        """
+        Returns date parameter value matching `field_name`.
+        """
         self.parse_date_parameter(self.get_text_parameter(field_name))
 
     def parse_date_parameter(self, param):

--- a/zou/app/utils/query.py
+++ b/zou/app/utils/query.py
@@ -29,7 +29,7 @@ def apply_criterions_to_db_query(model, db_query, criterions):
     return db_query.filter_by(**criterions)
 
 
-def get_paginated_results(query, page, relations=False):
+def get_paginated_results(query, page, limit=None, relations=False):
     """
     Apply pagination to the query object.
     """
@@ -37,7 +37,7 @@ def get_paginated_results(query, page, relations=False):
         entries = query.all()
         return fields.serialize_models(entries, relations=relations)
     else:
-        limit = app.config["NB_RECORDS_PER_PAGE"]
+        limit = limit or app.config["NB_RECORDS_PER_PAGE"]
         total = query.count()
         offset = (page - 1) * limit
 


### PR DESCRIPTION
**Problem**

* Project parameters can't be edited by a production manager.
* The project entity links resource can return a lot of data. It would be more efficient if pagination was allowed.

**Solution**

* Allow managers to edit projects.
* Allow to add a `page` and `limit` parameters to the entity links route to get a paginated result. Without the parameters, the route keeps its previous behaviour.
