### PR TITLE
Push stats information on database upgrade

### DIFF
--- a/zou/app/services/telemetry_services.py
+++ b/zou/app/services/telemetry_services.py
@@ -1,0 +1,41 @@
+import platform
+import requests
+
+from zou import __version__
+
+from zou.app.models.organisation import Organisation
+from zou.app.models.person import Person
+
+from zou.app.services import stats_service
+
+from zou.app import config
+
+
+def send_main_infos():
+    """
+    Send main usage informations to the CGWire website.
+
+    These infos are used to estimate the size of the Kitsu user community.
+    """
+
+    organisation = Organisation.query.first()
+    stats = stats_service.get_main_stats()
+    nb_active_users = Person.query.filter_by(active=True).count()
+
+    data = {
+        "organisation_id": str(organisation.id),
+        "nb_active_users": nb_active_users,
+        "nb_movie_previews": stats["number_of_video_previews"],
+        "nb_picture_previews": stats["number_of_picture_previews"],
+        "nb_model_previews": stats["number_of_model_previews"],
+        "nb_comments": stats["number_of_comments"],
+        "api_version": __version__,
+        "python_version": platform.python_version(),
+    }
+
+    if config.DEBUG:
+        url = "http://localhost:8000/api/selfhosted/telemetry/new/"
+    else:
+        url = "https://account.cg-wire.com/api/selfhosted/telemetry/new/"
+
+    requests.post(url, json=data)

--- a/zou/cli.py
+++ b/zou/cli.py
@@ -92,10 +92,24 @@ def reset_db():
 
 
 @cli.command()
-def upgrade_db():
-    "Upgrade database schema."
+@click.option("--no-telemetry", is_flag=True, default=False)
+def upgrade_db(no_telemetry=False):
+    """
+    Upgrade database schema. Send anonymized statistics to our telemery
+    services (user and preview amounts). It allows us to size the Kitsu
+    community.
+    """
     with app.app_context():
         flask_migrate.upgrade(directory=migrations_path)
+        if not no_telemetry:
+            from zou.app.services import telemetry_services
+
+            try:
+                telemetry_services.send_main_infos()
+            except Exception:
+                import traceback
+
+                traceback.print_exc()
 
 
 @cli.command()


### PR DESCRIPTION
**Problem**

There is no way to know how many Kitsu installations exist.

**Solution**

When a database upgrade is performed, it pushes anonymized statistics to the CGWire telemetry service to allow to know: 

- The number of studios using Kitsu
- The number of users
- The number of previews posted
- The number of comments posted
