### PR TITLE
Fix zou sync_full_files command 

### DIFF
--- a/zou/app/services/preview_files_service.py
+++ b/zou/app/services/preview_files_service.py
@@ -732,8 +732,8 @@ def generate_preview_extra(
     only_shots=False,
     only_assets=False,
     force_regenerate_tiles=False,
-    with_tiles=True,
-    with_metadata=True,
+    with_tiles=False,
+    with_metadata=False,
     with_thumbnails=False,
 ):
     """
@@ -771,7 +771,7 @@ def generate_preview_extra(
         )
 
     total = query.count()
-    print(f"{total} previews found")
+    print(f"{total} previews found.")
     for index, preview_file in enumerate(query.all()):
         preview_file_id = str(preview_file.id)
         prefix = "previews" if preview_file.extension == "mp4" else "original"
@@ -810,11 +810,8 @@ def generate_preview_extra(
                 and not preview_file_already_in_cache
             ):
                 try:
-                    print(
-                        f"Removing preview file from cache: {preview_file_path}"
-                    )
                     os.remove(preview_file_path)
-                except Exception:
+                except OSError:
                     pass
 
     print("Extra information generated.")
@@ -836,7 +833,7 @@ def _retrieve_preview_file(config, file_store, prefix, preview_file):
             preview_file.extension,
         )
     except Exception as e:
-        print(f"Failed to get preview file {preview_file.id}: {e}")
+        print(f"Failed to get preview file {preview_file.id}: {e}.")
         return None
     return preview_file_path
 
@@ -850,10 +847,10 @@ def _generate_thumbnails(preview_file, preview_file_path, total, index):
             preview_file.id, original_picture_path, with_original=False
         )
         print(
-            f"{total}/{index} Thumbnails generated for {preview_file.id}",
+            f"{index}/{total} Thumbnails generated for {preview_file.id}.",
         )
     except Exception as e:
-        print(f"Failed to generate thumbnails for {preview_file.id}: {e}")
+        print(f"Failed to generate thumbnails for {preview_file.id}: {e}.")
 
 
 def _generate_tiles(
@@ -861,18 +858,18 @@ def _generate_tiles(
 ):
     try:
         if preview_file.extension == "mp4" and (
-            not file_store.exists_picture("tiles", str(preview_file.id))
-            or force
+            force
+            or not file_store.exists_picture("tiles", str(preview_file.id))
         ):
             tile_path = movie.generate_tile(preview_file_path)
             file_store.add_picture("tiles", preview_file.id, tile_path)
             os.remove(tile_path)
         print(
-            f"{total}/{index} Tile generated for {preview_file.id}",
+            f"{index}/{total} Tile generated for {preview_file.id}.",
         )
     except Exception as e:
         print(
-            f"Failed to generate tile for preview file {preview_file.id}: {e}"
+            f"Failed to generate tile for preview file {preview_file.id}: {e}."
         )
 
 
@@ -900,9 +897,9 @@ def _reset_preview_file_metadata(
             },
         )
         print(
-            f"{total}/{index} Size information stored for {preview_file.id}",
+            f"{index}/{total} Size information stored for {preview_file.id}.",
         )
     except Exception as e:
         print(
-            f"Failed to store information for preview file {preview_file.id}: {e}",
+            f"Failed to store information for preview file {preview_file.id}: {e}.",
         )

--- a/zou/app/services/preview_files_service.py
+++ b/zou/app/services/preview_files_service.py
@@ -847,7 +847,7 @@ def _generate_thumbnails(preview_file, preview_file_path, total, index):
             preview_file.id, original_picture_path, with_original=False
         )
         print(
-            f"{index}/{total} Thumbnails generated for {preview_file.id}.",
+            f"{index:0{len(str(total))}}/{total} Thumbnails generated for {preview_file.id}.",
         )
     except Exception as e:
         print(f"Failed to generate thumbnails for {preview_file.id}: {e}.")
@@ -865,7 +865,7 @@ def _generate_tiles(
             file_store.add_picture("tiles", preview_file.id, tile_path)
             os.remove(tile_path)
         print(
-            f"{index}/{total} Tile generated for {preview_file.id}.",
+            f"{index:0{len(str(total))}}/{total} Tile generated for {preview_file.id}.",
         )
     except Exception as e:
         print(
@@ -897,7 +897,7 @@ def _reset_preview_file_metadata(
             },
         )
         print(
-            f"{index}/{total} Size information stored for {preview_file.id}.",
+            f"{index:0{len(str(total))}}/{total} Size information stored for {preview_file.id}.",
         )
     except Exception as e:
         print(

--- a/zou/app/services/sync_service.py
+++ b/zou/app/services/sync_service.py
@@ -927,7 +927,7 @@ def download_thumbnail_from_another_instance(
         force,
     )
     logger.info(
-        f"{index}/{total} Thumbnail {model_name} file {model_id} processed."
+        f"{index:0{len(str(total))}}/{total} Thumbnail {model_name} file {model_id} processed."
     )
 
 
@@ -1076,7 +1076,9 @@ def download_preview_from_another_instance(
             force,
         )
 
-    logger.info(f"{index}/{total} Preview file {preview_file_id} processed.")
+    logger.info(
+        f"{index:0{len(str(total))}}/{total} Preview file {preview_file_id} processed."
+    )
 
 
 def download_preview_background_from_another_instance(
@@ -1110,7 +1112,7 @@ def download_preview_background_from_another_instance(
             force,
         )
         logger.info(
-            f"{index}/{total} Preview background file {preview_background_file_id} processed."
+            f"{index:0{len(str(total))}}/{total} Preview background file {preview_background_file_id} processed."
         )
 
 
@@ -1174,7 +1176,7 @@ def download_attachment_file_from_another_instance(
         force,
     )
     logger.info(
-        f"{index}/{total} Attachment file {attachment_file_id} processed."
+        f"{index:0{len(str(total))}}/{total} Attachment file {attachment_file_id} processed."
     )
 
 

--- a/zou/app/services/sync_service.py
+++ b/zou/app/services/sync_service.py
@@ -927,7 +927,7 @@ def download_thumbnail_from_another_instance(
         force,
     )
     logger.info(
-        f"Thumbnail {model_name} file {model_id} processed ({index}/{total})."
+        f"{index}/{total} Thumbnail {model_name} file {model_id} processed."
     )
 
 
@@ -1076,7 +1076,7 @@ def download_preview_from_another_instance(
             force,
         )
 
-    logger.info(f"Preview file {preview_file_id} processed ({index}/{total}).")
+    logger.info(f"{index}/{total} Preview file {preview_file_id} processed.")
 
 
 def download_preview_background_from_another_instance(
@@ -1110,7 +1110,7 @@ def download_preview_background_from_another_instance(
             force,
         )
         logger.info(
-            f"Preview background file {preview_background_file_id} processed ({index}/{total})."
+            f"{index}/{total} Preview background file {preview_background_file_id} processed."
         )
 
 
@@ -1174,7 +1174,7 @@ def download_attachment_file_from_another_instance(
         force,
     )
     logger.info(
-        f"Attachment file {attachment_file_id} processed ({index}/{total})."
+        f"{index}/{total} Attachment file {attachment_file_id} processed."
     )
 
 

--- a/zou/app/utils/commands.py
+++ b/zou/app/utils/commands.py
@@ -541,23 +541,20 @@ def import_files_from_another_instance(
     multithreaded=False,
     number_workers=30,
     number_attemps=3,
+    force_resync=False,
 ):
     """
     Retrieve and save all the data related most recent events from another API
     instance. It doesn't change the IDs.
     """
     with app.app_context():
-        if multithreaded:
-            # allow poolsize in swift client HTTPSession to allow more than 10 simultaneous connections.
-            from requests import adapters
-
-            adapters.DEFAULT_POOLSIZE = number_workers
         sync_service.init(source, login, password)
         sync_service.download_files_from_another_instance(
             project=project,
             multithreaded=multithreaded,
             number_workers=number_workers,
             number_attemps=number_attemps,
+            force_resync=force_resync,
         )
 
 

--- a/zou/app/utils/commands.py
+++ b/zou/app/utils/commands.py
@@ -638,8 +638,8 @@ def generate_preview_extra(
     only_shots=False,
     only_assets=False,
     force_regenerate_tiles=False,
-    with_tiles=True,
-    with_metadata=True,
+    with_tiles=False,
+    with_metadata=False,
     with_thumbnails=False,
 ):
     with app.app_context():

--- a/zou/app/utils/commands.py
+++ b/zou/app/utils/commands.py
@@ -548,7 +548,9 @@ def import_files_from_another_instance(
     instance. It doesn't change the IDs.
     """
     with app.app_context():
