### PR TITLE
various improvements

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ install_requires =
     flask-migrate==4.1.0
     flask-socketio==5.5.1
     flask==3.1.0
-    gazu==0.10.23
+    gazu==0.10.24
     gevent-websocket==0.10.1
     gevent==24.11.1
     gunicorn==23.0.0
@@ -110,7 +110,7 @@ monitoring =
 lint =
     autoflake==2.3.1
     black==24.10.0
-    pre-commit==4.0.1
+    pre-commit==4.1.0
 
 [options.entry_points]
 console_scripts =

--- a/zou/app/blueprints/assets/resources.py
+++ b/zou/app/blueprints/assets/resources.py
@@ -484,7 +484,7 @@ class NewAssetResource(Resource, ArgsMixin):
                 ("data", {}, False, dict),
                 (
                     "is_shared",
-                    True,
+                    False,
                     False,
                     inputs.boolean,
                 ),

--- a/zou/app/blueprints/crud/preview_file.py
+++ b/zou/app/blueprints/crud/preview_file.py
@@ -98,7 +98,9 @@ class PreviewFileResource(BaseModelResource):
             instance_dict = instance.serialize()
             self.check_delete_permissions(instance_dict)
             self.pre_delete(instance_dict)
-            deletion_service.remove_preview_file(instance)
+            deletion_service.remove_preview_file(
+                instance, force=self.get_force()
+            )
             self.emit_delete_event(instance_dict)
             self.post_delete(instance_dict)
 

--- a/zou/app/blueprints/source/csv/task_type_estimations.py
+++ b/zou/app/blueprints/source/csv/task_type_estimations.py
@@ -123,6 +123,9 @@ class TaskTypeEstimationsCsvImportResource(BaseCsvProjectImportResource):
                 new_data["start_date"], float(row["Estimation"]) - 1
             )
 
+        if row.get("Difficulty") not in [None, ""]:
+            new_data["difficulty"] = int(row["Difficulty"])
+
         tasks_service.update_task(self.tasks_map[entity_id], new_data)
 
 

--- a/zou/app/blueprints/tasks/resources.py
+++ b/zou/app/blueprints/tasks/resources.py
@@ -78,7 +78,7 @@ class AddPreviewResource(Resource, ArgsMixin):
         return preview_file, 201
 
 
-class AddExtraPreviewResource(Resource):
+class AddExtraPreviewResource(Resource, ArgsMixin):
     """
     Add a preview to given comment.
     """
@@ -160,7 +160,9 @@ class AddExtraPreviewResource(Resource):
         """
         task = tasks_service.get_task(task_id)
         user_service.check_project_access(task["project_id"])
-        deletion_service.remove_preview_file_by_id(preview_file_id)
+        deletion_service.remove_preview_file_by_id(
+            preview_file_id, force=self.get_force()
+        )
         return "", 204
 
 

--- a/zou/app/services/comments_service.py
+++ b/zou/app/services/comments_service.py
@@ -252,24 +252,25 @@ def _run_status_automation(automation, task, person_id):
                         task["id"]
                     )
                 )
-                preview_files = (
-                    preview_files_service.get_preview_files_for_revision(
-                        preview_file["task_id"], preview_file["revision"]
-                    )
-                )
-
-                for preview_file in preview_files:
-                    new_preview_file = (
-                        tasks_service.add_preview_file_to_comment(
-                            new_comment["id"],
-                            new_comment["person_id"],
-                            task_to_update["id"],
+                if preview_file is not None:
+                    preview_files = (
+                        preview_files_service.get_preview_files_for_revision(
+                            preview_file["task_id"], preview_file["revision"]
                         )
                     )
 
-                    preview_files_service.copy_preview_file_in_another_one(
-                        preview_file["id"], new_preview_file["id"]
-                    )
+                    for preview_file in preview_files:
+                        new_preview_file = (
+                            tasks_service.add_preview_file_to_comment(
+                                new_comment["id"],
+                                new_comment["person_id"],
+                                task_to_update["id"],
+                            )
+                        )
+
+                        preview_files_service.copy_preview_file_in_another_one(
+                            preview_file["id"], new_preview_file["id"]
+                        )
 
     elif automation["out_field_type"] == "ready_for":
         try:


### PR DESCRIPTION
**Problem**
- There's no "force" parameter to delete files on the filesystem for preview file routes.
- For /data/projects/<project_id>/asset-types/<asset_type_id>/assets/new "is_shared" arg is at True by default. 
- When importing a task type CSV it's not possible to import difficulty field.
- For status automation when importing the last revision there's an exception when there are no preview files. 
- Some requirements are outdated. 

**Solution**
- Add a "force" parameter to delete files on the filesystem for preview file routes.
- For /data/projects/<project_id>/asset-types/<asset_type_id>/assets/new set "is_shared" arg at False by default. 
- When importing a task type CSV allow to import the "difficulty" field.
- For status automation when importing the last revision check before if there are no preview files. 
- Upgrade outdated requirements.  
