### PR TITLE
File routes improvements

### DIFF
--- a/tests/files/test_route_output_files.py
+++ b/tests/files/test_route_output_files.py
@@ -591,6 +591,30 @@ class RouteOutputFilesTestCase(ApiDBTestCase):
         )
         self.assertEqual(result[0]["id"], self.cache_type_id)
 
+    def test_get_output_files_for_project(self):
+        self.generate_fixture_output_type()
+        geometry = self.output_type
+
+        self.generate_fixture_output_file(geometry, 1, representation="obj")
+        self.generate_fixture_output_file(geometry, 2, representation="obj")
+        self.generate_fixture_output_file(geometry, 3, representation="obj")
+        self.generate_fixture_output_file(geometry, 4, representation="obj")
+        output_files = self.get(
+            "data/projects/%s/output-files" % self.project.id
+        )
+        self.assertEqual(len(output_files), 4)
+
+        self.generate_fixture_project("Sprite Fright")
+        self.generate_fixture_asset("Rabbit")
+        self.generate_fixture_output_file(geometry, 1, representation="max")
+        self.generate_fixture_output_file(geometry, 2, representation="max")
+        self.generate_fixture_output_file(geometry, 3, representation="max")
+
+        output_files = self.get(
+            "data/projects/%s/output-files" % self.project.id
+        )
+        self.assertEqual(len(output_files), 3)
+
     def test_get_output_files_for_output_type_and_entity(self):
         self.generate_fixture_output_type()
         geometry = self.output_type

--- a/zou/app/blueprints/crud/output_type.py
+++ b/zou/app/blueprints/crud/output_type.py
@@ -1,5 +1,11 @@
+from flask import abort, current_app
+
+from sqlalchemy.exc import StatementError
+from flask_jwt_extended import jwt_required
+
 from zou.app.models.output_type import OutputType
 from zou.app.blueprints.crud.base import BaseModelResource, BaseModelsResource
+from zou.app.services import files_service
 
 
 class OutputTypesResource(BaseModelsResource):
@@ -16,3 +22,46 @@ class OutputTypeResource(BaseModelResource):
 
     def check_read_permissions(self, instance):
         return True
+
+    @jwt_required()
+    def get(self, instance_id):
+        """
+        Retrieve an output type corresponding at given ID and return it as a
+        JSON object.
+        ---
+        tags:
+          - Crud
+        parameters:
+          - in: path
+            name: output_type_id
+            required: True
+            type: string
+            format: UUID
+            x-example: a24a6ea4-ce75-4665-a070-57453082c25
+        responses:
+            200:
+                description: Model as a JSON object
+            400:
+                description: Statement error
+            404:
+                description: Value error
+        """
+        try:
+            output_type = files_service.get_output_type(instance_id)
+            self.check_read_permissions(output_type)
+            return self.clean_get_result(output_type)
+
+        except StatementError as exception:
+            current_app.logger.error(str(exception), exc_info=1)
+            return {"message": str(exception)}, 400
+
+        except ValueError:
+            abort(404)
+
+    def post_update(self, instance_dict):
+        files_service.clear_output_type_cache(instance_dict["id"])
+        return instance_dict
+
+    def post_delete(self, instance_dict):
+        files_service.clear_output_type_cache(instance_dict["id"])
+        return instance_dict

--- a/zou/app/blueprints/crud/software.py
+++ b/zou/app/blueprints/crud/software.py
@@ -1,5 +1,11 @@
+from flask import abort, current_app
+
+from sqlalchemy.exc import StatementError
+from flask_jwt_extended import jwt_required
+
 from zou.app.models.software import Software
 from zou.app.blueprints.crud.base import BaseModelResource, BaseModelsResource
+from zou.app.services import files_service
 
 
 class SoftwaresResource(BaseModelsResource):
@@ -16,3 +22,46 @@ class SoftwareResource(BaseModelResource):
 
     def check_read_permissions(self, instance):
         return True
