### PR TITLE
[quotas] Give read access to managers for person quotas

### DIFF
--- a/zou/app/blueprints/persons/resources.py
+++ b/zou/app/blueprints/persons/resources.py
@@ -593,10 +593,10 @@ class PersonMonthQuotaShotsResource(Resource, ArgsMixin, PersonQuotaMixin):
                 description: Wrong date format
         """
         user_service.check_person_is_not_bot(person_id)
-        user_service.check_person_access(person_id)
         (project_id, task_type_id, count_mode, feedback, weighted) = (
             self.get_quota_arguments()
         )
+        user_service.check_person_read_access(project_id, person_id)
 
         try:
             return shots_service.get_month_quota_shots(
@@ -656,10 +656,10 @@ class PersonWeekQuotaShotsResource(Resource, ArgsMixin, PersonQuotaMixin):
                 description: Wrong date format
         """
         user_service.check_person_is_not_bot(person_id)
-        user_service.check_person_access(person_id)
         (project_id, task_type_id, count_mode, feedback, weighted) = (
             self.get_quota_arguments()
         )
+        user_service.check_person_read_access(project_id, person_id)
 
         try:
             return shots_service.get_week_quota_shots(
@@ -726,10 +726,10 @@ class PersonDayQuotaShotsResource(Resource, ArgsMixin, PersonQuotaMixin):
                 description: Wrong date format
         """
         user_service.check_person_is_not_bot(person_id)
-        user_service.check_person_access(person_id)
         (project_id, task_type_id, count_mode, feedback, weighted) = (
             self.get_quota_arguments()
         )
+        user_service.check_person_read_access(project_id, person_id)
 
         try:
             return shots_service.get_day_quota_shots(

--- a/zou/app/services/user_service.py
+++ b/zou/app/services/user_service.py
@@ -402,6 +402,22 @@ def check_person_access(person_id):
         raise permissions.PermissionDenied
 
 
+def check_person_read_access(project_id, person_id):
+    """
+    Return True if user is an admin, or a manager in the same project
+    or is matching given person id.
+    """
+    current_user = persons_service.get_current_user()
+
+    if permissions.has_admin_permissions() or current_user["id"] == person_id:
+        return True
+    elif permissions.has_manager_permissions():
+        check_belong_to_project(project_id)
+    else:
+        raise permissions.PermissionDenied
+
+
+
 def check_belong_to_project(project_id):
     """
     Return true if current user is assigned to a task of the given project or


### PR DESCRIPTION
**Problem**

Managers can't read detailed quotas for a given person.

**Solution**

Extend read permission quota permissions to managers.
