### PR TITLE
feat: include ID for persistent events in payload sent to handlers.

### DIFF
--- a/zou/app/utils/events.py
+++ b/zou/app/utils/events.py
@@ -70,7 +70,10 @@ def emit(event, data={}, persist=True, project_id=None):
     data = fields.serialize_dict(data)
     publisher_store.publish(event, data)
     if persist:
-        save_event(event, data, project_id=project_id)
+        # Create DB entry saving the data for the event, and include the ID in
+        # the data so that it can be read by the handlers.
+        api_event = save_event(event, data, project_id=project_id)
+        data["id"] = str(api_event.id)
 
     from zou.app.config import ENABLE_JOB_QUEUE
 


### PR DESCRIPTION
### Problem

Within our studio we're looking at building a robust syncing solution from Kitsu to a proprietary asset management solution. We are looking to setup a Kitsu event listener that will listen for events and emit webhooks for certain events that will be in turn sent to a syncing service that will put them into a queue.

We are setting up a DB that tracks the processing status of each Kitsu event - so that in case of an outage in the syncing server, we can re-submit any missed events to the queue in order, ensuring that no events are missed. We will only be listening for events that are persistent with ApiEvents created for them. 

We want to use the ID of the ApiEvent to track the events - but the problem is that this information isn't passed to the event handlers, it is only accessible via the `/data/events/last` endpoint. This means that we would need to periodically run this call and check which events are new - slowing down the service and making it's implementation more complex.

### Solution

This PR introduces a new `"id"` key to the payload sent to the event handlers **if** the event is persistent - that will give the ID of the ApiEvent created.

I've just created this PR to kick off discussion on a solution, and am open to suggestions on the name of the key and what the behaviour should be in the case of a non-persistent event. 

### Testing

All unit tests are passing, and the `id` key is coming through properly to the test event listener I've setup.