+
+    @jwt_required()
+    def get(self, instance_id):
+        """
+        Retrieve a software corresponding at given ID and return it as a
+        JSON object.
+        ---
+        tags:
+          - Crud
+        parameters:
+          - in: path
+            name: software_id
+            required: True
+            type: string
+            format: UUID
+            x-example: a24a6ea4-ce75-4665-a070-57453082c25
+        responses:
+            200:
+                description: Model as a JSON object
+            400:
+                description: Statement error
+            404:
+                description: Value error
+        """
+        try:
+            software = files_service.get_software(instance_id)
+            self.check_read_permissions(software)
+            return self.clean_get_result(software)
+
+        except StatementError as exception:
+            current_app.logger.error(str(exception), exc_info=1)
+            return {"message": str(exception)}, 400
+
+        except ValueError:
+            abort(404)
+
+    def post_update(self, instance_dict):
+        files_service.clear_software_cache(instance_dict["id"])
+        return instance_dict
+
+    def post_delete(self, instance_dict):
+        files_service.clear_software_cache(instance_dict["id"])
+        return instance_dict

--- a/zou/app/blueprints/crud/working_file.py
+++ b/zou/app/blueprints/crud/working_file.py
@@ -1,3 +1,8 @@
+from flask import abort, current_app
+
+from sqlalchemy.exc import StatementError
+from flask_jwt_extended import jwt_required
+
 from zou.app.blueprints.crud.base import BaseModelsResource, BaseModelResource
 
 from zou.app.models.entity import Entity
@@ -52,3 +57,46 @@ class WorkingFileResource(BaseModelResource):
         user_service.check_project_access(task["project_id"])
         user_service.check_entity_access(task["entity_id"])
         return True
+
+    @jwt_required()
+    def get(self, instance_id):
+        """
+        Retrieve a working file corresponding at given ID and return it as a
+        JSON object.
+        ---
+        tags:
+          - Crud
+        parameters:
+          - in: path
+            name: working_file_id
+            required: True
+            type: string
+            format: UUID
+            x-example: a24a6ea4-ce75-4665-a070-57453082c25
+        responses:
+            200:
+                description: Model as a JSON object
+            400:
+                description: Statement error
+            404:
+                description: Value error
+        """
+        try:
+            working_file = files_service.get_working_file(instance_id)
+            self.check_read_permissions(working_file)
+            return self.clean_get_result(working_file)
+
+        except StatementError as exception:
+            current_app.logger.error(str(exception), exc_info=1)
+            return {"message": str(exception)}, 400
+
+        except ValueError:
+            abort(404)
+
+    def post_update(self, instance_dict):
+        files_service.clear_working_file_cache(instance_dict["id"])
+        return instance_dict
+
+    def post_delete(self, instance_dict):
+        files_service.clear_working_file_cache(instance_dict["id"])
+        return instance_dict

