### PR TITLE
upgrade requirements + reset task info when adding not the last comment

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ install_requires =
     babel==2.15.0
     click==8.1.7
     discord.py==2.3.2
-    email-validator==2.1.1
+    email-validator==2.2.0
     ffmpeg-python==0.2.0
     fido2==1.1.3
     flasgger==0.9.7.1
@@ -46,7 +46,7 @@ install_requires =
     flask-migrate==4.0.7
     flask-socketio==5.3.6
     flask==3.0.3
-    gazu==0.10.9
+    gazu==0.10.10
     gevent-websocket==0.10.1
     gevent==24.2.1
     gunicorn==22.0.0
@@ -57,24 +57,24 @@ install_requires =
     matterhook==0.2
     meilisearch==0.31.3
     numpy==1.24.4; python_version == '3.8'
-    numpy==1.26.4; python_version >= '3.9'
-    opencv-python==4.10.0.82
+    numpy==2.0.0; python_version >= '3.9'
+    opencv-python==4.10.0.84
     OpenTimelineIO==0.16.0
-    orjson==3.10.4
+    orjson==3.10.5
     pillow==10.3.0
-    psutil==5.9.8
+    psutil==6.0.0
     psycopg[binary]==3.1.19
     pyotp==2.9.0
     python-nomad==2.0.1
     python-slugify==8.0.4
-    python-socketio==5.11.2
+    python-socketio==5.11.3
     pytz==2024.1
-    redis==5.0.5
+    redis==5.0.6
     requests==2.32.3
     rq==1.16.2
     slackclient==2.9.4
     sqlalchemy_utils==0.41.2
-    sqlalchemy==2.0.30
+    sqlalchemy==2.0.31
     ua-parser==0.18.0
     werkzeug==3.0.3
 
@@ -102,7 +102,7 @@ test =
 monitoring =
     prometheus-flask-exporter==0.23.0
     pygelf==0.4.2
-    sentry-sdk==2.5.1
+    sentry-sdk==2.6.0
 
 lint =
     autoflake==2.3.1

--- a/zou/app/services/comments_service.py
+++ b/zou/app/services/comments_service.py
@@ -136,43 +136,51 @@ def _get_comment_author(person_id):
 
 
 def _manage_status_change(task_status, task, comment):
-    status_changed = task_status["id"] != task["task_status_id"]
-    new_data = {
-        "task_status_id": task_status["id"],
-        "last_comment_date": comment["created_at"],
-    }
-    if status_changed:
-        if task_status["is_retake"]:
-            retake_count = task["retake_count"]
-            if retake_count is None or retake_count == "NoneType":
-                retake_count = 0
-            new_data["retake_count"] = retake_count + 1
+    is_last_comment = (
+        task["last_comment_date"] is None
+        or task["last_comment_date"] < comment["created_at"]
+    )
+    if not is_last_comment:
+        status_changed = False
+        task = tasks_service.reset_task_data(task["id"])
+    else:
+        status_changed = task_status["id"] != task["task_status_id"]
+        new_data = {
+            "task_status_id": task_status["id"],
+            "last_comment_date": comment["created_at"],
+        }
+        if status_changed:
+            if task_status["is_retake"]:
+                retake_count = task["retake_count"]
+                if retake_count is None or retake_count == "NoneType":
+                    retake_count = 0
+                new_data["retake_count"] = retake_count + 1
 
-        if task_status["is_feedback_request"]:
-            new_data["end_date"] = date_helpers.get_utc_now_datetime()
+            if task_status["is_feedback_request"]:
+                new_data["end_date"] = date_helpers.get_utc_now_datetime()
 
-        if (
-            task_status["short_name"] == "wip"
-            and task["real_start_date"] is None
-        ):
-            new_data["real_start_date"] = datetime.datetime.now(
-                datetime.timezone.utc
+            if (
+                task_status["short_name"] == "wip"
+                and task["real_start_date"] is None
+            ):
+                new_data["real_start_date"] = datetime.datetime.now(
+                    datetime.timezone.utc
+                )
+
+        tasks_service.update_task(task["id"], new_data)
+
+        if status_changed:
+            events.emit(
+                "task:status-changed",
+                {
+                    "task_id": task["id"],
+                    "new_task_status_id": new_data["task_status_id"],
+                    "previous_task_status_id": task["task_status_id"],
+                    "person_id": comment["person_id"],
+                },
+                project_id=task["project_id"],
             )
-
-    tasks_service.update_task(task["id"], new_data)
-
-    if status_changed:
-        events.emit(
-            "task:status-changed",
-            {
-                "task_id": task["id"],
-                "new_task_status_id": new_data["task_status_id"],
-                "previous_task_status_id": task["task_status_id"],
-                "person_id": comment["person_id"],
-            },
-            project_id=task["project_id"],
-        )
-    task.update(new_data)
+        task.update(new_data)
     return task, status_changed
 
 

--- a/zou/app/services/tasks_service.py
+++ b/zou/app/services/tasks_service.py
@@ -1812,7 +1812,7 @@ def reset_task_data(task_id):
     )
     project_id = str(task.project_id)
     events.emit("task:update", {"task_id": task.id}, project_id)
-    return task.serialize()
+    return task.serialize(relations=True)
 
 
 def get_persons_tasks_dates():


### PR DESCRIPTION
**Problem**
- Some requirements are outdated. 
- The task info (like last comment, task status etc) is not properly calculated when adding a comment that is not the last. 

**Solution**
- Upgrade outdated requirements. 
- Recaculate all the task info when adding a comment that is not the last.
