### PR TITLE
Fix login with Chrome on iOS

### DIFF
--- a/zou/app/utils/flask.py
+++ b/zou/app/utils/flask.py
@@ -57,6 +57,7 @@ def is_from_browser(user_agent):
         "Brave",
         "Chrome",
         "Chrome Mobile",
+        "Chrome Mobile iOS",
         "Edge",
         "Firefox",
         "Mobile Safari",


### PR DESCRIPTION
**Problem**
- Login failed with Chrome browser on iOS (Apple iPad)

**Solution**
- Fix check of user agent for Chrome on iOS, with the right browser name.