--- a/zou/app/blueprints/files/__init__.py
+++ b/zou/app/blueprints/files/__init__.py
@@ -22,6 +22,7 @@ from zou.app.blueprints.files.resources import (
     InstanceOutputTypesResource,
     InstanceOutputTypeOutputFilesResource,
     EntityOutputFilesResource,
+    ProjectOutputFilesResource,
     InstanceOutputFilesResource,
     SetTreeResource,
     FileResource,
@@ -88,6 +89,7 @@ routes = [
         EntityOutputTypeOutputFilesResource,
     ),
     ("/data/entities/<entity_id>/output-files", EntityOutputFilesResource),
+    ("/data/projects/<project_id>/output-files", ProjectOutputFilesResource),
     (
         "/data/asset-instances/<asset_instance_id>/output-files",
         InstanceOutputFilesResource,

--- a/zou/app/blueprints/files/resources.py
+++ b/zou/app/blueprints/files/resources.py
@@ -1511,9 +1511,34 @@ class LastInstanceOutputFilesResource(Resource, ArgsMixin):
             type: string
             format: UUID
             x-example: a24a6ea4-ce75-4665-a070-57453082c25
+          - in: query
+            name: output_type_id
+            required: true
+            type: string
+            format: UUID
+            x-example: a24a6ea4-ce75-4665-a070-57453082c25
+          - in: query
+            name: task_type_id
+            required: true
+            type: string
+            format: UUID
+            x-example: a24a6ea4-ce75-4665-a070-57453082c25
+          - in: query
+            name: file_status_id
+            required: true
+            type: string
+            format: UUID
+            x-example: a24a6ea4-ce75-4665-a070-57453082c25
+          - in: query
+            name: representation
+            required: true
+            type: string
+            format: UUID
+            x-example: cache
         responses:
             200:
-                description: Last revisions of output files for given instance grouped by output type and file name
+                description: Last revisions of output files for given instance
+                             grouped by output type and file name
         """
         args = self.get_args(
             [
@@ -1596,6 +1621,7 @@ class InstanceOutputTypesResource(Resource):
         responses:
             200:
                 description: All types of output generated for given instance
+                             and temporal_entity
         """
         asset_instance = assets_service.get_asset_instance(asset_instance_id)
         entity = entities_service.get_entity(asset_instance["asset_id"])
@@ -1700,6 +1726,70 @@ class InstanceOutputTypeOutputFilesResource(Resource, ArgsMixin):
         )
 
 
+class ProjectOutputFilesResource(Resource, ArgsMixin):
+    @jwt_required()
+    def get(self, project_id):
+        """
+        Get all output files for given poject.
+        ---
+        tags:
+        - Files
+        parameters:
+          - in: path
+            name: project_id
+            required: true
+            type: string
+            format: UUID
+            x-example: a24a6ea4-ce75-4665-a070-57453082c25
+          - in: query
+            name: output_type_id
+            required: true
+            type: string
+            format: UUID
+            x-example: a24a6ea4-ce75-4665-a070-57453082c25
+          - in: query
+            name: task_type_id
+            required: true
+            type: string
+            format: UUID
+            x-example: a24a6ea4-ce75-4665-a070-57453082c25
+          - in: query
+            name: file_status_id
+            required: true
+            type: string
+            format: UUID
+            x-example: a24a6ea4-ce75-4665-a070-57453082c25
+          - in: query
+            name: representation
+            required: true
+            type: string
+            format: UUID
+            x-example: cache
+        responses:
+            200:
+                description:  All output files for given project.
+        """
+        args = self.get_args(
+            [
+                "output_type_id",
+                "task_type_id",
+                "representation",
+                "file_status_id",
+                "name",
+            ],
+        )
+        user_service.check_manager_project_access(project_id)
+
+        return files_service.get_output_files_for_project(
+            project_id,
+            task_type_id=args["task_type_id"],
+            output_type_id=args["output_type_id"],
+            name=args["name"],
+            representation=args["representation"],
+            file_status_id=args["file_status_id"],
+        )
+
+
 class EntityOutputFilesResource(Resource, ArgsMixin):
     """
     Get all output files for given asset instance and given output type.
@@ -1708,7 +1798,7 @@ class EntityOutputFilesResource(Resource, ArgsMixin):
     @jwt_required()
     def get(self, entity_id):
         """
-        Get all output files for given asset instance and given output type.
+        Get all output files for given entity.
         ---
         tags:
         - Files
@@ -1719,9 +1809,33 @@ class EntityOutputFilesResource(Resource, ArgsMixin):
             type: string
             format: UUID
             x-example: a24a6ea4-ce75-4665-a070-57453082c25
+          - in: query
+            name: output_type_id
+            required: true
+            type: string
+            format: UUID
+            x-example: a24a6ea4-ce75-4665-a070-57453082c25
+          - in: query
+            name: task_type_id
+            required: true
+            type: string
+            format: UUID
+            x-example: a24a6ea4-ce75-4665-a070-57453082c25
+          - in: query
+            name: file_status_id
+            required: true
+            type: string
+            format: UUID
+            x-example: a24a6ea4-ce75-4665-a070-57453082c25
+          - in: query
+            name: representation
+            required: true
+            type: string
+            format: UUID
+            x-example: cache
         responses:
             200:
-                description:  All output files for given asset instance and given output type
+                description:  All output files for given entity
         """
         args = self.get_args(
             [
@@ -1765,9 +1879,40 @@ class InstanceOutputFilesResource(Resource):
             type: string
             format: UUID
             x-example: a24a6ea4-ce75-4665-a070-57453082c25
+          - in: query
+            name: temporal_entity_id
+            required: true
+            type: string
+            format: UUID
+            x-example: cache
+          - in: query
+            name: output_type_id
+            required: true
+            type: string
+            format: UUID
+            x-example: a24a6ea4-ce75-4665-a070-57453082c25
+          - in: query
+            name: task_type_id
+            required: true
+            type: string
+            format: UUID
+            x-example: a24a6ea4-ce75-4665-a070-57453082c25
+          - in: query
+            name: file_status_id
+            required: true
+            type: string
+            format: UUID
+            x-example: a24a6ea4-ce75-4665-a070-57453082c25
+          - in: query
+            name: representation
+            required: true
+            type: string
+            format: UUID
+            x-example: cache
         responses:
             200:
-                description: All output files for given asset instance and given output type
+                description: All output files for given asset instance and
+                             given temporal entity (shot, sequence, etc.)
         """
         args = self.get_args(
             [
@@ -1796,15 +1941,11 @@ class InstanceOutputFilesResource(Resource):
 
 
 class FileResource(Resource):
-    """
-    Get information about a file that could be a working file as much as an
-    output file.
-    """
-
     @jwt_required()
     def get(self, file_id):
         """
-        Get information about a file that could be a working file as much as an output file.
+        Get information about a file that could be a working file as much as an
+        output file.
         ---
         tags:
         - Files

--- a/zou/app/services/files_service.py
+++ b/zou/app/services/files_service.py
@@ -41,6 +41,30 @@ def clear_preview_file_cache(preview_file_id):
     cache.cache.delete_memoized(get_preview_file, preview_file_id)
 
 
+def clear_output_file_cache(output_file_id):
+    cache.cache.delete_memoized(get_output_file, output_file_id)
+
+
+def clear_working_file_cache(working_file_id):
+    cache.cache.delete_memoized(get_working_file, working_file_id)
+
+
+def clear_output_type_cache(output_type_id):
+    cache.cache.delete_memoized(get_output_type, output_type_id)
+
+
+def clear_software_cache(software_id):
+    cache.cache.delete_memoized(get_software, software_id)
+
+
+def clear_preview_background_file_cache(preview_background_file_id):
+    cache.cache.delete_memoized(
+        get_preview_background_file, preview_background_file_id
+    )
+    cache.cache.delete_memoized(get_preview_background_files)
+
+
+@cache.memoize_function(240)
 def get_default_status():
     """
     Return default file status to set on a file when it is created.
@@ -63,11 +87,12 @@ def get_working_file_raw(working_file_id):
     )
 
 
+@cache.memoize_function(240)
 def get_working_file(working_file_id):
     """
     Return given working file as dict.
     """
-    return get_working_file_raw(working_file_id).serialize()
+    return get_working_file_raw(working_file_id).serialize(relations=True)
 
 
 def get_output_file_raw(output_file_id):
@@ -79,6 +104,7 @@ def get_output_file_raw(output_file_id):
     )
 
 
+@cache.memoize_function(240)
 def get_output_file(output_file_id):
     """
     Return given output file as a dict.
@@ -93,6 +119,7 @@ def get_software_raw(software_id):
     return get_instance(Software, software_id, SoftwareNotFoundException)
 
 
+@cache.memoize_function(240)
 def get_software(software_id):
     """
     Return given software as dict.
@@ -109,6 +136,7 @@ def get_output_type_raw(output_type_id):
     )
 
 
