### PR TITLE
[openapi] Fix configuration links and resource tagging

### DIFF
--- a/zou/app/blueprints/entities/resources.py
+++ b/zou/app/blueprints/entities/resources.py
@@ -90,7 +90,7 @@ class EntitiesLinkedWithTasksResource(Resource):
         Resource to retrieve the entities linked on a given entity.
         ---
         tags:
-            - Entity
+            - Entities
         parameters:
           - in: path
             name: entity_id

--- a/zou/app/blueprints/previews/resources.py
+++ b/zou/app/blueprints/previews/resources.py
@@ -1496,7 +1496,7 @@ class CreatePreviewBackgroundFileResource(Resource):
         Main resource to add a preview background file.
         ---
         tags:
-          - Preview background file
+          - Previews
         consumes:
           - multipart/form-data
           - image/vnd.radiance

--- a/zou/app/blueprints/tasks/resources.py
+++ b/zou/app/blueprints/tasks/resources.py
@@ -1577,7 +1577,7 @@ class SetTaskMainPreviewResource(Resource):
         This preview will be used as thumbnail to illustrate the entity.
         ---
         tags:
-          - Task
+          - Tasks
         description: This preview will be used to illustrate the entity.
         parameters:
           - in: path

--- a/zou/app/swagger.py
+++ b/zou/app/swagger.py
@@ -35,10 +35,8 @@ you will have to get a JWT token to authorize your requests.
 
 <p>
 You will find the information to retrieve it in the 
-<a href="#tag/Authentication">Zou documentation</a>.
+[Zou documentation](https://zou.cg-wire.com/api/).
 </p>
-
-[OpenAPI definition](/openapi.json)
 """
 
 swagger_template = {
@@ -78,8 +76,11 @@ swagger_template = {
         {"name": "Authentication"},
         {"name": "Assets"},
         {"name": "Breakdown"},
+        {"name": "Chat"},
         {"name": "Comments"},
+        {"name": "Concepts"},
         {"name": "Crud"},
+        {"name": "Departments"},
         {"name": "Edits"},
         {"name": "Entities"},
         {"name": "Events"},


### PR DESCRIPTION
**Problem**

- Some links are broken in the OpenAPI description
- Some resources where not properly tagged

Note: all POST resources needs an update to be properly displayed in Bump documentation

**Solution**

- Put resources in existing tags
- Reorganise tags (put recence addition in alphabetical order)
- Fix introduction links
