### PR TITLE
[news] Add all preview files information to only preview news

### DIFF
--- a/zou/app/models/preview_file.py
+++ b/zou/app/models/preview_file.py
@@ -99,3 +99,14 @@ class PreviewFile(db.Model, BaseMixin, SerializerMixin):
                 "created_at": self.created_at,
             }
         )
+
+    def present_minimal(self):
+        return fields.serialize_dict(
+            {
+                "id": self.id,
+                "name": self.name,
+                "extension": self.extension,
+                "revision": self.revision,
+                "position": self.position
+            }
+        )

--- a/zou/app/services/preview_files_service.py
+++ b/zou/app/services/preview_files_service.py
@@ -579,7 +579,8 @@ def get_preview_files_for_entity(entity_id):
     Return all preview files related to given entity.
     """
     query = (
-        PreviewFile.query.join(Task)
+        PreviewFile.query
+        .join(Task)
         .join(TaskType)
         .filter(Task.entity_id == entity_id)
         .order_by(


### PR DESCRIPTION
**Problem**

* Subpreview information is missing in the newsfeed in only preview mode.

**Solution**

* Add missing information to news via a second SQL request. 
