### PR TITLE
[breakdown] Add a CLI command to reset data.

### DIFF
--- a/zou/app/services/breakdown_service.py
+++ b/zou/app/services/breakdown_service.py
@@ -16,6 +16,7 @@ from zou.app.utils import fields, events
 from zou.app.services import (
     assets_service,
     entities_service,
+    projects_service,
     shots_service,
 )
 
@@ -769,6 +770,17 @@ def refresh_shot_casting_stats(shot, priority_map=None):
             persist=False,
             project_id=shot["project_id"],
         )
+
+
+def refresh_all_shot_casting_stats():
+    """
+    For all shots in all open projects, it computes how many assets are
+    available. It saves the result on the task level.
+    """
+    for project in projects_service.open_projects():
+        for shot in shots_service.get_shots_for_project(project["id"]):
+            priority_map = _get_task_type_priority_map(project["id"])
+            refresh_shot_casting_stats(shot, priority_map)
 
 
 def _get_task_type_priority_map(project_id):

--- a/zou/app/utils/commands.py
+++ b/zou/app/utils/commands.py
@@ -12,6 +12,7 @@ from zou.app.stores import auth_tokens_store, file_store
 from zou.app.services import (
     assets_service,
     backup_service,
+    breakdown_service,
     deletion_service,
     edits_service,
     index_service,
@@ -697,3 +698,10 @@ def reset_movie_files_metadata():
 def reset_picture_files_metadata():
     with app.app_context():
         preview_files_service.reset_picture_files_metadata()
+
+
+def reset_breakdown_data():
+    with app.app_context():
+        print("Resetting breakdown data for all open projects.")
+        breakdown_service.refresh_all_shot_casting_stats()
+        print("Resetting done.")

--- a/zou/cli.py
+++ b/zou/cli.py
@@ -558,5 +558,13 @@ def reset_picture_files_metadata():
     commands.reset_picture_files_metadata()
 
 
+@cli.command()
+def reset_breakdown_data():
+    """
+    Reset breakdown statistics for all open projects.
+    """
+    commands.reset_breakdown_data()
+
+
 if __name__ == "__main__":
     cli()


### PR DESCRIPTION
**Problem**

Sometimes the breakdown statistics data stored at the task level are unsync.

**Solution**

Add a CLI command to clean the breakdown stats set at the task level.
