### PR TITLE
various improvements

### DIFF
--- a/zou/app/blueprints/source/csv/base.py
+++ b/zou/app/blueprints/source/csv/base.py
@@ -147,7 +147,9 @@ class BaseCsvProjectImportResource(BaseCsvImportResource, ArgsMixin):
         self.check_project_permissions(project_id)
         self.prepare_import(project_id, **kwargs)
         with open(file_path) as csvfile:
-            reader = csv.DictReader(csvfile, dialect=self.get_dialect(csvfile))
+            dialect = self.get_dialect(csvfile)
+            dialect.doublequote = True
+            reader = csv.DictReader(csvfile, dialect=dialect)
             line_number = 1
             for row in reader:
                 try:

--- a/zou/app/blueprints/source/csv/casting.py
+++ b/zou/app/blueprints/source/csv/casting.py
@@ -105,7 +105,9 @@ class CastingCsvImportResource(BaseCsvProjectImportResource):
         asset_id = self.asset_map.get(asset_key, None)
         target_id = self.shot_map.get(target_key, None)
         if target_id is None:
-            target_id = self.asset_map.get(target_key, None)
+            target_id = self.asset_map.get(
+                slugify(f"{row['Parent']}{row['Name']}"), None
+            )
             if target_id is None:
                 target_id = self.episode_name_map.get(target_key, None)
 

--- a/zou/cli.py
+++ b/zou/cli.py
@@ -473,9 +473,9 @@ def search_asset(query):
 @click.option("--episode-id", default=None, show_default=True)
 @click.option("--only-shots", is_flag=True, default=False, show_default=True)
 @click.option("--only-assets", is_flag=True, default=False, show_default=True)
-@click.option("--with-tiles", is_flag=False, default=True, show_default=True)
+@click.option("--with-tiles", is_flag=True, default=False, show_default=True)
 @click.option(
-    "--with-metadata", is_flag=False, default=True, show_default=True
+    "--with-metadata", is_flag=True, default=False, show_default=True
 )
 @click.option(
     "--with-thumbnails", is_flag=True, default=False, show_default=True


### PR DESCRIPTION
**Problem**
- When importing a casting of assets in a TV Show assets are not recognized due to episodes. 
- It's not possible to import csv with doublequoting (to allow to use the quoting character).
- CLI : for generetate-preview-extra : -with-metadata and --with-tiles are not correctly set as flag. 

**Solution**
- When importing a casting of assets in a TV Show assets ignore episodes in the target_key (assets are unique by name for a production). 
- It's now possible to import csv with doublequoting (to allow to use the quoting character).
- CLI : for generetate-preview-extra : -with-metadata and --with-tiles are now correctly set as flag. 
