### PR TITLE
Allow to paginate entity links via a created_at cursor.

### DIFF
--- a/tests/breakdown/test_routes.py
+++ b/tests/breakdown/test_routes.py
@@ -125,3 +125,29 @@ class BreakdownServiceTestCase(ApiDBTestCase):
         self.asset.update({"source_id": self.episode_id})
         assets = self.get("/data/assets?episode_id=%s" % self.episode_id)
         self.assertEqual(len(assets), 3)
+
+    def test_get_project_entity_links(self):
+        for i in range(10):
+            shot = self.generate_fixture_shot(f"SH00{i}")
+            new_casting = [
+                {"asset_id": self.asset_id, "nb_occurences": 1},
+                {"asset_id": self.asset_character_id, "nb_occurences": 1},
+            ]
+            self.put(
+                "/data/projects/%s/entities/%s/casting"
+                % (self.project_id, shot.id),
+                new_casting,
+            )
+        alllinks = self.get(
+            "/data/projects/%s/entity-links?limit=100" % self.project_id
+        )
+        self.assertEqual(len(alllinks), 22)
+
+        url = "/data/projects/%s/entity-links" % self.project_id
+        query = "?cursor_created_at=%s&limit=10" % alllinks[9]["created_at"]
+        links = self.get(url + query)["data"]
+        self.assertEqual(len(links), 10)
+        query = "?cursor_created_at=%s&limit=10" % links[9]["created_at"]
+        links = self.get(url + query)["data"]
+        self.assertEqual(len(links), 2)
+        self.assertEqual(links[1]["id"], alllinks[21]["id"])

