### PR TITLE
various improvements

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/psf/black
-    rev: 24.4.1
+    rev: 24.4.2
     hooks:
       - id: black
   - repo: https://github.com/PyCQA/autoflake

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/psf/black
-    rev: 24.3.0
+    rev: 24.4.1
     hooks:
       - id: black
   - repo: https://github.com/PyCQA/autoflake

--- a/setup.cfg
+++ b/setup.cfg
@@ -65,11 +65,11 @@ install_requires =
     psutil==5.9.8
     psycopg[binary]==3.1.18
     pyotp==2.9.0
-    python-nomad==2.0.0
+    python-nomad==2.0.1
     python-slugify==8.0.4
     python-socketio==5.11.2
     pytz==2024.1
-    redis==5.0.3
+    redis==5.0.4
     requests==2.31.0
     rq==1.16.1
     slackclient==2.9.4
@@ -102,11 +102,11 @@ test =
 monitoring =
     prometheus-flask-exporter==0.23.0
     pygelf==0.4.2
-    sentry-sdk==1.45.0
+    sentry-sdk==2.0.0
 
 lint =
     autoflake==2.3.1
-    black==24.4.0
+    black==24.4.1
     pre-commit==3.7.0; python_version >= '3.9'
 
 [options.entry_points]

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     fido2==1.1.3
     flasgger==0.9.7.1
     flask_bcrypt==1.0.1
-    flask_caching==2.1.0
+    flask_caching==2.2.0
     flask_fixtures==0.3.8
     flask_mail==0.9.1
     flask_principal==0.4.0
@@ -97,16 +97,16 @@ test =
     fakeredis==2.22.0
     mixer==7.2.2
     pytest-cov==5.0.0
-    pytest==8.1.1
+    pytest==8.2.0
 
 monitoring =
     prometheus-flask-exporter==0.23.0
     pygelf==0.4.2
-    sentry-sdk==2.0.0
+    sentry-sdk==2.0.1
 
 lint =
     autoflake==2.3.1
-    black==24.4.1
+    black==24.4.2
     pre-commit==3.7.0; python_version >= '3.9'
 
 [options.entry_points]

--- a/zou/app/blueprints/auth/resources.py
+++ b/zou/app/blueprints/auth/resources.py
@@ -733,6 +733,11 @@ class ResetPasswordResource(Resource, ArgsMixin):
 
         try:
             user = persons_service.get_person_by_email(args["email"])
+            if not user["active"]:
+                return (
+                    {"error": True, "message": "This user is inactive."},
+                    400,
+                )
         except PersonNotFoundException:
             return (
                 {"error": True, "message": "Email not listed in database."},

--- a/zou/utils/movie.py
+++ b/zou/utils/movie.py
@@ -107,10 +107,14 @@ def generate_tile(movie_path):
     ratio = get_movie_display_aspect_ratio(video_track=video_track)
     height = 100
     width = math.ceil(height * ratio)
-
+    if rows == 240:
+        select = f"select='not(mod(n\,{math.ceil(duration_in_frames/1920)}))',"
+    else:
+        select = ""
     try:
         ffmpeg.input(movie_path).output(
-            file_target_path, vf=f"scale={width}:{height},tile=8x{rows}"
+            file_target_path,
+            vf=f"{select}scale={width}:{height},tile=8x{rows}",
         ).overwrite_output().run(quiet=True)
     except ffmpeg._run.Error as e:
         log_ffmpeg_error(e, "An error occured while generating the tile.")

--- a/zou/utils/movie.py
+++ b/zou/utils/movie.py
@@ -103,12 +103,12 @@ def generate_tile(movie_path):
     duration = get_movie_duration(video_track=video_track)
     fps = get_movie_fps(video_track=video_track)
     duration_in_frames = int(duration * fps)
-    rows = min(math.ceil(duration_in_frames / 8), 240)
+    rows = min(math.ceil(duration_in_frames / 8), 480)
     ratio = get_movie_display_aspect_ratio(video_track=video_track)
     height = 100
     width = math.ceil(height * ratio)
-    if rows == 240:
-        select = f"select='not(mod(n\,{math.ceil(duration_in_frames/1920)}))',"
+    if rows == 480:
+        select = f"select='not(mod(n\,{math.ceil(duration_in_frames/3840)}))',"
     else:
         select = ""
     try:


### PR DESCRIPTION
**Problem**
- It's allowed to reset a password for an inactive user. 
- Some requirements are outdated.
- For tiles, videos longer than 1920 frames ffmpeg makes an error due to a number of extracted frames greater than the length of the tile (1920). 


**Solution**
- Disallow to reset a password for an inactive user. 
- Some requirements are outdated.
- For tiles and videos greater than 3840 frames do a ratio of frames to keep to fit in a tile of 8x480 (3840). 