+@cache.memoize_function(240)
 def get_output_type(output_type_id):
     """
     Return given output type as dict.
@@ -743,12 +771,14 @@ def create_preview_file(
 def update_working_file(working_file_id, data):
     working_file = get_working_file_raw(working_file_id)
     working_file.update(data)
+    clear_working_file_cache(working_file_id)
     return working_file.serialize()
 
 
 def update_output_file(output_file_id, data):
     output_file = get_output_file_raw(output_file_id)
     output_file.update(data)
+    clear_output_file_cache(output_file_id)
     return output_file.serialize()
 
 
@@ -842,13 +872,6 @@ def get_preview_files_for_project(project_id, page=-1):
         .order_by(desc(PreviewFile.updated_at))
     )
     return query_utils.get_paginated_results(query, page)
-
-
-def clear_preview_background_file_cache(preview_background_file_id):
-    cache.cache.delete_memoized(
-        get_preview_background_file, preview_background_file_id
-    )
-    cache.cache.delete_memoized(get_preview_background_files)
 
 
 def get_preview_background_file_raw(preview_background_file_id):


### PR DESCRIPTION
**Problem**

* Single elements querying for file management are not cached
* There is no route to grab all output files for a given project

**Solution**

* Cache `get_software`, `get_output_type`, `get_working_file`, `get_output_file`
* Add a `/data/projects/<project_id>/output-files` route
