### PR TITLE
Various improvements

### DIFF
--- a/zou/app/blueprints/previews/resources.py
+++ b/zou/app/blueprints/previews/resources.py
@@ -76,6 +76,7 @@ ALLOWED_FILE_EXTENSION = [
     "sbbkp",
     "svg",
     "swf",
+    "tvpp",
     "wav",
     "zip",
 ]

--- a/zou/app/blueprints/shots/resources.py
+++ b/zou/app/blueprints/shots/resources.py
@@ -49,6 +49,52 @@ class ShotResource(Resource, ArgsMixin):
         return shot
 
     @jwt_required()
+    def put(self, shot_id):
+        """
+        Update given shot.
+        ---
+        tags:
+        - Shots
+        parameters:
+          - in: path
+            name: shot_id
+            required: True
+            type: string
+            format: UUID
+            x-example: a24a6ea4-ce75-4665-a070-57453082c25
+         - in: body
+            name: data
+            required: True
+          type: object
+        responses:
+            200:
+                description: Update given shot
+        """
+        shot = shots_service.get_shot(shot_id)
+        user_service.check_manager_project_access(shot["project_id"])
+        data = request.json
+        if data is None:
+            raise ArgumentsException(
+                "Data are empty. Please verify that you sent JSON data and"
+                " that you set the right headers."
+            )
+        for field in [
+            "id",
+            "created_at",
+            "updated_at",
+            "instance_casting",
+            "project_id",
+            "entities_in",
+            "entities_out",
+            "type",
+            "shotgun_id",
+            "created_by"
+        ]:
+            data.pop(field, None)
+
+        return shots_service.update_shot(shot_id, data)
+
+    @jwt_required()
     def delete(self, shot_id):
         """
         Delete given shot.

--- a/zou/app/blueprints/tasks/resources.py
+++ b/zou/app/blueprints/tasks/resources.py
@@ -1463,7 +1463,6 @@ class ProjectTasksResource(Resource, ArgsMixin):
     """
 
     @jwt_required()
-    @permissions.require_admin
     def get(self, project_id):
         """
         Retrieve all tasks related to given project.
@@ -1478,13 +1477,37 @@ class ProjectTasksResource(Resource, ArgsMixin):
             type: string
             format: UUID
             x-example: a24a6ea4-ce75-4665-a070-57453082c25
+          - in: query
+            name: page
+            required: False
+            type: integer
+            x-example: 1
+          - in: query
+            name: task_type_id
+            required: False
+            type: string
+            format: UUID
+            x-example: a24a6ea4-ce75-4665-a070-57453082c25
+          - in: query
+            name: episode_id
+            required: False
+            type: string
+            format: UUID
+            x-example: a24a6ea4-ce75-4665-a070-57453082c25
         responses:
             200:
                 description: All tasks related to given project
         """
         projects_service.get_project(project_id)
         page = self.get_page()
-        return tasks_service.get_tasks_for_project(project_id, page)
+        task_type_id = self.get_task_type_id()
+        episode_id = self.get_episode_id()
+        return tasks_service.get_tasks_for_project(
+            project_id,
+            page,
+            task_type_id=task_type_id,
+            episode_id=episode_id
+        )
 
 
 class ProjectCommentsResource(Resource, ArgsMixin):

--- a/zou/app/utils/dbhelpers.py
+++ b/zou/app/utils/dbhelpers.py
@@ -1,4 +1,4 @@
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, inspect
 from sqlalchemy_utils import database_exists, create_database
 from sqlalchemy.engine.url import URL
 from sqlalchemy.orm import close_all_sessions
@@ -39,3 +39,15 @@ def drop_all():
     db.session.flush()
     close_all_sessions()
     return db.drop_all()
+
+
+def is_init():
+    """
+    Check if database is initialized.
+    """
+    from zou.app import db
+    from zou.app.models.project_status import ProjectStatus
+    return (
+      inspect(db.engine).has_table("person")
+      and db.session.query(ProjectStatus).count() == 2
+    )

--- a/zou/cli.py
+++ b/zou/cli.py
@@ -48,6 +48,21 @@ def init_db():
 
 
 @cli.command()
+def is_db_ready():
+    """
+    Return a message telling if the database wheter the database is 
+    initiliazed or not."
+    """
+    with app.app_context():
+        is_init = dbhelpers.is_init()
+        if is_init:
+            print("Database is initiliazed.")
+        else:
+            print("Database is not initiliazed. "
+                  "Run 'zou init-db' and 'init-data'.")
+
+
+@cli.command()
 @click.option("--message", default="")
 def migrate_db(message):
     """


### PR DESCRIPTION
**Problem**

* There is no way to check if the DB is initialized via the command line.
* Some TV Paint extensions are missing
* It's not possible to update shots via the `shots/shot_id` route
* Some routes are non accessible to non-admin users while there is no functional reason for that: `/entities` and `projects/poject_id/tasks`
* `projects/poject_id/tasks` cannot be filtered by episode

**Solution**

* Add a `is-db-ready` command to the CLI to check if the DB was initialized.
* Add TV Paint extensions
* Allow to update shots via PUT requests on the `shots/shot_id` route
* Open access to `/entities` and `projects/poject_id/tasks` by filtering on project teams (assigned tasks for vendors)
* Allow to filter tasks from `projects/poject_id/tasks`  via an `episode_id` parameter 
* Allow to filter tasks from `tasks`  via an `episode_id` parameter 

