### PR TITLE
Add Sentry config for Kitsu

### DIFF
--- a/zou/app/blueprints/index/resources.py
+++ b/zou/app/blueprints/index/resources.py
@@ -280,7 +280,7 @@ class ConfigResource(Resource):
             200:
                 description: Crisp token
         """
-        return {
+        config = {
             "is_self_hosted": app.config["IS_SELF_HOSTED"],
             "crisp_token": app.config["CRISP_TOKEN"],
             "indexer_configured": (
@@ -288,7 +288,12 @@ class ConfigResource(Resource):
                 and app.config["INDEXER"]["key"] != "masterkey"
             ),
         }
-
+        if app.config["SENTRY_KITSU_ENABLED"]:
+            config["sentry"] = {
+                "dsn": app.config["SENTRY_KITSU_DSN"],
+                "sampleRate": app.config["SENTRY_KITSU_SR"],
+            }
+        return config
 
 class TestEventsResource(Resource):
     def get(self):

--- a/zou/app/config.py
+++ b/zou/app/config.py
@@ -141,6 +141,10 @@ SENTRY_DSN = os.getenv("SENTRY_DSN", "")
 SENTRY_SR = float(os.getenv("SENTRY_SR", 1.0))
 SENTRY_DEBUG_URL = os.getenv("SENTRY_DEBUG_URL", False)
 
+SENTRY_KITSU_ENABLED = envtobool("SENTRY_KITSU_ENABLED", False)
+SENTRY_KITSU_DSN = os.getenv("SENTRY_KITSU_DSN", "")
+SENTRY_KITSU_SR = float(os.getenv("SENTRY_KITSU_SR", 0.1))
+
 PROMETHEUS_METRICS_ENABLED = envtobool("PROMETHEUS_METRICS_ENABLED", False)
 
 CRISP_TOKEN = os.getenv("CRISP_TOKEN", "")


### PR DESCRIPTION
**Problem**
- We need Sentry configuration data for Kitsu provided by the API.

**Solution**
- Add new environment variables related to Kitsu Sentry and send them via the `/config` endpoint if set.
