### PR TITLE
Docs env file and py conf

### DIFF
--- a/docs/backup.md
+++ b/docs/backup.md
@@ -10,7 +10,8 @@ To run a backup of the Zou database, run the following command:
 
 ```bash
 cd /opt/zou/backups
-DB_PASSWORD=mysecretpassword /opt/zou/zouenv/bin/zou dump-database
+. /etc/zou/zou.env
+/opt/zou/zouenv/bin/zou dump-database
 ```
 
 All data will be stored in a file in the current directory.  The generated file
@@ -43,9 +44,9 @@ ALTER DATABASE targetdb RENAME TO zoudb;
 ```
 you can also change the database being used by using an environment variable in
 
-/etc/systemd/system/zou.service
+/etc/zou/zou.env
 ```bash
-Environment="DB_DATABASE=targetdb"
+DB_DATABASE=targetdb
 ```
 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -291,7 +291,7 @@ sudo mkdir /etc/zou
 
 We need to run the application through *gunicorn*, a WSGI server that will run zou as a daemon. Let's write the *gunicorn* configuration:
 
-*Path: /etc/zou/gunicorn.conf*
+*Path: /etc/zou/gunicorn.py*
 
 ```
 accesslog = "/opt/zou/logs/gunicorn_access.log"
@@ -324,7 +324,7 @@ WorkingDirectory=/opt/zou
 # ffmpeg must be in PATH
 Environment="PATH=/opt/zou/zouenv/bin:/usr/bin"
 EnvironmentFile=/etc/zou/zou.env
-ExecStart=/opt/zou/zouenv/bin/gunicorn  -c /etc/zou/gunicorn.conf -b 127.0.0.1:5000 zou.app:app
+ExecStart=/opt/zou/zouenv/bin/gunicorn  -c /etc/zou/gunicorn.py -b 127.0.0.1:5000 zou.app:app
 
 [Install]
 WantedBy=multi-user.target
@@ -335,7 +335,7 @@ WantedBy=multi-user.target
 
 Let's write the *gunicorn* configuration:
 
-*Path: /etc/zou/gunicorn-events.conf*
+*Path: /etc/zou/gunicorn-events.py*
 
 ```
 accesslog = "/opt/zou/logs/gunicorn_events_access.log"
@@ -359,7 +359,7 @@ Group=www-data
 WorkingDirectory=/opt/zou
 Environment="PATH=/opt/zou/zouenv/bin"
 EnvironmentFile=/etc/zou/zou.env
-ExecStart=/opt/zou/zouenv/bin/gunicorn -c /etc/zou/gunicorn-events.conf -b 127.0.0.1:5001 zou.event_stream:app
+ExecStart=/opt/zou/zouenv/bin/gunicorn -c /etc/zou/gunicorn-events.py -b 127.0.0.1:5001 zou.event_stream:app
 
 [Install]
 WantedBy=multi-user.target

--- a/docs/indexer.md
+++ b/docs/indexer.md
@@ -71,11 +71,6 @@ database, you can reset it at any time. Simply use this command (assuming all
 environment variables are correctly set).
 
 ```
+. /etc/zou/zou.env
 zou reset-search-index
-```
-
-Or add directly your environment variables in the command:
-
-```
-DB_PASSWORD=yourdbpasword INDEXER_KEY=yourindexerapikey zou reset-search-index
 ```

--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -12,11 +12,11 @@ is required.
 
 ## Enabling job queue
 
-Set `ENABLE_JOB_QUEUE` environment variable to `True` in the main service file (zou.service).
+Set `ENABLE_JOB_QUEUE` environment variable to `True` in the variables file (/etc/zou/zou.env).
 
 ## S3 Storage
 
-If your main service file (zou.service) uses a S3 backend, you want to add the same variables to the job queue too (zou-jobs.service).
+If your variables file (/etc/zou/zou.env) uses a S3 backend.
 
 * `FS_BACKEND`: Set this variable with "s3"
 * `FS_BUCKET_PREFIX`: A prefix for your bucket names, it's mandatory to 
@@ -48,16 +48,8 @@ After=network.target
 User=zou
 Group=www-data
 WorkingDirectory=/opt/zou
-Environment="DB_PASSWORD=mysecretpassword"
-Environment="SECRET_KEY=yourrandomsecretkey"
+EnvironmentFile=/etc/zou/zou.env
 Environment="PATH=/opt/zou/zouenv/bin:/usr/bin"
-Environment="PREVIEW_FOLDER=/opt/zou/previews"
-# Environment="FS_BACKEND=s3"
-# Environment="FS_BUCKET_PREFIX=prefix"
-# Environment="FS_S3_REGION=region"
-# Environment="FS_S3_ENDPOINT=https://endpoint.url"
-# Environment="FS_S3_ACCESS_KEY=XXX"
-# Environment="FS_S3_SECRET_KEY=XXX"
 ExecStart=/opt/zou/zouenv/bin/rq worker -c zou.job_settings 
 
 [Install]
@@ -66,5 +58,6 @@ WantedBy=multi-user.target
 
 Start the service:
 ```
