### PR TITLE
[comments] allow production manager to delete an attachment from a co…

### DIFF
--- a/zou/app/blueprints/comments/resources.py
+++ b/zou/app/blueprints/comments/resources.py
@@ -289,7 +289,8 @@ class AttachmentResource(Resource):
         user = persons_service.get_current_user()
         comment = tasks_service.get_comment(comment_id)
         if comment["person_id"] != user["id"]:
-            permissions.check_admin_permissions()
+            task = tasks_service.get_task(task_id)
+            user_service.check_manager_project_access(task["project_id"])
 
         deletion_service.remove_attachment_file_by_id(attachment_id)
         return "", 204


### PR DESCRIPTION
…mment

**Problem**
- It's impossible for a PM to delete an attachment from a comment that is not his.

**Solution**
- Allow PM to delete attachment 
