### PR TITLE
prometheus

### DIFF
--- a/zou/app/__init__.py
+++ b/zou/app/__init__.py
@@ -162,24 +162,31 @@ def configure_auth():
 
 def load_api():
     from zou.app import api
+    from zou.app.utils import permissions
     from zou import __version__ as zou_version
 
     api.configure(app)
-    try:
-        from prometheus_flask_exporter.multiprocess import (
-            GunicornPrometheusMetrics,
-        )
 
-        metrics = GunicornPrometheusMetrics(
-            app, defaults_prefix="zou", group_by="url_rule"
-        )
-    except ValueError:
-        from prometheus_flask_exporter import RESTfulPrometheusMetrics
+    if config.PROMETHEUS_METRICS_ENABLED:
+        try:
+            from prometheus_flask_exporter.multiprocess import (
+                GunicornPrometheusMetrics,
+            )
 
-        metrics = RESTfulPrometheusMetrics(
-            app, api, defaults_prefix="zou", group_by="url_rule"
-        )
-    metrics.info("zou_info", "Application info", version=zou_version)
+            metrics = GunicornPrometheusMetrics(
+                app, defaults_prefix="zou", group_by="url_rule"
+            )
+        except ValueError:
+            from prometheus_flask_exporter import RESTfulPrometheusMetrics
+
+            metrics = RESTfulPrometheusMetrics(
+                app,
+                api,
+                defaults_prefix="zou",
+                group_by="url_rule",
+                metrics_decorator=permissions.require_admin,
+            )
+        metrics.info("zou_info", "Application info", version=zou_version)
 
     fs.mkdir_p(app.config["TMP_DIR"])
     configure_auth()

--- a/zou/app/config.py
+++ b/zou/app/config.py
@@ -135,6 +135,8 @@ SENTRY_DSN = os.getenv("SENTRY_DSN", False)
 SENTRY_SR = float(os.getenv("SENTRY_SR", 1.0))
 SENTRY_DEBUG_URL = os.getenv("SENTRY_DEBUG_URL", False)
 
+PROMETHEUS_METRICS_ENABLED = envtobool("PROMETHEUS_METRICS_ENABLED", False)
+
 CRISP_TOKEN = os.getenv("CRISP_TOKEN", "")
 
 DEFAULT_TIMEZONE = os.getenv("DEFAULT_TIMEZONE", "Europe/Paris")


### PR DESCRIPTION
… + admin auth

**Problem**
- We don't have any environment variable to enable / disable prometheus
- It's not possible to require admin auth for /metrics when it's in flask-restful

**Solution**
- Add an environment vairbale to enable / disable prometheus metrics : PROMETHEUS_METRICS_ENABLED
- require admin permissions for /metrics when it's in flask-restful