-sudo service zou-jobs start
+sudo systemctl enable zou-jobs
+sudo systemctl start zou-jobs
 ```

--- a/docs/ldap.md
+++ b/docs/ldap.md
@@ -6,7 +6,7 @@ allows you to start using Kitsu directly with the accounts listed in your LDAP.
 
 ## Activate LDAP
 
-To activate LDAP, you must set the *AUTH\_STRATEGY* environment variable with
+To activate LDAP, you must set the *AUTH\_STRATEGY* environment variable (in /etc/zou/zou.env) with
 the following value:
 
 ```

--- a/docs/log_rotation.md
+++ b/docs/log_rotation.md
@@ -20,7 +20,7 @@ Add this to the ExecStart line to create the pid file for zou
 -p /run/zou/zou.pid
 ```
 For example:
-> ExecStart=/opt/zou/zouenv/bin/gunicorn -p /run/zou/zou.pid  -c /etc/zou/gunicorn.conf -b 127.0.0.1:5000 zou.app:app
+> ExecStart=/opt/zou/zouenv/bin/gunicorn -p /run/zou/zou.pid  -c /etc/zou/gunicorn.py -b 127.0.0.1:5000 zou.app:app
 
 Edit the zou-events unit file to create the pid file for zou-events  
 (`/etc/systemd/system/zou-events.service`):

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -17,6 +17,7 @@ all your environment variables are loaded.
 Clear original database and rebuild tables:
 
 ```
+. /etc/zou/zou.env
 zou clear-db
 zou reset-migrations
 zou upgrade-db
@@ -27,6 +28,7 @@ zou upgrade-db
 Retrieve base data:
 
 ```
+. /etc/zou/zou.env
 SYNC_LOGIN="admin@yourstudio.com" \
 SYNC_PASSWORD="password" \
 zou sync-full --source http://yourpreviouskitsu.url/api --no-projects
@@ -35,6 +37,7 @@ zou sync-full --source http://yourpreviouskitsu.url/api --no-projects
 Retrieve project data:
 
 ```
+. /etc/zou/zou.env
 SYNC_LOGIN="admin@yourstudio.com" \
 SYNC_PASSWORD="password" \
 zou sync-full --source http://yourpreviouskitsu.url/api --only-projects
@@ -43,6 +46,7 @@ zou sync-full --source http://yourpreviouskitsu.url/api --only-projects
 Retrieve a given project:
 
 ```
+. /etc/zou/zou.env
 SYNC_LOGIN="admin@yourstudio.com" \
 SYNC_PASSWORD="password" \
 zou sync-full --source http://yourpreviouskitsu.url/api --project AwesomeProject
@@ -58,6 +62,7 @@ The previous steps were used to retrieve the data stored in the database.
 Retrieve all files:
 
 ```
+. /etc/zou/zou.env
 SYNC_LOGIN="admin@yourstudio.com" \
 SYNC_PASSWORD="password" \
 zou sync-full-files --source http://yourpreviouskitsu.url/api
@@ -66,6 +71,7 @@ zou sync-full-files --source http://yourpreviouskitsu.url/api
 Retrieve files for a given project:
 
 ```
+. /etc/zou/zou.env
 SYNC_LOGIN="admin@yourstudio.com" \
 SYNC_PASSWORD="password" \
 zou sync-full-files --source http://yourpreviouskitsu.url/api

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -10,7 +10,8 @@ Prior to look for logs or any clue about your problem, make sure that the
 database is up and up to date:
 
 ```bash
-DB_PASSWORD=mysecretpassword /opt/zou/zouenv/bin/zou upgrade-db
+. /etc/zou/zou.env
+/opt/zou/zouenv/bin/zou upgrade-db
 ```
 
 ## Error logs
@@ -49,7 +50,8 @@ If, for any reasons, the user cannot access to his rest password email, you can
 change his password with the following command:
 
 ```bash
-DB_PASSWORD=mysecretpassword /opt/zou/zouenv/bin/zou change-password email@studio.com --password newsecretpassword
+. /etc/zou/zou.env
+/opt/zou/zouenv/bin/zou change-password email@studio.com --password newsecretpassword
 ```
 
 ## Installing on Ubuntu server or minimal desktop
@@ -64,9 +66,7 @@ sudo apt-get install libjpeg-dev
 ## To enable zou to start on reboot
 
 ```bash
-sudo systemctl enable zou
-
-sudo systemctl enable zou-events
+sudo systemctl enable zou zou-events
 ```
 
 
@@ -146,8 +146,8 @@ edit for any other path differences. Run as &lt;script name> &lt;zou version>
 eg; ./zou_to_version.sh 0.14.12
 
 ```
+. /etc/zou/zou.env
 sudo /opt/zou/zouenv/bin/python -m pip install 'zou=='$1 #this is the version number variable
-DB_PASSWORD=<db password here> /opt/zou/zouenv/bin/zou upgrade-db
-sudo service zou restart
-sudo service zou-events restart
+/opt/zou/zouenv/bin/zou upgrade-db
+sudo systemctl restart zou zou-events
 ```


### PR DESCRIPTION
**Problem**
- Environements variables is to difficult to use, some users miss to define them when launching commands
- The .conf extension for gunicorn configuration files raises warnings

**Solution**
- Use `/etc/zou/zou.env` file for all variables
- Rename `/etc/zou/gunicorn*.conf` to `/etc/zou/gunicorn*.py`