### PR TITLE
Fix update filter

### DIFF
--- a/zou/app/blueprints/user/resources.py
+++ b/zou/app/blueprints/user/resources.py
@@ -615,7 +615,6 @@ class FilterResource(Resource, ArgsMixin):
                 ("search_filter_group_id", None, False),
             ]
         )
-        data = self.clear_empty_fields(data)
         user_filter = user_service.update_filter(filter_id, data)
         return user_filter, 200
 


### PR DESCRIPTION
**Problem**
- On updating filters, we can't unlink a filter from a filter group.

**Solution**
- Allow updating a filter without a group ID to unlink it from the group.

Example of payload:
```js
{
  name: "test",
  search_query: "test",
  search_filter_group_id: null
}
```
