### PR TITLE
various improvements

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -60,6 +60,7 @@ install_requires =
     numpy==2.0.0; python_version >= '3.9'
     opencv-python==4.10.0.84
     OpenTimelineIO==0.17.0
+    OpenTimelineIO-Plugins==0.17.0
     orjson==3.10.6
     pillow==10.4.0
     psutil==6.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,12 +41,12 @@ install_requires =
     flask_principal==0.4.0
     flask_restful==0.3.10
     flask_sqlalchemy==3.1.1
-    flask-fs2[swift, s3]==0.7.26
+    flask-fs2[swift, s3]==0.7.27
     flask-jwt-extended==4.6.0
     flask-migrate==4.0.7
     flask-socketio==5.3.6
     flask==3.0.3
-    gazu==0.10.10
+    gazu==0.10.11
     gevent-websocket==0.10.1
     gevent==24.2.1
     gunicorn==22.0.0
@@ -103,7 +103,7 @@ test =
 monitoring =
     prometheus-flask-exporter==0.23.1
     pygelf==0.4.2
-    sentry-sdk==2.9.0
+    sentry-sdk==2.10.0
 
 lint =
     autoflake==2.3.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,7 +55,7 @@ install_requires =
     Jinja2==3.1.4
     ldap3==2.9.1
     matterhook==0.2
-    meilisearch==0.31.3
+    meilisearch==0.31.4
     numpy==1.24.4; python_version == '3.8'
     numpy==2.0.0; python_version >= '3.9'
     opencv-python==4.10.0.84
@@ -100,9 +100,9 @@ test =
     pytest==8.2.2
 
 monitoring =
-    prometheus-flask-exporter==0.23.0
+    prometheus-flask-exporter==0.23.1
     pygelf==0.4.2
-    sentry-sdk==2.8.0
+    sentry-sdk==2.9.0
 
 lint =
     autoflake==2.3.1

--- a/tests/base.py
+++ b/tests/base.py
@@ -720,10 +720,7 @@ class ApiDBTestCase(ApiTestCase):
         return self.task_standard
 
     def generate_fixture_shot_task(
-        self,
-        name="Master",
-        shot_id=None,
-        task_type_id=None
+        self, name="Master", shot_id=None, task_type_id=None
     ):
         if task_type_id is None:
             task_type_id = self.task_type_animation.id
@@ -1087,10 +1084,7 @@ class ApiDBTestCase(ApiTestCase):
         self.generate_fixture_shot()
         self.generate_fixture_scene()
 
-    def generate_fixture_shot_tasks_and_previews(
-        self,
-        task_type_id
-    ):
+    def generate_fixture_shot_tasks_and_previews(self, task_type_id):
         episode_01 = self.episode
         sequence_01 = self.sequence
         shot_01 = self.shot
