### PR TITLE
Add entity-name in data payload for all delete events

### DIFF
--- a/tests/services/test_sync_service.py
+++ b/tests/services/test_sync_service.py
@@ -54,7 +54,10 @@ class SyncServiceTestCase(ApiDBTestCase):
         sync_service.sync_event(
             {
                 "name": "project:delete",
-                "data": {"project_id": self.new_project_id},
+                "data": {
+                    "project_id": self.new_project_id,
+                    "project_name": "test_delete_project",
+                },
             }
         )
         self.assertIsNone(Project.get(self.new_project_id))

--- a/zou/app/blueprints/crud/entity_type.py
+++ b/zou/app/blueprints/crud/entity_type.py
@@ -51,7 +51,11 @@ class EntityTypeResource(BaseModelResource):
 
     def emit_delete_event(self, instance_dict):
         events.emit(
-            "asset-type:delete", {"asset_type_id": instance_dict["id"]}
+            "asset-type:delete",
+            {
+                "asset_type_id": instance_dict["id"],
+                "asset_type_name": instance_dict["name"],
+            },
         )
 
     def update_data(self, data, instance_id):

--- a/zou/app/blueprints/crud/project.py
+++ b/zou/app/blueprints/crud/project.py
@@ -246,7 +246,13 @@ class ProjectResource(BaseModelResource, ArgsMixin):
                 deletion_service.remove_project(instance_id)
             else:
                 project.delete()
-                events.emit("project:delete", {"project_id": project.id})
+                events.emit(
+                    "project:delete",
+                    {
+                        "project_id": project.id,
+                        "project_name": project.name,
+                    },
+                )
             self.post_delete(project_dict)
             return "", 204
 

--- a/zou/app/services/assets_service.py
+++ b/zou/app/services/assets_service.py
@@ -660,7 +660,10 @@ def remove_asset(asset_id, force=False):
         index_service.remove_asset_index(str(asset_id))
         events.emit(
             "asset:delete",
-            {"asset_id": asset_id},
+            {
+                "asset_id": asset_id,
+                "asset_name": asset.name,
+            },
             project_id=str(asset.project_id),
         )
         EntityVersion.delete_all_by(entity_id=asset_id)
@@ -721,7 +724,10 @@ def cancel_asset(asset_id, force=True):
     asset_dict = asset.serialize(obj_type="Asset")
     events.emit(
         "asset:delete",
-        {"asset_id": asset_id},
+        {
+            "asset_id": asset_id,
+            "asset_name": asset.name,
+        },
         project_id=str(asset.project_id),
     )
     return asset_dict

--- a/zou/app/services/deletion_service.py
+++ b/zou/app/services/deletion_service.py
@@ -141,6 +141,7 @@ def remove_task(task_id, force=False):
         "task:delete",
         {
             "task_id": task_id,
+            "task_name": task.name,
             "entity_id": task_serialized["entity_id"],
             "task_type_id": task_serialized["task_type_id"],
         },
@@ -352,7 +353,13 @@ def remove_project(project_id):
     News.commit()
     project = Project.get(project_id)
     project.delete()
-    events.emit("project:delete", {"project_id": project.id})
+    events.emit(
+        "project:delete",
+        {
+            "project_id": project.id,
+            "project_name": project.name,
+        },
+    )
     return project_id
 
 
@@ -409,7 +416,13 @@ def remove_person(person_id, force=True):
 
     try:
         person.delete()
