### PR TITLE
various fixes

### DIFF
--- a/zou/app/blueprints/comments/resources.py
+++ b/zou/app/blueprints/comments/resources.py
@@ -180,6 +180,7 @@ class CommentTaskResource(Resource):
         task = tasks_service.get_task(task_id)
         user_service.check_project_access(task["project_id"])
         user_service.check_entity_access(task["entity_id"])
+        user_service.check_task_status_access(task_status_id)
         files = request.files
 
         if not permissions.has_manager_permissions():
@@ -384,6 +385,9 @@ class CommentManyTasksResource(Resource):
         result = []
         for comment in comments:
             try:
+                user_service.check_task_status_access(
+                    comment["task_status_id"]
+                )
                 comment = comments_service.create_comment(
                     person["id"],
                     comment["object_id"],

--- a/zou/app/blueprints/crud/comments.py
+++ b/zou/app/blueprints/crud/comments.py
@@ -104,7 +104,10 @@ class CommentResource(BaseModelResource):
         else:
             comment = self.get_model_or_404(instance["id"])
             current_user = persons_service.get_current_user()
-            return current_user["id"] == str(comment.person_id)
+            if current_user["id"] != str(comment.person_id):
+                raise permissions.PermissionDenied
+            user_service.check_task_status_access(data["task_status_id"])
+            return True
 
     def pre_delete(self, comment):
         task = tasks_service.get_task(comment["object_id"])

--- a/zou/app/models/project.py
+++ b/zou/app/models/project.py
@@ -65,7 +65,10 @@ class ProjectTaskStatusLink(db.Model, BaseMixin, SerializerMixin):
         primary_key=True,
     )
     priority = db.Column(db.Integer, default=None)