@@ -1106,50 +1100,34 @@ class ApiDBTestCase(ApiTestCase):
         )
 
         task_shot_01 = self.generate_fixture_shot_task(
-            shot_id=shot_01.id,
-            task_type_id=task_type_id
+            shot_id=shot_01.id, task_type_id=task_type_id
         )
         task_shot_02 = self.generate_fixture_shot_task(
-            shot_id=shot_02.id,
-            task_type_id=task_type_id
+            shot_id=shot_02.id, task_type_id=task_type_id
         )
         task_shot_03 = self.generate_fixture_shot_task(
-            shot_id=shot_03.id,
-            task_type_id=task_type_id
+            shot_id=shot_03.id, task_type_id=task_type_id
         )
         task_shot_e201 = self.generate_fixture_shot_task(
-            shot_id=shot_e201.id,
-            task_type_id=task_type_id
+            shot_id=shot_e201.id, task_type_id=task_type_id
         )
         preview_01 = self.generate_fixture_preview_file(
-            task_id=task_shot_01.id,
-            revision=1,
-            duration=15
+            task_id=task_shot_01.id, revision=1, duration=15
         )
         preview_01 = self.generate_fixture_preview_file(
-            task_id=task_shot_01.id,
-            revision=2,
-            duration=25
+            task_id=task_shot_01.id, revision=2, duration=25
         )
         preview_01 = self.generate_fixture_preview_file(
-            task_id=task_shot_01.id,
-            revision=3,
-            duration=30
+            task_id=task_shot_01.id, revision=3, duration=30
         )
         preview_02 = self.generate_fixture_preview_file(
-            task_id=task_shot_02.id,
-            revision=1,
-            duration=20
+            task_id=task_shot_02.id, revision=1, duration=20
         )
         preview_03 = self.generate_fixture_preview_file(
-            task_id=task_shot_03.id,
-            revision=1,
-            duration=10
+            task_id=task_shot_03.id, revision=1, duration=10
         )
         preview_e201 = self.generate_fixture_preview_file(
-            task_id=task_shot_e201.id,
-            revision=1,
-            duration=40
+            task_id=task_shot_e201.id, revision=1, duration=40
         )
         return (
             episode_01,

--- a/tests/services/test_auth_service.py
+++ b/tests/services/test_auth_service.py
@@ -94,10 +94,6 @@ class AuthTestCase(ApiDBTestCase):
         )
         self.assertEqual(person["first_name"], "John")
 
-    def test_register_tokens(self):
-        # Complex to test, jwt extended requires a proper flask context to run.
-        pass
-
     def test_revoke_tokens(self):
         # Complex to test, jwt extended requires a proper flask context to run.
         pass

--- a/tests/services/test_shots_service.py
+++ b/tests/services/test_shots_service.py
@@ -274,14 +274,10 @@ class ShotUtilsTestCase(ApiDBTestCase):
             preview_02,
             preview_03,
             preview_e201,
-        ) = self.generate_fixture_shot_tasks_and_previews(
-            task_type_id
-        )
+        ) = self.generate_fixture_shot_tasks_and_previews(task_type_id)
 
         shots_service.set_frames_from_task_type_preview_files(
-            project_id,
-            task_type_id,
-            episode_id=episode_01.id
+            project_id, task_type_id, episode_id=episode_01.id
         )
 
         self.assertEqual(
@@ -301,8 +297,7 @@ class ShotUtilsTestCase(ApiDBTestCase):
         self.assertEqual(shot_e201["nb_frames"], 0)
 
         shots_service.set_frames_from_task_type_preview_files(
-            project_id,
-            task_type_id
+            project_id, task_type_id
         )
         shot_e201 = shots_service.get_shot(shot_e201["id"])
         self.assertEqual(shot_e201["nb_frames"], 1000)

--- a/tests/shots/test_shots.py
+++ b/tests/shots/test_shots.py
@@ -183,35 +183,30 @@ class ShotTestCase(ApiDBTestCase):
             preview_e201,
         ) = self.generate_fixture_shot_tasks_and_previews(task_type_id)
 
-
         self.post(
-            "actions/projects/%s/task-types/%s/set-shot-nb-frames?episode_id=%s" % (
-                "wrong-id",
-                task_type_id,
-                str(episode_01.id)
-            ), {}, 400
+            "actions/projects/%s/task-types/%s/set-shot-nb-frames?episode_id=%s"
+            % ("wrong-id", task_type_id, str(episode_01.id)),
+            {},
+            400,
         )
         self.post(
-            "actions/projects/%s/task-types/%s/set-shot-nb-frames?episode_id=%s" % (
-                project_id,
-                "wrong-id",
-                str(episode_01.id)
-            ), {}, 400
+            "actions/projects/%s/task-types/%s/set-shot-nb-frames?episode_id=%s"
+            % (project_id, "wrong-id", str(episode_01.id)),
+            {},
+            400,
         )
 
         self.post(
-            "actions/projects/%s/task-types/%s/set-shot-nb-frames?episode_id=%s" % (
-                project_id,
-                task_type_id,
-                "wrong-id"
-            ), {}, 400
+            "actions/projects/%s/task-types/%s/set-shot-nb-frames?episode_id=%s"
+            % (project_id, task_type_id, "wrong-id"),
+            {},
+            400,
         )
         self.post(
-            "actions/projects/%s/task-types/%s/set-shot-nb-frames?episode_id=%s" % (
-                project_id,
-                task_type_id,
-                str(episode_01.id)
-            ), {}, 200
+            "actions/projects/%s/task-types/%s/set-shot-nb-frames?episode_id=%s"
+            % (project_id, task_type_id, str(episode_01.id)),
+            {},
+            200,
         )
         shot_01 = shots_service.get_shot(shot_01.id)
         shot_02 = shots_service.get_shot(shot_02.id)