--- a/zou/app/blueprints/breakdown/resources.py
+++ b/zou/app/blueprints/breakdown/resources.py
@@ -377,6 +377,10 @@ class ProjectEntityLinksResource(Resource, ArgsMixin):
     def get(self, project_id):
         """
         Retrieve all entity links related to given project.
+
+        Results can be paginated using page and limit query parameters. If you
+        prefer a more accurate pagination, you can use and
+        cursor_created_at to get the next page.
         ---
         tags:
           - Breakdown
@@ -388,6 +392,24 @@ class ProjectEntityLinksResource(Resource, ArgsMixin):
             type: string
             format: UUID
             x-example: a24a6ea4-ce75-4665-a070-57453082c25
+          - in: query
+            name: page
+            required: False
+            type: string
+            format: Number
+            x-example: 2
+          - in: limit
+            name: page
+            required: False
+            type: string
+            format: Number
+            x-example: 100
+          - in: cursor_created_at
+            name: page
+            required: False
+            type: string
+            format: Datetime
+            x-example: 2020-01-01T00:00:00
         responses:
             200:
                 description: All entity links related to given project
@@ -396,8 +418,12 @@ class ProjectEntityLinksResource(Resource, ArgsMixin):
         projects_service.get_project(project_id)
         page = self.get_page()
         limit = self.get_limit()
+        cursor_created_at = self.get_text_parameter("cursor_created_at")
         return entities_service.get_entity_links_for_project(
-            project_id, page, limit
+            project_id,
+            page=page,
+            limit=limit,
+            cursor_created_at=cursor_created_at,
         )
 
 

--- a/zou/app/blueprints/entities/resources.py
+++ b/zou/app/blueprints/entities/resources.py
@@ -1,4 +1,5 @@
 from flask_restful import Resource
+
 from flask_jwt_extended import jwt_required
 
 from zou.app.services import (

--- a/zou/app/blueprints/tasks/resources.py
+++ b/zou/app/blueprints/tasks/resources.py
@@ -1,5 +1,6 @@
 import datetime
 
+
 from flask import abort, request
 from flask_restful import Resource
 from flask_jwt_extended import jwt_required

--- a/zou/app/models/notification.py
+++ b/zou/app/models/notification.py
@@ -1,4 +1,5 @@
 from sqlalchemy_utils import UUIDType, ChoiceType
+
 from sqlalchemy.inspection import inspect
 
 from zou.app import db
@@ -60,10 +61,13 @@ class Notification(db.Model, BaseMixin, SerializerMixin):
         ),
     )
 
-    def serialize(self, obj_type=None, relations=False):
+    def serialize(self, obj_type=None, relations=False, milliseconds=False):
         attrs = inspect(self).attrs.keys()
         obj_dict = {
-            attr: serialize_value(getattr(self, attr)) for attr in attrs
+            attr: serialize_value(
+                getattr(self, attr), milliseconds=milliseconds
+            )
+            for attr in attrs
         }
         obj_dict["notification_type"] = obj_dict["type"]
         obj_dict["type"] = obj_type or type(self).__name__

--- a/zou/app/models/person.py
+++ b/zou/app/models/person.py
@@ -108,14 +108,20 @@ class Person(db.Model, BaseMixin, SerializerMixin):
                 for credential in self.fido_credentials
             ]
 
-    def serialize(self, obj_type="Person", relations=False):
-        data = SerializerMixin.serialize(self, "Person", relations=relations)
+    def serialize(
+        self, obj_type="Person", relations=False, milliseconds=False
+    ):
+        data = SerializerMixin.serialize(
+            self, "Person", relations=relations, milliseconds=milliseconds
+        )
         data["full_name"] = self.full_name()
         data["fido_devices"] = self.fido_devices()
         return data
 
-    def serialize_safe(self, relations=False):
-        data = SerializerMixin.serialize(self, "Person", relations=relations)
+    def serialize_safe(self, relations=False, milliseconds=False):
+        data = SerializerMixin.serialize(
+            self, "Person", relations=relations, milliseconds=milliseconds
+        )
         data["full_name"] = self.full_name()
         data["fido_devices"] = self.fido_devices()
         del data["password"]
@@ -125,8 +131,10 @@ class Person(db.Model, BaseMixin, SerializerMixin):
         del data["fido_credentials"]
         return data
 
-    def present_minimal(self, relations=False):
-        data = SerializerMixin.serialize(self, "Person", relations=relations)
+    def present_minimal(self, relations=False, milliseconds=False):
+        data = SerializerMixin.serialize(
+            self, "Person", relations=relations, milliseconds=milliseconds
+        )
         return {
             "id": data["id"],
             "first_name": data["first_name"],

--- a/zou/app/models/serializer.py
+++ b/zou/app/models/serializer.py
@@ -14,15 +14,20 @@ class SerializerMixin(object):
             orm.attributes.CollectionAttributeImpl,
         )
 
-    def serialize(self, obj_type=None, relations=False):
+    def serialize(self, obj_type=None, relations=False, milliseconds=False):
         attrs = inspect(self).attrs.keys()
         if relations:
             obj_dict = {
-                attr: serialize_value(getattr(self, attr)) for attr in attrs
+                attr: serialize_value(
+                    getattr(self, attr), milliseconds=milliseconds
+                )
+                for attr in attrs
             }
         else:
             obj_dict = {
-                attr: serialize_value(getattr(self, attr))
+                attr: serialize_value(
+                    getattr(self, attr), milliseconds=milliseconds
+                )
                 for attr in attrs
                 if not self.is_join(attr)
             }
@@ -30,8 +35,14 @@ class SerializerMixin(object):
         return obj_dict
 
     @staticmethod
-    def serialize_list(models, obj_type=None, relations=False):
+    def serialize_list(
+        models, obj_type=None, relations=False, milliseconds=False
+    ):
         return [
-            model.serialize(obj_type=obj_type, relations=relations)
+            model.serialize(
+                obj_type=obj_type,
+                relations=relations,
+                milliseconds=milliseconds,
+            )
             for model in models
         ]

--- a/zou/app/services/preview_files_service.py
+++ b/zou/app/services/preview_files_service.py
@@ -100,6 +100,7 @@ def get_project_from_preview_file(preview_file_id):
     Get project dict of related preview file.
     """
     preview_file = files_service.get_preview_file_raw(preview_file_id)
+
     task = Task.get(preview_file.task_id)
     project = Project.get(task.project_id)
     return project.serialize()

