### PR TITLE
Fix the Troubleshooting section

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -43,7 +43,7 @@ Zou cannot connect to it. Zou cannot run properly in that case.
 NB: Database refers to Posgres, Key Value Store refers to Redis, Event
 Stream refers to `zou-events` service, job queue refers to `zou-jobs` service.
 
-# Changing password
+## Changing password
 
 If, for any reasons, the user cannot access to his rest password email, you can
 change his password with the following command:


### PR DESCRIPTION
**Problem**
The menu in the Troubleshooting section is inconsistent:

<img width="394" alt="Monosnap Troubleshooting - Kitsu API Documentation 2024-11-18 14-53-15" src="https://github.com/user-attachments/assets/aaa6a9c8-e078-4f38-8a77-65b9aaa740ff">



---

**Solution**
- Fix the order of one title, to fix the Troubleshooting menu:

<img width="596" alt="Monosnap Troubleshooting - Kitsu API Documentation 2024-11-18 14-53-57" src="https://github.com/user-attachments/assets/caa7e73f-e0ad-45a2-90ef-bf0daf794b82">

