### PR TITLE
[previews] allow rev and riv file extensions as previews

### DIFF
--- a/zou/app/blueprints/previews/resources.py
+++ b/zou/app/blueprints/previews/resources.py
@@ -73,6 +73,8 @@ ALLOWED_FILE_EXTENSION = [
     "psd",
     "psb",
     "rar",
+    "rev",
+    "riv",
     "sai",
     "sai2",
     "sbbkp",


### PR DESCRIPTION
**Problem**
- This is not possible to upload rev and riv file extensions as previews. (see https://github.com/cgwire/kitsu/issues/1811)

**Solution**
- Allow them.