### PR TITLE
[comments] Add task status id to new comment event

### DIFF
--- a/zou/app/services/comments_service.py
+++ b/zou/app/services/comments_service.py
@@ -330,7 +330,11 @@ def new_comment(
     add_attachments_to_comment(comment, files)
     events.emit(
         "comment:new",
-        {"comment_id": comment["id"], "task_id": task_id},
+        {
+            "comment_id": comment["id"],
+            "task_id": task_id,
+            "task_status_id": task_status_id
+        },
         project_id=task["project_id"],
     )
     return comment


### PR DESCRIPTION
**Problem**

* The comment new event lacks information, leading to many comment reloading.


**Solution**

* Add the task status id linked to the new comment. It's the information in the vast majority of reloading.
