### PR TITLE
Fix shared assets

### DIFF
--- a/zou/app/blueprints/assets/resources.py
+++ b/zou/app/blueprints/assets/resources.py
@@ -435,6 +435,7 @@ class NewAssetResource(Resource, ArgsMixin):
                 - name
                 - description
                 - data
+                - is_shared
                 - source_id
                 properties:
                     name:
@@ -443,6 +444,8 @@ class NewAssetResource(Resource, ArgsMixin):
                         type: string
                     data:
                         type: string
+                    is_shared:
+                        type: boolean
                     source_id:
                         type: string
                         format: UUID
@@ -451,7 +454,7 @@ class NewAssetResource(Resource, ArgsMixin):
             201:
                 description: New asset resource created
         """
-        (name, description, data, source_id) = self.get_arguments()
+        (name, description, data, is_shared, source_id) = self.get_arguments()
 
         user_service.check_manager_project_access(project_id)
         asset = assets_service.create_asset(
@@ -460,6 +463,7 @@ class NewAssetResource(Resource, ArgsMixin):
             name,
             description,
             data,
+            is_shared,
             source_id,
             created_by=persons_service.get_current_user()["id"],
         )
@@ -475,6 +479,12 @@ class NewAssetResource(Resource, ArgsMixin):
                 },
                 "description",
                 ("data", {}, False, dict),
+                (
+                    "is_shared",
+                    True,
+                    False,
+                    bool,
+                ),
                 "episode_id",
             ]
         )
@@ -483,6 +493,7 @@ class NewAssetResource(Resource, ArgsMixin):
             args["name"],
             args.get("description", ""),
             args["data"],
+            args["is_shared"],
             args["episode_id"],
         )
 

--- a/zou/app/services/assets_service.py
+++ b/zou/app/services/assets_service.py
@@ -306,6 +306,7 @@ def get_assets_and_tasks(criterions={}, page=1, with_episode_ids=False):
                 "episode_id": source_id,
                 "casting_episode_ids": cast_in_episode_ids.get(asset_id, []),
                 "is_casting_standby": asset.is_casting_standby,
+                "is_shared": asset.is_shared,
                 "data": data,
                 "tasks": [],
             }
@@ -571,6 +572,7 @@ def create_asset(
     name,
     description,
     data,
+    is_shared=False,
     source_id=None,
     created_by=None,
 ):
@@ -587,6 +589,7 @@ def create_asset(
         name=name,
         description=description,
         data=data,
+        is_shared=is_shared,
         source_id=source_id,
         created_by=created_by,
     )

--- a/zou/app/services/breakdown_service.py
+++ b/zou/app/services/breakdown_service.py
@@ -99,11 +99,27 @@ def get_production_episodes_casting(project_id):
         .join(EntityType, Entity.entity_type_id == EntityType.id)
         .filter(Episode.project_id == project_id)
         .filter(Entity.canceled != True)
-        .add_columns(Entity.name, EntityType.name, Entity.preview_file_id)
-        .order_by(EntityType.name, Entity.name)
+        .add_columns(
+            Entity.name,
+            EntityType.name,
+            Entity.preview_file_id,
+            Entity.is_shared,
+            Entity.project_id,
+        )
+        .order_by(
+            EntityType.name,
+            Entity.name,
+        )
     )
 
-    for link, entity_name, entity_type_name, entity_preview_file_id in links:
+    for (
+        link,
+        entity_name,
+        entity_type_name,
+        entity_preview_file_id,
+        entity_is_shared,
+        entity_project_id,
+    ) in links:
         episode_id = str(link.entity_in_id)
         if episode_id not in castings:
             castings[episode_id] = []
@@ -118,6 +134,8 @@ def get_production_episodes_casting(project_id):
                 ),
                 "nb_occurences": link.nb_occurences,
                 "label": link.label,
+                "is_shared": entity_is_shared,
+                "project_id": entity_project_id,
             }
         )
     return castings
@@ -145,6 +163,8 @@ def get_sequence_casting(sequence_id, project_id=None, episode_id=None):
             Entity.name,
             EntityType.name,
             Entity.preview_file_id,
+            Entity.is_shared,
+            Entity.project_id,
             Sequence.name,
         )
     )
@@ -169,6 +189,8 @@ def get_sequence_casting(sequence_id, project_id=None, episode_id=None):
         entity_name,
         entity_type_name,
         entity_preview_file_id,
+        entity_is_shared,
+        entity_project_id,
         sequence_name,
     ) in links:
         shot_id = str(link.entity_in_id)
@@ -186,6 +208,8 @@ def get_sequence_casting(sequence_id, project_id=None, episode_id=None):
                 ),
                 "nb_occurences": link.nb_occurences,
                 "label": link.label,
+                "is_shared": entity_is_shared,
+                "project_id": entity_project_id,
             }
         )
     return castings


### PR DESCRIPTION
**Problem**
- On fetching a casting for an episode, some data related to shared assets are missing.
- An asset cannot be directly set as a shared asset when it is created.

**Solution**
-  Fetch missing columns (`is_shared`/`project_id`) on get casting with shared assets.
- Allow to set as shared when creating an asset.