### PR TITLE
various improvements 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,6 @@ jobs:
         run: >-
           python3 -m
           build
-          --wheel
       - name: Publish distribution 📦 to PyPI
         if: startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ install_requires =
     flask-migrate==4.0.7
     flask-socketio==5.3.6
     flask==3.0.3
-    gazu==0.10.3
+    gazu==0.10.5
     gevent-websocket==0.10.1
     gevent==24.2.1
     gunicorn==21.2.0
@@ -106,7 +106,7 @@ monitoring =
 
 lint =
     autoflake==2.3.1
-    black==24.3.0
+    black==24.4.0
     pre-commit==3.7.0; python_version >= '3.9'
 
 [options.entry_points]


### PR DESCRIPTION
**Problem**
- In the release GitHub workflow the source distributions are not built.
- Black & Gazu requirements are outdated.

**Solution**
- In the release GitHub workflow also builds the source distributions.
- Upgrade Black & Gazu requirements.

