### PR TITLE
patch error when reply is None in get_last_notifications()

### DIFF
--- a/zou/app/services/user_service.py
+++ b/zou/app/services/user_service.py
@@ -1452,12 +1452,17 @@ def get_last_notifications(
                 ),
                 None,
             )
-            reply_mentions = reply.get("mentions", []) or []
-            reply_department_mentions = (
-                reply.get("department_mentions", []) or []
-            )
             if reply is not None:
                 reply_text = reply["text"]
+                reply_mentions = reply.get("mentions", []) or []
+                reply_department_mentions = (
+                    reply.get("department_mentions", []) or []
+                )
+            else:
+                reply_mentions = []
+                reply_department_mentions = (
+                    []
+                )
 
         if role == "client" and is_current_user_artist:
             comment_text = ""


### PR DESCRIPTION

**Problem**
In some situation user can't view their notifications filtered by task type = ALL
api/data/user/notifications is returning a HTTP 500, as a workaround user have to filter by Task Type, one after another, to understand where the notification comes from.

**Solution**
around line 1459 a check is made for 'reply is not None', meaning that None is an accepted value. 
But few lines earlier reply.get("mentions", []) is called which will ultimately throw an AttributeError when reply is None ('NoneType' object has no attribute 'get'). 
Solution is to wrap everything into a if/else statement to define default values.
