### PR TITLE
display_aspect_ratio of video file may not exist

### DIFF
--- a/zou/utils/movie.py
+++ b/zou/utils/movie.py
@@ -168,10 +168,20 @@ def get_movie_fps(movie_path=None, video_track=None):
 
 def get_movie_display_aspect_ratio(movie_path=None, video_track=None):
     """
-    Returns movie display aspect ratio (width / height).
+    Returns movie display aspect ratio, if display aspect ratio
+    is not set, fallback on width / height.
     """
-    width, height = get_movie_size(movie_path=movie_path, video_track=video_track)
-    ratio = width / height
+    if video_track is None:
+        video_track = get_video_track(
+            movie_path, "get_movie_display_aspect_ratio"
+        )
+    ratio = 1
+    if video_track is not None:
+        try:
+            width, height = video_track["display_aspect_ratio"].split(":")
+        except KeyError:
+            width, height = video_track["width"], video_track["height"]
+        ratio = float(width) / float(height)
     return ratio
 
 

--- a/zou/utils/movie.py
+++ b/zou/utils/movie.py
@@ -170,10 +170,8 @@ def get_movie_display_aspect_ratio(movie_path=None, video_track=None):
     """
     Returns movie display aspect ratio (width / height).
     """
-    ratio = 1
-    if video_track is not None:
-        width, height = get_movie_size(movie_path=movie_path, video_track=video_track)
-        ratio = width / height
+    width, height = get_movie_size(movie_path=movie_path, video_track=video_track)
+    ratio = width / height
     return ratio
 
 

--- a/zou/utils/movie.py
+++ b/zou/utils/movie.py
@@ -170,14 +170,10 @@ def get_movie_display_aspect_ratio(movie_path=None, video_track=None):
     """
     Returns movie display aspect ratio (width / height).
     """
-    if video_track is None:
-        video_track = get_video_track(
-            movie_path, "get_movie_display_aspect_ratio"
-        )
     ratio = 1
     if video_track is not None:
-        width, height = video_track["display_aspect_ratio"].split(":")
-        ratio = float(width) / float(height)
+        width, height = get_movie_size(movie_path=movie_path, video_track=video_track)
+        ratio = width / height
     return ratio
 
 


### PR DESCRIPTION
**Problem**

In some cases, the `display_aspect_ratio` property is not set in video files, and FFprobe does not compute it, leading to the crash of the `get_movie_display_aspect_ratio` method.

**Solution**

Compute the aspect ratio using the video resolution.
