### PR TITLE
various improvements

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -56,11 +56,11 @@ install_requires =
     matterhook==0.2
     meilisearch==0.31.6
     numpy==2.0.1; python_version == '3.9'
-    numpy==2.1.2; python_version >= '3.10'
+    numpy==2.1.3; python_version >= '3.10'
     opencv-python==4.10.0.84
     OpenTimelineIO==0.17.0
     OpenTimelineIO-Plugins==0.17.0
-    orjson==3.10.10
+    orjson==3.10.11
     pillow==11.0.0
     psutil==6.1.0
     psycopg[binary]==3.2.3
@@ -103,7 +103,7 @@ test =
 monitoring =
     prometheus-flask-exporter==0.23.1
     pygelf==0.4.2
-    sentry-sdk==2.17.0
+    sentry-sdk==2.18.0
 
 lint =
     autoflake==2.3.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -97,7 +97,7 @@ dev =
 test =
     fakeredis==2.26.1
     mixer==7.2.2
-    pytest-cov==5.0.0
+    pytest-cov==6.0.0
     pytest==8.3.3
 
 monitoring =

--- a/tests/services/test_breakdown_service.py
+++ b/tests/services/test_breakdown_service.py
@@ -288,7 +288,10 @@ class BreakdownServiceTestCase(ApiDBTestCase):
         self.assertEqual(priority_map[self.task_type_layout_id], 1)
         self.assertEqual(priority_map[self.task_type_animation_id], 2)
         self.assertEqual(priority_map[self.task_type_compositing_id], 3)
