### PR TITLE
various improvements

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -78,7 +78,7 @@ install_requires =
     sqlalchemy_utils==0.41.2
     sqlalchemy==2.0.32
     ua-parser==0.18.0
-    werkzeug==3.0.3
+    werkzeug==3.0.4
 
 [options.package_data]
 * = app/file_trees/*.json,migrations/*,migrations/versions/*.py


### PR DESCRIPTION
**Problem**
- Werkzeug requirement is outdated.
- It's possible to break sqlalchemy requests from the db by setting an entity.status not in the ChoiceType.


**Solution**
- Upgrade werkzeug.
- Disallow the possibility to add an entity.status not in the choices list. 