@@ -223,10 +218,13 @@ class ShotTestCase(ApiDBTestCase):
         self.assertEqual(shot_e201["nb_frames"], 0)
 
         self.post(
-            "actions/projects/%s/task-types/%s/set-shot-nb-frames?episode_id=" % (
+            "actions/projects/%s/task-types/%s/set-shot-nb-frames?episode_id="
+            % (
                 project_id,
                 task_type_id,
-            ), {}, 200
+            ),
+            {},
+            200,
         )
         shot_e201 = shots_service.get_shot(shot_e201["id"])
         self.assertEqual(shot_e201["nb_frames"], 1000)

--- a/tests/stores/test_auth_tokens_store.py
+++ b/tests/stores/test_auth_tokens_store.py
@@ -25,7 +25,7 @@ class AuthTokensTestCase(ApiTestCase):
         self.assertIsNone(self.store.get("key-1"))
 
     def test_is_revoked(self):
-        self.assertTrue(self.store.is_revoked("key-1"))
+        self.assertFalse(self.store.is_revoked("key-1"))
         self.store.add("key-1", "true")
         self.assertTrue(self.store.is_revoked("key-1"))
         self.store.add("key-1", "false")

--- a/tests/thumbnails/test_route_thumbnail.py
+++ b/tests/thumbnails/test_route_thumbnail.py
@@ -5,7 +5,6 @@ from tests.base import ApiDBTestCase
 
 from zou.app.utils import fs, thumbnail
 from zou.app.services import assets_service
-from zou.app.models.entity import Entity
 
 from PIL import Image
 
@@ -119,23 +118,6 @@ class RouteThumbnailTestCase(ApiDBTestCase):
 
         asset = assets_service.get_asset(self.asset_id)
         self.assertEqual(asset["preview_file_id"], str(self.preview_file_id))
-
-        self.put(
-            "/actions/entities/%s/set-main-preview/%s"
-            % (self.preview_file_id, self.preview_file_id),
-            {},
-            404,
-        )
-
-        self.put(
-            "/actions/entities/%s/set-main-preview/%s"
-            % (self.asset_id, self.asset_id),
-            {},
-            404,
-        )
-        entity = Entity.get(self.asset_id)
-        entity.preview_file_id = None
-        entity.save()
 
     def test_add_preview_background(self):
         self.generate_fixture_preview_background_file()

--- a/zou/app/blueprints/auth/resources.py
+++ b/zou/app/blueprints/auth/resources.py
@@ -217,7 +217,6 @@ class LoginResource(Resource, ArgsMixin):
                     "identity_type": "person",
                 },
             )
-            auth_service.register_tokens(app, access_token, refresh_token)
             identity_changed.send(
                 current_app._get_current_object(),
                 identity=Identity(user["id"], "person"),
@@ -383,7 +382,6 @@ class RefreshTokenResource(Resource):
                 "identity_type": "person",
             },
         )
-        auth_service.register_tokens(app, access_token)
         if is_from_browser(request.user_agent):
             response = jsonify({"refresh": True})
             set_access_cookies(response, access_token)

