### PR TITLE
 Add project_id to output files events

### DIFF
--- a/tests/tasks/test_publish.py
+++ b/tests/tasks/test_publish.py
@@ -2,7 +2,6 @@ import os
 
 from tests.base import ApiDBTestCase
 
-from zou.app.utils import events
 from zou.app.services import (
     assets_service,
     persons_service,
@@ -36,13 +35,6 @@ class RouteTaskChangeTestCase(ApiDBTestCase):
         self.wip_status_id = str(self.task_status_wip.id)
         self.retake_status_id = str(self.task_status_retake.id)
         self.done_status_id = str(self.task_status_done.id)
-
-        self.is_event_fired = False
-        events.unregister_all()
-
-    def handle_event(self, data):
-        self.is_event_fired = True
-        self.assertEqual(data["previous_task_status_id"], self.open_status_id)
 
     def generate_team(self):
         self.generate_fixture_user_manager()

--- a/tests/tasks/test_route_task_change.py
+++ b/tests/tasks/test_route_task_change.py
@@ -35,16 +35,6 @@ class RouteTaskChangeTestCase(ApiDBTestCase):
         self.retake_status_id = str(self.task_status_retake.id)
         self.done_status_id = str(self.task_status_done.id)
 
-        self.is_event_fired = False
-        events.unregister_all()
-
-    def handle_event(self, data):
-        self.is_event_fired = True
-        self.assertEqual(data["previous_task_status_id"], self.open_status_id)
-
-    def assert_event_is_fired(self):
-        self.assertTrue(self.is_event_fired)
-
     def test_retake_count(self):
         task_id = str(self.task.id)
         self.post(

--- a/zou/app/services/auth_service.py
+++ b/zou/app/services/auth_service.py
@@ -8,7 +8,7 @@ from datetime import datetime, timedelta
 from flask import request, session, current_app
 from babel.dates import format_datetime
 
-from flask_jwt_extended import get_jti, get_jwt
+from flask_jwt_extended import get_jti
 from ldap3 import Server, Connection, ALL, NTLM, SIMPLE
 from ldap3.core.exceptions import (
     LDAPSocketOpenError,
@@ -37,7 +37,6 @@ from zou.app.services.exception import (
 )
 from zou.app.stores import auth_tokens_store
 from zou.app.utils import date_helpers, emails
-from zou.app.models.person import Person
 from zou.app import config
 
 from fido2.webauthn import (
@@ -222,23 +221,6 @@ def ldap_auth_strategy(person, password, app):
         return local_auth_strategy(person, password, app)
     else:
         raise UserCantConnectDueToNoFallback()
-
-
-def check_login_failed_attemps(person):
-    """
-    Checks that the person has not reached the failed login limit.
-    """
-    login_failed_attemps = person["login_failed_attemps"]
-    if login_failed_attemps is None:
-        login_failed_attemps = 0
-    if (
-        login_failed_attemps >= 5
-        and date_helpers.get_datetime_from_string(person["last_login_failed"])
-        + timedelta(minutes=1)
-        > datetime.utcnow()
-    ):
-        raise TooMuchLoginFailedAttemps()
-    return login_failed_attemps
 
 
 def update_login_failed_attemps(


### PR DESCRIPTION
**Problem**

Output file events don't give the project ID which leads to unnecessary requests.

**Solution**

Add the project id information from the entity information.
