### PR TITLE
[tasks] Add a route to get statistics for all open projects

### DIFF
--- a/zou/app/blueprints/tasks/__init__.py
+++ b/zou/app/blueprints/tasks/__init__.py
@@ -35,11 +35,13 @@ from zou.app.blueprints.tasks.resources import (
     SetTaskMainPreviewResource,
     PersonsTasksDatesResource,
     CreateConceptTasksResource,
+    OpenTasksStatsResource,
 )
 
 
 routes = [
     ("/data/tasks/open-tasks", OpenTasksResource),
+    ("/data/tasks/open-tasks/stats", OpenTasksStatsResource),
     ("/data/tasks/<task_id>/comments", TaskCommentsResource),
     ("/data/tasks/<task_id>/comments/<comment_id>", TaskCommentResource),
     ("/data/tasks/<task_id>/previews", TaskPreviewsResource),

--- a/zou/app/blueprints/tasks/resources.py
+++ b/zou/app/blueprints/tasks/resources.py
@@ -1739,3 +1739,23 @@ class OpenTasksResource(Resource, ArgsMixin):
             page=args["page"],
             limit=args["limit"],
         )
+
+
+
+class OpenTasksStatsResource(Resource, ArgsMixin):
+
+    @jwt_required()
+    def get(self):
+        """
+        Return task amount, task done amount, total estimation, total duration
+        by status by task type by project for open projects. It aggregates the
+        result at the project level.
+        ---
+        tags:
+        - Tasks
+        responses:
+            200:
+                description: A dict organized by project that contains
+                the results for each task type and status pairs.
+        """
+        return tasks_service.get_open_tasks_stats()


### PR DESCRIPTION
**Problem**

* There is no route to get an overview of open productions statistics.

**Solution**

Add a route giving the number of tasks, of done tasks, the total estimation, the total duration per project
