### PR TITLE
Fix Set Task Main Preview when no preview

### DIFF
--- a/zou/app/blueprints/tasks/resources.py
+++ b/zou/app/blueprints/tasks/resources.py
@@ -2681,6 +2681,7 @@ class SetTaskMainPreviewResource(Resource):
         preview_file = preview_files_service.get_last_preview_file_for_task(
             task_id
         )
+        entity = None
         if preview_file is not None:
             entity = entities_service.update_entity_preview(
                 task["entity_id"], preview_file["id"]


### PR DESCRIPTION
**Problem**
- The Set Task Main endpoint fails when a task doesn't have a preview.

**Solution**
- Fix Set Task Main Preview when no preview by adding the missing initial value.
