### PR TITLE
add a command to renormalize preview files

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -102,7 +102,7 @@ test =
 monitoring =
     prometheus-flask-exporter==0.23.0
     pygelf==0.4.2
-    sentry-sdk==2.7.0
+    sentry-sdk==2.7.1
 
 lint =
     autoflake==2.3.1

--- a/zou/app/blueprints/previews/resources.py
+++ b/zou/app/blueprints/previews/resources.py
@@ -338,8 +338,6 @@ class CreatePreviewFilePictureResource(Resource, ArgsMixin):
             preview_files_service.prepare_and_store_movie(
                 preview_file_id, uploaded_movie_path, normalize=normalize
             )
-            preview_file = files_service.get_preview_file(preview_file_id)
-            tasks_service.update_preview_file_info(preview_file)
         return preview_file_id
 
     def save_file_preview(self, instance_id, uploaded_file, extension):

--- a/zou/app/services/preview_files_service.py
+++ b/zou/app/services/preview_files_service.py
@@ -163,7 +163,10 @@ def set_preview_file_as_ready(preview_file_id):
 
 
 def prepare_and_store_movie(
-    preview_file_id, uploaded_movie_path, normalize=True
+    preview_file_id,
+    uploaded_movie_path,
+    normalize=True,
+    add_source_to_file_store=True,
 ):
     """
     Prepare movie preview, normalize the movie as a .mp4, build the thumbnails
@@ -196,13 +199,14 @@ def prepare_and_store_movie(
         if normalize:
             current_app.logger.info("start normalization")
             try:
+                if add_source_to_file_store:
+                    file_store.add_movie(
+                        "source", preview_file_id, uploaded_movie_path
+                    )
                 if (
                     config.ENABLE_JOB_QUEUE_REMOTE
                     and len(config.JOB_QUEUE_NOMAD_NORMALIZE_JOB) > 0
                 ):
-                    file_store.add_movie(
-                        "source", preview_file_id, uploaded_movie_path
-                    )
                     result = _run_remote_normalize_movie(
                         current_app, preview_file_id, fps, width, height
                     )

--- a/zou/cli.py
+++ b/zou/cli.py
@@ -456,13 +456,13 @@ def upload_files_to_cloud_storage(days):
 
 
 @cli.command()
-@click.option("--projectid")
-def clean_tasks_data(projectid):
+@click.option("--project-id")
+def clean_tasks_data(project_id):
     """
     Reset task models data (retake count, wip start date and end date)
     """
-    if projectid is not None:
-        commands.reset_tasks_data(projectid)
+    if project_id is not None:
+        commands.reset_tasks_data(project_id)
 
 
 @cli.command()
@@ -569,7 +569,7 @@ def reset_breakdown_data():
 @click.option("--email", required=True)
 @click.option("--name", required=True)
 @click.option(
-    "--expiration_date",
+    "--expiration-date",
     required=False,
     default=None,
     show_default=True,
@@ -590,6 +590,40 @@ def create_bot(
         name,
         expiration_date,
         role,
+    )
+
+
+@cli.command()
+@click.option(
+    "--preview-file-id",
+    required=False,
+    default=None,
+    show_default=True,
+)
+@click.option(
+    "--project-id",
+    required=False,
+    default=None,
+    show_default=True,
+)
+@click.option("--all-broken", is_flag=True, default=False, show_default=True)
+@click.option(
+    "--all-processing", is_flag=True, default=False, show_default=True
+)
+def renormalize_movie_preview_files(
+    preview_file_id,
+    project_id,
+    all_broken,
+    all_processing,
+):
+    """
+    Renormalize all preview files.
+    """
+    commands.renormalize_movie_preview_files(
+        preview_file_id,
+        project_id,
+        all_broken,
+        all_processing,
     )
 
 


### PR DESCRIPTION
**Problem**
- When a movie preview file fails to be normalized in nomad for example it's impossible to relaunch the normalization.

**Solution**
- Add a new command to renormalize movie preview files. 

