### PR TITLE
[projects] Fix thumbnail resizing

### DIFF
--- a/zou/app/blueprints/previews/resources.py
+++ b/zou/app/blueprints/previews/resources.py
@@ -981,6 +981,7 @@ class BaseThumbnailResource(Resource):
 
 
 class PersonThumbnailResource(BaseThumbnailResource):
+
     def __init__(self):
         BaseThumbnailResource.__init__(
             self,
@@ -1028,6 +1029,7 @@ class ProjectThumbnailResource(BaseThumbnailResource):
             "projects",
             projects_service.get_project,
             projects_service.update_project,
+            thumbnail_utils.BIG_SQUARE_SIZE,
         )
 
     def check_allowed_to_get(self, instance_id):


### PR DESCRIPTION
**Problem**

Project thumbnails are not correctly resized to square.

**Solution**

Put back the size enforcement in the project thumbnail resource
