### PR TITLE
Move Meilisearch install instructions from index.md to indexer.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -231,51 +231,12 @@ article](https://www.techandme.se/performance-tips-for-redis-cache-server/).
 
 ### Set up the indexer (optional)
 
-Create a Meilisearch user:
+To allow full-text search, Kitsu relies on an Indexing engine. It uses the
+[Meilisearch](https://www.meilisearch.com/docs) technology.
 
-```
-sudo useradd meilisearch 
-```
+The indexer is optional. Kitsu can run without it.
 
-Install Meilisearch:
-
-```
-echo "deb [trusted=yes] https://apt.fury.io/meilisearch/ /" | sudo tee /etc/apt/sources.list.d/fury.list
-sudo apt-get update && sudo apt-get install meilisearch
-```
-
-Create a folder for the index:
-```
-sudo mkdir /opt/meilisearch
-sudo chown -R meilisearch: /opt/meilisearch
-```
-
-
-Define a master key then create the service file for Meilisearch:
-
-*Path: /etc/systemd/system/meilisearch.service*
-
-```
-[Unit]
-Description=Meilisearch search engine
-After=network.target
-
-[Service]
-User=meilisearch
-Group=meilisearch
-WorkingDirectory=/opt/meilisearch
-ExecStart=/usr/bin/meilisearch --master-key="masterkey"
-
-[Install]
-WantedBy=multi-user.target
-```
-
-To finish, start the Meilisearch indexer:
-
-```
-sudo systemctl enable meilisearch
-sudo systemctl start meilisearch
-```
+See [Data Indexation](https://zou.cg-wire.com/indexer/)
 
 
 ### Configure Gunicorn

--- a/docs/indexer.md
+++ b/docs/indexer.md
@@ -7,7 +7,13 @@ The indexer is optional. Kitsu can run without it.
 
 ## Setup the indexer
 
-First, retrieve the Meilisearch package:
+Create a Meilisearch user:
+
+```
+sudo useradd meilisearch 
+```
+
+Install the Meilisearch package:
 
 ```
 # Add Meilisearch package
@@ -17,7 +23,14 @@ echo "deb [trusted=yes] https://apt.fury.io/meilisearch/ /" | sudo tee /etc/apt/
 sudo apt update && sudo apt install meilisearch
 ```
 
-Define a master key then create the service file for Meilisearch:
+Create a folder for the index:
+
+```
+sudo mkdir /opt/meilisearch
+sudo chown -R meilisearch: /opt/meilisearch
+```
+
+Define a master key (any alphanumeric string with 16 or more bytes) then create the service file for Meilisearch:
 
 *Path: /etc/systemd/system/meilisearch.service*
 
@@ -38,14 +51,17 @@ WantedBy=multi-user.target
 Finally, start the Meilisearch indexer:
 
 ```
-sudo service meilisearch start
+sudo systemctl enable meilisearch
+sudo systemctl start meilisearch
 ```
-
 
 
 ## Configuring the connection to the indexer
 
 To connect to the indexer Kitsu relies on three environment variables.
+Add them to the zou environment variables file.
+
+*Path: /etc/zou/zou.env*
 
 The first one is the master key you set when you started Meilisearch.
 
@@ -62,6 +78,11 @@ INDEXER_PORT="7700"
 
 Once set, Kitsu will be able to connect to the indexer and will enable
 full-text search.
+
+## Verify the indexer is up and running
+
+Browse to [http://localhost/api/status](http://localhost/api/status)
+You should see "indexer-up": "true"
 
 
 ## Refreshing indexes


### PR DESCRIPTION
**Problem**
The installation instructions Meilisearch are spread between index.md and indexer.md. Also the instructions on index.md were incomplete because they fail to mention the environment variables needed to make the indexing work, and the instructions on index.md fail to have you create the meilisearch user.

**Solution**
Merge the two separate instructions into one and move it to the indexer.md page.
Include a link to the indexer.md instructions in index.md where the previous instructions were.

As this is an optional install, it's not necessary to be included with the main install instructions.
This is a better solution as having the instructions in one place means less to maintain.
This addresses the second bullet point for [issue #996](https://github.com/cgwire/zou/issues/966)