### PR TITLE
[projects] Improve efficiency of related projects filters

### DIFF
--- a/tests/user/test_route_context.py
+++ b/tests/user/test_route_context.py
@@ -606,10 +606,11 @@ class UserContextRoutesTestCase(ApiDBTestCase):
         self.log_in_cg_artist()
         result = self.get(path)
         self.assertEqual(len(result["asset"][project_id]), 2)
-        self.assertEqual(result["asset"][project_id][0]["name"], "my filter")
-        self.assertEqual(result["asset"][project_id][0]["is_shared"], False)
-        self.assertEqual(result["asset"][project_id][1]["name"], "team filter")
-        self.assertEqual(result["asset"][project_id][1]["is_shared"], True)
+        asset_filters = sorted(result["asset"][project_id], key=lambda x: x["name"])
+        self.assertEqual(asset_filters[0]["name"], "my filter")
+        self.assertEqual(asset_filters[0]["is_shared"], False)
+        self.assertEqual(asset_filters[1]["name"], "team filter")
+        self.assertEqual(asset_filters[1]["is_shared"], True)
 
         projects_service.add_team_member(
             self.project_id, self.user_cg_artist["id"]
@@ -658,10 +659,11 @@ class UserContextRoutesTestCase(ApiDBTestCase):
         result = self.get(path)
         user_service.clear_filter_cache()
         self.assertEqual(len(result["asset"][project_id]), 2)
-        self.assertEqual(result["asset"][project_id][0]["name"], "my filter")
-        self.assertEqual(
-            result["asset"][project_id][1]["name"], "team updated"
+        asset_filters = sorted(
+            result["asset"][project_id], key=lambda x: x["name"]
         )
+        self.assertEqual(asset_filters[0]["name"], "my filter")
+        self.assertEqual(asset_filters[1]["name"], "team updated")
 
         # Filter is shared with the artist's department
         self.log_in_admin()
@@ -676,25 +678,23 @@ class UserContextRoutesTestCase(ApiDBTestCase):
         result = self.get(path)
         user_service.clear_filter_cache()
         self.assertEqual(len(result["asset"][project_id]), 2)
-        self.assertEqual(
-            result["asset"][project_id][0]["name"], "team updated"
+        asset_filters = sorted(
+            result["asset"][project_id], key=lambda x: x["name"]
         )
-        self.assertEqual(
-            result["asset"][project_id][1]["name"], "department updated"
-        )
+        self.assertEqual(asset_filters[0]["name"], "department updated")
+        self.assertEqual(asset_filters[1]["name"], "team updated")
 
         # Now artist can see the department filter
         self.log_in_cg_artist()
         user_service.clear_filter_cache()
         result = self.get(path)
         self.assertEqual(len(result["asset"][project_id]), 3)
-        self.assertEqual(
-            result["asset"][project_id][2]["name"], "department updated"
+        asset_filters = sorted(
+            result["asset"][project_id], key=lambda x: x["name"]
         )
-        self.assertEqual(
-            result["asset"][project_id][1]["name"], "team updated"
-        )
-        self.assertEqual(result["asset"][project_id][0]["name"], "my filter")
+        self.assertEqual(asset_filters[0]["name"], "department updated")
+        self.assertEqual(asset_filters[1]["name"], "my filter")
+        self.assertEqual(asset_filters[2]["name"], "team updated")
 
     def test_shared_group_filters(self):
         project_id = str(self.project.id)

--- a/zou/app/services/assets_service.py
+++ b/zou/app/services/assets_service.py
@@ -656,8 +656,6 @@ def remove_asset(asset_id, force=False):
         for task in tasks:
             deletion_service.remove_task(task.id, force=True)
             tasks_service.clear_task_cache(str(task.id))
-        asset.delete()
-        clear_asset_cache(str(asset_id))
         index_service.remove_asset_index(str(asset_id))
         events.emit(
             "asset:delete",
@@ -670,6 +668,8 @@ def remove_asset(asset_id, force=False):
         EntityLink.delete_all_by(entity_out_id=asset_id)
         EntityConceptLink.delete_all_by(entity_in_id=asset_id)
         EntityConceptLink.delete_all_by(entity_out_id=asset_id)
+        asset.delete()
+        clear_asset_cache(str(asset_id))
     deleted_asset = asset.serialize(obj_type="Asset")
     return deleted_asset
 


### PR DESCRIPTION
**Problem**

The "related projects" query is very slow.

**Solution**

* There was a wrong join on task table 
* Make filtering more straightforward by filtering directly on the PersonLink table instead of using built-in SQL alchemy function.