--- a/zou/app/services/preview_files_service.py
+++ b/zou/app/services/preview_files_service.py
@@ -864,9 +864,10 @@ def _generate_tiles(
             tile_path = movie.generate_tile(preview_file_path)
             file_store.add_picture("tiles", preview_file.id, tile_path)
             os.remove(tile_path)
-        print(
-            f"{index:0{len(str(total))}}/{total} Tile generated for {preview_file.id}.",
-        )
+            print(
+                f"{index:0{len(str(total))}}/{total} Tile "
+                + "generated for {preview_file.id}.",
+            )
     except Exception as e:
         print(
             f"Failed to generate tile for preview file {preview_file.id}: {e}."

--- a/zou/app/services/tasks_service.py
+++ b/zou/app/services/tasks_service.py
@@ -661,6 +661,7 @@ def _build_preview_map_for_comments(comment_ids, is_client=False):
                     "extension": preview.extension,
                     "width": preview.width,
                     "height": preview.height,
+                    "duration": preview.duration,
                     "status": status,
                     "validation_status": validation_status,
                     "original_name": preview.original_name,

--- a/zou/app/utils/date_helpers.py
+++ b/zou/app/utils/date_helpers.py
@@ -18,6 +18,13 @@ def get_date_diff(date_a, date_b):
     return abs((date_b - date_a).total_seconds())
 
 
+def get_date_string(date_obj, milliseconds=False):
+    if milliseconds:
+        return date_obj.strftime("%Y-%m-%dT%H:%M:%S.%f")
+    else:
+        return date_obj.strftime("%Y-%m-%dT%H:%M:%S")
+
+
 def get_date_string_with_timezone(date_string, timezone):
     """
     Apply given timezone to given date and return it as a string.
@@ -54,11 +61,14 @@ def get_date_from_string(date_str):
     return datetime.strptime(date_str, "%Y-%m-%d")
 
 
-def get_datetime_from_string(date_str):
+def get_datetime_from_string(date_str, milliseconds=False):
     """
     Parse a datetime string and returns a datetime object.
     """
-    return datetime.strptime(date_str, "%Y-%m-%dT%H:%M:%S")
+    if milliseconds:
+        return datetime.strptime(date_str, "%Y-%m-%dT%H:%M:%S.%f")
+    else:
+        return datetime.strptime(date_str, "%Y-%m-%dT%H:%M:%S")
 
 
 def get_year_interval(year):

--- a/zou/app/utils/fields.py
+++ b/zou/app/utils/fields.py
@@ -8,14 +8,19 @@ from babel import Locale
 from ipaddress import IPv4Address
 from sqlalchemy_utils.types.choice import Choice
 
+from zou.app.utils import date_helpers
 
-def serialize_value(value):
+
+def serialize_value(value, milliseconds=False):
     """
     Utility function to handle the normalizing of specific fields.
     The aim is to make the result JSON serializable
     """
     if isinstance(value, datetime.datetime):
-        return value.replace(microsecond=0).isoformat()
+        if milliseconds:
+            return value.isoformat()
+        else:
+            return value.replace(microsecond=0).isoformat()
     if isinstance(value, datetime.date):
         return value.isoformat()
     elif isinstance(value, uuid.UUID):
@@ -74,12 +79,12 @@ def serialize_orm_arrays(array_value):
     return [serialize_value(val.id) for val in array_value]
 
 
-def serialize_models(models, relations=False):
+def serialize_models(models, relations=False, milliseconds=False):
     """
     Serialize a list of models (useful for json dumping)
     """
     return [
-        model.serialize(relations=relations)
+        model.serialize(relations=relations, milliseconds=milliseconds)
         for model in models
         if model is not None
     ]

--- a/zou/app/utils/query.py
+++ b/zou/app/utils/query.py
@@ -67,6 +67,32 @@ def get_paginated_results(query, page, limit=None, relations=False):
         return result
 
 
+def get_cursor_results(
+    model,
+    query,
+    cursor_created_at,
+    limit=None,
+    relations=False,
+):
+    """ """
+    limit = limit or app.config["NB_RECORDS_PER_PAGE"]
+    total = query.count()
+    query = (
+        query.filter(model.created_at > cursor_created_at)
+        .order_by(model.created_at)
+        .limit(limit)
+    )
+    models = fields.serialize_models(
+        query.all(), relations=relations, milliseconds=True
+    )
+    result = {
+        "data": models,
+        "total": total,
+        "limit": limit,
+    }
+    return result
+
+
 def apply_sort_by(model, query, sort_by):
     """
     Apply an order by clause to a sqlalchemy query from a string parameter.

--- a/zou/cli.py
+++ b/zou/cli.py
@@ -27,6 +27,16 @@ def cli():
 
 
 @cli.command()
+def version():
+    """
+    Returns current installation version.
+    """
+    from zou import __version__
+
+    print(f"Zou version: {__version__}")
+
+
+@cli.command()
 def init_db():
     "Creates datababase table (database must be created through PG client)."
 


### PR DESCRIPTION
**Problem**

The pagination for entity links is broken due to the offset/limit limitations and the big numbers of entries to return (especially when rows are added or removed during the querying).

**Solution**

Allow to get the next page based on the created_at field (microseconds precision).