-        sync_service.init(source, login, password)
+        sync_service.init(
+            source, login, password, multithreaded, number_workers
+        )
         sync_service.download_files_from_another_instance(
             project=project,
             multithreaded=multithreaded,

--- a/zou/cli.py
+++ b/zou/cli.py
@@ -292,13 +292,20 @@ def sync_full(
 
 @cli.command()
 @click.option("--source", default="http://localhost:5000", show_default=True)
+@click.option("--project", default=None, show_default=True)
 @click.option(
     "--multithreaded", is_flag=True, show_default=True, default=False
 )
 @click.option("--number-workers", default=30, show_default=True, type=int)
 @click.option("--number-attemps", default=3, show_default=True, type=int)
+@click.option("--force-resync", is_flag=True, show_default=True, default=False)
 def sync_full_files(
-    source, multithreaded, number_workers, number_attemps, project=None
+    source,
+    project,
+    multithreaded,
+    number_workers,
+    number_attemps,
+    force_resync,
 ):
     """
     Retrieve all files from source instance. It expects that credentials to
@@ -316,6 +323,7 @@ def sync_full_files(
         multithreaded=multithreaded,
         number_workers=number_workers,
         number_attemps=number_attemps,
+        force_resync=force_resync,
     )
     print("Syncing ended.")
 

--- a/zou/cli.py
+++ b/zou/cli.py
@@ -473,9 +473,9 @@ def search_asset(query):
 @click.option("--episode-id", default=None, show_default=True)
 @click.option("--only-shots", is_flag=True, default=False, show_default=True)
 @click.option("--only-assets", is_flag=True, default=False, show_default=True)
-@click.option("--with-tiles", is_flag=True, default=False, show_default=True)
+@click.option("--with-tiles", is_flag=False, default=True, show_default=True)
 @click.option(
-    "--with-metadata", is_flag=True, default=False, show_default=True
+    "--with-metadata", is_flag=False, default=True, show_default=True
 )
 @click.option(
     "--with-thumbnails", is_flag=True, default=False, show_default=True


### PR DESCRIPTION
**Problem**
- sync_full_files command use wrong paths to get files from source instance. 
- there's no progression for sync_full_files.
- there's no option to force redownload for sync_full_files.

**Solution**
- Fix sync_full_files command paths for getting previews on source instance.
- Add a progression for sync_full_files. 
- Add an option to force redownload for sync_full_files.