--- a/zou/app/blueprints/comments/resources.py
+++ b/zou/app/blueprints/comments/resources.py
@@ -81,7 +81,7 @@ class DownloadAttachmentResource(Resource):
                 download_name=attachment_file["name"],
                 max_age=config.CLIENT_CACHE_MAX_AGE,
                 last_modified=date_helpers.get_datetime_from_string(
-                    self.preview_file["updated_at"]
+                    attachment_file["updated_at"]
                 ),
             )
         except Exception:

--- a/zou/app/blueprints/comments/resources.py
+++ b/zou/app/blueprints/comments/resources.py
@@ -5,7 +5,7 @@ from flask_restful import Resource, reqparse
 from flask_jwt_extended import jwt_required
 
 from zou.app.mixin import ArgsMixin
-from zou.app.utils import permissions
+from zou.app.utils import permissions, date_helpers
 
 from zou.app.services import (
     chats_service,
@@ -80,6 +80,9 @@ class DownloadAttachmentResource(Resource):
                 as_attachment=False,
                 download_name=attachment_file["name"],
                 max_age=config.CLIENT_CACHE_MAX_AGE,
+                last_modified=date_helpers.get_datetime_from_string(
+                    self.preview_file["updated_at"]
+                ),
             )
         except Exception:
             current_app.logger.error(

--- a/zou/app/blueprints/crud/entity.py
+++ b/zou/app/blueprints/crud/entity.py
@@ -23,7 +23,7 @@ from zou.app.services import (
     user_service,
     concepts_service,
 )
-from zou.app.utils import events, fields, date_helpers
+from zou.app.utils import events, date_helpers
 
 from werkzeug.exceptions import NotFound
 
@@ -187,11 +187,11 @@ class EntityResource(BaseModelResource, EntityEventMixin):
         version = None
         if frame_in != pframe_in or frame_out != pframe_out or name != pname:
             current_user_id = persons_service.get_current_user()["id"]
-            previous_updated_at = fields.get_date_object(
-                previous_shot["updated_at"], date_format="%Y-%m-%dT%H:%M:%S"
+            previous_updated_at = date_helpers.get_datetime_from_string(
+                previous_shot["updated_at"]
             )
-            updated_at = fields.get_date_object(
-                shot["updated_at"], date_format="%Y-%m-%dT%H:%M:%S"
+            updated_at = date_helpers.get_datetime_from_string(
+                shot["updated_at"]
             )
             if (
                 date_helpers.get_date_diff(previous_updated_at, updated_at)

--- a/zou/app/blueprints/events/resources.py
+++ b/zou/app/blueprints/events/resources.py
@@ -2,7 +2,7 @@ from flask_restful import Resource
 from flask_jwt_extended import jwt_required
 
 from zou.app.mixin import ArgsMixin
-from zou.app.utils import fields, permissions
+from zou.app.utils import fields, permissions, date_helpers
 
 from zou.app.services import events_service
 from zou.app.services.exception import WrongParameterException
@@ -105,8 +105,6 @@ class LoginLogsResource(Resource, ArgsMixin):
         permissions.check_manager_permissions()
         before = None
         if args["before"] is not None:
-            before = fields.get_date_object(
-                args["before"], "%Y-%m-%dT%H:%M:%S"
-            )
+            before = date_helpers.get_datetime_from_string(args["before"])
         page_size = args["page_size"]
         return events_service.get_last_login_logs(before, page_size)

--- a/zou/app/blueprints/files/resources.py
+++ b/zou/app/blueprints/files/resources.py
@@ -32,7 +32,10 @@ from zou.app.services.exception import (
 
 
 def send_storage_file(
-    working_file_id, as_attachment=False, max_age=config.CLIENT_CACHE_MAX_AGE
+    working_file_id,
+    as_attachment=False,
+    max_age=config.CLIENT_CACHE_MAX_AGE,
+    last_modified=None,
 ):
     """
     Send file from storage. If it's not a local storage, cache the file in
@@ -60,6 +63,7 @@ def send_storage_file(
             as_attachment=as_attachment,
             download_name=download_name,
             max_age=max_age,
+            last_modified=last_modified,
         )
     except IOError as e:
         current_app.logger.error(e)
@@ -125,8 +129,13 @@ class WorkingFileFileResource(Resource):
               schema:
                 type: file
         """
-        self.check_access(working_file_id)
-        return send_storage_file(working_file_id)
+        working_file = self.check_access(working_file_id)
+        return send_storage_file(
+            working_file_id,
+            last_modified=date_helpers.get_datetime_from_string(
+                working_file["updated_at"]
+            ),
+        )
 
     @jwt_required()
     def post(self, working_file_id):

--- a/zou/app/blueprints/previews/__init__.py
+++ b/zou/app/blueprints/previews/__init__.py
@@ -14,14 +14,13 @@ from zou.app.blueprints.previews.resources import (
     PreviewFilePreviewResource,
     PreviewFileOriginalResource,
     PreviewFileTileResource,
-    CreateOrganisationThumbnailResource,
     OrganisationThumbnailResource,
-    CreateProjectThumbnailResource,
+    CreateOrganisationThumbnailResource,
     ProjectThumbnailResource,
-    CreatePersonThumbnailResource,
+    CreateProjectThumbnailResource,
     PersonThumbnailResource,
+    CreatePersonThumbnailResource,
     RunningPreviewFiles,
-    LegacySetMainPreviewResource,
     SetMainPreviewResource,
     UpdateAnnotationsResource,
     UpdatePreviewPositionResource,
@@ -117,10 +116,6 @@ routes = [
     (
         "/pictures/preview-background-files/<instance_id>.<extension>",
         PreviewBackgroundFileResource,
-    ),
-    (
-        "/actions/entities/<entity_id>/set-main-preview/<preview_file_id>",
-        LegacySetMainPreviewResource,
     ),
     (
         "/actions/preview-files/<preview_file_id>/set-main-preview",

--- a/zou/app/blueprints/shots/__init__.py
+++ b/zou/app/blueprints/shots/__init__.py
@@ -98,7 +98,7 @@ routes = [
     (
         "/actions/projects/<project_id>/task-types/<task_type_id>/set-shot-nb-frames",
         SetShotsFramesResource,
-    )
+    ),
 ]
 
 

--- a/zou/app/blueprints/shots/resources.py
+++ b/zou/app/blueprints/shots/resources.py
@@ -1529,7 +1529,6 @@ class ProjectQuotasResource(Resource, ArgsMixin):
             )
 
 
-
 class SetShotsFramesResource(Resource, ArgsMixin):
     @jwt_required()
     def post(self, project_id, task_type_id):
@@ -1558,13 +1557,13 @@ class SetShotsFramesResource(Resource, ArgsMixin):
                 description: Frames set for given shots
         """
         user_service.check_manager_project_access(project_id)
-        if not fields.is_valid_id(task_type_id) or \
-           not fields.is_valid_id(project_id):
+        if not fields.is_valid_id(task_type_id) or not fields.is_valid_id(
+            project_id
+        ):
             raise WrongParameterException("Invalid project or task type id")
 
         episode_id = self.get_episode_id()
-        if not episode_id in ["", None] and \
-           not fields.is_valid_id(episode_id):
+        if not episode_id in ["", None] and not fields.is_valid_id(episode_id):
             raise WrongParameterException("Invalid episode id")
 
         if episode_id == "":

--- a/zou/app/mixin.py
+++ b/zou/app/mixin.py
@@ -146,9 +146,7 @@ class ArgsMixin(object):
         if param is None:
             return date
         try:
-            date = date_helpers.get_datetime_from_string(
-                param, "%Y-%m-%dT%H:%M:%S", milliseconds=True
-            )
+            date = date_helpers.get_datetime_from_string(param)
         except Exception:
             try:
                 date = date_helpers.get_date_from_string(param)

--- a/zou/app/mixin.py
+++ b/zou/app/mixin.py
@@ -1,7 +1,7 @@
 from flask_restful import reqparse
 from flask import request
 
-from zou.app.utils import fields
+from zou.app.utils import date_helpers
 from zou.app.services.exception import WrongParameterException
 
 
@@ -146,10 +146,12 @@ class ArgsMixin(object):
         if param is None:
             return date
         try:
-            date = fields.get_date_object(param, "%Y-%m-%dT%H:%M:%S")
+            date = date_helpers.get_datetime_from_string(
+                param, "%Y-%m-%dT%H:%M:%S", milliseconds=True
+            )
         except Exception:
             try:
-                date = fields.get_date_object(param, "%Y-%m-%d")
+                date = date_helpers.get_date_from_string(param)
             except Exception:
                 raise WrongParameterException(
                     "Wrong date format for before argument."

--- a/zou/app/services/auth_service.py
+++ b/zou/app/services/auth_service.py
@@ -9,7 +9,6 @@ from datetime import timedelta
 from flask import request, session, current_app
 from babel.dates import format_datetime
 
-from flask_jwt_extended import get_jti
 from ldap3 import Server, Connection, ALL, NTLM, SIMPLE
 from ldap3.core.exceptions import (
     LDAPSocketOpenError,
@@ -676,24 +675,6 @@ def generate_new_recovery_codes(person_id):
     person.commit()
     persons_service.clear_person_cache()
     return otp_recovery_codes
-
-
-def register_tokens(app, access_token, refresh_token=None):
-    """
-    Register access and refresh tokens to auth token store. That way they
-    can be used like a session.
-    """
-    access_jti = get_jti(encoded_token=access_token)
-
-    auth_tokens_store.add(
-        access_jti, "false", app.config["JWT_ACCESS_TOKEN_EXPIRES"]
-    )
-
-    if refresh_token is not None:
-        refresh_jti = get_jti(encoded_token=refresh_token)
-        auth_tokens_store.add(
-            refresh_jti, "false", app.config["JWT_REFRESH_TOKEN_EXPIRES"]
-        )
 
 
 def revoke_tokens(app, jti):

--- a/zou/app/services/comments_service.py
+++ b/zou/app/services/comments_service.py
@@ -306,8 +306,8 @@ def new_comment(
             )
         except ValueError:
             try:
-                created_at_date = fields.get_date_object(
-                    created_at, date_format="%Y-%m-%dT%H:%M:%S"
+                created_at_date = date_helpers.get_datetime_from_string(
+                    created_at
                 )
             except ValueError:
                 pass

--- a/zou/app/stores/auth_tokens_store.py
+++ b/zou/app/stores/auth_tokens_store.py
@@ -58,4 +58,4 @@ def is_revoked(jti):
     """
     Tell if a stored auth token is revoked or not.
     """
-    return get(jti) in [None, "true"]
+    return get(jti) == "true"


### PR DESCRIPTION
**Problem**
- Black
- All JTI are registered in redis we need only to use redis as a blocklist. 
- Some requirements are outdated.
- Some plugins for OTIO are missing due to upgrading to last version (see here: https://github.com/AcademySoftwareFoundation/OpenTimelineIO/releases/tag/v0.17.0)
- Some files (project thumbnails for example) are not properly redownloaded due to the cache (max age HTTP header). We need to add a last_modified header.

**Solution**
- Black 
- Upgrade outdated requirements.
- Only use redis as a blocklist for JTIs.
- Add OpenTimelineIO-Plugins to requirements for any plugins like EDL, XML, etc.
- Add a last_modified header for every file + refactoring.

