### PR TITLE
use cn for simple ad user creation and auth

### DIFF
--- a/zou/app/services/auth_service.py
+++ b/zou/app/services/auth_service.py
@@ -180,7 +180,7 @@ def ldap_auth_strategy(person, password, app):
         try:
             SSL = app.config["LDAP_SSL"]
             if app.config["LDAP_IS_AD_SIMPLE"]:
-                user = f"sAMAccountName={person['desktop_login']},{app.config['LDAP_BASE_DN']}"
+                user = f"cn={person['desktop_login']},{app.config['LDAP_BASE_DN']}"
                 authentication = SIMPLE
             elif app.config["LDAP_IS_AD"]:
                 user = (


### PR DESCRIPTION
**Problem**
The previous change proved to not work with all AD server setups in production.
Binding with *sAMAccountName* lead to problems depending on the directory.

**Solution**
Use CN for binding again. Store CN as `desktop_login` on user creation. Although CN is not unique by design, it can be considered unique in the Zou context since it is appended to a single LDAP_BASE_DN. Ambiguous requests are practically impossible and it should be safe for user identification. In the worst case, email is always available as identifier.
Regular (non-SIMPLE) AD remains untouched.
I thoroughly tested this against our production directory servers this time.
