### PR TITLE
[previews] Add .psb to allowed files

### DIFF
--- a/zou/app/blueprints/previews/resources.py
+++ b/zou/app/blueprints/previews/resources.py
@@ -70,6 +70,7 @@ ALLOWED_FILE_EXTENSION = [
     "obj",
     "pdf",
     "psd",
+    "psb",
     "rar",
     "sbbkp",
     "svg",


### PR DESCRIPTION
**Problem**

The .psb extension stands for large Photoshop files. But it's not allowed by the Kitsu API as an uploadable preview.

**Solution**

Add .psb extension to the extension allow list.
