### PR TITLE
[login] on login set cookies for mobile browsers (chrome)

### DIFF
--- a/zou/app/blueprints/auth/resources.py
+++ b/zou/app/blueprints/auth/resources.py
@@ -57,6 +57,7 @@ def is_from_browser(user_agent):
     return user_agent.browser in [
         "Brave",
         "Chrome",
+        "Chrome Mobile",
         "Edge",
         "Firefox",
         "Mobile Safari",


### PR DESCRIPTION
**Problem**
- We don't set cookies on login for chrome mobile browsers. (related to #732)

**Solution**
- Set cookies on login for chrome mobile.
