### PR TITLE
various improvements

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -64,9 +64,9 @@ install_requires =
     psycopg[binary]==3.1.17
     pyotp==2.9.0
     python-nomad==2.0.0
-    python-slugify==8.0.1
+    python-slugify==8.0.2
     python-socketio==5.11.0
-    pytz==2023.3.post1
+    pytz==2023.4
     redis==5.0.1
     requests==2.31.0
     rq==1.15.1
@@ -95,7 +95,7 @@ test =
     fakeredis==2.20.1
     mixer==7.2.2
     pytest-cov==4.1.0
-    pytest==7.4.4
+    pytest==8.0.0
 
 monitoring =
     prometheus-flask-exporter==0.23.0
@@ -103,7 +103,7 @@ monitoring =
     sentry-sdk==1.39.2
 
 lint =
-    black==23.12.1
+    black==24.1.1
     pre-commit==3.6.0; python_version >= '3.9'
 
 [options.entry_points]

--- a/zou/app/config.py
+++ b/zou/app/config.py
@@ -152,6 +152,11 @@ USER_LIMIT = int(os.getenv("USER_LIMIT", "100"))
 MIN_PASSWORD_LENGTH = int(os.getenv("MIN_PASSWORD_LENGTH", 8))
 PROTECTED_ACCOUNTS = env_with_semicolon_to_list("PROTECTED_ACCOUNTS")
 
+TELEMETRY_URL = os.getenv(
+    "TELEMETRY_URL",
+    f"{'http://localhost:8000' if DEBUG else 'https://account.cg-wire.com'}/api/selfhosted/telemetry/new/",
+)
+
 # Deprecated
 TO_REVIEW_TASK_STATUS = "To review"
 DEFAULT_FILE_STATUS = "To review"

--- a/zou/app/services/telemetry_services.py
+++ b/zou/app/services/telemetry_services.py
@@ -33,9 +33,4 @@ def send_main_infos():
         "python_version": platform.python_version(),
     }
 
-    if config.DEBUG:
-        url = "http://localhost:8000/api/selfhosted/telemetry/new/"
-    else:
-        url = "https://account.cg-wire.com/api/selfhosted/telemetry/new/"
-
-    requests.post(url, json=data)
+    requests.post(config.TELEMETRY_URL, json=data)

--- a/zou/cli.py
+++ b/zou/cli.py
@@ -101,7 +101,7 @@ def upgrade_db(no_telemetry=False):
     """
     with app.app_context():
         flask_migrate.upgrade(directory=migrations_path)
-        if not no_telemetry:
+        if not no_telemetry and config.IS_SELF_HOSTED:
             from zou.app.services import telemetry_services
 
             try:


### PR DESCRIPTION
**Problem**
- Some libs are outdated : python-slugify, pytz, pytest, black. 
- We don't want to launch telemetry if zou is not self hosted. 

**Solution**
- Upgrade some libs : python-slugify, pytz, pytest, black. 
- Don't launch telemetry if environment variable IS_SELF_HOSTED=False. 
