### PR TITLE
Added missing field on present_minimal method of Person

### DIFF
--- a/zou/app/models/person.py
+++ b/zou/app/models/person.py
@@ -182,6 +182,7 @@ class Person(db.Model, BaseMixin, SerializerMixin):
         )
         return {
             "id": data["id"],
+            "type": data["type"],
             "first_name": data["first_name"],
             "last_name": data["last_name"],
             "full_name": self.full_name,


### PR DESCRIPTION
**Problem**
The user service runs persons_service.get_persons as minimal if the given user doesn't have Manager permissions.
The problem is that the present_minimal method in /zou/app/models/person.py#179 doesn't return the "type" field.
This broke our pipeline, as the output of the /data/Persons webhook was different between Artists and Managers

**Solution**
Added the "type" field to the representation for non-manager users.