-    roles_for_board = db.Column(db.ARRAY(ChoiceType(ROLE_TYPES)))
+    roles_for_board = db.Column(
+        db.ARRAY(ChoiceType(ROLE_TYPES)),
+        default=["user", "admin", "supervisor", "manager", "vendor"],
+    )
 
     __table_args__ = (
         db.UniqueConstraint(

--- a/zou/app/services/comments_service.py
+++ b/zou/app/services/comments_service.py
@@ -175,7 +175,8 @@ def _manage_subscriptions(task, comment, status_changed):
 
 def _run_status_automation(automation, task, person_id):
     is_automation_to_run = (
-        task["task_type_id"] == automation["in_task_type_id"]
+        not automation["archived"]
+        and task["task_type_id"] == automation["in_task_type_id"]
         and task["task_status_id"] == automation["in_task_status_id"]
     )
     if not is_automation_to_run:

--- a/zou/app/services/user_service.py
+++ b/zou/app/services/user_service.py
@@ -439,6 +439,21 @@ def check_entity_access(entity_id):
     return is_allowed
 
 
+def check_task_status_access(task_status_id):
+    """
+    Return true if current user can use this task status.
+    """
+    is_artist = permissions.has_artist_permissions()
+    is_client = permissions.has_client_permissions()
+    if is_artist or is_client:
+        task_status = tasks_service.get_task_status(task_status_id)
+        if is_artist and not task_status["is_artist_allowed"]:
+            raise permissions.PermissionDenied
+        if is_client and not task_status["is_client_allowed"]:
+            raise permissions.PermissionDenied
+    return True
+
+
 def check_comment_access(comment_id):
     """
     Return true if current user can have access to a comment.

--- a/zou/app/utils/permissions.py
+++ b/zou/app/utils/permissions.py
@@ -7,6 +7,7 @@ manager_permission = Permission(RoleNeed("manager"))
 supervisor_permission = Permission(RoleNeed("supervisor"))
 client_permission = Permission(RoleNeed("client"))
 vendor_permission = Permission(RoleNeed("vendor"))
+artist_permission = Permission(RoleNeed("user"))
 
 
 class PermissionDenied(Forbidden):
@@ -18,6 +19,13 @@ def has_manager_permissions():
     Return True if user is an admin or a manager.
     """
     return admin_permission.can() or manager_permission.can()
+
+
+def has_artist_permissions():
+    """
+    Return True if user is an artist.
+    """
+    return artist_permission.can()
 
 
 def has_admin_permissions():

--- a/zou/migrations/versions/deeacd38d373_for_projecttaskstatuslink_set_default_.py
+++ b/zou/migrations/versions/deeacd38d373_for_projecttaskstatuslink_set_default_.py
@@ -1,0 +1,74 @@
+"""For ProjectTaskStatusLink set default roles_for_board
+
+Revision ID: deeacd38d373
+Revises: 20dfeb36142b
+Create Date: 2024-01-16 23:48:25.874470
+
+"""
+from alembic import op
+import sqlalchemy as sa
+import sqlalchemy_utils
+import uuid
+from sqlalchemy.orm.session import Session
+from sqlalchemy.ext.declarative import declarative_base
+from zou.migrations.utils.base import BaseMixin
+
+# revision identifiers, used by Alembic.
+revision = "deeacd38d373"
+down_revision = "20dfeb36142b"
+branch_labels = None
+depends_on = None
+
+base = declarative_base()
+
+ROLE_TYPES = [
+    ("user", "Artist"),
+    ("admin", "Studio Manager"),
+    ("supervisor", "Supervisor"),
+    ("manager", "Production Manager"),
+    ("client", "Client"),
+    ("vendor", "Vendor"),
+]
+
+
+class ProjectTaskStatusLink(base, BaseMixin):
+    __tablename__ = "project_task_status_link"
+    project_id = sa.Column(
+        sqlalchemy_utils.types.UUIDType(binary=False),
+        primary_key=True,
+    )
+    task_status_id = sa.Column(
+        sqlalchemy_utils.types.UUIDType(binary=False),
+        primary_key=True,
+    )
+    priority = sa.Column(sa.Integer, default=None)
+    roles_for_board = sa.Column(
+        sa.ARRAY(sqlalchemy_utils.types.choice.ChoiceType(ROLE_TYPES)),
+        default=["user", "admin", "supervisor", "manager", "vendor"],
+    )
+
+    __table_args__ = (
+        sa.UniqueConstraint(
+            "project_id", "task_status_id", name="project_taskstatus_uc"
+        ),
+    )
+
+
+def upgrade():
+    session = Session(bind=op.get_bind())
+    session.query(ProjectTaskStatusLink).update(
+        {
+            ProjectTaskStatusLink.roles_for_board: [
+                "user",
+                "admin",
+                "supervisor",
+                "manager",
+                "vendor",
+            ]
+        }
+    )
+    session.commit()
+
+
+def downgrade():
+    pass

--- a/zou/migrations/versions/feffd3c5b806_introduce_concepts.py
+++ b/zou/migrations/versions/feffd3c5b806_introduce_concepts.py
@@ -68,6 +68,12 @@ class TaskType(base, BaseMixin):
         UUIDType(binary=False), sa.ForeignKey("department.id"), index=True
     )
 
+    __table_args__ = (
+        sa.UniqueConstraint(
+            "name", "for_entity", "department_id", name="task_type_uc"
+        ),
+    )
+
 
 class Department(base, BaseMixin):
     """
@@ -119,9 +125,9 @@ def upgrade():
         is_artist_allowed=False,
         is_client_allowed=False,
     )
-    session.add(neutral_status)
-    session.add(approved_status)
-    session.add(rejected_status)
+    session.merge(neutral_status)
+    session.merge(approved_status)
+    session.merge(rejected_status)
 
     concept_department = (
         session.query(Department).filter_by(name="Concept").one_or_none()
@@ -136,7 +142,7 @@ def upgrade():
         else None,
         for_entity="Concept",
     )
-    session.add(task_type_concept)
+    session.merge(task_type_concept)
     session.commit()
 
     # ### end Alembic commands ###


### PR DESCRIPTION
**Problem**
- All roles for board are not set by default when adding a new task status to a project. 
- An archived status automation is run when it should not
- is_artist_allowed / is_client_allowed for task status permissions are not checked when setting a new task status.
- In migration for concepts if new task type / task status are already here there's a migration problem.

**Solution**
- All roles for board are now set by default when adding a new task status to a project. 
- An archived status automation is not run when it should not
- is_artist_allowed / is_client_allowed for task status permissions are now checked when setting a new task status.
- Fix migration for concepts if new task type / task status are already here.
