### PR TITLE
Various fixes

### DIFF
--- a/zou/app/blueprints/crud/entity_type.py
+++ b/zou/app/blueprints/crud/entity_type.py
@@ -4,6 +4,9 @@ from zou.app.models.entity_type import EntityType
 from zou.app.utils import events
 from zou.app.services import entities_service, assets_service
 
+from zou.app.services.exception import WrongParameterException
+
+
 
 class EntityTypesResource(BaseModelsResource):
     def __init__(self):
@@ -27,6 +30,18 @@ class EntityTypesResource(BaseModelsResource):
     def post_creation(self, instance):
         assets_service.clear_asset_type_cache()
         return instance.serialize(relations=True)
+
+    def check_creation_integrity(self, data):
+        entity_type = (
+            EntityType.query
+            .filter(EntityType.name.ilike(data.get("name", "")))
+            .first()
+        )
+        if entity_type is not None:
+            raise WrongParameterException(
+                "Entity type with this name already exists"
+            )
+        return data
 
 
 class EntityTypeResource(BaseModelResource):

--- a/zou/app/services/deletion_service.py
+++ b/zou/app/services/deletion_service.py
@@ -362,6 +362,11 @@ def remove_project(project_id):
 
     ApiEvent.delete_all_by(project_id=project_id)
     Entity.delete_all_by(project_id=project_id)
+
+    descriptors = MetadataDescriptor.query.filter_by(project_id=project_id)
+    for descriptor in descriptors:
+        descriptor.departments = []
+        descriptor.save()
     MetadataDescriptor.delete_all_by(project_id=project_id)
     Milestone.delete_all_by(project_id=project_id)
     ScheduleItem.delete_all_by(project_id=project_id)

--- a/zou/app/swagger.py
+++ b/zou/app/swagger.py
@@ -30,21 +30,13 @@ An easy to use Python client to access this API is available:
 
 <p>Before you can use any of the endpoints outline below,
 you will have to get a JWT token to authorize your requests.
+</p>
 
-You can get a authorization token using a (form-encoded) POST request to ```/auth/login```.
-With curl this would look something like ```curl -X POST <server_address>/auth/login -d "email=<youremail>&password=<yourpassword>```.
+<p>
+You will find the information to retrieve it in the 
+<a href="#tag/Authentication">Zou documentation</a>.
+</p>
 
-The response is a JSON object, specifically you'll need to provide the ```access_token``` for your future requests.
-
-Here is a complete authentication process as an example (again using curl):
-```
-$ curl -X POST <server_address>/api/auth/login -d "email=<youremail>&password=<yourpassword>"'
-{{"login": true", "access_token": "eyJ0e...", ...}}
-$ jwt=eyJ0e...  # Store the access token for easier use
-$ curl -H "Authorization: Bearer $jwt" <server_address>/api/data/projects
-[{{...}},
-{{...}}]
-```
 [OpenAPI definition](/openapi.json)
 """
 


### PR DESCRIPTION
**Problem**

* Project deletion fails when there is a descriptor tied to a department.
* It's possible to create asset types with the same name if cases are different.
* Bump.sh doesn't accept the open API documentation due to curl examples restrictions.

**Solution**

* Remove descriptor <-> department links before deleting the project.
* Refuse the asset type creation with name equals whether letters are uppercased or not.
* Remove curl examples and send to the Zou documentation.
