### PR TITLE
added user section and cosmetic fixes to configuration page

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5,15 +5,15 @@ the list of all expected parameters.
 
 ## Database
 
-* `DB_HOST` (default: localhost): The database server host.
+* `DB_HOST` (default: localhost): The database server host.
 * `DB_PORT` (default: 5432): The port on which the database is running.
 * `DB_USERNAME` (default: postgres): The username used to access the database.
 * `DB_PASSWORD` (default: mysecretpassword): The password used to access the
   database.
-* `DB_DATABASE` (default: zoudb): The database name to use.
-* `DB_POOL_SIZE` (default: 30): The number of connections opened simultaneously 
+* `DB_DATABASE` (default: zoudb): The database name to use.
+* `DB_POOL_SIZE` (default: 30): The number of connections opened simultaneously 
   to access the database.
-* `DB_MAX_OVERFLOW` (default: 60): The number of additional connections available 
+* `DB_MAX_OVERFLOW` (default: 60): The number of additional connections available 
   once the pool is full. They are disconnected when the request is finished. They
   are not reused.
 
@@ -34,7 +34,7 @@ Kitsu uses the Meilisearch service for its indexation.
 
 * `AUTH_STRATEGY` (default: auth\_local\_classic): Allow to choose between
 traditional auth and Active Directory auth (auth\_remote\_active\_directory).
-* `SECRET_KEY` (default: mysecretkey) complex key used for auth token encryption.
+* `SECRET_KEY` (default: mysecretkey) Complex key used for auth token encryption.
 
 ## Previews
 
@@ -42,23 +42,31 @@ traditional auth and Active Directory auth (auth\_remote\_active\_directory).
   thumbnails will be stored. The default value is set for development
   environments. We encourage you to set an absolute path when you use it in
   production.
+* `REMOVE_FILES` (default: "False"): Delete files when deleting comments and revisions
+
+## Users
+
+* `USER_LIMIT` (default: "100"): Max number of users
+* `MIN_PASSWORD_LENGTH` (default: "8"): The minimum password length
+* `DEFAULT_TIMEZONE` (default: "Europe/Paris"): The default timezone for new user accounts
+* `DEFAULT_LOCALE` (default: "en_US"): The default language for new user accounts
 
 ## Emails
 
 The email configuration is required for emails sent after a password reset and,
 email notifications.
 
-* `MAIL_SERVER` (default: "localhost"): the host of your email server
-* `MAIL_PORT` (default: "25"): the port of your email server
-* `MAIL_USERNAME` (default: ""): the username to access to your mail server
-* `MAIL_PASSWORD` (default: ""): the password to access to your mail server
-* `MAIL_DEBUG` (default: "0"): set 1 if you are in a development environment
+* `MAIL_SERVER` (default: "localhost"): The host of your email server
+* `MAIL_PORT` (default: "25"): The port of your email server
+* `MAIL_USERNAME` (default: ""): The username to access to your mail server
+* `MAIL_PASSWORD` (default: ""): The password to access to your mail server
+* `MAIL_DEBUG` (default: "0"): Set 1 if you are in a development environment
   (emails are printed in the console instead of being sent).
 * `MAIL_USE_TLS` (default: "False"): To use TLS to communicate with the email
   server.
 * `MAIL_USE_SSL` (default: "False"): To use SSL to communicate with the email
   server.
-* `MAIL_DEFAULT_SENDER` (default: "no-reply@cg-wire.com"): to set the sender
+* `MAIL_DEFAULT_SENDER` (default: "no-reply@cg-wire.com"): To set the sender
   email.
 * `DOMAIN_NAME` (default: "localhost:8080"): To build URLs (for a password reset
   for instance).
@@ -97,7 +105,7 @@ cd /opt/zou
 pip install boto3
 ```
 
-When you restart Zou, it should use S3 to store and retrieve files.
+When you restart Zou, it should use S3 to store and retrieve files.
 
 ## Swift Storage
 
@@ -116,11 +124,11 @@ variables (Only Auth 2.0 and 3.0 are supported).
 
 These variables are active only if auth\_remote\_ldap strategy is selected.
 
-* `LDAP_HOST` (default: "127.0.0.1"): the IP address of your LDAP server.
-* `LDAP_PORT` (default: "389"): the listening port of your LDAP server.
-* `LDAP_BASE_DN` (default: "CN=Users,DC=studio,DC=local"): the base domain of your
+* `LDAP_HOST` (default: "127.0.0.1"): The IP address of your LDAP server.
+* `LDAP_PORT` (default: "389"): The listening port of your LDAP server.
+* `LDAP_BASE_DN` (default: "CN=Users,DC=studio,DC=local"): The base domain of your
    LDAP configuration.
-* `LDAP_DOMAIN` (default: "studio.local"): the domain used for your LDAP
+* `LDAP_DOMAIN` (default: "studio.local"): The domain used for your LDAP
   authentication (NTLM).
 * `LDAP_FALLBACK` (default: "False"): Set to True if you want to allow admins
   to fallback on default auth strategy when the LDAP server is down.


### PR DESCRIPTION
**Problem**
Missing options in the configuration page of the docs

**Solution**
I added a new User section, included USER_LIMIT, MIN_PASSWORD_LENGTH, DEFAULT_TIMEZONE, and DEFAULT_LOCALE
I also added REMOVE_FILES to the Previews section
I changed the capitalization of some of the explanations to conform to the rest of the document. 
There were a few errant <0xa0> non breaking whitespaces I cleaned up.
There are many more options in zou/app/config.py but I'm not knowledgeable enough to know what they do and I didn't think it would help to clutter up the page with many unexplained options.
It might be helpful to link to the zou/app/config.py file explaining that there are more unexplained options contained there for advanced users.