### PR TITLE
Various improvements

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -62,15 +62,15 @@ install_requires =
     opencv-python==4.10.0.84
     OpenTimelineIO==0.17.0
     OpenTimelineIO-Plugins==0.17.0
-    orjson==3.10.12
-    pillow==11.0.0
+    orjson==3.10.13
+    pillow==11.1.0
     psutil==6.1.1
     psycopg[binary]==3.2.3
     pyotp==2.9.0
     pysaml2==7.5.0
     python-nomad==2.0.1
     python-slugify==8.0.4
-    python-socketio==5.12.0
+    python-socketio==5.12.1
     pytz==2024.2
     redis==5.2.1
     requests==2.32.3

--- a/zou/app/blueprints/previews/__init__.py
+++ b/zou/app/blueprints/previews/__init__.py
@@ -2,6 +2,7 @@ from flask import Blueprint
 from zou.app.utils.api import configure_api_from_blueprint
 
 from zou.app.blueprints.previews.resources import (
+    AddCommentsPreviewsResource,
     AttachmentThumbnailResource,
     CreatePreviewFilePictureResource,
     PreviewFileLowMovieResource,
@@ -36,6 +37,10 @@ routes = [
     (
         "/pictures/preview-files/<instance_id>",
         CreatePreviewFilePictureResource,
+    ),
+    (
+        "/actions/tasks/<task_id>/add-comments-previews",
+        AddCommentsPreviewsResource,
     ),
     (
         "/movies/originals/preview-files/<instance_id>.mp4",

--- a/zou/app/blueprints/tasks/__init__.py
+++ b/zou/app/blueprints/tasks/__init__.py
@@ -94,8 +94,7 @@ routes = [
         AddPreviewResource,
     ),
     (
-        "/actions/tasks/<task_id>/comments/<comment_id>/preview-files/"
-        "<preview_file_id>",
+        "/actions/tasks/<task_id>/comments/<comment_id>/preview-files/<preview_file_id>",
         AddExtraPreviewResource,
     ),
     ("/actions/tasks/<task_id>/to-review", ToReviewResource),

--- a/zou/app/blueprints/tasks/resources.py
+++ b/zou/app/blueprints/tasks/resources.py
@@ -73,9 +73,6 @@ class AddPreviewResource(Resource, ArgsMixin):
         user_service.check_project_access(task["project_id"])
         user_service.check_entity_access(task["entity_id"])
 
-        tasks_service.clear_comment_cache(comment_id)
-        comment = tasks_service.get_comment(comment_id)
-        tasks_service.get_task_status(comment["task_status_id"])
         person = persons_service.get_current_user()
         preview_file = tasks_service.add_preview_file_to_comment(
             comment_id, person["id"], task_id, args["revision"]

--- a/zou/app/services/comments_service.py
+++ b/zou/app/services/comments_service.py
@@ -74,9 +74,9 @@ def create_comment(
     task_id,
     task_status_id,
     text,
-    checklist,
-    files,
-    created_at,
+    checklist=[],
+    files={},
+    created_at="",
     links=[],
 ):
     """

--- a/zou/event_stream.py
+++ b/zou/event_stream.py
@@ -2,7 +2,7 @@ from gevent import monkey
 
 monkey.patch_all()
 
-from flask import Flask, jsonify
+from flask import jsonify
 from flask_jwt_extended import (
     get_jwt_identity,
     jwt_required,
@@ -10,12 +10,9 @@ from flask_jwt_extended import (
     JWTManager,
 )
 from flask_socketio import SocketIO, disconnect, join_room, emit
-from flask_sqlalchemy import SQLAlchemy
 
-from zou.app import config
+from zou.app import config, app
 from zou.app.stores import auth_tokens_store
-from zou.app.utils.monitoring import init_monitoring
-from zou.app.utils.flask import ORJSONProvider
 from zou.app.services import persons_service
 
 server_stats = {"nb_connections": 0}
@@ -227,12 +224,6 @@ def create_app():
     socketio = SocketIO(
         logger=True, cors_allowed_origins=[], cors_credentials=False
     )
-    app = Flask(__name__)
-    app.json = ORJSONProvider(app)
-    app.config.from_object(config)
-    init_monitoring(app)
-    db = SQLAlchemy(app)
-    app.extensions["sqlalchemy"].db = db
     set_info_routes(socketio, app)
     set_application_routes(socketio, app)
     set_playlist_room_routes(socketio, app)


### PR DESCRIPTION
**Problem**
- There's no route to publish multiple comments/previews/attachments in one request. 
- Some requirements are outdated.
- The bots can't listen to Zou events (see https://github.com/cgwire/zou/issues/905).

**Solution**
- Add new route for that : "/actions/tasks/<task_id>/add-comments-previews"
- Upgrade outdated requirements.
- Fix https://github.com/cgwire/zou/issues/905, use only one flask app in Zou.