### PR TITLE
[playlists] Use default previews for temp playlists

### DIFF
--- a/zou/app/services/entities_service.py
+++ b/zou/app/services/entities_service.py
@@ -140,6 +140,21 @@ def update_entity_preview(entity_id, preview_file_id):
     return entity.serialize()
 
 
+def get_for_entity_from_task(task):
+    """
+    Return the entity type name for given task. All asset types are returned
+    as "Asset".
+    """
+    entity = get_entity(task["entity_id"])
+    entity_type = get_entity_type(entity["entity_type_id"])
+    for_entity = entity_type["name"]
+    if for_entity.lower() not in [
+        "shot", "sequence", "episode", "edit", "concept"
+    ]:
+        for_entity = "Asset"
+    return for_entity
+
+
 def get_entities_for_project(
     project_id,
     entity_type_id,

--- a/zou/app/services/projects_service.py
+++ b/zou/app/services/projects_service.py
@@ -696,6 +696,20 @@ def get_task_type_priority_map(project_id, for_entity="Asset"):
     }
 
 
+def get_task_type_links(project_id, for_entity="Asset"):
+    """
+    Return a lisk of links for given project and entity type.
+    """
+    task_type_links = (
+        ProjectTaskTypeLink.query
+        .join(TaskType)
+        .filter(ProjectTaskTypeLink.project_id == project_id)
+        .filter(TaskType.for_entity == for_entity)
+        .order_by(ProjectTaskTypeLink.priority.desc())
+    ).all()
+    return ProjectTaskTypeLink.serialize_list(task_type_links)
+
+
 def get_department_team(project_id, department_id):
     persons = (
         Person.query.join(


### PR DESCRIPTION
**Problem**

When generating an on-the-fly playlist, if a preview is missing for the selection, the user expects that the last task with previews is selected instead of a random one.

**Solution**

If a preview is missing for the given task, it gets the preview of the last task based on task type priorities. Then it is used for the temp playlist instead of letting the preview empty.

