### PR TITLE
Customize host binding on DEBUG

### DIFF
--- a/zou/app/config.py
+++ b/zou/app/config.py
@@ -7,6 +7,7 @@ from zou.app.utils.env import envtobool, env_with_semicolon_to_list
 
 PROPAGATE_EXCEPTIONS = True
 DEBUG = envtobool("DEBUG", False)
+DEBUG_HOST = os.getenv("DEBUG_HOST", "127.0.0.1")
 DEBUG_PORT = int(os.getenv("DEBUG_PORT", 5000))
 
 APP_NAME = "Zou"

--- a/zou/debug.py
+++ b/zou/debug.py
@@ -13,6 +13,8 @@ socketio = SocketIO(app, cors_allowed_origins=[], cors_credentials=False)
 
 if __name__ == "__main__":
     print(
-        "The Kitsu API server is listening on port %s..." % config.DEBUG_PORT
+        f"The Kitsu API server is listening on http://{config.DEBUG_HOST}:{config.DEBUG_PORT}"
     )
-    socketio.run(app, port=config.DEBUG_PORT, debug=True)
+    socketio.run(
+        app, host=config.DEBUG_HOST, port=config.DEBUG_PORT, debug=True
+    )


### PR DESCRIPTION
**Problem**
Unable to customize address to bind server IP other than localhost

**Solution**
Add `DEBUG_PORT` variable to customize binding