-        events.emit("person:delete", {"person_id": person.id})
+        events.emit(
+            "person:delete",
+            {
+                "person_id": person.id,
+                "person_name": person.name,
+            },
+        )
     except IntegrityError:
         raise ModelWithRelationsDeletionException(
             "Some data are still linked to given person."
@@ -473,7 +486,10 @@ def remove_episode(episode_id, force=False):
         episode.delete()
         events.emit(
             "episode:delete",
-            {"episode_id": episode_id},
+            {
+                "episode_id": episode_id,
+                "episode_name": episode.name,
+            },
             project_id=str(episode.project_id),
         )
     except IntegrityError:

--- a/zou/app/services/edits_service.py
+++ b/zou/app/services/edits_service.py
@@ -333,7 +333,10 @@ def remove_edit(edit_id, force=False):
         clear_edit_cache(edit_id)
         events.emit(
             "edit:delete",
-            {"edit_id": edit_id},
+            {
+                "edit_id": edit_id,
+                "edit_name": edit.name,
+            },
             project_id=str(edit.project_id),
         )
 

--- a/zou/app/services/persons_service.py
+++ b/zou/app/services/persons_service.py
@@ -285,7 +285,13 @@ def delete_person(person_id):
     person_dict = person.serialize()
     person.delete()
     index_service.remove_person_index(person_id)
-    events.emit("person:delete", {"person_id": person_id})
+    events.emit(
+        "person:delete",
+        {
+            "person_id": person_id,
+            "person_name": person.name,
+        },
+    )
     clear_person_cache()
     return person_dict
 

--- a/zou/app/services/playlists_service.py
+++ b/zou/app/services/playlists_service.py
@@ -760,7 +760,10 @@ def remove_playlist(playlist_id):
     playlist.delete()
     events.emit(
         "playlist:delete",
-        {"playlist_id": playlist_dict["id"]},
+        {
+            "playlist_id": playlist_dict["id"],
+            "playlist_name": playlist_dict["name"],
+        },
         project_id=playlist_dict["project_id"],
     )
     return playlist_dict

--- a/zou/app/services/projects_service.py
+++ b/zou/app/services/projects_service.py
@@ -604,7 +604,10 @@ def remove_metadata_descriptor(metadata_descriptor_id):
         pass
     events.emit(
         "metadata-descriptor:delete",
-        {"metadata_descriptor_id": str(descriptor.id)},
+        {
+            "metadata_descriptor_id": str(descriptor.id),
+            "metadata_descriptor_name": descriptor.name,
+        },
         project_id=descriptor.project_id,
     )
     clear_project_cache(str(descriptor.project_id))

--- a/zou/app/services/shots_service.py
+++ b/zou/app/services/shots_service.py
@@ -856,7 +856,10 @@ def remove_shot(shot_id, force=False):
         shot.delete()
         events.emit(
             "shot:delete",
-            {"shot_id": shot_id},
+            {
+                "shot_id": shot_id,
+                "shot_name": shot.name,
+            },
             project_id=str(shot.project_id),
         )
         index_service.remove_shot_index(shot_id)
@@ -879,7 +882,10 @@ def remove_scene(scene_id):
     deleted_scene = scene.serialize(obj_type="Scene")
     events.emit(
         "scene:delete",
-        {"scene_id": scene_id},
+        {
+            "scene_id": scene_id,
+            "scene_name": scene.name,
+        },
         project_id=str(scene.project_id),
     )
     return deleted_scene
@@ -907,7 +913,10 @@ def remove_sequence(sequence_id, force=False):
         sequence.delete()
         events.emit(
             "sequence:delete",
-            {"sequence_id": sequence_id},
+            {
+                "sequence_id": sequence_id,
+                "sequence_name": sequence.name,
+            },
             project_id=str(sequence.project_id),
         )
     except IntegrityError:


### PR DESCRIPTION
**Problem**
I'm working on the Kitsu integration for Ayon (old OpenPype).
When an entity gets deleted we get the event from Gazu. We get the id of the entity but Ayon's code it built using names by default. This means we have to go through all entities in Ayon to find the one with a matching ID tag. It would be way easier to also get the name of the entity that got deleted.

**Solution**
Pass the name of the entity together with the event.

**Info**
I don't really know how to build and test Zou, I simply install it normally from pip.
So if this PR is of interest I would love if someone of you with a Zou test-environment already setup could test the few events I have edited.