### PR TITLE
Fix event emitting

### DIFF
--- a/zou/app/blueprints/crud/task.py
+++ b/zou/app/blueprints/crud/task.py
@@ -114,6 +114,7 @@ class TasksResource(BaseModelsResource, ArgsMixin):
             if assignees is not None:
                 instance.assignees = persons
             instance.save()
+            self.emit_create_event(instance.serialize())
 
             return tasks_service.get_task_with_relations(str(instance.id)), 201
 

--- a/zou/app/services/assets_service.py
+++ b/zou/app/services/assets_service.py
@@ -722,6 +722,7 @@ def set_shared_assets(
     project_id=None,
     asset_type_id=None,
     asset_ids=None,
+    with_events=False
 ):
     """
     Set all assets of a project to is_shared=True or False.
@@ -748,11 +749,12 @@ def set_shared_assets(
     for asset in assets:
         asset_id = str(asset.id)
         clear_asset_cache(asset_id)
-        events.emit(
-            "asset:update",
-            {"asset_id": asset_id},
-            project_id=project_id,
-        )
+        if with_events:
+            events.emit(
+                "asset:update",
+                {"asset_id": asset_id},
+                project_id=project_id,
+            )
 
     return Entity.serialize_list(assets, obj_type="Asset")
 


### PR DESCRIPTION
**Problem**

* Adding an asset to the library generates too many update notifications.
* Task creation via CRUD routes doesn't generate a new event.

**Solution**

* Do not generate update events on asset library addition.
* Emit a `task:new` event on task creation.