### PR TITLE
[previews] Allow to download videos picture file used for thumbnails

### DIFF
--- a/zou/app/blueprints/previews/resources.py
+++ b/zou/app/blueprints/previews/resources.py
@@ -670,6 +670,10 @@ class PreviewFileDownloadResource(PreviewFileResource):
                 return send_standard_file(
                     instance_id, extension, mimetype, as_attachment=True
                 )
+            if extension == "mp4":
+                return send_picture_file(
+                    "original", instance_id, as_attachment=True
+                )
             else:
                 return send_standard_file(
                     instance_id, extension, as_attachment=True


### PR DESCRIPTION
**Problem**

When downloading a picture file for a movie, a raw movie file is returned.

**Solution**

Because a picture is expected, send the frame used to make the thumbnail instead of a raw file.
