### PR TITLE
Fix permissions for global search

### DIFF
--- a/tests/search/test_search.py
+++ b/tests/search/test_search.py
@@ -55,6 +55,12 @@ class AssetSearchTestCase(ApiDBTestCase):
         assets = self.post("data/search", {"query": "rabbit"}, 200)["assets"]
         self.assertEqual(len(assets), 1)
 
+    def test_search_assets_not_allowed(self):
+        self.generate_fixture_user_manager()
+        self.log_in_manager()
+        assets = self.post("data/search", {"query": "rabbit"}, 200)["assets"]
+        self.assertEqual(len(assets), 0)
+
     def test_search_assets_partial(self):
         assets = self.post("data/search", {"query": "rab"}, 200)["assets"]
         self.assertEqual(len(assets), 1)
@@ -122,6 +128,12 @@ class AssetSearchTestCase(ApiDBTestCase):
     def test_search_shots_exact(self):
         shots = self.post("data/search", {"query": "sh001"}, 200)["shots"]
         self.assertEqual(len(shots), 1)
+
+    def test_search_shots_not_allowed(self):
+        self.generate_fixture_user_manager()
+        self.log_in_manager()
+        assets = self.post("data/search", {"query": "sh001"}, 200)["shots"]
+        self.assertEqual(len(assets), 0)
 
     def test_search_shots_partial(self):
         shots = self.post("data/search", {"query": "sH00"}, 200)["shots"]

--- a/zou/app/blueprints/search/resources.py
+++ b/zou/app/blueprints/search/resources.py
@@ -78,12 +78,24 @@ class SearchResource(Resource, ArgsMixin):
                 query, limit=limit, offset=offset
             )
         if "assets" in index_names:
-            results["assets"] = index_service.search_assets(
-                query, project_ids, limit=limit, offset=offset
-            )
+            if (
+                len(project_ids) == 0
+                and not permissions.has_admin_permissions()
+            ):
+                results["assets"] = []
+            else:
+                results["assets"] = index_service.search_assets(
+                    query, project_ids, limit=limit, offset=offset
+                )
         if "shots" in index_names:
-            results["shots"] = index_service.search_shots(
-                query, project_ids, limit=limit, offset=offset
-            )
+            if (
+                len(project_ids) == 0
+                and not permissions.has_admin_permissions()
+            ):
+                results["shots"] = []
+            else:
+                results["shots"] = index_service.search_shots(
+                    query, project_ids, limit=limit, offset=offset
+                )
 
         return results


### PR DESCRIPTION
**Problem**
- In the global search, it is possible to search for assets and shots from projects for which we do not have permission.


**Solution**
- When a person has no projects (and is not an admin) return an empty list of assets and shots. 
