### PR TITLE
various improvements

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -61,7 +61,7 @@ install_requires =
     orjson==3.9.10
     pillow==10.1.0
     psutil==5.9.6
-    psycopg[binary]==3.1.12
+    psycopg[binary]==3.1.13
     pyotp==2.9.0
     python-nomad==2.0.0
     python-slugify==8.0.1
@@ -100,7 +100,7 @@ test =
 monitoring =
     prometheus-flask-exporter==0.23.0
     pygelf==0.4.2
-    sentry-sdk==1.35.0
+    sentry-sdk==1.38.0
 
 lint =
     black==23.11.0

--- a/zou/app/blueprints/source/edl.py
+++ b/zou/app/blueprints/source/edl.py
@@ -117,6 +117,11 @@ class EDLBaseResource(Resource, ArgsMixin):
     def run_import(self, project_id, file_path):
         result = {"updated_shots": [], "created_shots": []}
         try:
+            with open(file_path, "r+", errors="replace") as edl_file:
+                contents = edl_file.read()
+                edl_file.seek(0)
+                edl_file.write(contents)
+
             timeline = otio.adapters.read_from_file(
                 file_path,
                 rate=projects_service.get_project_fps(project_id),
@@ -210,9 +215,6 @@ class EDLBaseResource(Resource, ArgsMixin):
                             shot_id, future_shot_values
                         )
                         result["updated_shots"].append(shot)
-
-                if isinstance(track, otio.schema.Transition):
-                    pass
 
         for task_type in self.task_types_in_project_for_shots:
             create_tasks(task_type.serialize(), result["created_shots"])

--- a/zou/app/utils/commands.py
+++ b/zou/app/utils/commands.py
@@ -551,7 +551,7 @@ def import_files_from_another_instance(
         sync_service.init(
             source, login, password, multithreaded, number_workers
         )
-        sync_service.download_files_from_another_instance(
+        return sync_service.download_files_from_another_instance(
             project=project,
             multithreaded=multithreaded,
             number_workers=number_workers,

--- a/zou/app/utils/commands.py
+++ b/zou/app/utils/commands.py
@@ -632,9 +632,9 @@ def search_asset(query):
 
 
 def generate_preview_extra(
-    project_id=None,
+    project=None,
     entity_id=None,
-    episode_id=None,
+    episodes=[],
     only_shots=False,
     only_assets=False,
     force_regenerate_tiles=False,
@@ -644,9 +644,9 @@ def generate_preview_extra(
 ):
     with app.app_context():
         preview_files_service.generate_preview_extra(
-            project_id=project_id,
+            project=project,
             entity_id=entity_id,
-            episode_id=episode_id,
+            episodes=episodes,
             only_shots=only_shots,
             only_assets=only_assets,
             force_regenerate_tiles=force_regenerate_tiles,

--- a/zou/cli.py
+++ b/zou/cli.py
@@ -478,9 +478,9 @@ def search_asset(query):
 
 
 @cli.command()
-@click.option("--project-id", default=None, show_default=True)
+@click.option("--project", default=None, show_default=True)
 @click.option("--entity-id", default=None, show_default=True)
-@click.option("--episode-id", default=None, show_default=True)
+@click.option("--episode", default=None, show_default=True, multiple=True)
 @click.option("--only-shots", is_flag=True, default=False, show_default=True)
 @click.option("--only-assets", is_flag=True, default=False, show_default=True)
 @click.option("--with-tiles", is_flag=True, default=False, show_default=True)
@@ -494,9 +494,9 @@ def search_asset(query):
     "--force-regenerate-tiles", is_flag=True, default=False, show_default=True
 )
 def generate_preview_extra(
-    project_id,
+    project,
     entity_id,
-    episode_id,
+    episode,
     only_shots,
     only_assets,
     with_tiles,
@@ -508,9 +508,9 @@ def generate_preview_extra(
     Generate tiles, thumbnails and metadata for all previews.
     """
     commands.generate_preview_extra(
-        project_id=project_id,
+        project=project,
         entity_id=entity_id,
-        episode_id=episode_id,
+        episodes=episode,
         only_shots=only_shots,
         only_assets=only_assets,
         force_regenerate_tiles=force_regenerate_tiles,

--- a/zou/cli.py
+++ b/zou/cli.py
@@ -325,7 +325,7 @@ def sync_full_files(
     print("Start syncing.")
     login = os.getenv("SYNC_LOGIN")
     password = os.getenv("SYNC_PASSWORD")
-    commands.import_files_from_another_instance(
+    dict_errors = commands.import_files_from_another_instance(
         source,
         login,
         password,
@@ -336,6 +336,14 @@ def sync_full_files(
         force_resync=force_resync,
     )
     print("Syncing ended.")
+    if dict_errors:
+        print("Errors summary:")
+        for prefix, value in dict_errors.items():
+            print(f"{prefix}:")
+            for id, error in value.items():
+                print(f"{id}:\n{error}")
+            print()
+        sys.exit(1)
 
 
 @cli.command()

--- a/zou/utils/movie.py
+++ b/zou/utils/movie.py
@@ -29,13 +29,9 @@ EncodingParameters = namedtuple(
 def log_ffmpeg_error(e, action):
     logger.info(f"Error (in action {action}):")
     if e.stdout:
-        logger.info("stdout:")
-        logger.info(e.stdout.decode())
-        logger.info("======")
+        logger.info(f"stdout:\n{e.stdout.decode(errors='replace')}\n======")
     if e.stderr:
-        logger.error("stderr:")
-        logger.error(e.stderr.decode())
-        logger.error("======")
+        logger.error(f"stderr:\n{e.stderr.decode(errors='replace')}\n======")
 
 
 def save_file(tmp_folder, instance_id, file_to_save):


### PR DESCRIPTION
**Problem**
- CLI :  for generate_preview_extra it's not possible to set multiple episodes + for project and episode it's not possible to give a name instead of an id.
- When we log ffmpeg errors, errors can be undecodable.
- When we read an EDL file, some chars can be undecodable.
- Some libs are outdated : psycopg & sentry-sdk.
- CLI : for sync_full_files we don't have a summary of errors at the end of the sync. 

**Solution**
- CLI :  for generate_preview_extra it's allow to set multiple episodes + for project and episode allow to give a name instead of an id.
- When we log ffmpeg errors, replace undecodable chars.
- Replace undecodable chars in EDL file before passing file to OTIO.
- Upgrade some libs : psycopg & sentry-sdk.
- CLI : for sync_full_files add a summary of errors at the end of the sync. 
