### PR TITLE
Fix a typo "Search index resetted." to "Search index reset."

### DIFF
--- a/zou/app/utils/commands.py
+++ b/zou/app/utils/commands.py
@@ -663,7 +663,7 @@ def reset_search_index():
     with app.app_context():
         print("Resetting search index.")
         index_service.reset_index()
-        print("Search index resetted.")
+        print("Search index reset.")
 
 
 def search_asset(query):


### PR DESCRIPTION
**Problem**
A simple typo. 
Past tense of reset is reset, not resetted.
**Solution**
Fixed the typo.
