### PR TITLE
[persons] Fix condition to update protected users

### DIFF
--- a/zou/app/blueprints/crud/person.py
+++ b/zou/app/blueprints/crud/person.py
@@ -604,7 +604,7 @@ class PersonResource(BaseModelResource, ArgsMixin):
         if (
             instance_dict["email"] in config.PROTECTED_ACCOUNTS
             and instance_dict["id"] != persons_service.get_current_user()["id"]
-            and instance_dict["is_bot"] == False
+            # and instance_dict["is_bot"] == False
         ):
             message = None
             if data.get("active") is False:

--- a/zou/app/services/persons_service.py
+++ b/zou/app/services/persons_service.py
@@ -287,7 +287,7 @@ def update_person(person_id, data, bypass_protected_accounts=False):
     if (
         not bypass_protected_accounts
         and person.email in config.PROTECTED_ACCOUNTS
-        and not person.is_bot
+        # and not person.is_bot
     ):
         message = None
         if data.get("active") is False:


### PR DESCRIPTION
**Problem**
`person.is_bot` can be `False`, or `None` for a legacy Zou database.

**Solution**
Fix the condition to update protected users
