### PR TITLE
Fix event emitting

### DIFF
--- a/zou/app/services/assets_service.py
+++ b/zou/app/services/assets_service.py
@@ -534,10 +534,7 @@ def get_or_create_asset_type(name):
     if asset_type is None:
         asset_type = EntityType.create(name=name)
         clear_asset_type_cache()
-
-        events.emit(
-            "asset-type:new", {"name": asset_type.name, "id": asset_type.id}
-        )
+        events.emit("asset-type:new", {"asset_type_id": asset_type.id})
 
     return asset_type.serialize(obj_type="AssetType")
 


### PR DESCRIPTION
**Problem**
The `asset-type:new` socket event is not consistent:
https://github.com/cgwire/zou/blob/fa44c59725e8ed1751d970f05fc2a10750c2c87a/zou/app/blueprints/crud/entity_type.py#L27
https://github.com/cgwire/zou/blob/fa44c59725e8ed1751d970f05fc2a10750c2c87a/zou/app/services/assets_service.py#L539

Kitsu uses only the `asset_type_id` attribute from the event:
https://github.com/cgwire/kitsu/blob/833f86080c0d805e294829b27b6f48a899ebb57d/src/App.vue#L377

**Solution**
- Harmonize data events for Kitsu, keep only `asset_type_id`
