### PR TITLE
Hide concept tasks in open tasks

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ install_requires =
     flask_sqlalchemy==3.1.1
     flask-fs2[swift, s3]==0.7.24
     flask-jwt-extended==4.6.0
-    flask-migrate==4.0.5
+    flask-migrate==4.0.7
     flask-socketio==5.3.6
     flask==3.0.2
     gazu==0.10.1
@@ -92,7 +92,7 @@ dev =
     wheel
 
 test =
-    fakeredis==2.21.2
+    fakeredis==2.21.3
     mixer==7.2.2
     pytest-cov==4.1.0
     pytest==8.1.1

--- a/zou/app/services/tasks_service.py
+++ b/zou/app/services/tasks_service.py
@@ -30,7 +30,8 @@ from zou.app.models.task_type import TaskType
 from zou.app.models.task_status import TaskStatus
 from zou.app.models.time_spent import TimeSpent
 
-from zou.app.utils import cache, fields, query as query_utils
+from zou.app.utils import cache, fields, query as query_utils, permissions
+
 
 from zou.app.services.exception import (
     CommentNotFoundException,
@@ -1886,8 +1887,6 @@ def get_open_tasks(
         query = query.filter(Project.id == project_id)
         query_stats = query_stats.filter(Project.id == project_id)
     else:
-        from zou.app.utils import permissions
-
         if permissions.has_admin_permissions():
             query = query.filter(ProjectStatus.name == "Open")
             query_stats = query_stats.filter(ProjectStatus.name == "Open")
@@ -1900,6 +1899,8 @@ def get_open_tasks(
     if task_type_id is not None:
         query = query.filter(TaskType.id == task_type_id)
         query_stats = query_stats.filter(TaskType.id == task_type_id)
+    else:
+        query = query.filter(TaskType.for_entity != "Concept")
 
     if task_status_id is not None:
         query = query.filter(TaskStatus.id == task_status_id)


### PR DESCRIPTION
**Problem**
- We don't want tasks from concepts in /data/tasks/open-tasks.

**Solution**
- Filter on task-types.for_entity != "Concept".
