### PR TITLE
Simple AD fixes

### DIFF
--- a/zou/app/services/auth_service.py
+++ b/zou/app/services/auth_service.py
@@ -180,7 +180,7 @@ def ldap_auth_strategy(person, password, app):
         try:
             SSL = app.config["LDAP_SSL"]
             if app.config["LDAP_IS_AD_SIMPLE"]:
-                user = f"CN={person['full_name']},{app.config['LDAP_BASE_DN']}"
+                user = f"sAMAccountName={person['desktop_login']},{app.config['LDAP_BASE_DN']}"
                 authentication = SIMPLE
             elif app.config["LDAP_IS_AD"]:
                 user = (

--- a/zou/app/utils/commands.py
+++ b/zou/app/utils/commands.py
@@ -243,8 +243,10 @@ def sync_with_ldap_server():
             if (
                 clean_value(entry.sAMAccountName if is_ad else entry.uid)
                 not in excluded_accounts
-                and group_members is None
-                or entry.entry_dn in group_members
+                and (
+                    group_members is None
+                    or entry.entry_dn in group_members
+                )
             ):
                 if is_ad:
                     ldap_uid = clean_value(entry.objectGUID)


### PR DESCRIPTION
**Problem**
Simple AD authentication is using different attributes for user creation (sAMAccountname) and authentication (CN).
CN in combination with `full_name` only resolves properly when user admins follow a schema using spaces, which is not guaranteed and should therefore be avoided.
Addionally: When using LDAP_GROUP, there was a bug in the condition structure that led to None being iterated.

**Solution**
sAMAccountname should be used when logging in, since the attribute is stored as `desktop_login`.
This provides consistency and guarantees successful authentication, no matter which user naming schema is used.