-        asset = {"ready_for": str(self.task_type_animation.id)}
+        asset = {
+            "ready_for": str(self.task_type_animation.id),
+            "is_shared": False,
+        }
         self.assertTrue(
             breakdown_service._is_asset_ready(
                 asset, self.task_layout, priority_map
@@ -302,6 +305,33 @@ class BreakdownServiceTestCase(ApiDBTestCase):
         self.assertFalse(
             breakdown_service._is_asset_ready(
                 asset, self.task_compositing, priority_map
+            )
+        )
+
+        asset = {
+            "ready_for": str(self.task_type_animation.id),
+            "is_shared": True,
+            "project_id": self.project_id,
+        }
+        self.assertTrue(
+            breakdown_service._is_asset_ready(
+                asset, self.task_layout, priority_map
+            )
+        )
+        self.assertTrue(
+            breakdown_service._is_asset_ready(
+                asset, self.task_animation, priority_map
+            )
+        )
+        self.assertFalse(
+            breakdown_service._is_asset_ready(
+                asset, self.task_compositing, priority_map
+            )
+        )
+        asset["project_id"] = "000000000000000000000000"
+        self.assertTrue(
+            breakdown_service._is_asset_ready(
+                asset, self.task_layout, priority_map
             )
         )
 

--- a/zou/app/blueprints/crud/base.py
+++ b/zou/app/blueprints/crud/base.py
@@ -127,7 +127,7 @@ class BaseModelsResource(Resource, ArgsMixin):
 
         return query
 
-    def check_read_permissions(self):
+    def check_read_permissions(self, options=None):
         return permissions.check_admin_permissions()
 
     def add_project_permission_filter(self, query):
@@ -165,13 +165,14 @@ class BaseModelsResource(Resource, ArgsMixin):
                 description: Permission denied
         """
         try:
-            self.check_read_permissions()
             query = self.model.query
             if not request.args:
+                self.check_read_permissions()
                 query = self.add_project_permission_filter(query)
                 return self.all_entries(query)
             else:
                 options = request.args
+                self.check_read_permissions(options)
                 query = self.apply_filters(query, options)
                 query = self.add_project_permission_filter(query)
                 page = int(options.get("page", "-1"))

--- a/zou/app/blueprints/crud/comments.py
+++ b/zou/app/blueprints/crud/comments.py
@@ -28,6 +28,19 @@ class CommentsResource(BaseModelsResource):
     def __init__(self):
         BaseModelsResource.__init__(self, Comment)
 
+    def check_read_permissions(self, options=None):
+        if options is not None:
+            if "project_id" in options:
+                user_service.check_project_access(options["project_id"])
+                if (
+                    permissions.has_vendor_permissions()
+                    or permissions.has_client_permissions()
+                ):
+                    raise permissions.PermissionDenied
+                else:
+                    return True
+        return permissions.check_admin_permissions()
+
 
 class CommentResource(BaseModelResource):
     def __init__(self):

--- a/zou/app/blueprints/crud/custom_action.py
+++ b/zou/app/blueprints/crud/custom_action.py
@@ -9,7 +9,7 @@ class CustomActionsResource(BaseModelsResource):
     def __init__(self):
         BaseModelsResource.__init__(self, CustomAction)
 
-    def check_read_permissions(self):
+    def check_read_permissions(self, options=None):
         user_service.block_access_to_vendor()
         return True
 

--- a/zou/app/blueprints/crud/department.py
+++ b/zou/app/blueprints/crud/department.py
@@ -9,7 +9,7 @@ class DepartmentsResource(BaseModelsResource):
     def __init__(self):
         BaseModelsResource.__init__(self, Department)
 
-    def check_read_permissions(self):
+    def check_read_permissions(self, options=None):
         return True
 
     def post_creation(self, instance):

--- a/zou/app/blueprints/crud/entity.py
+++ b/zou/app/blueprints/crud/entity.py
@@ -61,7 +61,7 @@ class EntitiesResource(BaseModelsResource, EntityEventMixin):
     def emit_create_event(self, entity_dict):
         self.emit_event("new", entity_dict)
 
-    def check_read_permissions(self):
+    def check_read_permissions(self, options=None):
         return True
 
     def add_project_permission_filter(self, query):

--- a/zou/app/blueprints/crud/entity_type.py
+++ b/zou/app/blueprints/crud/entity_type.py
@@ -20,7 +20,7 @@ class EntityTypesResource(BaseModelsResource):
             for asset_type in query.all()
         ]
 
-    def check_read_permissions(self):
+    def check_read_permissions(self, options=None):
         return True
 
     def emit_create_event(self, instance_dict):

--- a/zou/app/blueprints/crud/file_status.py
+++ b/zou/app/blueprints/crud/file_status.py
@@ -6,7 +6,7 @@ class FileStatusesResource(BaseModelsResource):
     def __init__(self):
         BaseModelsResource.__init__(self, FileStatus)
 
-    def check_read_permissions(self):
+    def check_read_permissions(self, options=None):
         return True
 
 

--- a/zou/app/blueprints/crud/metadata_descriptor.py
+++ b/zou/app/blueprints/crud/metadata_descriptor.py
@@ -17,7 +17,7 @@ class MetadataDescriptorsResource(BaseModelsResource):
     def __init__(self):
         BaseModelsResource.__init__(self, MetadataDescriptor)
 
-    def check_read_permissions(self):
+    def check_read_permissions(self, options=None):
         return not permissions.has_vendor_permissions()
 
     def add_project_permission_filter(self, query):

--- a/zou/app/blueprints/crud/metadata_descriptor.py
+++ b/zou/app/blueprints/crud/metadata_descriptor.py
@@ -6,6 +6,7 @@ from zou.app.models.metadata_descriptor import (
 from zou.app.blueprints.crud.base import BaseModelResource, BaseModelsResource
 from zou.app.utils import permissions
 from zou.app.models.project import Project
+from zou.app.services import user_service
 
 from zou.app.services.exception import (
     WrongParameterException,

--- a/zou/app/blueprints/crud/organisation.py
+++ b/zou/app/blueprints/crud/organisation.py
@@ -8,7 +8,7 @@ class OrganisationsResource(BaseModelsResource):
     def __init__(self):
         BaseModelsResource.__init__(self, Organisation)
 
-    def check_read_permissions(self):
+    def check_read_permissions(self, options=None):
         return True
 
 

--- a/zou/app/blueprints/crud/output_file.py
+++ b/zou/app/blueprints/crud/output_file.py
@@ -17,7 +17,7 @@ class OutputFilesResource(BaseModelsResource):
     def __init__(self):
         BaseModelsResource.__init__(self, OutputFile)
 
-    def check_read_permissions(self):
+    def check_read_permissions(self, options=None):
         user_service.block_access_to_vendor()
         return True
 

--- a/zou/app/blueprints/crud/output_type.py
+++ b/zou/app/blueprints/crud/output_type.py
@@ -12,7 +12,7 @@ class OutputTypesResource(BaseModelsResource):
     def __init__(self):
         BaseModelsResource.__init__(self, OutputType)
 
-    def check_read_permissions(self):
+    def check_read_permissions(self, options=None):
         return True
 
 

--- a/zou/app/blueprints/crud/person.py
+++ b/zou/app/blueprints/crud/person.py
@@ -52,7 +52,7 @@ class PersonsResource(BaseModelsResource):
                 for person in query.all()
             ]
 
-    def check_read_permissions(self):
+    def check_read_permissions(self, options=None):
         return True
 
     def check_create_permissions(self, data):

--- a/zou/app/blueprints/crud/playlist.py
+++ b/zou/app/blueprints/crud/playlist.py
@@ -9,7 +9,7 @@ class PlaylistsResource(BaseModelsResource):
     def __init__(self):
         BaseModelsResource.__init__(self, Playlist)
 
-    def check_read_permissions(self):
+    def check_read_permissions(self, options=None):
         return True
 
     def check_create_permissions(self, playlist):

--- a/zou/app/blueprints/crud/preview_background_file.py
+++ b/zou/app/blueprints/crud/preview_background_file.py
@@ -9,7 +9,7 @@ class PreviewBackgroundFilesResource(BaseModelsResource):
     def __init__(self):
         BaseModelsResource.__init__(self, PreviewBackgroundFile)
 
-    def check_read_permissions(self):
+    def check_read_permissions(self, options=None):
         return True
 
     def update_data(self, data):

--- a/zou/app/blueprints/crud/preview_file.py
+++ b/zou/app/blueprints/crud/preview_file.py
@@ -37,7 +37,7 @@ class PreviewFilesResource(BaseModelsResource):
 
         return query
 
-    def check_read_permissions(self):
+    def check_read_permissions(self, options=None):
         return True
 
 

--- a/zou/app/blueprints/crud/project.py
+++ b/zou/app/blueprints/crud/project.py
@@ -31,7 +31,7 @@ class ProjectsResource(BaseModelsResource):
         else:
             return query.filter(user_service.build_related_projects_filter())
 
-    def check_read_permissions(self):
+    def check_read_permissions(self, options=None):
         return True
 
     def check_creation_integrity(self, data):

--- a/zou/app/blueprints/crud/project_status.py
+++ b/zou/app/blueprints/crud/project_status.py
@@ -6,7 +6,7 @@ class ProjectStatussResource(BaseModelsResource):
     def __init__(self):
         BaseModelsResource.__init__(self, ProjectStatus)
 
-    def check_read_permissions(self):
+    def check_read_permissions(self, options=None):
         return True
 
 

--- a/zou/app/blueprints/crud/software.py
+++ b/zou/app/blueprints/crud/software.py
@@ -12,7 +12,7 @@ class SoftwaresResource(BaseModelsResource):
     def __init__(self):
         BaseModelsResource.__init__(self, Software)
 
-    def check_read_permissions(self):
+    def check_read_permissions(self, options=None):
         return True
 
 

--- a/zou/app/blueprints/crud/status_automation.py
+++ b/zou/app/blueprints/crud/status_automation.py
@@ -13,7 +13,7 @@ class StatusAutomationsResource(BaseModelsResource):
     def __init__(self):
         BaseModelsResource.__init__(self, StatusAutomation)
 
-    def check_read_permissions(self):
+    def check_read_permissions(self, options=None):
         user_service.block_access_to_vendor()
         return True
 

--- a/zou/app/blueprints/crud/studio.py
+++ b/zou/app/blueprints/crud/studio.py
@@ -9,7 +9,7 @@ class StudiosResource(BaseModelsResource):
     def __init__(self):
         BaseModelsResource.__init__(self, Studio)
 
-    def check_read_permissions(self):
+    def check_read_permissions(self, options=None):
         return True
 
     def post_creation(self, instance):

--- a/zou/app/blueprints/crud/task.py
+++ b/zou/app/blueprints/crud/task.py
@@ -28,7 +28,7 @@ class TasksResource(BaseModelsResource, ArgsMixin):
     def __init__(self):
         BaseModelsResource.__init__(self, Task)
 
-    def check_read_permissions(self):
+    def check_read_permissions(self, options=None):
         return True
 
     def add_project_permission_filter(self, query):

--- a/zou/app/blueprints/crud/task_status.py
+++ b/zou/app/blueprints/crud/task_status.py
@@ -7,7 +7,7 @@ class TaskStatusesResource(BaseModelsResource):
     def __init__(self):
         BaseModelsResource.__init__(self, TaskStatus)
 
-    def check_read_permissions(self):
+    def check_read_permissions(self, options=None):
         return True
 
     def post_creation(self, instance):

--- a/zou/app/blueprints/crud/task_type.py
+++ b/zou/app/blueprints/crud/task_type.py
@@ -9,7 +9,7 @@ class TaskTypesResource(BaseModelsResource):
     def __init__(self):
         BaseModelsResource.__init__(self, TaskType)
 
-    def check_read_permissions(self):
+    def check_read_permissions(self, options=None):
         return True
 
     def update_data(self, data):

--- a/zou/app/blueprints/crud/working_file.py
+++ b/zou/app/blueprints/crud/working_file.py
@@ -16,7 +16,7 @@ class WorkingFilesResource(BaseModelsResource):
     def __init__(self):
         BaseModelsResource.__init__(self, WorkingFile)
 
-    def check_read_permissions(self):
+    def check_read_permissions(self, options=None):
         """
         Overriding so that people without admin credentials can still access
         this resource.

--- a/zou/app/blueprints/tasks/resources.py
+++ b/zou/app/blueprints/tasks/resources.py
@@ -1518,7 +1518,6 @@ class ProjectCommentsResource(Resource, ArgsMixin):
     """
 
     @jwt_required()
-    @permissions.require_admin
     def get(self, project_id):
         """
         Retrieve all comments to tasks related to given project.
@@ -1538,6 +1537,12 @@ class ProjectCommentsResource(Resource, ArgsMixin):
                 description: All comments to tasks related to given project
         """
         projects_service.get_project(project_id)
+        user_service.check_project_access(project_id)
+        if (
+            permissions.has_vendor_permissions()
+            or permissions.has_client_permissions()
+        ):
+            raise permissions.PermissionDenied
         page = self.get_page()
         return tasks_service.get_comments_for_project(project_id, page)
 

--- a/zou/app/services/breakdown_service.py
+++ b/zou/app/services/breakdown_service.py
@@ -829,7 +829,9 @@ def _get_task_type_priority_map(project_id):
 
 def _is_asset_ready(asset, task, priority_map):
     is_ready = False
-    if "ready_for" in asset and asset["ready_for"] is not None:
+    if asset["is_shared"] and asset["project_id"] != str(task.project_id):
+        is_ready = True
+    elif "ready_for" in asset and asset["ready_for"] is not None:
         priority_ready = priority_map.get(asset["ready_for"], -1) or -1
         priority_task = priority_map.get(str(task.task_type_id), 0) or 0
         is_ready = priority_task <= priority_ready


### PR DESCRIPTION
**Problem**
- Some requirements are outdated. 
- For the breakdown when you use shared assets (from another project) they are not ready.
- There is a missing import. 
- For the routes: "data/comments" and "data/projects/<project_id>/comments" it's only possible to get all comments for a project when you are a studio manager.

**Solution**
- Upgrade outdated requirements. 
- For the breakdown when you use shared assets (from another project) always set them as ready.
- Fix missing import. 
- For the routes: "data/comments" and "data/projects/<project_id>/comments" allow to get all comments for a project when you are a manager, supervisor, or artist (only if they have access to that project).
