### PR TITLE
Improve github actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,7 @@
 ---
 name: Zou CI
 
-on:
-  pull_request:
-    branches:
-      - master
-  push:
-    branches:
-      - master
+on: [push, pull_request]
 
 jobs:
   ci:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,43 +7,44 @@ on:
 
 jobs:
   build:
+    if: github.repository_owner == 'cgwire'
     name: Build
     runs-on: ubuntu-latest
     steps:
-    - name: Update Zou on staging server
-      uses: appleboy/ssh-action@v0.1.4
-      with:
-       host: ${{ secrets.HOST }}
-       username: ${{ secrets.USERNAME }}
-       key: ${{ secrets.KEY }}
-       port: ${{ secrets.PORT }}
-       script_stop: true
-       script: |
-         cd /opt/zou
-         source /etc/zou/zou.env
-         sudo /opt/zou/zouenv/bin/pip uninstall -y zou
-         sudo /opt/zou/zouenv/bin/pip install --upgrade git+https://github.com/cgwire/zou.git
-         sudo -E -u zou /opt/zou/zouenv/bin/zou upgrade-db
-         sudo systemctl restart zou zou-events zou-jobs
-    - uses: actions/checkout@v4
-      with:
-        ref: apidocs 
-    - name: Update openapi.json
-      run: |
-        cd docs
-        curl --output openapi.json https://kitsu-staging.cg-wire.com/api/openapi.json
-        git config --global user.email "no-reply@cg-wire.com"
-        git config --global user.name "CGWire bot"
-        git add openapi.json || false
-        git commit -m "Update openapi.json" || true
-    - name: Push changes
-      uses: ad-m/github-push-action@master
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        branch: apidocs
-    - name: Push on bump.sh
-      uses: bump-sh/github-action@v1
-      with:
-        doc: kitsu-api
-        token: ${{secrets.BUMP_TOKEN}}
-        file: docs/openapi.json
+      - name: Update Zou on staging server
+        uses: appleboy/ssh-action@v0.1.4
+        with:
+          host: ${{ secrets.HOST }}
+          username: ${{ secrets.USERNAME }}
+          key: ${{ secrets.KEY }}
+          port: ${{ secrets.PORT }}
+          script_stop: true
+          script: |
+            cd /opt/zou
+            source /etc/zou/zou.env
+            sudo /opt/zou/zouenv/bin/pip uninstall -y zou
+            sudo /opt/zou/zouenv/bin/pip install --upgrade git+https://github.com/cgwire/zou.git
+            sudo -E -u zou /opt/zou/zouenv/bin/zou upgrade-db
+            sudo systemctl restart zou zou-events zou-jobs
+      - uses: actions/checkout@v4
+        with:
+          ref: apidocs
+      - name: Update openapi.json
+        run: |
+          cd docs
+          curl --output openapi.json https://kitsu-staging.cg-wire.com/api/openapi.json
+          git config --global user.email "no-reply@cg-wire.com"
+          git config --global user.name "CGWire bot"
+          git add openapi.json || false
+          git commit -m "Update openapi.json" || true
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: apidocs
+      - name: Push on bump.sh
+        uses: bump-sh/github-action@v1
+        with:
+          doc: kitsu-api
+          token: ${{secrets.BUMP_TOKEN}}
+          file: docs/openapi.json


### PR DESCRIPTION
**Problem**
- For ci.yml the tests are not launched on every branch, only on master.
- For main.yml that update the api specs it's launched on forks, it always fail due to a lack of secrets.

**Solution**
- For ci.yml launch the tests jobs on every branch. 
- For main.yml update the api specs only on the master repo (cgwire/zou)
