### PR TITLE
Update index.md to remove duplicate SECRET_KEY definition

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -188,7 +188,6 @@ Create the environment variables file for the database:
 *Path: /etc/zou/zou.env*
 ```bash
 DB_PASSWORD=mysecretpassword
-SECRET_KEY=yourrandomsecretkey
 PREVIEW_FOLDER=/opt/zou/previews
 TMP_DIR=/opt/zou/tmp
 SECRET_KEY=yourrandomsecretkey


### PR DESCRIPTION
I don't think it is needed to define SECRET_KEY twice in /etc/zou/zou.env

**Problem**
I don't think it is needed to define SECRET_KEY twice in /etc/zou/zou.env.  It appears twice in the example.

**Solution**
Remove one line of SECRET_KEY declaration in /etc/zou/zou.env section of doc.