### PR TITLE
Add new openapi spec route to add advanced bash/curl code samples

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Update openapi.json
         run: |
           cd docs
-          curl --output openapi.json https://kitsu-staging.cg-wire.com/api/openapi.json
+          curl --output openapi.json https://kitsu-staging.cg-wire.com/api/openapispecs
           git config --global user.email "no-reply@cg-wire.com"
           git config --global user.name "CGWire bot"
           git add openapi.json || false

--- a/zou/app/openapi-code-samples.json
+++ b/zou/app/openapi-code-samples.json
@@ -1,0 +1,12001 @@
+{
+  "paths": {
+    "/data/asset-instances/": {
+      "get": {
+        "summary": "Get asset instances",
+        "description": "Retrieve all asset instances. Supports filtering via query parameters and pagination.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/asset-instances/?page=1&limit=50&relations=false\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/asset-instances/\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"page\": 1,\n    \"limit\": 50,\n    \"relations\": false\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Create asset instance",
+        "description": "Create a new asset instance with data provided in the request body. JSON format is expected.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/asset-instances/\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"asset_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n  \"name\": \"Instance Name\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/asset-instances/\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"asset_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"name\": \"Instance Name\"\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/asset-instances/{instance_id}": {
+      "delete": {
+        "summary": "Delete asset instance",
+        "description": "Delete an asset instance by its ID. Returns empty response on success.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/data/asset-instances/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/asset-instances/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "get": {
+        "summary": "Get asset instance",
+        "description": "Retrieve an asset instance by its ID and return it as a JSON object. Supports including relations.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/asset-instances/a24a6ea4-ce75-4665-a070-57453082c25?relations=true\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/asset-instances/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"relations\": true\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "put": {
+        "summary": "Update asset instance",
+        "description": "Update an asset instance with data provided in the request body. JSON format is expected.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X PUT \"http://api.example.com/data/asset-instances/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"Updated Instance Name\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/asset-instances/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"Updated Instance Name\"\n}\n\nresponse = requests.put(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/asset-instances/{asset_instance_id}/entities/{temporal_entity_id}/output-files/new": {
+      "post": {
+        "summary": "Create new instance output file",
+        "description": "Create a new output file linked to an asset instance for a specific shot. Output files track the source working file and require output type and task type for categorization.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/asset-instances/a24a6ea4-ce75-4665-a070-57453082c25/entities/b35b7fb5-df86-5776-b181-68564193d36/output-files/new\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"main\",\n  \"mode\": \"output\",\n  \"output_type_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n  \"task_type_id\": \"b35b7fb5-df86-5776-b181-68564193d36\",\n  \"person_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n  \"working_file_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n  \"file_status_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n  \"is_sequence\": false,\n  \"comment\": \"Final render\",\n  \"extension\": \".mp4\",\n  \"representation\": \"mp4\",\n  \"revision\": 1,\n  \"nb_elements\": 1,\n  \"sep\": \"/\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/asset-instances/a24a6ea4-ce75-4665-a070-57453082c25/entities/b35b7fb5-df86-5776-b181-68564193d36/output-files/new\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"main\",\n    \"mode\": \"output\",\n    \"output_type_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"task_type_id\": \"b35b7fb5-df86-5776-b181-68564193d36\",\n    \"person_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"working_file_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"file_status_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"is_sequence\": false,\n    \"comment\": \"Final render\",\n    \"extension\": \".mp4\",\n    \"representation\": \"mp4\",\n    \"revision\": 1,\n    \"nb_elements\": 1,\n    \"sep\": \"/\"\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/asset-instances/{asset_instance_id}/entities/{temporal_entity_id}/output-files/next-revision": {
+      "post": {
+        "summary": "Get next instance output file revision",
+        "description": "Get the next revision number for an output file based on asset instance, output type, task type, and name. Used for automatic revision numbering.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/asset-instances/a24a6ea4-ce75-4665-a070-57453082c25/entities/b35b7fb5-df86-5776-b181-68564193d36/output-files/next-revision\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"main\",\n  \"output_type_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n  \"task_type_id\": \"b35b7fb5-df86-5776-b181-68564193d36\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/asset-instances/a24a6ea4-ce75-4665-a070-57453082c25/entities/b35b7fb5-df86-5776-b181-68564193d36/output-files/next-revision\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"main\",\n    \"output_type_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"task_type_id\": \"b35b7fb5-df86-5776-b181-68564193d36\"\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/asset-instances/{asset_instance_id}/entities/{temporal_entity_id}/output-files/last-revisions": {
+      "get": {
+        "summary": "Get last instance output files",
+        "description": "Retrieve the last revisions of output files for a given instance grouped by output type and file name. Returns the most recent version of each output file.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/asset-instances/a24a6ea4-ce75-4665-a070-57453082c25/entities/b35b7fb5-df86-5776-b181-68564193d36/output-files/last-revisions?output_type_id=c46c8gc6-eg97-6887-c292-79675204e47&task_type_id=d57d9hd7-fh08-7998-d403-80786315f58&file_status_id=e68e0ie8-gi19-8009-e514-91897426g69&representation=cache&name=main\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/asset-instances/a24a6ea4-ce75-4665-a070-57453082c25/entities/b35b7fb5-df86-5776-b181-68564193d36/output-files/last-revisions\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"output_type_id\": \"c46c8gc6-eg97-6887-c292-79675204e47\",\n    \"task_type_id\": \"d57d9hd7-fh08-7998-d403-80786315f58\",\n    \"file_status_id\": \"e68e0ie8-gi19-8009-e514-91897426g69\",\n    \"representation\": \"cache\",\n    \"name\": \"main\"\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/asset-instances/{asset_instance_id}/entities/{temporal_entity_id}/output-types": {
+      "get": {
+        "summary": "Get instance output types",
+        "description": "Retrieve all types of output files generated for a given asset instance and temporal entity. Returns list of output types available for the instance.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/asset-instances/a24a6ea4-ce75-4665-a070-57453082c25/entities/b35b7fb5-df86-5776-b181-68564193d36/output-types\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/asset-instances/a24a6ea4-ce75-4665-a070-57453082c25/entities/b35b7fb5-df86-5776-b181-68564193d36/output-types\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/asset-instances/{asset_instance_id}/entities/{temporal_entity_id}/output-types/{output_type_id}/output-files": {
+      "get": {
+        "summary": "Get instance output type files",
+        "description": "Retrieve all output files for a given asset instance, temporal entity, and output type. Optionally filter by representation.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/asset-instances/a24a6ea4-ce75-4665-a070-57453082c25/entities/b35b7fb5-df86-5776-b181-68564193d36/output-types/c46c8gc6-eg97-6887-c292-79675204e47/output-files?representation=mp4\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/asset-instances/a24a6ea4-ce75-4665-a070-57453082c25/entities/b35b7fb5-df86-5776-b181-68564193d36/output-types/c46c8gc6-eg97-6887-c292-79675204e47/output-files\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"representation\": \"mp4\"\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/asset-instances/{asset_instance_id}/entities/{temporal_entity_id}/output-file-path": {
+      "post": {
+        "summary": "Generate instance output file path",
+        "description": "Generate an output file path from file tree template based on asset instance parameters. Revision can be computed automatically if not provided.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/asset-instances/a24a6ea4-ce75-4665-a070-57453082c25/entities/b35b7fb5-df86-5776-b181-68564193d36/output-file-path\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"main\",\n  \"mode\": \"output\",\n  \"output_type_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n  \"task_type_id\": \"b35b7fb5-df86-5776-b181-68564193d36\",\n  \"extension\": \".mp4\",\n  \"representation\": \"mp4\",\n  \"revision\": 1,\n  \"separator\": \"/\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/asset-instances/a24a6ea4-ce75-4665-a070-57453082c25/entities/b35b7fb5-df86-5776-b181-68564193d36/output-file-path\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"main\",\n    \"mode\": \"output\",\n    \"output_type_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"task_type_id\": \"b35b7fb5-df86-5776-b181-68564193d36\",\n    \"extension\": \".mp4\",\n    \"representation\": \"mp4\",\n    \"revision\": 1,\n    \"separator\": \"/\"\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/asset-instances/{asset_instance_id}/output-files": {
+      "get": {
+        "summary": "Get instance output files",
+        "description": "Retrieve all output files for a given asset instance and temporal entity with optional filtering by output type, task type, representation, file status, and name.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/asset-instances/a24a6ea4-ce75-4665-a070-57453082c25/output-files?temporal_entity_id=b35b7fb5-df86-5776-b181-68564193d36&output_type_id=c46c8gc6-eg97-6887-c292-79675204e47&task_type_id=d57d9hd7-fh08-7998-d403-80786315f58&file_status_id=e68e0ie8-gi19-8009-e514-91897426g69&representation=cache&name=main\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/asset-instances/a24a6ea4-ce75-4665-a070-57453082c25/output-files\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"temporal_entity_id\": \"b35b7fb5-df86-5776-b181-68564193d36\",\n    \"output_type_id\": \"c46c8gc6-eg97-6887-c292-79675204e47\",\n    \"task_type_id\": \"d57d9hd7-fh08-7998-d403-80786315f58\",\n    \"file_status_id\": \"e68e0ie8-gi19-8009-e514-91897426g69\",\n    \"representation\": \"cache\",\n    \"name\": \"main\"\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/asset-types": {
+      "get": {
+        "summary": "Get asset types",
+        "description": "Retrieve all available asset types (entity types that are not shot, sequence, or episode) with filtering support",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/asset-types?project_id=a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/asset-types\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"project_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\"\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/asset-types/{asset_type_id}": {
+      "get": {
+        "summary": "Get asset type",
+        "description": "Retrieve detailed information about a specific asset type including metadata and configuration",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/asset-types/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/asset-types/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/assets": {
+      "get": {
+        "summary": "Get all assets",
+        "description": "Retrieve all production assets with filtering and pagination. Supports advanced filtering by project, asset type, task status, and other criteria",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/assets?project_id=a24a6ea4-ce75-4665-a070-57453082c25&asset_type_id=a24a6ea4-ce75-4665-a070-57453082c25&page=1&limit=100\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/assets\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"project_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"asset_type_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"page\": 1,\n    \"limit\": 100\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/assets/all": {
+      "get": {
+        "summary": "Get all assets",
+        "description": "Retrieve all production assets with filtering and pagination. Supports advanced filtering by project, asset type, task status, and other criteria",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/assets/all?project_id=a24a6ea4-ce75-4665-a070-57453082c25&asset_type_id=a24a6ea4-ce75-4665-a070-57453082c25&page=1&limit=100\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/assets/all\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"project_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"asset_type_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"page\": 1,\n    \"limit\": 100\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/assets/with-tasks": {
+      "get": {
+        "summary": "Get assets with tasks",
+        "description": "Retrieve all production assets with their related tasks. Includes project name, asset type name, and all associated tasks. Supports filtering by episode",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/assets/with-tasks?project_id=a24a6ea4-ce75-4665-a070-57453082c25&episode_id=a24a6ea4-ce75-4665-a070-57453082c25&asset_type_id=a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/assets/with-tasks\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"project_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"episode_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"asset_type_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\"\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/assets/{asset_id}": {
+      "delete": {
+        "summary": "Delete asset",
+        "description": "Permanently remove an asset from the system. Only asset creators or project managers can delete assets",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/data/assets/a24a6ea4-ce75-4665-a070-57453082c25?force=false\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/assets/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"force\": false\n}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "get": {
+        "summary": "Get asset ok",
+        "description": "Retrieve detailed information about a specific asset including metadata, project context, and related data",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/assets/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/assets/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/assets/{asset_id}/assets": {
+      "get": {
+        "summary": "Get linked assets",
+        "description": "Retrieve all assets that are linked to a specific asset through casting relationships",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/assets/a24a6ea4-ce75-4665-a070-57453082c25/assets\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/assets/a24a6ea4-ce75-4665-a070-57453082c25/assets\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/assets/{asset_id}/tasks": {
+      "get": {
+        "summary": "Get asset tasks",
+        "description": "Retrieve all tasks related to a specific asset.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/assets/a24a6ea4-ce75-4665-a070-57453082c25/tasks?task_type_id=a24a6ea4-ce75-4665-a070-57453082c25&task_status_id=a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/assets/a24a6ea4-ce75-4665-a070-57453082c25/tasks\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"task_type_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"task_status_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\"\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/assets/{asset_id}/task-types": {
+      "get": {
+        "summary": "Get asset task types",
+        "description": "Retrieve all task types that are used for tasks related to a specific asset.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/assets/a24a6ea4-ce75-4665-a070-57453082c25/task-types\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/assets/a24a6ea4-ce75-4665-a070-57453082c25/task-types\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/assets/{asset_id}/cast-in": {
+      "get": {
+        "summary": "Get shots casting asset",
+        "description": "Retrieve all shots that cast a specific asset in their breakdown.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/assets/a24a6ea4-ce75-4665-a070-57453082c25/cast-in\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/assets/a24a6ea4-ce75-4665-a070-57453082c25/cast-in\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/assets/{asset_id}/casting": {
+      "put": {
+        "summary": "Update asset casting",
+        "description": "Modify the casting relationships for a specific asset by updating which shots or sequences use this asset.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X PUT \"http://api.example.com/data/assets/a24a6ea4-ce75-4665-a070-57453082c25/casting\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"casting\": [\n    {\n      \"entity_id\": \"d57d9hd7-fh08-7998-d403-80786315f58\",\n      \"entity_type\": \"shot\"\n    }\n  ]\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/assets/a24a6ea4-ce75-4665-a070-57453082c25/casting\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"casting\": [\n        {\n            \"entity_id\": \"d57d9hd7-fh08-7998-d403-80786315f58\",\n            \"entity_type\": \"shot\"\n        }\n    ]\n}\n\nresponse = requests.put(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "get": {
+        "summary": "Get asset casting",
+        "description": "Retrieve the casting information for a specific asset showing which shots or sequences use this asset",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/assets/a24a6ea4-ce75-4665-a070-57453082c25/casting\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/assets/a24a6ea4-ce75-4665-a070-57453082c25/casting\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/assets/{asset_id}/shot-asset-instances": {
+      "get": {
+        "summary": "Get shot asset instances",
+        "description": "Retrieve all shot asset instances that are linked to a specific asset.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/assets/a24a6ea4-ce75-4665-a070-57453082c25/shot-asset-instances\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/assets/a24a6ea4-ce75-4665-a070-57453082c25/shot-asset-instances\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/assets/{asset_id}/scene-asset-instances": {
+      "get": {
+        "summary": "Get scene asset instances",
+        "description": "Retrieve all scene asset instances that are linked to a specific asset.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/assets/a24a6ea4-ce75-4665-a070-57453082c25/scene-asset-instances\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/assets/a24a6ea4-ce75-4665-a070-57453082c25/scene-asset-instances\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/assets/{asset_id}/asset-asset-instances": {
+      "get": {
+        "summary": "Get asset instances",
+        "description": "Retrieve all asset instances that are instantiated inside a specific asset.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/assets/a24a6ea4-ce75-4665-a070-57453082c25/asset-asset-instances\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/assets/a24a6ea4-ce75-4665-a070-57453082c25/asset-asset-instances\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Create asset instance",
+        "description": "Create a new asset instance inside a specific asset by instantiating another asset.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/assets/a24a6ea4-ce75-4665-a070-57453082c25/asset-asset-instances\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"asset_to_instantiate_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n  \"description\": \"Asset instance description\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/assets/a24a6ea4-ce75-4665-a070-57453082c25/asset-asset-instances\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"asset_to_instantiate_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"description\": \"Asset instance description\"\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/actions/assets/share": {
+      "post": {
+        "summary": "Set assets shared",
+        "description": "Share or unshare a specific list of assets by their IDs.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/actions/assets/share\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"asset_ids\": [\n    \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"b35b7fb5-df86-5776-b181-68564193d36\"\n  ],\n  \"is_shared\": true\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/actions/assets/share\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"asset_ids\": [\n        \"a24a6ea4-ce75-4665-a070-57453082c25\",\n        \"b35b7fb5-df86-5776-b181-68564193d36\"\n    ],\n    \"is_shared\": true\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/attachment-files/{attachment_file_id}/file/{file_name}": {
+      "get": {
+        "summary": "Download attachment file",
+        "description": "Download a specific attachment file from a comment or chat message. Supports various file types including images and documents.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/attachment-files/a24a6ea4-ce75-4665-a070-57453082c25/file/document.pdf\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/attachment-files/a24a6ea4-ce75-4665-a070-57453082c25/file/document.pdf\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/attachment-files": {
+      "get": {
+        "summary": "Get attachment files",
+        "description": "Retrieve all attachment files. Supports filtering via query parameters and pagination.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/attachment-files?page=1&limit=50&relations=false\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/attachment-files\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"page\": 1,\n    \"limit\": 50,\n    \"relations\": false\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Create attachment file",
+        "description": "Create a new attachment file with data provided in the request body. JSON format is expected.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/attachment-files\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"attachment.pdf\",\n  \"comment_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/attachment-files\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"attachment.pdf\",\n    \"comment_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\"\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/attachment-files/{instance_id}": {
+      "delete": {
+        "summary": "Delete attachment file",
+        "description": "Delete an attachment file by its ID. Returns empty response on success.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/data/attachment-files/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/attachment-files/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "get": {
+        "summary": "Get attachment file",
+        "description": "Retrieve an attachment file by its ID and return it as a JSON object. Supports including relations.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/attachment-files/a24a6ea4-ce75-4665-a070-57453082c25?relations=true\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/attachment-files/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"relations\": true\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "put": {
+        "summary": "Update attachment file",
+        "description": "Update an attachment file with data provided in the request body. JSON format is expected.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X PUT \"http://api.example.com/data/attachment-files/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"updated_attachment.pdf\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/attachment-files/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"updated_attachment.pdf\"\n}\n\nresponse = requests.put(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/auth/login": {
+      "post": {
+        "summary": "Login user",
+        "description": "Log in user by creating and registering auth tokens. Login is based on email and password. If no user matches given email It fallbacks to a desktop ID. It is useful for desktop tools that don't know user email. It is also possible to login with TOTP, Email OTP, FIDO and recovery code.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/auth/login\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"email\": \"admin@example.com\",\n  \"password\": \"mysecretpassword\",\n  \"totp\": 123456,\n  \"email_otp\": 123456,\n  \"fido_authentication_response\": {},\n  \"recovery_code\": \"ABCD-EFGH-IJKL-MNOP\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/auth/login\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"email\": \"admin@example.com\",\n    \"password\": \"mysecretpassword\",\n    \"totp\": 123456,\n    \"email_otp\": 123456,\n    \"fido_authentication_response\": {},\n    \"recovery_code\": \"ABCD-EFGH-IJKL-MNOP\"\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/auth/logout": {
+      "get": {
+        "summary": "Logout user",
+        "description": "Log user out by revoking auth tokens. Once logged out, current user cannot access the API anymore.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/auth/logout\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/auth/logout\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/auth/authenticated": {
+      "get": {
+        "summary": "Check authentication status",
+        "description": "Returns information if the user is authenticated. It can be used by third party tools, especially browser frontend, to know if current user is still logged in.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/auth/authenticated\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/auth/authenticated\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/auth/register": {
+      "post": {
+        "summary": "Register new user",
+        "description": "Allow a user to register himself to the service.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/auth/register\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"email\": \"admin@example.com\",\n  \"password\": \"\",\n  \"password_2\": \"\",\n  \"first_name\": \"\",\n  \"last_name\": \"\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/auth/register\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"email\": \"admin@example.com\",\n    \"password\": \"\",\n    \"password_2\": \"\",\n    \"first_name\": \"\",\n    \"last_name\": \"\"\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/auth/change-password": {
+      "post": {
+        "summary": "Change user password",
+        "description": "Allow the user to change his password. Requires current password for verification and password confirmation to ensure accuracy.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/auth/change-password\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"old_password\": \"\",\n  \"password\": \"\",\n  \"password_2\": \"\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/auth/change-password\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"old_password\": \"\",\n    \"password\": \"\",\n    \"password_2\": \"\"\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/auth/reset-password": {
+      "put": {
+        "summary": "Reset password with token",
+        "description": "Allow a user to change his password when he forgets it. It uses a token sent by email to the user to verify it is the user who requested the password reset.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X PUT \"http://api.example.com/auth/reset-password\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"email\": \"admin@example.com\",\n  \"token\": \"\",\n  \"password\": \"\",\n  \"password2\": \"\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/auth/reset-password\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"email\": \"admin@example.com\",\n    \"token\": \"\",\n    \"password\": \"\",\n    \"password2\": \"\"\n}\n\nresponse = requests.put(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Request password reset",
+        "description": "Send a password reset token by email to the user. It uses a classic scheme where a token is sent by email.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/auth/reset-password\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"email\": \"admin@example.com\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/auth/reset-password\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"email\": \"admin@example.com\"\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/auth/refresh-token": {
+      "get": {
+        "summary": "Refresh access token",
+        "description": "Tokens are considered outdated every two weeks. This route allows to extend their lifetime before they get outdated.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/auth/refresh-token\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/auth/refresh-token\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/auth/totp": {
+      "delete": {
+        "summary": "Disable TOTP",
+        "description": "Disable TOTP (Time-based One-Time Password) authentication. It requires two-factor authentication verification.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/auth/totp\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"totp\": \"\",\n  \"email_otp\": \"\",\n  \"fido_authentication_response\": {},\n  \"recovery_code\": \"\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/auth/totp\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"totp\": \"\",\n    \"email_otp\": \"\",\n    \"fido_authentication_response\": {},\n    \"recovery_code\": \"\"\n}\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "put": {
+        "summary": "Pre-enable TOTP",
+        "description": "Prepare TOTP (Time-based One-Time Password) for enabling. It returns provisioning URI and secret for authenticator app setup.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X PUT \"http://api.example.com/auth/totp\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/auth/totp\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.put(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Enable TOTP",
+        "description": "Enable TOTP (Time-based One-Time Password) authentication. It requires verification code from authenticator app.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/auth/totp\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"totp\": \"\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/auth/totp\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"totp\": \"\"\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/auth/email-otp": {
+      "delete": {
+        "summary": "Disable email OTP",
+        "description": "Disable email OTP (One-Time Password) authentication. It requires two-factor authentication verification.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/auth/email-otp\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"totp\": \"\",\n  \"email_otp\": \"\",\n  \"fido_authentication_response\": {},\n  \"recovery_code\": \"\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/auth/email-otp\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"totp\": \"\",\n    \"email_otp\": \"\",\n    \"fido_authentication_response\": {},\n    \"recovery_code\": \"\"\n}\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "get": {
+        "summary": "Send email OTP",
+        "description": "Send a one-time password by email to the user for authentication.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/auth/email-otp?email=\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/auth/email-otp\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"email\": \"\"\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "put": {
+        "summary": "Pre-enable email OTP",
+        "description": "Prepare email OTP (One-Time Password) for enabling. It sets up email-based two-factor authentication.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X PUT \"http://api.example.com/auth/email-otp\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/auth/email-otp\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.put(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Enable email OTP",
+        "description": "Enable email OTP (One-Time Password) authentication. It requires verification code sent to email.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/auth/email-otp\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"email_otp\": \"\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/auth/email-otp\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"email_otp\": \"\"\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/auth/recovery-codes": {
+      "put": {
+        "summary": "Generate recovery codes",
+        "description": "Generate new recovery codes for two-factor authentication. It requires two-factor authentication verification.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X PUT \"http://api.example.com/auth/recovery-codes\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"totp\": \"\",\n  \"email_otp\": \"\",\n  \"fido_authentication_response\": {},\n  \"recovery_code\": \"\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/auth/recovery-codes\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"totp\": \"\",\n    \"email_otp\": \"\",\n    \"fido_authentication_response\": {},\n    \"recovery_code\": \"\"\n}\n\nresponse = requests.put(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/auth/fido": {
+      "delete": {
+        "summary": "Unregister FIDO device",
+        "description": "Unregister a FIDO device from WebAuthn authentication. It requires two-factor authentication verification.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/auth/fido\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"totp\": \"\",\n  \"email_otp\": \"\",\n  \"fido_authentication_response\": {},\n  \"recovery_code\": \"\",\n  \"device_name\": \"\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/auth/fido\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"totp\": \"\",\n    \"email_otp\": \"\",\n    \"fido_authentication_response\": {},\n    \"recovery_code\": \"\",\n    \"device_name\": \"\"\n}\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "get": {
+        "summary": "Get FIDO challenge",
+        "description": "Get a challenge for FIDO device authentication. It is used for WebAuthn authentication flow.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/auth/fido?email=\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/auth/fido\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"email\": \"\"\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "put": {
+        "summary": "Pre-register FIDO device",
+        "description": "Prepare FIDO device for registration. It returns registration options for WebAuthn.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X PUT \"http://api.example.com/auth/fido\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/auth/fido\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.put(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Register FIDO device",
+        "description": "Register a FIDO device for WebAuthn authentication. It requires registration response from the device.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/auth/fido\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"registration_response\": {},\n  \"device_name\": \"\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/auth/fido\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"registration_response\": {},\n    \"device_name\": \"\"\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/auth/saml/sso": {
+      "post": {
+        "summary": "SAML SSO login",
+        "description": "Handle SAML SSO login response. Processes authentication response from SAML identity provider and creates a new user if they don't exist.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/auth/saml/sso\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/auth/saml/sso\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/auth/saml/login": {
+      "get": {
+        "summary": "SAML SSO login redirect",
+        "description": "Initiate SAML SSO login by redirecting to SAML identity provider.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/auth/saml/login\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/auth/saml/login\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/chat-messages/": {
+      "get": {
+        "summary": "Get chat messages",
+        "description": "Retrieve all chat messages. Supports filtering via query parameters and pagination.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/chat-messages/?page=1&limit=50&relations=false\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/chat-messages/\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"page\": 1,\n    \"limit\": 50,\n    \"relations\": false\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Create chat message",
+        "description": "Create a new chat message with data provided in the request body. JSON format is expected.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/chat-messages/\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"chat_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n  \"person_id\": \"b24a6ea4-ce75-4665-a070-57453082c25\",\n  \"text\": \"Message text\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/chat-messages/\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"chat_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"person_id\": \"b24a6ea4-ce75-4665-a070-57453082c25\",\n    \"text\": \"Message text\"\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/chat-messages/{instance_id}": {
+      "delete": {
+        "summary": "Delete chat message",
+        "description": "Delete a chat message by its ID. Returns empty response on success.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/data/chat-messages/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/chat-messages/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "get": {
+        "summary": "Get chat message",
+        "description": "Retrieve a chat message by its ID and return it as a JSON object. Supports including relations.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/chat-messages/a24a6ea4-ce75-4665-a070-57453082c25?relations=true\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/chat-messages/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"relations\": true\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "put": {
+        "summary": "Update chat message",
+        "description": "Update a chat message with data provided in the request body. JSON format is expected.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X PUT \"http://api.example.com/data/chat-messages/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"text\": \"Updated message text\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/chat-messages/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"text\": \"Updated message text\"\n}\n\nresponse = requests.put(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/chats/": {
+      "get": {
+        "summary": "Get chats",
+        "description": "Retrieve all chats. Supports filtering via query parameters and pagination.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/chats/?page=1&limit=50&relations=false\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/chats/\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"page\": 1,\n    \"limit\": 50,\n    \"relations\": false\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Create chat",
+        "description": "Create a new chat with data provided in the request body. JSON format is expected.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/chats/\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"object_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n  \"object_type\": \"Asset\",\n  \"name\": \"Chat Name\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/chats/\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"object_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"object_type\": \"Asset\",\n    \"name\": \"Chat Name\"\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/chats/{instance_id}": {
+      "delete": {
+        "summary": "Delete chat",
+        "description": "Delete a chat by its ID. Returns empty response on success.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/data/chats/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/chats/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "get": {
+        "summary": "Get chat",
+        "description": "Retrieve a chat by its ID and return it as a JSON object. Supports including relations.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/chats/a24a6ea4-ce75-4665-a070-57453082c25?relations=true\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/chats/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"relations\": true\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "put": {
+        "summary": "Update chat",
+        "description": "Update a chat with data provided in the request body. JSON format is expected.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X PUT \"http://api.example.com/data/chats/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"Updated Chat Name\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/chats/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"Updated Chat Name\"\n}\n\nresponse = requests.put(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/comments": {
+      "get": {
+        "summary": "Get comments",
+        "description": "Retrieve all comments. Supports filtering via query parameters and pagination.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/comments?page=1&limit=50&relations=false\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/comments\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"page\": 1,\n    \"limit\": 50,\n    \"relations\": false\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Create comment",
+        "description": "Create a new comment with data provided in the request body. JSON format is expected.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/comments\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"object_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n  \"person_id\": \"b24a6ea4-ce75-4665-a070-57453082c25\",\n  \"task_status_id\": \"c24a6ea4-ce75-4665-a070-57453082c25\",\n  \"text\": \"Comment text\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/comments\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"object_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"person_id\": \"b24a6ea4-ce75-4665-a070-57453082c25\",\n    \"task_status_id\": \"c24a6ea4-ce75-4665-a070-57453082c25\",\n    \"text\": \"Comment text\"\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/comments/{instance_id}": {
+      "delete": {
+        "summary": "Delete comment",
+        "description": "Delete a comment by its ID. Returns empty response on success. Updates task status if comment had status change.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/data/comments/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/comments/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "get": {
+        "summary": "Get comment",
+        "description": "Retrieve a comment by its ID and return it as a JSON object. Supports including relations. Client users can only see their own comments or comments from other clients.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/comments/a24a6ea4-ce75-4665-a070-57453082c25?relations=true\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/comments/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"relations\": true\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "put": {
+        "summary": "Update comment",
+        "description": "Update a comment with data provided in the request body. JSON format is expected. May update task status if task_status_id is changed.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X PUT \"http://api.example.com/data/comments/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"text\": \"Updated comment text\",\n  \"task_status_id\": \"b24a6ea4-ce75-4665-a070-57453082c25\",\n  \"pinned\": true,\n  \"checklist\": [\n    {\n      \"text\": \"Item 1\",\n      \"checked\": false\n    }\n  ]\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/comments/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"text\": \"Updated comment text\",\n    \"task_status_id\": \"b24a6ea4-ce75-4665-a070-57453082c25\",\n    \"pinned\": true,\n    \"checklist\": [\n        {\n            \"text\": \"Item 1\",\n            \"checked\": false\n        }\n    ]\n}\n\nresponse = requests.put(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/concepts": {
+      "get": {
+        "summary": "Get all concepts",
+        "description": "Retrieve all concept entries with filtering support. Filters can be specified in the query string to narrow down results by project or parent concept.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/concepts?project_id=a24a6ea4-ce75-4665-a070-57453082c25&parent_id=b35b7fb5-df86-5776-b181-68564193d36\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/concepts\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"project_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"parent_id\": \"b35b7fb5-df86-5776-b181-68564193d36\"\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/concepts/with-tasks": {
+      "get": {
+        "summary": "Get concepts and tasks",
+        "description": "Retrieve all concepts and all related tasks included in the response.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/concepts/with-tasks?project_id=a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/concepts/with-tasks\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"project_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\"\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/concepts/{concept_id}": {
+      "delete": {
+        "summary": "Delete concept",
+        "description": "Permanently remove a concept from the system. Only concept creators or project managers can delete concepts.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/data/concepts/a24a6ea4-ce75-4665-a070-57453082c25?force=false\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/concepts/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"force\": false\n}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "get": {
+        "summary": "Get concept",
+        "description": "Retrieve detailed information about a specific concept including metadata, project context, and related data.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/concepts/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/concepts/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/concepts/{concept_id}/task-types": {
+      "get": {
+        "summary": "Get concept task types",
+        "description": "Retrieve all task types that are related to a specific concept.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/concepts/a24a6ea4-ce75-4665-a070-57453082c25/task-types\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/concepts/a24a6ea4-ce75-4665-a070-57453082c25/task-types\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/concepts/{concept_id}/tasks": {
+      "get": {
+        "summary": "Get concept tasks",
+        "description": "Retrieve all tasks that are related to a specific concept.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/concepts/a24a6ea4-ce75-4665-a070-57453082c25/tasks?relations=true\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/concepts/a24a6ea4-ce75-4665-a070-57453082c25/tasks\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"relations\": true\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/concepts/{concept_id}/preview-files": {
+      "get": {
+        "summary": "Get concept previews",
+        "description": "Retrieve all preview files related to a specific concept. Returns them as a dictionary where keys are related task type IDs and values are arrays of previews for that task type.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/concepts/a24a6ea4-ce75-4665-a070-57453082c25/preview-files\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/concepts/a24a6ea4-ce75-4665-a070-57453082c25/preview-files\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/config": {
+      "get": {
+        "summary": "Get the configuration of the Kitsu instance",
+        "description": "The configuration includes self-hosted status, Crisp token, indexer configuration, SAML status, and dark theme status.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/config\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/config\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/custom-actions/": {
+      "get": {
+        "summary": "Get custom actions",
+        "description": "Retrieve all custom actions. Supports filtering via query parameters and pagination. Vendor access is blocked.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/custom-actions/?page=1&limit=50&relations=false\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/custom-actions/\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"page\": 1,\n    \"limit\": 50,\n    \"relations\": false\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Create custom action",
+        "description": "Create a new custom action with data provided in the request body. JSON format is expected.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/custom-actions/\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"Custom Action Name\",\n  \"url_pattern\": \"/api/actions/{id}\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/custom-actions/\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"Custom Action Name\",\n    \"url_pattern\": \"/api/actions/{id}\"\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/custom-actions/{instance_id}": {
+      "delete": {
+        "summary": "Delete custom action",
+        "description": "Delete a custom action by its ID. Returns empty response on success.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/data/custom-actions/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/custom-actions/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "get": {
+        "summary": "Get custom action",
+        "description": "Retrieve a custom action by its ID and return it as a JSON object. Supports including relations.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/custom-actions/a24a6ea4-ce75-4665-a070-57453082c25?relations=true\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/custom-actions/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"relations\": true\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "put": {
+        "summary": "Update custom action",
+        "description": "Update a custom action with data provided in the request body. JSON format is expected.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X PUT \"http://api.example.com/data/custom-actions/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"Updated Custom Action Name\",\n  \"url_pattern\": \"/api/actions/{id}\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/custom-actions/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"Updated Custom Action Name\",\n    \"url_pattern\": \"/api/actions/{id}\"\n}\n\nresponse = requests.put(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/day-offs/": {
+      "get": {
+        "summary": "Get day offs",
+        "description": "Retrieve all day offs. Supports filtering via query parameters and pagination.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/day-offs/?page=1&limit=50&relations=false\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/day-offs/\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"page\": 1,\n    \"limit\": 50,\n    \"relations\": false\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Create day off",
+        "description": "Create a new day off with data provided in the request body. JSON format is expected. Deletes overlapping time spent entries.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/day-offs/\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"date\": \"2024-01-15\",\n  \"end_date\": \"2024-01-20\",\n  \"person_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/day-offs/\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"date\": \"2024-01-15\",\n    \"end_date\": \"2024-01-20\",\n    \"person_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\"\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/day-offs/{instance_id}": {
+      "delete": {
+        "summary": "Delete day off",
+        "description": "Delete a day off by its ID. Returns empty response on success.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/data/day-offs/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/day-offs/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "get": {
+        "summary": "Get day off",
+        "description": "Retrieve a day off by its ID and return it as a JSON object. Supports including relations.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/day-offs/a24a6ea4-ce75-4665-a070-57453082c25?relations=true\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/day-offs/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"relations\": true\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "put": {
+        "summary": "Update day off",
+        "description": "Update a day off with data provided in the request body. JSON format is expected. Deletes overlapping time spent entries.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X PUT \"http://api.example.com/data/day-offs/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"date\": \"2024-01-16\",\n  \"end_date\": \"2024-01-21\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/day-offs/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"date\": \"2024-01-16\",\n    \"end_date\": \"2024-01-21\"\n}\n\nresponse = requests.put(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/departments": {
+      "get": {
+        "summary": "Get departments",
+        "description": "Retrieve all departments. Supports filtering via query parameters and pagination.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/departments?page=1&limit=50&relations=false\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/departments\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"page\": 1,\n    \"limit\": 50,\n    \"relations\": false\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Create department",
+        "description": "Create a new department with data provided in the request body. JSON format is expected.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/departments\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"Animation\",\n  \"color\": \"#FF5733\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/departments\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"Animation\",\n    \"color\": \"#FF5733\"\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/departments/{instance_id}": {
+      "delete": {
+        "summary": "Delete department",
+        "description": "Delete a department by its ID. Returns empty response on success.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/data/departments/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/departments/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "get": {
+        "summary": "Get department",
+        "description": "Retrieve a department by its ID and return it as a JSON object. Supports including relations.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/departments/a24a6ea4-ce75-4665-a070-57453082c25?relations=true\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/departments/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"relations\": true\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "put": {
+        "summary": "Update department",
+        "description": "Update a department with data provided in the request body. JSON format is expected.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X PUT \"http://api.example.com/data/departments/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"Updated Animation\",\n  \"color\": \"#FF5734\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/departments/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"Updated Animation\",\n    \"color\": \"#FF5734\"\n}\n\nresponse = requests.put(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/departments/software-licenses": {
+      "get": {
+        "summary": "Get all department software licenses",
+        "description": "Retrieve all software licenses organized by department. Returns a dictionary where each department contains its associated software licenses.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/departments/software-licenses\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/departments/software-licenses\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/departments/{department_id}/software-licenses": {
+      "post": {
+        "summary": "Add software license to department",
+        "description": "Associate a software license with a specific department. This allows the department to use the specified software in budget forecasting.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/departments/a24a6ea4-ce75-4665-a070-57453082c25/software-licenses\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"software_id\": \"b35b7fb5-df86-5776-b181-68564193d36\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/departments/a24a6ea4-ce75-4665-a070-57453082c25/software-licenses\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"software_id\": \"b35b7fb5-df86-5776-b181-68564193d36\"\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/departments/{department_id}/software-licenses/{software_id}": {
+      "delete": {
+        "summary": "Remove software license from department",
+        "description": "Remove a software license from a specific department. This disassociates the software license from the department.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/data/departments/a24a6ea4-ce75-4665-a070-57453082c25/software-licenses/b35b7fb5-df86-5776-b181-68564193d36\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/departments/a24a6ea4-ce75-4665-a070-57453082c25/software-licenses/b35b7fb5-df86-5776-b181-68564193d36\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "get": {
+        "summary": "Get department software licenses",
+        "description": "Retrieve all software items that are associated with a specific department.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/departments/a24a6ea4-ce75-4665-a070-57453082c25/software-licenses/{software_id}\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/departments/a24a6ea4-ce75-4665-a070-57453082c25/software-licenses/{software_id}\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/departments/hardware-items": {
+      "get": {
+        "summary": "Get all department hardware items",
+        "description": "Retrieve all hardware items organized by department. Returns a dictionary where each department contains its associated hardware items.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/departments/hardware-items\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/departments/hardware-items\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/departments/{department_id}/hardware-items": {
+      "post": {
+        "summary": "Add hardware item to department",
+        "description": "Associate a hardware item with a specific department. This allows the department to use the specified hardware in budget forecasting.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/departments/a24a6ea4-ce75-4665-a070-57453082c25/hardware-items\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"hardware_item_id\": \"b35b7fb5-df86-5776-b181-68564193d36\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/departments/a24a6ea4-ce75-4665-a070-57453082c25/hardware-items\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"hardware_item_id\": \"b35b7fb5-df86-5776-b181-68564193d36\"\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/departments/{department_id}/hardware-items/{hardware_item_id}": {
+      "delete": {
+        "summary": "Remove hardware item from department",
+        "description": "Remove a hardware item from a specific department. This disassociates the hardware from the department.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/data/departments/a24a6ea4-ce75-4665-a070-57453082c25/hardware-items/b35b7fb5-df86-5776-b181-68564193d36\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/departments/a24a6ea4-ce75-4665-a070-57453082c25/hardware-items/b35b7fb5-df86-5776-b181-68564193d36\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "get": {
+        "summary": "Get department hardware items",
+        "description": "Retrieve all hardware items that are associated with a specific department.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/departments/a24a6ea4-ce75-4665-a070-57453082c25/hardware-items/{hardware_item_id}\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/departments/a24a6ea4-ce75-4665-a070-57453082c25/hardware-items/{hardware_item_id}\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/edits": {
+      "get": {
+        "summary": "Get all edits",
+        "description": "Retrieve all edit entries with filtering support. Filters can be specified in the query string.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/edits?project_id=a24a6ea4-ce75-4665-a070-57453082c25&name=Opening%20Sequence&force=false\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/edits\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"project_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"name\": \"Opening Sequence\",\n    \"force\": false\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/edits/all": {
+      "get": {
+        "summary": "Get edits",
+        "description": "Retrieve all edit entries with filtering support. Filters can be specified in the query string.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/edits/all?project_id=a24a6ea4-ce75-4665-a070-57453082c25&name=Opening%20Sequence&force=false\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/edits/all\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"project_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"name\": \"Opening Sequence\",\n    \"force\": false\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/edits/with-tasks": {
+      "get": {
+        "summary": "Get edits and tasks",
+        "description": "Retrieve all edits with project name and all related tasks.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/edits/with-tasks?project_id=a24a6ea4-ce75-4665-a070-57453082c25&name=Opening%20Sequence&force=false\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/edits/with-tasks\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"project_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"name\": \"Opening Sequence\",\n    \"force\": false\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/edits/{edit_id}": {
+      "delete": {
+        "summary": "Delete edit",
+        "description": "Permanently remove an edit from the system. Only edit creators or project managers can delete edits.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/data/edits/a24a6ea4-ce75-4665-a070-57453082c25?force=false\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/edits/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"force\": false\n}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "get": {
+        "summary": "Get edit",
+        "description": "Retrieve detailed information about a specific edit.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/edits/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/edits/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/edits/{edit_id}/task-types": {
+      "get": {
+        "summary": "Get edit task types",
+        "description": "Retrieve all task types that are related to a specific edit.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/edits/a24a6ea4-ce75-4665-a070-57453082c25/task-types\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/edits/a24a6ea4-ce75-4665-a070-57453082c25/task-types\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/edits/{edit_id}/tasks": {
+      "get": {
+        "summary": "Get edit tasks",
+        "description": "Retrieve all tasks that are related to a specific edit.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/edits/a24a6ea4-ce75-4665-a070-57453082c25/tasks?relations=true\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/edits/a24a6ea4-ce75-4665-a070-57453082c25/tasks\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"relations\": true\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/edits/{edit_id}/preview-files": {
+      "get": {
+        "summary": "Get edit previews",
+        "description": "Retrieve all preview files related to a specific edit. Returns them as a dictionary where keys are related task type IDs and values are arrays of previews for that task type.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/edits/a24a6ea4-ce75-4665-a070-57453082c25/preview-files\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/edits/a24a6ea4-ce75-4665-a070-57453082c25/preview-files\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/edits/{edit_id}/versions": {
+      "get": {
+        "summary": "Get edit versions",
+        "description": "Retrieve all data versions of a specific edit. This includes historical versions and metadata about changes over time.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/edits/a24a6ea4-ce75-4665-a070-57453082c25/versions\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/edits/a24a6ea4-ce75-4665-a070-57453082c25/versions\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/entities/{entity_id}/chat": {
+      "get": {
+        "summary": "Get chat details",
+        "description": "Retrieve chat information and messages for a specific entity. Returns chat metadata including participants and all associated messages.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/entities/a24a6ea4-ce75-4665-a070-57453082c25/chat\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/entities/a24a6ea4-ce75-4665-a070-57453082c25/chat\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/entities/{entity_id}/chat/messages": {
+      "get": {
+        "summary": "Get chat messages",
+        "description": "Retrieve all chat messages for a specific entity. Returns a list of messages with sender information and timestamps.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/entities/a24a6ea4-ce75-4665-a070-57453082c25/chat/messages\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/entities/a24a6ea4-ce75-4665-a070-57453082c25/chat/messages\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Create chat message",
+        "description": "Create a new chat message for a specific entity. Supports both JSON and form data with optional file attachments. Only chat participants can send messages.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/entities/a24a6ea4-ce75-4665-a070-57453082c25/chat/messages\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"message\": \"Hello, world!\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/entities/a24a6ea4-ce75-4665-a070-57453082c25/chat/messages\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"message\": \"Hello, world!\"\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/entities/{entity_id}/chat/messages/{chat_message_id}": {
+      "delete": {
+        "summary": "Delete chat message",
+        "description": "Delete a specific chat message. Only the message author or administrators can delete messages.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/data/entities/a24a6ea4-ce75-4665-a070-57453082c25/chat/messages/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/entities/a24a6ea4-ce75-4665-a070-57453082c25/chat/messages/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "get": {
+        "summary": "Get chat message",
+        "description": "Retrieve a specific chat message by its ID. Returns detailed message information including content and metadata.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/entities/a24a6ea4-ce75-4665-a070-57453082c25/chat/messages/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/entities/a24a6ea4-ce75-4665-a070-57453082c25/chat/messages/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/entities": {
+      "get": {
+        "summary": "Get entities",
+        "description": "Retrieve all entities. Supports filtering via query parameters and pagination. Includes project permission filtering for non-admin users.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/entities?page=1&limit=50&relations=false\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/entities\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"page\": 1,\n    \"limit\": 50,\n    \"relations\": false\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Create entity",
+        "description": "Create a new entity with data provided in the request body. JSON format is expected. Requires manager access to the project.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/entities\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"SH010\",\n  \"project_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n  \"entity_type_id\": \"b24a6ea4-ce75-4665-a070-57453082c25\",\n  \"status\": \"running\",\n  \"data\": {\n    \"frame_in\": 1001,\n    \"frame_out\": 1120\n  }\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/entities\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"SH010\",\n    \"project_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"entity_type_id\": \"b24a6ea4-ce75-4665-a070-57453082c25\",\n    \"status\": \"running\",\n    \"data\": {\n        \"frame_in\": 1001,\n        \"frame_out\": 1120\n    }\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/entities/{instance_id}": {
+      "delete": {
+        "summary": "Delete entity",
+        "description": "Delete an entity by its ID. Returns empty response on success. Can only be deleted by creator or project manager.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/data/entities/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/entities/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "get": {
+        "summary": "Get entity",
+        "description": "Retrieve an entity by its ID and return it as a JSON object. Supports including relations. Requires project access.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/entities/a24a6ea4-ce75-4665-a070-57453082c25?relations=true\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/entities/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"relations\": true\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "put": {
+        "summary": "Update entity",
+        "description": "Update an entity with data provided in the request body. JSON format is expected. Supports shot versioning when frame data changes.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X PUT \"http://api.example.com/data/entities/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"SH010\",\n  \"data\": {\n    \"frame_in\": 1001,\n    \"frame_out\": 1120\n  }\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/entities/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"SH010\",\n    \"data\": {\n        \"frame_in\": 1001,\n        \"frame_out\": 1120\n    }\n}\n\nresponse = requests.put(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/entities/{entity_id}/news": {
+      "get": {
+        "summary": "Get entity news",
+        "description": "Retrieve all news entries that are linked to a specific entity.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/entities/a24a6ea4-ce75-4665-a070-57453082c25/news\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/entities/a24a6ea4-ce75-4665-a070-57453082c25/news\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/entities/{entity_id}/preview-files": {
+      "get": {
+        "summary": "Get entity preview files",
+        "description": "Retrieve all preview files that are linked to a specific entity. This includes images, videos, and other preview media associated with the entity.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/entities/a24a6ea4-ce75-4665-a070-57453082c25/preview-files\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/entities/a24a6ea4-ce75-4665-a070-57453082c25/preview-files\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/entities/{entity_id}/time-spents": {
+      "get": {
+        "summary": "Get entity time spent",
+        "description": "Retrieve all time spent entries that are linked to a specific entity.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/entities/a24a6ea4-ce75-4665-a070-57453082c25/time-spents\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/entities/a24a6ea4-ce75-4665-a070-57453082c25/time-spents\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/entities/{entity_id}/entities-linked/with-tasks": {
+      "get": {
+        "summary": "Get linked entities",
+        "description": "Retrieve all entities that are linked to a specific entity along with their associated tasks. This includes related entities, dependencies, and hierarchical relationships.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/entities/a24a6ea4-ce75-4665-a070-57453082c25/entities-linked/with-tasks\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/entities/a24a6ea4-ce75-4665-a070-57453082c25/entities-linked/with-tasks\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/entities/{entity_id}/working-files": {
+      "get": {
+        "summary": "Get entity working files",
+        "description": "Retrieve all working files for a given entity with optional filtering by task and name. Returns complete list of working files with their revisions.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/entities/a24a6ea4-ce75-4665-a070-57453082c25/working-files?task_id=b35b7fb5-df86-5776-b181-68564193d36&name=main\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/entities/a24a6ea4-ce75-4665-a070-57453082c25/working-files\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"task_id\": \"b35b7fb5-df86-5776-b181-68564193d36\",\n    \"name\": \"main\"\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/entities/{entity_id}/output-files/new": {
+      "post": {
+        "summary": "Create new entity output file",
+        "description": "Create a new output file linked to a specific entity. Output files are created when artists are satisfied with their working files. They track the source working file and require output type and task type for categorization. An output type is required for better categorization (textures, caches, ...). A task type can be set too to give the department related to the output file. The revision is automatically set.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/entities/a24a6ea4-ce75-4665-a070-57453082c25/output-files/new\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"main\",\n  \"mode\": \"output\",\n  \"output_type_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n  \"task_type_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n  \"person_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n  \"working_file_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n  \"file_status_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n  \"comment\": \"Final render\",\n  \"extension\": \".mp4\",\n  \"representation\": \"mp4\",\n  \"revision\": 1,\n  \"nb_elements\": 1,\n  \"sep\": \"/\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/entities/a24a6ea4-ce75-4665-a070-57453082c25/output-files/new\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"main\",\n    \"mode\": \"output\",\n    \"output_type_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"task_type_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"person_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"working_file_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"file_status_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"comment\": \"Final render\",\n    \"extension\": \".mp4\",\n    \"representation\": \"mp4\",\n    \"revision\": 1,\n    \"nb_elements\": 1,\n    \"sep\": \"/\"\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/entities/{entity_id}/output-files/next-revision": {
+      "post": {
+        "summary": "Get next entity output file revision",
+        "description": "Get the next revision number for an output file based on entity, output type, task type, and name. Used for automatic revision numbering.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/entities/a24a6ea4-ce75-4665-a070-57453082c25/output-files/next-revision\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"main\",\n  \"output_type_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n  \"task_type_id\": \"b35b7fb5-df86-5776-b181-68564193d36\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/entities/a24a6ea4-ce75-4665-a070-57453082c25/output-files/next-revision\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"main\",\n    \"output_type_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"task_type_id\": \"b35b7fb5-df86-5776-b181-68564193d36\"\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/entities/{entity_id}/output-files/last-revisions": {
+      "get": {
+        "summary": "Get last entity output files",
+        "description": "Retrieve the last revisions of output files for a given entity grouped by output type and file name. Returns the most recent version of each output file.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/entities/a24a6ea4-ce75-4665-a070-57453082c25/output-files/last-revisions?output_type_id=b35b7fb5-df86-5776-b181-68564193d36&task_type_id=c46c8gc6-eg97-6887-c292-79675204e47&representation=mp4&file_status_id=d57d9hd7-fh08-7998-d403-80786315f58&name=main\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/entities/a24a6ea4-ce75-4665-a070-57453082c25/output-files/last-revisions\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"output_type_id\": \"b35b7fb5-df86-5776-b181-68564193d36\",\n    \"task_type_id\": \"c46c8gc6-eg97-6887-c292-79675204e47\",\n    \"representation\": \"mp4\",\n    \"file_status_id\": \"d57d9hd7-fh08-7998-d403-80786315f58\",\n    \"name\": \"main\"\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/entities/{entity_id}/output-types": {
+      "get": {
+        "summary": "Get entity output types",
+        "description": "Retrieve all types of output files generated for a given entity. Returns list of output types available for the entity.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/entities/a24a6ea4-ce75-4665-a070-57453082c25/output-types\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/entities/a24a6ea4-ce75-4665-a070-57453082c25/output-types\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/entities/{entity_id}/output-types/{output_type_id}/output-files": {
+      "get": {
+        "summary": "Get entity output type files",
+        "description": "Retrieve all output files for a given entity and output type. Optionally filter by representation.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/entities/a24a6ea4-ce75-4665-a070-57453082c25/output-types/b35b7fb5-df86-5776-b181-68564193d36/output-files?representation=mp4\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/entities/a24a6ea4-ce75-4665-a070-57453082c25/output-types/b35b7fb5-df86-5776-b181-68564193d36/output-files\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"representation\": \"mp4\"\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/entities/{entity_id}/output-files": {
+      "get": {
+        "summary": "Get entity output files",
+        "description": "Retrieve all output files for a given entity with optional filtering by output type, task type, representation, file status, and name.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/entities/a24a6ea4-ce75-4665-a070-57453082c25/output-files?output_type_id=b35b7fb5-df86-5776-b181-68564193d36&task_type_id=c46c8gc6-eg97-6887-c292-79675204e47&file_status_id=d57d9hd7-fh08-7998-d403-80786315f58&representation=cache&name=main\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/entities/a24a6ea4-ce75-4665-a070-57453082c25/output-files\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"output_type_id\": \"b35b7fb5-df86-5776-b181-68564193d36\",\n    \"task_type_id\": \"c46c8gc6-eg97-6887-c292-79675204e47\",\n    \"file_status_id\": \"d57d9hd7-fh08-7998-d403-80786315f58\",\n    \"representation\": \"cache\",\n    \"name\": \"main\"\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/entities/{entity_id}/output-file-path": {
+      "post": {
+        "summary": "Generate entity output file path",
+        "description": "Generate an output file path from file tree template based on entity parameters. Revision can be computed automatically if not provided.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/entities/a24a6ea4-ce75-4665-a070-57453082c25/output-file-path\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"main\",\n  \"mode\": \"output\",\n  \"output_type_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n  \"task_type_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n  \"extension\": \".mp4\",\n  \"representation\": \"mp4\",\n  \"revision\": 1,\n  \"separator\": \"/\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/entities/a24a6ea4-ce75-4665-a070-57453082c25/output-file-path\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"main\",\n    \"mode\": \"output\",\n    \"output_type_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"task_type_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"extension\": \".mp4\",\n    \"representation\": \"mp4\",\n    \"revision\": 1,\n    \"separator\": \"/\"\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/entities/guess_from_path": {
+      "post": {
+        "summary": "Guess file tree template",
+        "description": "Get list of possible project file tree templates matching a file path and data ids corresponding to template tokens.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/entities/guess_from_path\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"project_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n  \"file_path\": \"/project/asset/working/main_v001.blend\",\n  \"sep\": \"/\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/entities/guess_from_path\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"project_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"file_path\": \"/project/asset/working/main_v001.blend\",\n    \"sep\": \"/\"\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/entities/{entity_id}/task-types/{task_type_id}/tasks": {
+      "get": {
+        "summary": "Get tasks for entity and type",
+        "description": "Return tasks related to the entity (asset, episode, sequence, shot, or scene) for a task type.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/entities/a24a6ea4-ce75-4665-a070-57453082c25/task-types/a24a6ea4-ce75-4665-a070-57453082c25/tasks\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/entities/a24a6ea4-ce75-4665-a070-57453082c25/task-types/a24a6ea4-ce75-4665-a070-57453082c25/tasks\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/entity-links/": {
+      "get": {
+        "summary": "Get entity links",
+        "description": "Retrieve all entity links. Supports filtering via query parameters and pagination.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/entity-links/?page=1&limit=50&relations=false\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/entity-links/\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"page\": 1,\n    \"limit\": 50,\n    \"relations\": false\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Create entity link",
+        "description": "Create a new entity link with data provided in the request body. JSON format is expected. Links entities together in casting relationships.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/entity-links/\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"entity_in_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n  \"entity_out_id\": \"b24a6ea4-ce75-4665-a070-57453082c25\",\n  \"nb_occurences\": 1,\n  \"label\": \"fixed\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/entity-links/\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"entity_in_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"entity_out_id\": \"b24a6ea4-ce75-4665-a070-57453082c25\",\n    \"nb_occurences\": 1,\n    \"label\": \"fixed\"\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/entity-links/{instance_id}": {
+      "delete": {
+        "summary": "Delete entity link",
+        "description": "Delete an entity link by its ID. Returns empty response on success.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/data/entity-links/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/entity-links/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "get": {
+        "summary": "Get entity link",
+        "description": "Retrieve an entity link by its ID and return it as a JSON object. Supports including relations.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/entity-links/a24a6ea4-ce75-4665-a070-57453082c25?relations=true\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/entity-links/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"relations\": true\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "put": {
+        "summary": "Update entity link",
+        "description": "Update an entity link with data provided in the request body. JSON format is expected.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X PUT \"http://api.example.com/data/entity-links/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"nb_occurences\": 2,\n  \"label\": \"updated\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/entity-links/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"nb_occurences\": 2,\n    \"label\": \"updated\"\n}\n\nresponse = requests.put(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/entity-types": {
+      "get": {
+        "summary": "Get entity types",
+        "description": "Retrieve all entity types. Supports filtering via query parameters and pagination.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/entity-types?page=1&limit=50&relations=false\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/entity-types\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"page\": 1,\n    \"limit\": 50,\n    \"relations\": false\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Create entity type",
+        "description": "Create a new entity type with data provided in the request body. JSON format is expected. Entity type names must be unique.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/entity-types\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"Character\",\n  \"color\": \"#FF5733\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/entity-types\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"Character\",\n    \"color\": \"#FF5733\"\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/entity-types/{instance_id}": {
+      "delete": {
+        "summary": "Delete entity type",
+        "description": "Delete an entity type by its ID. Returns empty response on success.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/data/entity-types/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/entity-types/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "get": {
+        "summary": "Get entity type",
+        "description": "Retrieve an entity type by its ID and return it as a JSON object. Supports including relations.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/entity-types/a24a6ea4-ce75-4665-a070-57453082c25?relations=true\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/entity-types/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"relations\": true\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "put": {
+        "summary": "Update entity type",
+        "description": "Update an entity type with data provided in the request body. JSON format is expected.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X PUT \"http://api.example.com/data/entity-types/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"Updated Character\",\n  \"color\": \"#FF5734\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/entity-types/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"Updated Character\",\n    \"color\": \"#FF5734\"\n}\n\nresponse = requests.put(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/episodes": {
+      "get": {
+        "summary": "Get episodes",
+        "description": "Get episodes with optional filters. Use project_id to filter by project.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/episodes?project_id=a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/episodes\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"project_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\"\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/episodes/with-tasks": {
+      "get": {
+        "summary": "Get episodes and tasks",
+        "description": "Get episodes and their related tasks. Optionally filter by project.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/episodes/with-tasks?project_id=a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/episodes/with-tasks\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"project_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\"\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/episodes/{episode_id}": {
+      "delete": {
+        "summary": "Delete episode",
+        "description": "Delete an episode by id. Requires manager access or ownership.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/data/episodes/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/episodes/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "get": {
+        "summary": "Get episode",
+        "description": "Get an episode by id. needs.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/episodes/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/episodes/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/episodes/{episode_id}/shots": {
+      "get": {
+        "summary": "Get episode shots",
+        "description": "Get shots for an episode. Supports including relations via query params.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/episodes/a24a6ea4-ce75-4665-a070-57453082c25/shots\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/episodes/a24a6ea4-ce75-4665-a070-57453082c25/shots\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/episodes/{episode_id}/sequences": {
+      "get": {
+        "summary": "Get episode sequences",
+        "description": "Get sequences for an episode. You can add query filters if needed.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/episodes/a24a6ea4-ce75-4665-a070-57453082c25/sequences?project_id=a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/episodes/a24a6ea4-ce75-4665-a070-57453082c25/sequences\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"project_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\"\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/episodes/{episode_id}/tasks": {
+      "get": {
+        "summary": "Get episode tasks",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/episodes/a24a6ea4-ce75-4665-a070-57453082c25/tasks\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/episodes/a24a6ea4-ce75-4665-a070-57453082c25/tasks\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/episodes/{episode_id}/task-types": {
+      "get": {
+        "summary": "Get episode task types",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/episodes/a24a6ea4-ce75-4665-a070-57453082c25/task-types\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/episodes/a24a6ea4-ce75-4665-a070-57453082c25/task-types\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/episodes/{episode_id}/shot-tasks": {
+      "get": {
+        "summary": "Get episode shot tasks",
+        "description": "Get shot tasks for an episode. Restricted for vendor permissions.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/episodes/a24a6ea4-ce75-4665-a070-57453082c25/shot-tasks\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/episodes/a24a6ea4-ce75-4665-a070-57453082c25/shot-tasks\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/episodes/{episode_id}/asset-tasks": {
+      "get": {
+        "summary": "Get episode asset tasks",
+        "description": "Get asset tasks for an episode. Restricted for vendor permissions.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/episodes/a24a6ea4-ce75-4665-a070-57453082c25/asset-tasks\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/episodes/a24a6ea4-ce75-4665-a070-57453082c25/asset-tasks\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/episodes/{episode_id}/edits": {
+      "get": {
+        "summary": "Get episode edits",
+        "description": "Retrieve all edits that are related to a specific episode.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/episodes/a24a6ea4-ce75-4665-a070-57453082c25/edits?relations=true\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/episodes/a24a6ea4-ce75-4665-a070-57453082c25/edits\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"relations\": true\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/episodes/{episode_id}/edit-tasks": {
+      "get": {
+        "summary": "Get episode edit tasks",
+        "description": "Retrieve all tasks that are related to a specific episode.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/episodes/a24a6ea4-ce75-4665-a070-57453082c25/edit-tasks?relations=true\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/episodes/a24a6ea4-ce75-4665-a070-57453082c25/edit-tasks\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"relations\": true\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/events/": {
+      "get": {
+        "summary": "Get events",
+        "description": "Retrieve all events. Supports filtering via query parameters and pagination. Limited to 1000 results.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/events/?page=1&limit=50&relations=false\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/events/\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"page\": 1,\n    \"limit\": 50,\n    \"relations\": false\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Create model",
+        "description": "Create a new model instance with data provided in the request body. JSON format is expected. The model performs validation automatically when instantiated.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/events/\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"Model Name\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/events/\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"Model Name\"\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/events/{instance_id}": {
+      "delete": {
+        "summary": "Delete event",
+        "description": "Delete an event by its ID. Returns empty response on success.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/data/events/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/events/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "get": {
+        "summary": "Get event",
+        "description": "Retrieve an event by its ID and return it as a JSON object. Supports including relations.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/events/a24a6ea4-ce75-4665-a070-57453082c25?relations=true\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/events/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"relations\": true\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "put": {
+        "summary": "Update event",
+        "description": "Update an event with data provided in the request body. JSON format is expected.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X PUT \"http://api.example.com/data/events/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"Updated Event Name\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/events/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"Updated Event Name\"\n}\n\nresponse = requests.put(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/events/last": {
+      "get": {
+        "summary": "Get events",
+        "description": "Retrieve last events with filtering support. Filters can be specified in the query string to narrow down results by date range, project, or other criteria.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/events/last?after=2022-07-12&before=2022-07-12&only_files=false&cursor_event_id=a24a6ea4-ce75-4665-a070-57453082c25&limit=100&project_id=a24a6ea4-ce75-4665-a070-57453082c25&name=user_login\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/events/last\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"after\": \"2022-07-12\",\n    \"before\": \"2022-07-12\",\n    \"only_files\": false,\n    \"cursor_event_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"limit\": 100,\n    \"project_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"name\": \"user_login\"\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/events/login-logs/last": {
+      "get": {
+        "summary": "Get login logs",
+        "description": "Retrieve all login logs with filtering support. Filters can be specified in the query string to narrow down results by date range and limit.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/events/login-logs/last?before=2022-07-12T00%3A00%3A00&limit=100\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/events/login-logs/last\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"before\": \"2022-07-12T00:00:00\",\n    \"limit\": 100\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/export/csv/projects/{project_id}/assets.csv": {
+      "get": {
+        "summary": "        Export assets csv",
+        "description": "        ",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/export/csv/projects/a24a6ea4-ce75-4665-a070-57453082c25/assets.csv\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/export/csv/projects/a24a6ea4-ce75-4665-a070-57453082c25/assets.csv\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/export/csv/projects/{project_id}/shots.csv": {
+      "get": {
+        "summary": "        Export shots csv",
+        "description": "        ",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/export/csv/projects/a24a6ea4-ce75-4665-a070-57453082c25/shots.csv\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/export/csv/projects/a24a6ea4-ce75-4665-a070-57453082c25/shots.csv\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/export/csv/projects/{project_id}/casting.csv": {
+      "get": {
+        "summary": "        Export casting csv",
+        "description": "        ",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/export/csv/projects/a24a6ea4-ce75-4665-a070-57453082c25/casting.csv?episode_id=b24a6ea4-ce75-4665-a070-57453082c25&is_shot_casting=false\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/export/csv/projects/a24a6ea4-ce75-4665-a070-57453082c25/casting.csv\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"episode_id\": \"b24a6ea4-ce75-4665-a070-57453082c25\",\n    \"is_shot_casting\": false\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/export/csv/projects/{project_id}/edits.csv": {
+      "get": {
+        "summary": "        Export edits csv",
+        "description": "        ",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/export/csv/projects/a24a6ea4-ce75-4665-a070-57453082c25/edits.csv\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/export/csv/projects/a24a6ea4-ce75-4665-a070-57453082c25/edits.csv\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/export/csv/playlists/{playlist_id}": {
+      "get": {
+        "summary": "        Export playlist csv",
+        "description": "        ",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/export/csv/playlists/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/export/csv/playlists/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/export/csv/persons.csv": {
+      "get": {
+        "summary": "        Export persons csv",
+        "description": "        ",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/export/csv/persons.csv\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/export/csv/persons.csv\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/export/csv/projects.csv": {
+      "get": {
+        "summary": "        Export projects csv",
+        "description": "        ",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/export/csv/projects.csv\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/export/csv/projects.csv\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/export/csv/tasks.csv": {
+      "get": {
+        "summary": "        Export tasks csv",
+        "description": "        ",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/export/csv/tasks.csv\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/export/csv/tasks.csv\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/export/csv/time-spents.csv": {
+      "get": {
+        "summary": "        Export time spents csv",
+        "description": "        ",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/export/csv/time-spents.csv\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/export/csv/time-spents.csv\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/export/csv/task-types.csv": {
+      "get": {
+        "summary": "        Export task types csv",
+        "description": "        ",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/export/csv/task-types.csv\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/export/csv/task-types.csv\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/file-status/": {
+      "get": {
+        "summary": "Get file statuses",
+        "description": "Retrieve all file statuses. Supports filtering via query parameters and pagination.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/file-status/?page=1&limit=50&relations=false\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/file-status/\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"page\": 1,\n    \"limit\": 50,\n    \"relations\": false\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Create file status",
+        "description": "Create a new file status with data provided in the request body. JSON format is expected.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/file-status/\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"Approved\",\n  \"color\": \"#00FF00\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/file-status/\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"Approved\",\n    \"color\": \"#00FF00\"\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/file-status/{instance_id}": {
+      "delete": {
+        "summary": "Delete file status",
+        "description": "Delete a file status by its ID. Returns empty response on success.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/data/file-status/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/file-status/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "get": {
+        "summary": "Get file status",
+        "description": "Retrieve a file status by its ID and return it as a JSON object. Supports including relations.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/file-status/a24a6ea4-ce75-4665-a070-57453082c25?relations=true\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/file-status/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"relations\": true\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "put": {
+        "summary": "Update file status",
+        "description": "Update a file status with data provided in the request body. JSON format is expected.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X PUT \"http://api.example.com/data/file-status/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"Rejected\",\n  \"color\": \"#FF0000\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/file-status/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"Rejected\",\n    \"color\": \"#FF0000\"\n}\n\nresponse = requests.put(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/files/{file_id}": {
+      "get": {
+        "summary": "Get file information",
+        "description": "Retrieve information about a file that could be either a working file or an output file. Returns detailed file metadata and properties.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/files/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/files/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/hardware-items": {
+      "get": {
+        "summary": "Get hardware items",
+        "description": "Retrieve all hardware items. Supports filtering via query parameters and pagination.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/hardware-items?page=1&limit=50&relations=false\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/hardware-items\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"page\": 1,\n    \"limit\": 50,\n    \"relations\": false\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Create hardware item",
+        "description": "Create a new hardware item with data provided in the request body. JSON format is expected.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/hardware-items\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"Workstation 01\",\n  \"serial_number\": \"SN123456\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/hardware-items\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"Workstation 01\",\n    \"serial_number\": \"SN123456\"\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/hardware-items/{instance_id}": {
+      "delete": {
+        "summary": "Delete hardware item",
+        "description": "Delete a hardware item by its ID. Returns empty response on success.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/data/hardware-items/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/hardware-items/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "get": {
+        "summary": "Get hardware item",
+        "description": "Retrieve a hardware item by its ID and return it as a JSON object. Supports including relations.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/hardware-items/a24a6ea4-ce75-4665-a070-57453082c25?relations=true\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/hardware-items/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"relations\": true\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "put": {
+        "summary": "Update hardware item",
+        "description": "Update a hardware item with data provided in the request body. JSON format is expected.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X PUT \"http://api.example.com/data/hardware-items/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"Updated Workstation 01\",\n  \"serial_number\": \"SN123457\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/hardware-items/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"Updated Workstation 01\",\n    \"serial_number\": \"SN123457\"\n}\n\nresponse = requests.put(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/import/shotgun/persons": {
+      "post": {
+        "summary": "Import shotgun persons",
+        "description": "Import Shotgun persons (users). Send a list of Shotgun person entries in the JSON body. Returns created or updated persons with department associations.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/import/shotgun/persons\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '[\n  {\n    \"id\": 12345,\n    \"firstname\": \"John\",\n    \"lastname\": \"Doe\",\n    \"email\": \"john.doe@example.com\",\n    \"login\": \"jdoe\",\n    \"sg_status_list\": \"act\",\n    \"permission_rule_set\": {\n      \"name\": \"Manager\"\n    },\n    \"department\": {\n      \"name\": \"Animation\"\n    }\n  }\n]'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/import/shotgun/persons\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = [\n    {\n        \"id\": 12345,\n        \"firstname\": \"John\",\n        \"lastname\": \"Doe\",\n        \"email\": \"john.doe@example.com\",\n        \"login\": \"jdoe\",\n        \"sg_status_list\": \"act\",\n        \"permission_rule_set\": {\n            \"name\": \"Manager\"\n        },\n        \"department\": {\n            \"name\": \"Animation\"\n        }\n    }\n]\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/import/shotgun/projects": {
+      "post": {
+        "summary": "Import shotgun projects",
+        "description": "Import Shotgun projects. Send a list of Shotgun project entries in the JSON body. Returns created or updated projects with custom fields preserved.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/import/shotgun/projects\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '[\n  {\n    \"id\": 12345,\n    \"name\": \"My Project\",\n    \"sg_status\": \"Active\"\n  }\n]'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/import/shotgun/projects\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = [\n    {\n        \"id\": 12345,\n        \"name\": \"My Project\",\n        \"sg_status\": \"Active\"\n    }\n]\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/import/shotgun/episodes": {
+      "post": {
+        "summary": "Import shotgun episodes",
+        "description": "Import Shotgun episodes. Send a list of Shotgun episode entries in the JSON body. Returns created or updated episodes.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/import/shotgun/episodes\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '[\n  {\n    \"id\": 12345,\n    \"code\": \"EP01\",\n    \"description\": \"First episode\",\n    \"project\": {\n      \"name\": \"My Project\"\n    }\n  }\n]'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/import/shotgun/episodes\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = [\n    {\n        \"id\": 12345,\n        \"code\": \"EP01\",\n        \"description\": \"First episode\",\n        \"project\": {\n            \"name\": \"My Project\"\n        }\n    }\n]\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/import/shotgun/sequences": {
+      "post": {
+        "summary": "Import shotgun sequences",
+        "description": "Import Shotgun sequences. Send a list of Shotgun sequence entries in the JSON body. Returns created or updated sequences linked to episodes.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/import/shotgun/sequences\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '[\n  {\n    \"id\": 12345,\n    \"code\": \"SQ01\",\n    \"description\": \"Main sequence\",\n    \"project\": {\n      \"name\": \"My Project\"\n    },\n    \"episode\": {\n      \"id\": 11111\n    }\n  }\n]'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/import/shotgun/sequences\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = [\n    {\n        \"id\": 12345,\n        \"code\": \"SQ01\",\n        \"description\": \"Main sequence\",\n        \"project\": {\n            \"name\": \"My Project\"\n        },\n        \"episode\": {\n            \"id\": 11111\n        }\n    }\n]\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/import/shotgun/shots": {
+      "post": {
+        "summary": "Import shotgun shots",
+        "description": "Import Shotgun shots. Send a list of Shotgun shot entries in the JSON body. Returns created or updated shots with frame ranges, custom fields, and asset links.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/import/shotgun/shots\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '[\n  {\n    \"id\": 12345,\n    \"code\": \"SH010\",\n    \"sg_cut_in\": 1001,\n    \"sg_cut_duration\": 50,\n    \"project\": {\n      \"name\": \"My Project\"\n    },\n    \"sg_sequence\": {\n      \"id\": 11111\n    },\n    \"sg_scene\": {\n      \"id\": 22222\n    },\n    \"assets\": [\n      {\n        \"id\": 33333\n      }\n    ]\n  }\n]'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/import/shotgun/shots\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = [\n    {\n        \"id\": 12345,\n        \"code\": \"SH010\",\n        \"sg_cut_in\": 1001,\n        \"sg_cut_duration\": 50,\n        \"project\": {\n            \"name\": \"My Project\"\n        },\n        \"sg_sequence\": {\n            \"id\": 11111\n        },\n        \"sg_scene\": {\n            \"id\": 22222\n        },\n        \"assets\": [\n            {\n                \"id\": 33333\n            }\n        ]\n    }\n]\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/import/shotgun/scenes": {
+      "post": {
+        "summary": "Import shotgun scenes",
+        "description": "Import Shotgun scenes. Send a list of Shotgun scene entries in the JSON body. Returns created or updated scenes linked to sequences.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/import/shotgun/scenes\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '[\n  {\n    \"id\": 12345,\n    \"code\": \"SC01\",\n    \"project\": {\n      \"name\": \"My Project\"\n    }\n  }\n]'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/import/shotgun/scenes\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = [\n    {\n        \"id\": 12345,\n        \"code\": \"SC01\",\n        \"project\": {\n            \"name\": \"My Project\"\n        }\n    }\n]\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/import/shotgun/assets": {
+      "post": {
+        "summary": "Import shotgun assets",
+        "description": "Import Shotgun assets. Send a list of Shotgun asset entries in the JSON body. Returns created or updated assets with parent-child relationships.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/import/shotgun/assets\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '[\n  {\n    \"id\": 12345,\n    \"code\": \"Asset01\",\n    \"description\": \"Main character asset\",\n    \"sg_asset_type\": \"Character\",\n    \"project\": {\n      \"id\": 11111\n    },\n    \"parents\": [\n      {\n        \"id\": 22222\n      }\n    ]\n  }\n]'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/import/shotgun/assets\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = [\n    {\n        \"id\": 12345,\n        \"code\": \"Asset01\",\n        \"description\": \"Main character asset\",\n        \"sg_asset_type\": \"Character\",\n        \"project\": {\n            \"id\": 11111\n        },\n        \"parents\": [\n            {\n                \"id\": 22222\n            }\n        ]\n    }\n]\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/import/shotgun/steps": {
+      "post": {
+        "summary": "Import shotgun steps",
+        "description": "Import Shotgun steps (task types). Send a list of Shotgun step entries in the JSON body. Returns created or updated task types with departments.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/import/shotgun/steps\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '[\n  {\n    \"id\": 12345,\n    \"code\": \"Animation Modeling\",\n    \"short_name\": \"mod\",\n    \"color\": \"255,128,0\",\n    \"entity_type\": \"Asset\"\n  }\n]'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/import/shotgun/steps\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = [\n    {\n        \"id\": 12345,\n        \"code\": \"Animation Modeling\",\n        \"short_name\": \"mod\",\n        \"color\": \"255,128,0\",\n        \"entity_type\": \"Asset\"\n    }\n]\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/import/shotgun/status": {
+      "post": {
+        "summary": "Import shotgun task statuses",
+        "description": "Import Shotgun task statuses. Send a list of Shotgun status entries in the JSON body. Returns created or updated task statuses with colors.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/import/shotgun/status\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '[\n  {\n    \"id\": 12345,\n    \"name\": \"In Progress\",\n    \"code\": \"IP\",\n    \"bg_color\": \"255,128,0\"\n  }\n]'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/import/shotgun/status\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = [\n    {\n        \"id\": 12345,\n        \"name\": \"In Progress\",\n        \"code\": \"IP\",\n        \"bg_color\": \"255,128,0\"\n    }\n]\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/import/shotgun/tasks": {
+      "post": {
+        "summary": "Import shotgun tasks",
+        "description": "Import Shotgun tasks. Send a list of Shotgun task entries in the JSON body. Only tasks with steps and projects are imported. Returns created or updated tasks with assignees.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/import/shotgun/tasks\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '[\n  {\n    \"id\": 12345,\n    \"cached_display_name\": \"Modeling for Asset\",\n    \"start_date\": \"2024-01-15\",\n    \"due_date\": \"2024-02-15\",\n    \"sg_sort_order\": 1,\n    \"duration\": 30,\n    \"step\": {\n      \"id\": 11111\n    },\n    \"project\": {\n      \"id\": 22222\n    },\n    \"entity\": {\n      \"id\": 33333,\n      \"type\": \"Asset\"\n    },\n    \"sg_status_list\": \"IP\",\n    \"created_by\": {\n      \"id\": 44444\n    },\n    \"task_assignees\": [\n      {\n        \"id\": 55555\n      }\n    ]\n  }\n]'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/import/shotgun/tasks\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = [\n    {\n        \"id\": 12345,\n        \"cached_display_name\": \"Modeling for Asset\",\n        \"start_date\": \"2024-01-15\",\n        \"due_date\": \"2024-02-15\",\n        \"sg_sort_order\": 1,\n        \"duration\": 30,\n        \"step\": {\n            \"id\": 11111\n        },\n        \"project\": {\n            \"id\": 22222\n        },\n        \"entity\": {\n            \"id\": 33333,\n            \"type\": \"Asset\"\n        },\n        \"sg_status_list\": \"IP\",\n        \"created_by\": {\n            \"id\": 44444\n        },\n        \"task_assignees\": [\n            {\n                \"id\": 55555\n            }\n        ]\n    }\n]\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/import/shotgun/versions": {
+      "post": {
+        "summary": "Import shotgun versions",
+        "description": "Import Shotgun versions (preview files). Send a list of Shotgun version entries in the JSON body. Only versions linked to tasks are imported. Returns created or updated preview files.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/import/shotgun/versions\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '[\n  {\n    \"id\": 12345,\n    \"code\": \"v001\",\n    \"description\": \"First version\",\n    \"sg_task\": {\n      \"id\": 11111\n    },\n    \"user\": {\n      \"id\": 22222\n    },\n    \"sg_uploaded_movie\": {\n      \"url\": \"https://example.com/movie.mp4\",\n      \"name\": \"movie.mp4\"\n    }\n  }\n]'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/import/shotgun/versions\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = [\n    {\n        \"id\": 12345,\n        \"code\": \"v001\",\n        \"description\": \"First version\",\n        \"sg_task\": {\n            \"id\": 11111\n        },\n        \"user\": {\n            \"id\": 22222\n        },\n        \"sg_uploaded_movie\": {\n            \"url\": \"https://example.com/movie.mp4\",\n            \"name\": \"movie.mp4\"\n        }\n    }\n]\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/import/shotgun/notes": {
+      "post": {
+        "summary": "Import shotgun notes",
+        "description": "Import Shotgun notes (comments) linked to tasks. Send a list of Shotgun note entries in the JSON body. Only notes linked to tasks are imported. Returns created or updated comments.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/import/shotgun/notes\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '[\n  {\n    \"id\": 12345,\n    \"content\": \"This is a comment\",\n    \"tasks\": [\n      {\n        \"id\": 67890\n      }\n    ],\n    \"user\": {\n      \"id\": 11111\n    },\n    \"created_at\": \"2024-01-15T10:30:00Z\"\n  }\n]'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/import/shotgun/notes\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = [\n    {\n        \"id\": 12345,\n        \"content\": \"This is a comment\",\n        \"tasks\": [\n            {\n                \"id\": 67890\n            }\n        ],\n        \"user\": {\n            \"id\": 11111\n        },\n        \"created_at\": \"2024-01-15T10:30:00Z\"\n    }\n]\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/import/shotgun/errors": {
+      "get": {
+        "summary": "Get shotgun import errors",
+        "description": "Get all Shotgun import errors from the database. Returns a list of data import errors with source \"shotgun\".",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/import/shotgun/errors\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/import/shotgun/errors\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Create shotgun import error",
+        "description": "Create a new Shotgun import error record. The error event data should be provided in the JSON body.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/import/shotgun/errors\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"error\": \"Failed to import asset\",\n  \"details\": {\n    \"shotgun_id\": 12345,\n    \"reason\": \"Missing required field\"\n  }\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/import/shotgun/errors\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"error\": \"Failed to import asset\",\n    \"details\": {\n        \"shotgun_id\": 12345,\n        \"reason\": \"Missing required field\"\n    }\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/import/shotgun/projectconnections": {
+      "post": {
+        "summary": "Import shotgun project connections",
+        "description": "Import Shotgun project-user connections. Send a list of Shotgun project connection entries in the JSON body. Returns projects with team members added.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/import/shotgun/projectconnections\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '[\n  {\n    \"id\": 12345,\n    \"project\": {\n      \"id\": 11111\n    },\n    \"user\": {\n      \"id\": 22222\n    }\n  }\n]'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/import/shotgun/projectconnections\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = [\n    {\n        \"id\": 12345,\n        \"project\": {\n            \"id\": 11111\n        },\n        \"user\": {\n            \"id\": 22222\n        }\n    }\n]\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/import/shotgun/errors/{error_id}": {
+      "delete": {
+        "summary": "Delete shotgun import error",
+        "description": "Delete a Shotgun import error by its unique identifier. Returns success confirmation when the error is deleted.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/import/shotgun/errors/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/import/shotgun/errors/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/import/shotgun/remove/project": {
+      "post": {
+        "summary": "Remove shotgun project",
+        "description": "Remove a Shotgun project from the database. Provide the Shotgun entry ID in the JSON body.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/import/shotgun/remove/project\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"id\": 12345\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/import/shotgun/remove/project\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"id\": 12345\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/import/shotgun/remove/person": {
+      "post": {
+        "summary": "Remove shotgun person",
+        "description": "Remove a Shotgun person (user) from the database. Provide the Shotgun entry ID in the JSON body.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/import/shotgun/remove/person\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"id\": 12345\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/import/shotgun/remove/person\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"id\": 12345\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/import/shotgun/remove/shot": {
+      "post": {
+        "summary": "Remove shotgun shot",
+        "description": "Remove a Shotgun shot from the database. Provide the Shotgun entry ID in the JSON body.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/import/shotgun/remove/shot\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"id\": 12345\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/import/shotgun/remove/shot\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"id\": 12345\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/import/shotgun/remove/scene": {
+      "post": {
+        "summary": "Remove shotgun scene",
+        "description": "Remove a Shotgun scene from the database. Provide the Shotgun entry ID in the JSON body.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/import/shotgun/remove/scene\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"id\": 12345\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/import/shotgun/remove/scene\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"id\": 12345\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/import/shotgun/remove/episode": {
+      "post": {
+        "summary": "Remove shotgun episode",
+        "description": "Remove a Shotgun episode from the database. Provide the Shotgun entry ID in the JSON body.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/import/shotgun/remove/episode\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"id\": 12345\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/import/shotgun/remove/episode\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"id\": 12345\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/import/shotgun/remove/sequence": {
+      "post": {
+        "summary": "Remove shotgun sequence",
+        "description": "Remove a Shotgun sequence from the database. Provide the Shotgun entry ID in the JSON body.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/import/shotgun/remove/sequence\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"id\": 12345\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/import/shotgun/remove/sequence\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"id\": 12345\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/import/shotgun/remove/asset": {
+      "post": {
+        "summary": "Remove shotgun asset",
+        "description": "Remove a Shotgun asset from the database. Provide the Shotgun entry ID in the JSON body. If the asset has working files linked to tasks, it will be cancelled instead of deleted.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/import/shotgun/remove/asset\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"id\": 12345\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/import/shotgun/remove/asset\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"id\": 12345\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/import/shotgun/remove/projectconnection": {
+      "post": {
+        "summary": "Remove shotgun project connection",
+        "description": "Remove a Shotgun project-user connection from the database. Provide the Shotgun entry ID in the JSON body.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/import/shotgun/remove/projectconnection\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"id\": 12345\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/import/shotgun/remove/projectconnection\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"id\": 12345\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/import/shotgun/remove/step": {
+      "post": {
+        "summary": "Remove shotgun step",
+        "description": "Remove a Shotgun step (task type) from the database. Provide the Shotgun entry ID in the JSON body.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/import/shotgun/remove/step\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"id\": 12345\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/import/shotgun/remove/step\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"id\": 12345\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/import/shotgun/remove/status": {
+      "post": {
+        "summary": "Remove shotgun task status",
+        "description": "Remove a Shotgun task status from the database. Provide the Shotgun entry ID in the JSON body.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/import/shotgun/remove/status\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"id\": 12345\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/import/shotgun/remove/status\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"id\": 12345\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/import/shotgun/remove/task": {
+      "post": {
+        "summary": "Remove shotgun task",
+        "description": "Remove a Shotgun task from the database. Provide the Shotgun entry ID in the JSON body.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/import/shotgun/remove/task\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"id\": 12345\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/import/shotgun/remove/task\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"id\": 12345\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/import/shotgun/remove/note": {
+      "post": {
+        "summary": "Remove shotgun note",
+        "description": "Remove a Shotgun note (comment) from the database. Provide the Shotgun entry ID in the JSON body.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/import/shotgun/remove/note\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"id\": 12345\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/import/shotgun/remove/note\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"id\": 12345\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/import/shotgun/remove/version": {
+      "post": {
+        "summary": "Remove shotgun version",
+        "description": "Remove a Shotgun version (preview file) from the database. Provide the Shotgun entry ID in the JSON body.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/import/shotgun/remove/version\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"id\": 12345\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/import/shotgun/remove/version\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"id\": 12345\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/import/csv/persons": {
+      "post": {
+        "summary": "Import persons csv",
+        "description": "Import persons from a CSV file. Creates or updates persons based on CSV rows. Supports role, contract type, and active status updates.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/import/csv/persons?update=false\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/import/csv/persons\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"update\": false\n}\npayload = None\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/import/csv/projects/{project_id}/assets": {
+      "post": {
+        "summary": "Import assets csv",
+        "description": "Import project assets from a CSV file. Creates or updates assets based on CSV rows. Supports metadata descriptors and task status updates.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/import/csv/projects/a24a6ea4-ce75-4665-a070-57453082c25/assets?update=false\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/import/csv/projects/a24a6ea4-ce75-4665-a070-57453082c25/assets\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"update\": false\n}\npayload = None\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/import/csv/projects/{project_id}/shots": {
+      "post": {
+        "summary": "Import shots csv",
+        "description": "Import project shots from a CSV file. Creates or updates shots based on CSV rows. Supports sequences, episodes, and task status updates.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/import/csv/projects/a24a6ea4-ce75-4665-a070-57453082c25/shots?update=false\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/import/csv/projects/a24a6ea4-ce75-4665-a070-57453082c25/shots\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"update\": false\n}\npayload = None\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/import/csv/projects/{project_id}/edits": {
+      "post": {
+        "summary": "Import edits csv",
+        "description": "Import project edits from a CSV file. Creates or updates edits based on CSV rows. Supports metadata descriptors and task status updates.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/import/csv/projects/a24a6ea4-ce75-4665-a070-57453082c25/edits?update=false\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/import/csv/projects/a24a6ea4-ce75-4665-a070-57453082c25/edits\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"update\": false\n}\npayload = None\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/import/csv/projects/{project_id}/casting": {
+      "post": {
+        "summary": "Import casting csv",
+        "description": "Import project casting links from a CSV file. Links assets to shots, sequences, or episodes based on CSV rows.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/import/csv/projects/a24a6ea4-ce75-4665-a070-57453082c25/casting?update=false\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/import/csv/projects/a24a6ea4-ce75-4665-a070-57453082c25/casting\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"update\": false\n}\npayload = None\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/import/csv/projects/{project_id}/task-types/{task_type_id}/estimations": {
+      "post": {
+        "summary": "Import task type estimations csv",
+        "description": "Import task type estimations from a CSV file. Updates estimations, dates, and other task properties for assets or shots based on CSV rows.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/import/csv/projects/a24a6ea4-ce75-4665-a070-57453082c25/task-types/b24a6ea4-ce75-4665-a070-57453082c25/estimations\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/import/csv/projects/a24a6ea4-ce75-4665-a070-57453082c25/task-types/b24a6ea4-ce75-4665-a070-57453082c25/estimations\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/import/csv/projects/{project_id}/episodes/{episode_id}/task-types/{task_type_id}/estimations": {
+      "post": {
+        "summary": "Import episode task type estimations csv",
+        "description": "Import task type estimations from a CSV file for a specific episode. Updates estimations, dates, and other task properties for assets or shots based on CSV rows.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/import/csv/projects/a24a6ea4-ce75-4665-a070-57453082c25/episodes/c24a6ea4-ce75-4665-a070-57453082c25/task-types/b24a6ea4-ce75-4665-a070-57453082c25/estimations\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/import/csv/projects/a24a6ea4-ce75-4665-a070-57453082c25/episodes/c24a6ea4-ce75-4665-a070-57453082c25/task-types/b24a6ea4-ce75-4665-a070-57453082c25/estimations\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/import/otio/projects/{project_id}": {
+      "post": {
+        "summary": "Import otio EDL",
+        "description": "Import an OTIO file to set frame_in, frame_out, and nb_frames for shots. Supports any OpenTimelineIO adapter format like EDL or OTIO. Uses naming convention to match shots.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/import/otio/projects/a24a6ea4-ce75-4665-a070-57453082c25?naming_convention=%24%7Bproject_name%7D_%24%7Bsequence_name%7D-%24%7Bshot_name%7D&match_case=true\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/import/otio/projects/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"naming_convention\": \"${project_name}_${sequence_name}-${shot_name}\",\n    \"match_case\": true\n}\npayload = None\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/import/otio/projects/{project_id}/episodes/{episode_id}": {
+      "post": {
+        "summary": "Import episode otio",
+        "description": "Import an OTIO file to set frame_in, frame_out, and nb_frames for shots in an episode. Supports any OpenTimelineIO adapter format like EDL or OTIO. Uses naming convention with episode name to match shots.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/import/otio/projects/a24a6ea4-ce75-4665-a070-57453082c25/episodes/b24a6ea4-ce75-4665-a070-57453082c25?naming_convention=%24%7Bproject_name%7D_%24%7Bepisode_name%7D-%24%7Bsequence_name%7D-%24%7Bshot_name%7D&match_case=true\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/import/otio/projects/a24a6ea4-ce75-4665-a070-57453082c25/episodes/b24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"naming_convention\": \"${project_name}_${episode_name}-${sequence_name}-${shot_name}\",\n    \"match_case\": true\n}\npayload = None\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/import/kitsu/comments": {
+      "post": {
+        "summary": "Import kitsu comments",
+        "description": "Import Kitsu comments. Send a list of Kitsu comment entries in the JSON body. Returns created or updated comments linked to tasks.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/import/kitsu/comments\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '[\n  {\n    \"id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"object_id\": \"b24a6ea4-ce75-4665-a070-57453082c25\",\n    \"text\": \"This is a comment\",\n    \"person_id\": \"c24a6ea4-ce75-4665-a070-57453082c25\"\n  }\n]'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/import/kitsu/comments\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = [\n    {\n        \"id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n        \"object_id\": \"b24a6ea4-ce75-4665-a070-57453082c25\",\n        \"text\": \"This is a comment\",\n        \"person_id\": \"c24a6ea4-ce75-4665-a070-57453082c25\"\n    }\n]\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/import/kitsu/entities": {
+      "post": {
+        "summary": "Import kitsu entities",
+        "description": "Import Kitsu entities (assets, shots, sequences, etc.). Send a list of Kitsu entity entries in the JSON body. Returns created or updated entities.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/import/kitsu/entities\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '[\n  {\n    \"id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"name\": \"Asset01\",\n    \"project_id\": \"b24a6ea4-ce75-4665-a070-57453082c25\",\n    \"entity_type_id\": \"c24a6ea4-ce75-4665-a070-57453082c25\"\n  }\n]'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/import/kitsu/entities\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = [\n    {\n        \"id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n        \"name\": \"Asset01\",\n        \"project_id\": \"b24a6ea4-ce75-4665-a070-57453082c25\",\n        \"entity_type_id\": \"c24a6ea4-ce75-4665-a070-57453082c25\"\n    }\n]\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/import/kitsu/entity-links": {
+      "post": {
+        "summary": "Import kitsu entity links",
+        "description": "Import Kitsu entity links (casting links). Send a list of Kitsu entity link entries in the JSON body. Returns created or updated entity links.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/import/kitsu/entity-links\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '[\n  {\n    \"id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"entity_in_id\": \"b24a6ea4-ce75-4665-a070-57453082c25\",\n    \"entity_out_id\": \"c24a6ea4-ce75-4665-a070-57453082c25\"\n  }\n]'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/import/kitsu/entity-links\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = [\n    {\n        \"id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n        \"entity_in_id\": \"b24a6ea4-ce75-4665-a070-57453082c25\",\n        \"entity_out_id\": \"c24a6ea4-ce75-4665-a070-57453082c25\"\n    }\n]\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/import/kitsu/projects": {
+      "post": {
+        "summary": "Import kitsu projects",
+        "description": "Import Kitsu projects. Send a list of Kitsu project entries in the JSON body. Returns created or updated projects.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/import/kitsu/projects\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '[\n  {\n    \"id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"name\": \"My Project\",\n    \"production_type\": \"tvshow\"\n  }\n]'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/import/kitsu/projects\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = [\n    {\n        \"id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n        \"name\": \"My Project\",\n        \"production_type\": \"tvshow\"\n    }\n]\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/import/kitsu/tasks": {
+      "post": {
+        "summary": "Import kitsu tasks",
+        "description": "Import Kitsu tasks. Send a list of Kitsu task entries in the JSON body. Returns created or updated tasks.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/import/kitsu/tasks\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '[\n  {\n    \"id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"name\": \"Modeling\",\n    \"project_id\": \"b24a6ea4-ce75-4665-a070-57453082c25\",\n    \"entity_id\": \"c24a6ea4-ce75-4665-a070-57453082c25\",\n    \"task_type_id\": \"d24a6ea4-ce75-4665-a070-57453082c25\"\n  }\n]'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/import/kitsu/tasks\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = [\n    {\n        \"id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n        \"name\": \"Modeling\",\n        \"project_id\": \"b24a6ea4-ce75-4665-a070-57453082c25\",\n        \"entity_id\": \"c24a6ea4-ce75-4665-a070-57453082c25\",\n        \"task_type_id\": \"d24a6ea4-ce75-4665-a070-57453082c25\"\n    }\n]\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/metadata-descriptors/": {
+      "get": {
+        "summary": "Get metadata descriptors",
+        "description": "Retrieve all metadata descriptors. Supports filtering via query parameters and pagination. Vendor access is blocked. Includes project permission filtering for non-admin users.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/metadata-descriptors/?page=1&limit=50&relations=true\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/metadata-descriptors/\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"page\": 1,\n    \"limit\": 50,\n    \"relations\": true\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Create metadata descriptor",
+        "description": "Create a new metadata descriptor with data provided in the request body. JSON format is expected. Validates data_type.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/metadata-descriptors/\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"Custom Field\",\n  \"field_name\": \"custom_field\",\n  \"data_type\": \"text\",\n  \"project_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n  \"entity_type\": \"Asset\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/metadata-descriptors/\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"Custom Field\",\n    \"field_name\": \"custom_field\",\n    \"data_type\": \"text\",\n    \"project_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"entity_type\": \"Asset\"\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/metadata-descriptors/{instance_id}": {
+      "delete": {
+        "summary": "Delete metadata descriptor",
+        "description": "Delete a metadata descriptor by its ID. Returns empty response on success.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/data/metadata-descriptors/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/metadata-descriptors/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "get": {
+        "summary": "Get metadata descriptor",
+        "description": "Retrieve a metadata descriptor by its ID and return it as a JSON object. Supports including relations.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/metadata-descriptors/a24a6ea4-ce75-4665-a070-57453082c25?relations=true\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/metadata-descriptors/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"relations\": true\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "put": {
+        "summary": "Update metadata descriptor",
+        "description": "Update a metadata descriptor with data provided in the request body. JSON format is expected. Validates data_type.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X PUT \"http://api.example.com/data/metadata-descriptors/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"Updated Custom Field\",\n  \"data_type\": \"number\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/metadata-descriptors/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"Updated Custom Field\",\n    \"data_type\": \"number\"\n}\n\nresponse = requests.put(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/milestones/": {
+      "get": {
+        "summary": "Get milestones",
+        "description": "Retrieve all milestones. Supports filtering via query parameters and pagination.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/milestones/?page=1&limit=50&relations=false\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/milestones/\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"page\": 1,\n    \"limit\": 50,\n    \"relations\": false\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Create milestone",
+        "description": "Create a new milestone with data provided in the request body. JSON format is expected. Requires manager access to the project.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/milestones/\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"Milestone Name\",\n  \"project_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n  \"date\": \"2024-03-31\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/milestones/\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"Milestone Name\",\n    \"project_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"date\": \"2024-03-31\"\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/milestones/{instance_id}": {
+      "delete": {
+        "summary": "Delete milestone",
+        "description": "Delete a milestone by its ID. Returns empty response on success.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/data/milestones/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/milestones/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "get": {
+        "summary": "Get milestone",
+        "description": "Retrieve a milestone by its ID and return it as a JSON object. Supports including relations. Vendor access is blocked. Requires project access.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/milestones/a24a6ea4-ce75-4665-a070-57453082c25?relations=true\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/milestones/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"relations\": true\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "put": {
+        "summary": "Update milestone",
+        "description": "Update a milestone with data provided in the request body. JSON format is expected. Requires manager access to the project.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X PUT \"http://api.example.com/data/milestones/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"Updated Milestone Name\",\n  \"date\": \"2024-04-30\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/milestones/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"Updated Milestone Name\",\n    \"date\": \"2024-04-30\"\n}\n\nresponse = requests.put(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/movies/originals/preview-files/{instance_id}.mp4": {
+      "get": {
+        "summary": "Get preview movie",
+        "description": "Download a movie preview file.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/movies/originals/preview-files/a24a6ea4-ce75-4665-a070-57453082c25.mp4\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/movies/originals/preview-files/a24a6ea4-ce75-4665-a070-57453082c25.mp4\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/movies/originals/preview-files/{instance_id}/download": {
+      "get": {
+        "summary": "Download preview movie",
+        "description": "Download a movie preview file as attachment.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/movies/originals/preview-files/a24a6ea4-ce75-4665-a070-57453082c25/download\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/movies/originals/preview-files/a24a6ea4-ce75-4665-a070-57453082c25/download\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/movies/low/preview-files/{instance_id}.mp4": {
+      "get": {
+        "summary": "Get preview lowdef movie",
+        "description": "Download a low definition movie preview file. Falls back to full quality if lowdef version is not available.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/movies/low/preview-files/a24a6ea4-ce75-4665-a070-57453082c25.mp4\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/movies/low/preview-files/a24a6ea4-ce75-4665-a070-57453082c25.mp4\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/movies/tiles/preview-files/{instance_id}.png": {
+      "get": {
+        "summary": "Get preview thumbnail",
+        "description": "Download a thumbnail for a preview file.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/movies/tiles/preview-files/a24a6ea4-ce75-4665-a070-57453082c25.png\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/movies/tiles/preview-files/a24a6ea4-ce75-4665-a070-57453082c25.png\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/news/": {
+      "get": {
+        "summary": "Get news",
+        "description": "Retrieve all news entries. Supports filtering via query parameters and pagination.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/news/?page=1&limit=50&relations=false\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/news/\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"page\": 1,\n    \"limit\": 50,\n    \"relations\": false\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Create news",
+        "description": "Create a new news entry with data provided in the request body. JSON format is expected.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/news/\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"title\": \"Project Update\",\n  \"project_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n  \"content\": \"News content text\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/news/\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"title\": \"Project Update\",\n    \"project_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"content\": \"News content text\"\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/news/{instance_id}": {
+      "delete": {
+        "summary": "Delete news",
+        "description": "Delete a news entry by its ID. Returns empty response on success.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/data/news/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/news/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "get": {
+        "summary": "Get news",
+        "description": "Retrieve a news entry by its ID and return it as a JSON object. Supports including relations.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/news/a24a6ea4-ce75-4665-a070-57453082c25?relations=true\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/news/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"relations\": true\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "put": {
+        "summary": "Update news",
+        "description": "Update a news entry with data provided in the request body. JSON format is expected.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X PUT \"http://api.example.com/data/news/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"title\": \"Updated Project Update\",\n  \"content\": \"Updated news content text\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/news/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"title\": \"Updated Project Update\",\n    \"content\": \"Updated news content text\"\n}\n\nresponse = requests.put(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/notifications/": {
+      "get": {
+        "summary": "Get notifications",
+        "description": "Retrieve all notifications. Supports filtering via query parameters and pagination.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/notifications/?page=1&limit=50&relations=false\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/notifications/\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"page\": 1,\n    \"limit\": 50,\n    \"relations\": false\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Create notification",
+        "description": "Create a new notification with data provided in the request body. JSON format is expected.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/notifications/\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"person_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n  \"comment_id\": \"b24a6ea4-ce75-4665-a070-57453082c25\",\n  \"read\": false\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/notifications/\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"person_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"comment_id\": \"b24a6ea4-ce75-4665-a070-57453082c25\",\n    \"read\": false\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/notifications/{instance_id}": {
+      "delete": {
+        "summary": "Delete notification",
+        "description": "Delete a notification by its ID. Returns empty response on success.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/data/notifications/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/notifications/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "get": {
+        "summary": "Get notification",
+        "description": "Retrieve a notification by its ID and return it as a JSON object. Supports including relations.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/notifications/a24a6ea4-ce75-4665-a070-57453082c25?relations=true\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/notifications/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"relations\": true\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "put": {
+        "summary": "Update notification",
+        "description": "Update a notification with data provided in the request body. JSON format is expected.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X PUT \"http://api.example.com/data/notifications/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"read\": true\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/notifications/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"read\": true\n}\n\nresponse = requests.put(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/organisations": {
+      "get": {
+        "summary": "Get organisations",
+        "description": "Retrieve all organisations. Supports filtering via query parameters and pagination.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/organisations?page=1&limit=50&relations=false\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/organisations\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"page\": 1,\n    \"limit\": 50,\n    \"relations\": false\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Create organisation",
+        "description": "Create a new organisation with data provided in the request body. JSON format is expected.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/organisations\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"Studio Name\",\n  \"hours_by_day\": 8\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/organisations\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"Studio Name\",\n    \"hours_by_day\": 8\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/organisations/{instance_id}": {
+      "delete": {
+        "summary": "Delete organisation",
+        "description": "Delete an organisation by its ID. Returns empty response on success.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/data/organisations/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/organisations/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "get": {
+        "summary": "Get organisation",
+        "description": "Retrieve an organisation by its ID and return it as a JSON object. Supports including relations. Non-admin users cannot see chat tokens.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/organisations/a24a6ea4-ce75-4665-a070-57453082c25?relations=true\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/organisations/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"relations\": true\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "put": {
+        "summary": "Update organisation",
+        "description": "Update an organisation with data provided in the request body. JSON format is expected.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X PUT \"http://api.example.com/data/organisations/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"Updated Studio Name\",\n  \"hours_by_day\": 7.5\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/organisations/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"Updated Studio Name\",\n    \"hours_by_day\": 7.5\n}\n\nresponse = requests.put(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/output-files": {
+      "get": {
+        "summary": "Get models",
+        "description": "Retrieve all entries for the given model. Supports filtering via query parameters and pagination.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/output-files?page=1&limit=50&relations=false\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/output-files\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"page\": 1,\n    \"limit\": 50,\n    \"relations\": false\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Create model",
+        "description": "Create a new model instance with data provided in the request body. JSON format is expected. The model performs validation automatically when instantiated.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/output-files\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"Model Name\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/output-files\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"Model Name\"\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/output-files/{instance_id}": {
+      "delete": {
+        "summary": "Delete model",
+        "description": "Delete a model instance by its ID. Returns empty response on success.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/data/output-files/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/output-files/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "get": {
+        "summary": "Get output file",
+        "description": "Retrieve an output file instance by its ID and return it as a JSON object.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/output-files/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/output-files/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "put": {
+        "summary": "Update model",
+        "description": "Update a model instance with data provided in the request body. JSON format is expected. Model performs validation automatically when fields are modified.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X PUT \"http://api.example.com/data/output-files/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"Updated Model Name\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/output-files/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"Updated Model Name\"\n}\n\nresponse = requests.put(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/output-types": {
+      "get": {
+        "summary": "Get models",
+        "description": "Retrieve all entries for the given model. Supports filtering via query parameters and pagination.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/output-types?page=1&limit=50&relations=false\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/output-types\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"page\": 1,\n    \"limit\": 50,\n    \"relations\": false\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Create model",
+        "description": "Create a new model instance with data provided in the request body. JSON format is expected. The model performs validation automatically when instantiated.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/output-types\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"Model Name\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/output-types\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"Model Name\"\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/output-types/{instance_id}": {
+      "delete": {
+        "summary": "Delete model",
+        "description": "Delete a model instance by its ID. Returns empty response on success.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/data/output-types/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/output-types/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "get": {
+        "summary": "Get output type",
+        "description": "Retrieve an output type instance by its ID and return it as a JSON object.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/output-types/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/output-types/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "put": {
+        "summary": "Update model",
+        "description": "Update a model instance with data provided in the request body. JSON format is expected. Model performs validation automatically when fields are modified.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X PUT \"http://api.example.com/data/output-types/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"Updated Model Name\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/output-types/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"Updated Model Name\"\n}\n\nresponse = requests.put(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/persons": {
+      "get": {
+        "summary": "Get persons",
+        "description": "Retrieve all persons. Supports filtering via query parameters and pagination. Admin users can include password hashes. Non-admin users only see minimal information.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/persons?page=1&limit=50&relations=false&with_pass_hash=false\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/persons\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"page\": 1,\n    \"limit\": 50,\n    \"relations\": false,\n    \"with_pass_hash\": false\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Create person",
+        "description": "Create a new person with data provided in the request body. JSON format is expected. Requires admin permissions. Validates role, contract_type, two_factor_authentication, email, and expiration_date. Checks user limit for active non-bot users.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/persons\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"first_name\": \"John\",\n  \"last_name\": \"Doe\",\n  \"email\": \"john.doe@example.com\",\n  \"password\": \"securepassword123\",\n  \"role\": \"user\",\n  \"active\": true,\n  \"contract_type\": \"permanent\",\n  \"two_factor_authentication\": \"none\",\n  \"expiration_date\": \"2025-12-31\",\n  \"is_bot\": false\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/persons\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"first_name\": \"John\",\n    \"last_name\": \"Doe\",\n    \"email\": \"john.doe@example.com\",\n    \"password\": \"securepassword123\",\n    \"role\": \"user\",\n    \"active\": true,\n    \"contract_type\": \"permanent\",\n    \"two_factor_authentication\": \"none\",\n    \"expiration_date\": \"2025-12-31\",\n    \"is_bot\": false\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/persons/{instance_id}": {
+      "delete": {
+        "summary": "Delete person",
+        "description": "Delete a person by their ID. Returns empty response on success. Cannot delete yourself.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/data/persons/a24a6ea4-ce75-4665-a070-57453082c25?force=false\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/persons/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"force\": false\n}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "get": {
+        "summary": "Get person",
+        "description": "Retrieve a person by their ID and return it as a JSON object. Supports including relations. Managers see safe serialization, others see minimal information.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/persons/a24a6ea4-ce75-4665-a070-57453082c25?relations=true\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/persons/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"relations\": true\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "put": {
+        "summary": "Update person",
+        "description": "Update a person with data provided in the request body. JSON format is expected. Users can only update themselves unless they have admin permissions. Non-admins cannot change certain protected fields. Validates role, contract_type, two_factor_authentication, email, and expiration_date. Checks user limit when activating non-bot users. Protected accounts have restrictions.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X PUT \"http://api.example.com/data/persons/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"first_name\": \"Jane\",\n  \"last_name\": \"Smith\",\n  \"email\": \"jane.smith@example.com\",\n  \"password\": \"newsecurepassword123\",\n  \"role\": \"manager\",\n  \"active\": true,\n  \"contract_type\": \"freelance\",\n  \"two_factor_authentication\": \"totp\",\n  \"expiration_date\": \"2025-12-31\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/persons/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"first_name\": \"Jane\",\n    \"last_name\": \"Smith\",\n    \"email\": \"jane.smith@example.com\",\n    \"password\": \"newsecurepassword123\",\n    \"role\": \"manager\",\n    \"active\": true,\n    \"contract_type\": \"freelance\",\n    \"two_factor_authentication\": \"totp\",\n    \"expiration_date\": \"2025-12-31\"\n}\n\nresponse = requests.put(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/persons/{person_id}/desktop-login-logs": {
+      "get": {
+        "summary": "Get desktop login logs",
+        "description": "Retrieve desktop login logs for a person. Desktop login logs can only be created by current user.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/persons/a24a6ea4-ce75-4665-a070-57453082c25/desktop-login-logs\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/persons/a24a6ea4-ce75-4665-a070-57453082c25/desktop-login-logs\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Create desktop login log",
+        "description": "Add a new log entry for desktop logins for a person.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/persons/a24a6ea4-ce75-4665-a070-57453082c25/desktop-login-logs\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"date\": \"2022-07-12\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/persons/a24a6ea4-ce75-4665-a070-57453082c25/desktop-login-logs\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"date\": \"2022-07-12\"\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/persons/presence-logs/{month_date}": {
+      "get": {
+        "summary": "Get presence logs",
+        "description": "Return a CSV file containing the presence logs based on a daily basis for the given month.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/persons/presence-logs/2022-07\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/persons/presence-logs/2022-07\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/persons/{person_id}/time-spents": {
+      "get": {
+        "summary": "Get time spents",
+        "description": "Get all time spents for the given person. Optionally can accept date range parameters.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/persons/a24a6ea4-ce75-4665-a070-57453082c25/time-spents?start_date=2022-07-01&end_date=2022-07-31\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/persons/a24a6ea4-ce75-4665-a070-57453082c25/time-spents\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"start_date\": \"2022-07-01\",\n    \"end_date\": \"2022-07-31\"\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/persons/{person_id}/time-spents/{date}": {
+      "get": {
+        "summary": "Get time spents for date",
+        "description": "Get time spents for given person and specific date.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/persons/a24a6ea4-ce75-4665-a070-57453082c25/time-spents/2022-07-12\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/persons/a24a6ea4-ce75-4665-a070-57453082c25/time-spents/2022-07-12\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/persons/{person_id}/day-offs/{date}": {
+      "get": {
+        "summary": "Get day off",
+        "description": "Get day off object for given person and date.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/persons/a24a6ea4-ce75-4665-a070-57453082c25/day-offs/2022-07-12\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/persons/a24a6ea4-ce75-4665-a070-57453082c25/day-offs/2022-07-12\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/persons/{person_id}/time-spents/year/{year}": {
+      "get": {
+        "summary": "Get year time spents",
+        "description": "Get aggregated time spents for given person and year.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/persons/a24a6ea4-ce75-4665-a070-57453082c25/time-spents/year/2022\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/persons/a24a6ea4-ce75-4665-a070-57453082c25/time-spents/year/2022\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/persons/{person_id}/time-spents/month/{year}/{month}": {
+      "get": {
+        "summary": "Get month time spents",
+        "description": "Get aggregated time spents for given person and month.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/persons/a24a6ea4-ce75-4665-a070-57453082c25/time-spents/month/2022/7\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/persons/a24a6ea4-ce75-4665-a070-57453082c25/time-spents/month/2022/7\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/persons/{person_id}/time-spents/month/all/{year}/{month}": {
+      "get": {
+        "summary": "Get all month time spents",
+        "description": "Get all time spents for a given person and month.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/persons/a24a6ea4-ce75-4665-a070-57453082c25/time-spents/month/all/2022/7\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/persons/a24a6ea4-ce75-4665-a070-57453082c25/time-spents/month/all/2022/7\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/persons/{person_id}/time-spents/week/{year}/{week}": {
+      "get": {
+        "summary": "Get week time spents",
+        "description": "Get aggregated time spents for given person and week.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/persons/a24a6ea4-ce75-4665-a070-57453082c25/time-spents/week/2022/35\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/persons/a24a6ea4-ce75-4665-a070-57453082c25/time-spents/week/2022/35\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/persons/{person_id}/time-spents/day/{year}/{month}/{day}": {
+      "get": {
+        "summary": "Get day time spents",
+        "description": "Get aggregated time spents for given person and day.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/persons/a24a6ea4-ce75-4665-a070-57453082c25/time-spents/day/2022/7/12\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/persons/a24a6ea4-ce75-4665-a070-57453082c25/time-spents/day/2022/7/12\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/persons/{person_id}/quota-shots/month/{year}/{month}": {
+      "get": {
+        "summary": "Get month quota shots",
+        "description": "Get ended shots used for quota calculation of this month.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/persons/a24a6ea4-ce75-4665-a070-57453082c25/quota-shots/month/2022/7?count_mode=weighted\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/persons/a24a6ea4-ce75-4665-a070-57453082c25/quota-shots/month/2022/7\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"count_mode\": \"weighted\"\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/persons/{person_id}/quota-shots/week/{year}/{week}": {
+      "get": {
+        "summary": "Get week quota shots",
+        "description": "Get ended shots used for quota calculation of this week.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/persons/a24a6ea4-ce75-4665-a070-57453082c25/quota-shots/week/2022/35?count_mode=weighted\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/persons/a24a6ea4-ce75-4665-a070-57453082c25/quota-shots/week/2022/35\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"count_mode\": \"weighted\"\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/persons/{person_id}/quota-shots/day/{year}/{month}/{day}": {
+      "get": {
+        "summary": "Get day quota shots",
+        "description": "Get ended shots used for quota calculation of this day.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/persons/a24a6ea4-ce75-4665-a070-57453082c25/quota-shots/day/2022/7/12?count_mode=weighted\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/persons/a24a6ea4-ce75-4665-a070-57453082c25/quota-shots/day/2022/7/12\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"count_mode\": \"weighted\"\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/persons/time-spents/year-table/": {
+      "get": {
+        "summary": "Get time spent years table",
+        "description": "Return a table giving time spent by user and by month for all years.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/persons/time-spents/year-table/\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/persons/time-spents/year-table/\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/persons/time-spents/month-table/{year}": {
+      "get": {
+        "summary": "Get time spent months table",
+        "description": "Return a table giving time spent by user and by month for given year.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/persons/time-spents/month-table/2022\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/persons/time-spents/month-table/2022\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/persons/time-spents/week-table/{year}": {
+      "get": {
+        "summary": "Get time spent weeks table",
+        "description": "Return a table giving time spent by user and by week for given year.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/persons/time-spents/week-table/2022\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/persons/time-spents/week-table/2022\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/persons/time-spents/day-table/{year}/{month}": {
+      "get": {
+        "summary": "Get time spent month table",
+        "description": "Return a table giving time spent by user and by day for given year and month.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/persons/time-spents/day-table/2022/7\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/persons/time-spents/day-table/2022/7\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/persons/day-offs/{year}/{month}": {
+      "get": {
+        "summary": "Get day offs for month",
+        "description": "Return all day off recorded for given month. Admins get all day offs, regular users get only their own.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/persons/day-offs/2022/7\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/persons/day-offs/2022/7\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/persons/{person_id}/day-offs/week/{year}/{week}": {
+      "get": {
+        "summary": "Get person week day offs",
+        "description": "Return all day off recorded for given week and person.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/persons/a24a6ea4-ce75-4665-a070-57453082c25/day-offs/week/2022/35\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/persons/a24a6ea4-ce75-4665-a070-57453082c25/day-offs/week/2022/35\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/persons/{person_id}/day-offs/month/{year}/{month}": {
+      "get": {
+        "summary": "Get person month day offs",
+        "description": "Return all day off recorded for given month and person.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/persons/a24a6ea4-ce75-4665-a070-57453082c25/day-offs/month/2022/7\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/persons/a24a6ea4-ce75-4665-a070-57453082c25/day-offs/month/2022/7\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/persons/{person_id}/day-offs/year/{year}": {
+      "get": {
+        "summary": "Get person year day offs",
+        "description": "Return all day off recorded for given year and person.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/persons/a24a6ea4-ce75-4665-a070-57453082c25/day-offs/year/2022\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/persons/a24a6ea4-ce75-4665-a070-57453082c25/day-offs/year/2022\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/persons/{person_id}/day-offs": {
+      "get": {
+        "summary": "Get person day offs",
+        "description": "Return all day offs recorded for given person.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/persons/a24a6ea4-ce75-4665-a070-57453082c25/day-offs\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/persons/a24a6ea4-ce75-4665-a070-57453082c25/day-offs\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/actions/persons/{person_id}/invite": {
+      "get": {
+        "summary": "Invite person",
+        "description": "Sends an email to given person to invite him or her to connect to Kitsu.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/actions/persons/a24a6ea4-ce75-4665-a070-57453082c25/invite\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/actions/persons/a24a6ea4-ce75-4665-a070-57453082c25/invite\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/actions/persons/{person_id}/departments/add": {
+      "post": {
+        "summary": "Add person to department",
+        "description": "Add a user to given department.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/actions/persons/a24a6ea4-ce75-4665-a070-57453082c25/departments/add\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"department_id\": \"b35b7fb5-df86-5776-b181-68564193d36\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/actions/persons/a24a6ea4-ce75-4665-a070-57453082c25/departments/add\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"department_id\": \"b35b7fb5-df86-5776-b181-68564193d36\"\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/actions/persons/{person_id}/departments/{department_id}": {
+      "delete": {
+        "summary": "Remove person from department",
+        "description": "Remove a user from given department.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/actions/persons/a24a6ea4-ce75-4665-a070-57453082c25/departments/b35b7fb5-df86-5776-b181-68564193d36\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/actions/persons/a24a6ea4-ce75-4665-a070-57453082c25/departments/b35b7fb5-df86-5776-b181-68564193d36\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/actions/persons/{person_id}/change-password": {
+      "post": {
+        "summary": "Change person password",
+        "description": "Allow admin to change password for given user. An admin can't change other admins password. The new password requires a confirmation to ensure that the admin didn't make a mistake by typing the new password.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/actions/persons/a24a6ea4-ce75-4665-a070-57453082c25/change-password\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"password\": \"newSecurePassword123\",\n  \"password_2\": \"newSecurePassword123\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/actions/persons/a24a6ea4-ce75-4665-a070-57453082c25/change-password\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"password\": \"newSecurePassword123\",\n    \"password_2\": \"newSecurePassword123\"\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/actions/persons/{person_id}/disable-two-factor-authentication": {
+      "delete": {
+        "summary": "Disable two factor authentication",
+        "description": "Allow admin to disable two factor authentication for given user. An admin can't disable two factor authentication for other admins.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/actions/persons/a24a6ea4-ce75-4665-a070-57453082c25/disable-two-factor-authentication\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/actions/persons/a24a6ea4-ce75-4665-a070-57453082c25/disable-two-factor-authentication\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/actions/persons/{person_id}/clear-avatar": {
+      "delete": {
+        "summary": "Clear person avatar",
+        "description": "Set has_avatar flag to False for current user and remove its avatar file.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/actions/persons/a24a6ea4-ce75-4665-a070-57453082c25/clear-avatar\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/actions/persons/a24a6ea4-ce75-4665-a070-57453082c25/clear-avatar\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/persons/{person_id}/tasks": {
+      "get": {
+        "summary": "Get person open tasks",
+        "description": "List tasks assigned to a person where the status is not done.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/persons/a24a6ea4-ce75-4665-a070-57453082c25/tasks\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/persons/a24a6ea4-ce75-4665-a070-57453082c25/tasks\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/persons/{person_id}/related-tasks/{task_type_id}": {
+      "get": {
+        "summary": "Get person tasks for type",
+        "description": "For all entities assigned to the person, return tasks for the given task type.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/persons/a24a6ea4-ce75-4665-a070-57453082c25/related-tasks/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/persons/a24a6ea4-ce75-4665-a070-57453082c25/related-tasks/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/persons/{person_id}/done-tasks": {
+      "get": {
+        "summary": "Get person done tasks",
+        "description": "Return tasks assigned to the person that are done. Only tasks in open projects are returned.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/persons/a24a6ea4-ce75-4665-a070-57453082c25/done-tasks\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/persons/a24a6ea4-ce75-4665-a070-57453082c25/done-tasks\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/persons/task-dates": {
+      "get": {
+        "summary": "Get persons tasks dates",
+        "description": "For each active person, return the first start date of all tasks assigned to them and the last end date. Useful for schedule planning.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/persons/task-dates?project_id=a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/persons/task-dates\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"project_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\"\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/actions/persons/{person_id}/assign": {
+      "put": {
+        "summary": "Assign tasks to person",
+        "description": "Assign a list of tasks to a person. Unknown task ids are ignored.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X PUT \"http://api.example.com/actions/persons/a24a6ea4-ce75-4665-a070-57453082c25/assign\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"task_ids\": [\n    \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"b24a6ea4-ce75-4665-a070-57453082c25\"\n  ]\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/actions/persons/a24a6ea4-ce75-4665-a070-57453082c25/assign\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"task_ids\": [\n        \"a24a6ea4-ce75-4665-a070-57453082c25\",\n        \"b24a6ea4-ce75-4665-a070-57453082c25\"\n    ]\n}\n\nresponse = requests.put(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/pictures/preview-files/{instance_id}": {
+      "post": {
+        "summary": "Create preview file",
+        "description": "Main resource to add a preview. It stores the preview file and generates three picture files (thumbnails) matching preview when it's possible, a square thumbnail, a rectangle thumbnail and a midsize file.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/pictures/preview-files/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/pictures/preview-files/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/pictures/thumbnails/preview-files/{instance_id}.png": {
+      "get": {
+        "summary": "Get preview thumbnail",
+        "description": "Download a thumbnail for a preview file.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/pictures/thumbnails/preview-files/a24a6ea4-ce75-4665-a070-57453082c25.png\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/pictures/thumbnails/preview-files/a24a6ea4-ce75-4665-a070-57453082c25.png\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/pictures/thumbnails/attachment-files/{attachment_file_id}.png": {
+      "get": {
+        "summary": "Get attachment thumbnail",
+        "description": "Download the thumbnail representing given attachment file.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/pictures/thumbnails/attachment-files/a24a6ea4-ce75-4665-a070-57453082c25.png\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/pictures/thumbnails/attachment-files/a24a6ea4-ce75-4665-a070-57453082c25.png\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/pictures/thumbnails-square/preview-files/{instance_id}.png": {
+      "get": {
+        "summary": "Get preview thumbnail",
+        "description": "Download a thumbnail for a preview file.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/pictures/thumbnails-square/preview-files/a24a6ea4-ce75-4665-a070-57453082c25.png\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/pictures/thumbnails-square/preview-files/a24a6ea4-ce75-4665-a070-57453082c25.png\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/pictures/originals/preview-files/{instance_id}.png": {
+      "get": {
+        "summary": "Get preview thumbnail",
+        "description": "Download a thumbnail for a preview file.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/pictures/originals/preview-files/a24a6ea4-ce75-4665-a070-57453082c25.png\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/pictures/originals/preview-files/a24a6ea4-ce75-4665-a070-57453082c25.png\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/pictures/originals/preview-files/{instance_id}.{extension}": {
+      "get": {
+        "summary": "Get preview file",
+        "description": "Download a generic file preview by extension.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/pictures/originals/preview-files/a24a6ea4-ce75-4665-a070-57453082c25.png\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/pictures/originals/preview-files/a24a6ea4-ce75-4665-a070-57453082c25.png\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/pictures/originals/preview-files/{instance_id}/download": {
+      "get": {
+        "summary": "Download preview file",
+        "description": "Download a generic file preview as attachment.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/pictures/originals/preview-files/a24a6ea4-ce75-4665-a070-57453082c25/download\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/pictures/originals/preview-files/a24a6ea4-ce75-4665-a070-57453082c25/download\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/pictures/previews/preview-files/{instance_id}.png": {
+      "get": {
+        "summary": "Get preview thumbnail",
+        "description": "Download a thumbnail for a preview file.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/pictures/previews/preview-files/a24a6ea4-ce75-4665-a070-57453082c25.png\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/pictures/previews/preview-files/a24a6ea4-ce75-4665-a070-57453082c25.png\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/pictures/thumbnails/organisations/{instance_id}": {
+      "get": {
+        "summary": "Get thumbnail",
+        "description": "Download the thumbnail linked to given object instance.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/pictures/thumbnails/organisations/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/pictures/thumbnails/organisations/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Create thumbnail",
+        "description": "Create a thumbnail for given object instance.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/pictures/thumbnails/organisations/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/pictures/thumbnails/organisations/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/pictures/thumbnails/organisations/{instance_id}.png": {
+      "get": {
+        "summary": "Get thumbnail",
+        "description": "Download the thumbnail linked to given object instance.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/pictures/thumbnails/organisations/a24a6ea4-ce75-4665-a070-57453082c25.png\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/pictures/thumbnails/organisations/a24a6ea4-ce75-4665-a070-57453082c25.png\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Create thumbnail",
+        "description": "Create a thumbnail for given object instance.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/pictures/thumbnails/organisations/a24a6ea4-ce75-4665-a070-57453082c25.png\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/pictures/thumbnails/organisations/a24a6ea4-ce75-4665-a070-57453082c25.png\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/pictures/thumbnails/persons/{instance_id}": {
+      "get": {
+        "summary": "Get thumbnail",
+        "description": "Download the thumbnail linked to given object instance.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/pictures/thumbnails/persons/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/pictures/thumbnails/persons/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Create thumbnail",
+        "description": "Create a thumbnail for given object instance.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/pictures/thumbnails/persons/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/pictures/thumbnails/persons/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/pictures/thumbnails/persons/{instance_id}.png": {
+      "get": {
+        "summary": "Get thumbnail",
+        "description": "Download the thumbnail linked to given object instance.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/pictures/thumbnails/persons/a24a6ea4-ce75-4665-a070-57453082c25.png\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/pictures/thumbnails/persons/a24a6ea4-ce75-4665-a070-57453082c25.png\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Create thumbnail",
+        "description": "Create a thumbnail for given object instance.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/pictures/thumbnails/persons/a24a6ea4-ce75-4665-a070-57453082c25.png\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/pictures/thumbnails/persons/a24a6ea4-ce75-4665-a070-57453082c25.png\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/pictures/thumbnails/projects/{instance_id}": {
+      "get": {
+        "summary": "Get thumbnail",
+        "description": "Download the thumbnail linked to given object instance.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/pictures/thumbnails/projects/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/pictures/thumbnails/projects/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Create thumbnail",
+        "description": "Create a thumbnail for given object instance.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/pictures/thumbnails/projects/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/pictures/thumbnails/projects/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/pictures/thumbnails/projects/{instance_id}.png": {
+      "get": {
+        "summary": "Get thumbnail",
+        "description": "Download the thumbnail linked to given object instance.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/pictures/thumbnails/projects/a24a6ea4-ce75-4665-a070-57453082c25.png\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/pictures/thumbnails/projects/a24a6ea4-ce75-4665-a070-57453082c25.png\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Create thumbnail",
+        "description": "Create a thumbnail for given object instance.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/pictures/thumbnails/projects/a24a6ea4-ce75-4665-a070-57453082c25.png\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/pictures/thumbnails/projects/a24a6ea4-ce75-4665-a070-57453082c25.png\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/pictures/preview-background-files/{instance_id}": {
+      "post": {
+        "summary": "Create preview background file",
+        "description": "Main resource to add a preview background file. It stores the preview background file and generates a rectangle thumbnail.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/pictures/preview-background-files/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/pictures/preview-background-files/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/pictures/thumbnails/preview-background-files/{instance_id}.png": {
+      "get": {
+        "summary": "Get thumbnail",
+        "description": "Download the thumbnail linked to given object instance.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/pictures/thumbnails/preview-background-files/a24a6ea4-ce75-4665-a070-57453082c25.png\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/pictures/thumbnails/preview-background-files/a24a6ea4-ce75-4665-a070-57453082c25.png\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Create thumbnail",
+        "description": "Create a thumbnail for given object instance.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/pictures/thumbnails/preview-background-files/a24a6ea4-ce75-4665-a070-57453082c25.png\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/pictures/thumbnails/preview-background-files/a24a6ea4-ce75-4665-a070-57453082c25.png\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/pictures/preview-background-files/{instance_id}.{extension}": {
+      "get": {
+        "summary": "Get preview background file",
+        "description": "Download a preview background file.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/pictures/preview-background-files/a24a6ea4-ce75-4665-a070-57453082c25.hdr\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/pictures/preview-background-files/a24a6ea4-ce75-4665-a070-57453082c25.hdr\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/playlists/": {
+      "get": {
+        "summary": "Get playlists",
+        "description": "Retrieve all playlists. Supports filtering via query parameters and pagination.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/playlists/?page=1&limit=50&relations=false\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/playlists/\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"page\": 1,\n    \"limit\": 50,\n    \"relations\": false\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Create playlist",
+        "description": "Create a new playlist with data provided in the request body. JSON format is expected. Requires supervisor access to the project.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/playlists/\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"Playlist Name\",\n  \"project_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n  \"episode_id\": \"b24a6ea4-ce75-4665-a070-57453082c25\",\n  \"task_type_id\": \"c24a6ea4-ce75-4665-a070-57453082c25\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/playlists/\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"Playlist Name\",\n    \"project_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"episode_id\": \"b24a6ea4-ce75-4665-a070-57453082c25\",\n    \"task_type_id\": \"c24a6ea4-ce75-4665-a070-57453082c25\"\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/playlists/{instance_id}": {
+      "delete": {
+        "summary": "Delete playlist",
+        "description": "Delete a playlist by its ID. Returns empty response on success.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/data/playlists/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/playlists/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "get": {
+        "summary": "Get playlist",
+        "description": "Retrieve a playlist by its ID and return it as a JSON object. Supports including relations. Requires project access. Vendor access is blocked.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/playlists/a24a6ea4-ce75-4665-a070-57453082c25?relations=true\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/playlists/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"relations\": true\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "put": {
+        "summary": "Update playlist",
+        "description": "Update a playlist with data provided in the request body. JSON format is expected. Requires project access. Vendor access is blocked.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X PUT \"http://api.example.com/data/playlists/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"Updated Playlist Name\",\n  \"shots\": []\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/playlists/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"Updated Playlist Name\",\n    \"shots\": []\n}\n\nresponse = requests.put(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/playlists/entities/{entity_id}/preview-files": {
+      "get": {
+        "summary": "Get entity previews",
+        "description": "Retrieve all previews related to a given entity. It sends them as a dict. Keys are related task type ids and values are arrays of preview for this task type.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/playlists/entities/a24a6ea4-ce75-4665-a070-57453082c25/preview-files\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/playlists/entities/a24a6ea4-ce75-4665-a070-57453082c25/preview-files\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/playlists/{playlist_id}/jobs/{build_job_id}": {
+      "delete": {
+        "summary": "Delete build job",
+        "description": "Remove given build job related to given playlist.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/data/playlists/a24a6ea4-ce75-4665-a070-57453082c25/jobs/b35b7fb5-df86-5776-b181-68564193d36\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/playlists/a24a6ea4-ce75-4665-a070-57453082c25/jobs/b35b7fb5-df86-5776-b181-68564193d36\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "get": {
+        "summary": "Get build job",
+        "description": "Retrieve build job related to given playlist.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/playlists/a24a6ea4-ce75-4665-a070-57453082c25/jobs/b35b7fb5-df86-5776-b181-68564193d36\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/playlists/a24a6ea4-ce75-4665-a070-57453082c25/jobs/b35b7fb5-df86-5776-b181-68564193d36\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/playlists/{playlist_id}/build/mp4": {
+      "get": {
+        "summary": "Build playlist movie",
+        "description": "Build given playlist as MP4 movie. Starts a build job that processes the playlist shots into a video file.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/playlists/a24a6ea4-ce75-4665-a070-57453082c25/build/mp4?full=true\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/playlists/a24a6ea4-ce75-4665-a070-57453082c25/build/mp4\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"full\": true\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/playlists/{playlist_id}/jobs/{build_job_id}/build/mp4": {
+      "get": {
+        "summary": "Download playlist build",
+        "description": "Download given playlist build as MP4 file.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/playlists/a24a6ea4-ce75-4665-a070-57453082c25/jobs/b35b7fb5-df86-5776-b181-68564193d36/build/mp4\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/playlists/a24a6ea4-ce75-4665-a070-57453082c25/jobs/b35b7fb5-df86-5776-b181-68564193d36/build/mp4\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/playlists/{playlist_id}/download/zip": {
+      "get": {
+        "summary": "Download playlist zip",
+        "description": "Download given playlist as ZIP file containing all preview files.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/playlists/a24a6ea4-ce75-4665-a070-57453082c25/download/zip\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/playlists/a24a6ea4-ce75-4665-a070-57453082c25/download/zip\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/playlists/{playlist_id}/notify-clients": {
+      "post": {
+        "summary": "Notify clients playlist ready",
+        "description": "Notify clients that given playlist is ready for review.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/playlists/a24a6ea4-ce75-4665-a070-57453082c25/notify-clients\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"studio_id\": \"b35b7fb5-df86-5776-b181-68564193d36\",\n  \"department_id\": \"c46c8gc6-eg97-6887-c292-79675204e47\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/playlists/a24a6ea4-ce75-4665-a070-57453082c25/notify-clients\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"studio_id\": \"b35b7fb5-df86-5776-b181-68564193d36\",\n    \"department_id\": \"c46c8gc6-eg97-6887-c292-79675204e47\"\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/playlists/preview-files/running": {
+      "get": {
+        "summary": "Get running preview files",
+        "description": "Retrieve all preview files from open productions with states equal to processing or broken.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/playlists/preview-files/running?cursor_preview_file_id=a24a6ea4-ce75-4665-a070-57453082c25&limit=100\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/playlists/preview-files/running\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"cursor_preview_file_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"limit\": 100\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/plugins/{instance_id}": {
+      "delete": {
+        "summary": "Delete plugin",
+        "description": "Delete a plugin by its ID. Returns empty response on success.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/data/plugins/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/plugins/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "get": {
+        "summary": "Get plugin",
+        "description": "Retrieve a plugin by its ID and return it as a JSON object. Supports including relations.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/plugins/a24a6ea4-ce75-4665-a070-57453082c25?relations=true\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/plugins/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"relations\": true\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "put": {
+        "summary": "Update plugin",
+        "description": "Update a plugin with data provided in the request body. JSON format is expected.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X PUT \"http://api.example.com/data/plugins/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"Updated Plugin Name\",\n  \"active\": true\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/plugins/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"Updated Plugin Name\",\n    \"active\": true\n}\n\nresponse = requests.put(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/plugins": {
+      "get": {
+        "summary": "Get plugins",
+        "description": "Retrieve all plugins. Supports filtering via query parameters and pagination.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/plugins?page=1&limit=50&relations=false\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/plugins\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"page\": 1,\n    \"limit\": 50,\n    \"relations\": false\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Create plugin",
+        "description": "Create a new plugin with data provided in the request body. JSON format is expected.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/plugins\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"Plugin Name\",\n  \"active\": false\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/plugins\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"Plugin Name\",\n    \"active\": false\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/preview-background-files": {
+      "get": {
+        "summary": "Get preview background files",
+        "description": "Retrieve all preview background files. Supports filtering via query parameters and pagination.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/preview-background-files?page=1&limit=50&relations=false\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/preview-background-files\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"page\": 1,\n    \"limit\": 50,\n    \"relations\": false\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Create preview background file",
+        "description": "Create a new preview background file with data provided in the request body. JSON format is expected. Names must be unique. If is_default is true, resets other defaults.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/preview-background-files\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"background_file_name\",\n  \"is_default\": false\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/preview-background-files\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"background_file_name\",\n    \"is_default\": false\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/preview-background-files/{instance_id}": {
+      "delete": {
+        "summary": "Delete preview background file",
+        "description": "Delete a preview background file by its ID. Returns empty response on success.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/data/preview-background-files/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/preview-background-files/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "get": {
+        "summary": "Get preview background file",
+        "description": "Retrieve a preview background file by its ID and return it as a JSON object. Supports including relations.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/preview-background-files/a24a6ea4-ce75-4665-a070-57453082c25?relations=true\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/preview-background-files/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"relations\": true\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "put": {
+        "summary": "Update preview background file",
+        "description": "Update a preview background file with data provided in the request body. JSON format is expected. Names must be unique. If is_default is set to true, resets other defaults.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X PUT \"http://api.example.com/data/preview-background-files/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"updated_background_file_name\",\n  \"is_default\": true\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/preview-background-files/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"updated_background_file_name\",\n    \"is_default\": true\n}\n\nresponse = requests.put(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/preview-files": {
+      "get": {
+        "summary": "Get preview files",
+        "description": "Retrieve all preview files. Supports filtering via query parameters and pagination. Includes project permission filtering. Vendor users only see assigned tasks.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/preview-files?page=1&limit=50&relations=false\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/preview-files\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"page\": 1,\n    \"limit\": 50,\n    \"relations\": false\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Create preview file",
+        "description": "Create a new preview file with data provided in the request body. JSON format is expected.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/preview-files\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"preview_file_v001\",\n  \"task_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n  \"revision\": 1\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/preview-files\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"preview_file_v001\",\n    \"task_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"revision\": 1\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/preview-files/{instance_id}": {
+      "delete": {
+        "summary": "Delete preview file",
+        "description": "Delete a preview file by its ID. Returns empty response on success. May require force flag if file has associated data.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/data/preview-files/a24a6ea4-ce75-4665-a070-57453082c25?force=false\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/preview-files/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"force\": false\n}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "get": {
+        "summary": "Get preview file",
+        "description": "Retrieve a preview file by its ID and return it as a JSON object. Supports including relations. Vendors must be working on the task. Artists must have project access.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/preview-files/a24a6ea4-ce75-4665-a070-57453082c25?relations=true\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/preview-files/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"relations\": true\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "put": {
+        "summary": "Update preview file",
+        "description": "Update a preview file with data provided in the request body. JSON format is expected. Requires project access. Non-managers must be working on the task.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X PUT \"http://api.example.com/data/preview-files/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"updated_preview_file_v001\",\n  \"revision\": 2\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/preview-files/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"updated_preview_file_v001\",\n    \"revision\": 2\n}\n\nresponse = requests.put(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/actions/preview-files/{preview_file_id}/set-main-preview": {
+      "put": {
+        "summary": "Set main preview",
+        "description": "Set given preview as main preview of the related entity. This preview will be used to illustrate the entity.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X PUT \"http://api.example.com/actions/preview-files/a24a6ea4-ce75-4665-a070-57453082c25/set-main-preview?frame_number=120\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/actions/preview-files/a24a6ea4-ce75-4665-a070-57453082c25/set-main-preview\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"frame_number\": 120\n}\npayload = None\n\nresponse = requests.put(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/actions/preview-files/{preview_file_id}/extract-frame": {
+      "get": {
+        "summary": "Extract frame from preview",
+        "description": "Extract a frame from a preview file movie. Frame number can be specified as query parameter, defaults to 0.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/actions/preview-files/a24a6ea4-ce75-4665-a070-57453082c25/extract-frame?frame_number=120\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/actions/preview-files/a24a6ea4-ce75-4665-a070-57453082c25/extract-frame\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"frame_number\": 120\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/actions/preview-files/{preview_file_id}/update-position": {
+      "put": {
+        "summary": "Update preview position",
+        "description": "Allow to change orders of previews for a single revision.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X PUT \"http://api.example.com/actions/preview-files/a24a6ea4-ce75-4665-a070-57453082c25/update-position\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"position\": 2\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/actions/preview-files/a24a6ea4-ce75-4665-a070-57453082c25/update-position\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"position\": 2\n}\n\nresponse = requests.put(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/actions/preview-files/{preview_file_id}/update-annotations": {
+      "put": {
+        "summary": "Update preview annotations",
+        "description": "Allow to modify the annotations stored at the preview level. Modifications are applied via three fields, additions to give all the annotations that need to be added, updates that list annotations that needs to be modified, and deletions to list the IDs of annotations that needs to be removed.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X PUT \"http://api.example.com/actions/preview-files/a24a6ea4-ce75-4665-a070-57453082c25/update-annotations\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"additions\": [\n    {\n      \"type\": \"drawing\",\n      \"x\": 100,\n      \"y\": 200\n    }\n  ],\n  \"updates\": [\n    {\n      \"id\": \"uuid\",\n      \"x\": 150,\n      \"y\": 250\n    }\n  ],\n  \"deletions\": [\n    \"a24a6ea4-ce75-4665-a070-57453082c25\"\n  ]\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/actions/preview-files/a24a6ea4-ce75-4665-a070-57453082c25/update-annotations\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"additions\": [\n        {\n            \"type\": \"drawing\",\n            \"x\": 100,\n            \"y\": 200\n        }\n    ],\n    \"updates\": [\n        {\n            \"id\": \"uuid\",\n            \"x\": 150,\n            \"y\": 250\n        }\n    ],\n    \"deletions\": [\n        \"a24a6ea4-ce75-4665-a070-57453082c25\"\n    ]\n}\n\nresponse = requests.put(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/actions/preview-files/{preview_file_id}/extract-tile": {
+      "get": {
+        "summary": "Extract tile from preview",
+        "description": "Extract a tile from a preview file movie.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/actions/preview-files/a24a6ea4-ce75-4665-a070-57453082c25/extract-tile\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/actions/preview-files/a24a6ea4-ce75-4665-a070-57453082c25/extract-tile\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/production-schedule-version-task-links/{instance_id}": {
+      "delete": {
+        "summary": "Delete production schedule version task link",
+        "description": "Delete a production schedule version task link by its ID. Returns empty response on success. Requires manager access to the project.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/data/production-schedule-version-task-links/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/production-schedule-version-task-links/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "get": {
+        "summary": "Get production schedule version task link",
+        "description": "Retrieve a production schedule version task link by its ID and return it as a JSON object. Supports including relations. Vendor and client access is blocked. Requires project access.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/production-schedule-version-task-links/a24a6ea4-ce75-4665-a070-57453082c25?relations=true\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/production-schedule-version-task-links/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"relations\": true\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "put": {
+        "summary": "Update production schedule version task link",
+        "description": "Update a production schedule version task link with data provided in the request body. JSON format is expected. Protected fields cannot be changed. Requires manager access to the project.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X PUT \"http://api.example.com/data/production-schedule-version-task-links/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/production-schedule-version-task-links/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {}\n\nresponse = requests.put(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/production-schedule-version-task-links": {
+      "get": {
+        "summary": "Get production schedule version task links",
+        "description": "Retrieve all production schedule version task links. Supports filtering via query parameters and pagination. Vendor and client access is blocked. Requires project access or admin permissions.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/production-schedule-version-task-links?page=1&limit=50&relations=false&project_id=a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/production-schedule-version-task-links\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"page\": 1,\n    \"limit\": 50,\n    \"relations\": false,\n    \"project_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\"\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Create production schedule version task link",
+        "description": "Create a link between a production schedule version and a task. JSON format is expected. Task and schedule version must be in the same project. Requires manager access to the project.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/production-schedule-version-task-links\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"production_schedule_version_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n  \"task_id\": \"b24a6ea4-ce75-4665-a070-57453082c25\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/production-schedule-version-task-links\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"production_schedule_version_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"task_id\": \"b24a6ea4-ce75-4665-a070-57453082c25\"\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/production-schedule-versions": {
+      "get": {
+        "summary": "Get production schedule versions",
+        "description": "Retrieve all production schedule versions. Supports filtering via query parameters and pagination. Vendor and client access is blocked. Requires project access or admin permissions.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/production-schedule-versions?page=1&limit=50&relations=false&project_id=a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/production-schedule-versions\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"page\": 1,\n    \"limit\": 50,\n    \"relations\": false,\n    \"project_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\"\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Create production schedule version",
+        "description": "Create a new production schedule version with data provided in the request body. JSON format is expected. Requires manager access to the project.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/production-schedule-versions\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"Schedule Version 1\",\n  \"project_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/production-schedule-versions\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"Schedule Version 1\",\n    \"project_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\"\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/production-schedule-versions/{instance_id}": {
+      "delete": {
+        "summary": "Delete production schedule version",
+        "description": "Delete a production schedule version by its ID. Returns empty response on success.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/data/production-schedule-versions/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/production-schedule-versions/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "get": {
+        "summary": "Get production schedule version",
+        "description": "Retrieve a production schedule version by its ID and return it as a JSON object. Supports including relations. Vendor and client access is blocked. Requires project access.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/production-schedule-versions/a24a6ea4-ce75-4665-a070-57453082c25?relations=true\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/production-schedule-versions/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"relations\": true\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "put": {
+        "summary": "Update production schedule version",
+        "description": "Update a production schedule version with data provided in the request body. JSON format is expected. Requires manager access to the project.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X PUT \"http://api.example.com/data/production-schedule-versions/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"Updated Schedule Version 1\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/production-schedule-versions/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"Updated Schedule Version 1\"\n}\n\nresponse = requests.put(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/production-schedule-versions/{production_schedule_version_id}/task-links": {
+      "get": {
+        "summary": "Get production schedule version task links",
+        "description": "Get task links for given production schedule version.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/production-schedule-versions/a24a6ea4-ce75-4665-a070-57453082c25/task-links?task_type_id=b35b7fb5-df86-5776-b181-68564193d36\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/production-schedule-versions/a24a6ea4-ce75-4665-a070-57453082c25/task-links\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"task_type_id\": \"b35b7fb5-df86-5776-b181-68564193d36\"\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/actions/production-schedule-versions/{production_schedule_version_id}/set-task-links-from-production": {
+      "post": {
+        "summary": "Set task links from tasks",
+        "description": "Set task links for given production schedule version from tasks.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/actions/production-schedule-versions/a24a6ea4-ce75-4665-a070-57453082c25/set-task-links-from-production\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/actions/production-schedule-versions/a24a6ea4-ce75-4665-a070-57453082c25/set-task-links-from-production\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/actions/production-schedule-versions/{production_schedule_version_id}/set-task-links-from-production-schedule-version": {
+      "post": {
+        "summary": "Set task links from production schedule version",
+        "description": "Set task links for given production schedule version from another production schedule version.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/actions/production-schedule-versions/a24a6ea4-ce75-4665-a070-57453082c25/set-task-links-from-production-schedule-version\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"production_schedule_version_id\": \"b35b7fb5-df86-5776-b181-68564193d36\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/actions/production-schedule-versions/a24a6ea4-ce75-4665-a070-57453082c25/set-task-links-from-production-schedule-version\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"production_schedule_version_id\": \"b35b7fb5-df86-5776-b181-68564193d36\"\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/actions/production-schedule-versions/{production_schedule_version_id}/apply-to-production": {
+      "post": {
+        "summary": "Apply production schedule version",
+        "description": "Apply production schedule version to production.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/actions/production-schedule-versions/a24a6ea4-ce75-4665-a070-57453082c25/apply-to-production\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/actions/production-schedule-versions/a24a6ea4-ce75-4665-a070-57453082c25/apply-to-production\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/project-status": {
+      "get": {
+        "summary": "Get project statuses",
+        "description": "Retrieve all project statuses. Supports filtering via query parameters and pagination.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/project-status?page=1&limit=50&relations=false\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/project-status\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"page\": 1,\n    \"limit\": 50,\n    \"relations\": false\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Create project status",
+        "description": "Create a new project status with data provided in the request body. JSON format is expected.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/project-status\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"Open\",\n  \"color\": \"#00FF00\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/project-status\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"Open\",\n    \"color\": \"#00FF00\"\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/project-status/{instance_id}": {
+      "delete": {
+        "summary": "Delete project status",
+        "description": "Delete a project status by its ID. Returns empty response on success.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/data/project-status/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/project-status/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "get": {
+        "summary": "Get project status",
+        "description": "Retrieve a project status by its ID and return it as a JSON object. Supports including relations.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/project-status/a24a6ea4-ce75-4665-a070-57453082c25?relations=true\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/project-status/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"relations\": true\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "put": {
+        "summary": "Update project status",
+        "description": "Update a project status with data provided in the request body. JSON format is expected.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X PUT \"http://api.example.com/data/project-status/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"Closed\",\n  \"color\": \"#FF0000\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/project-status/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"Closed\",\n    \"color\": \"#FF0000\"\n}\n\nresponse = requests.put(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/projects/{project_id}/asset-types/{asset_type_id}/assets": {
+      "get": {
+        "summary": "Get project asset type assets",
+        "description": "Retrieve all assets of a specific type within a project.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/asset-types/a24a6ea4-ce75-4665-a070-57453082c25/assets?page=1&limit=100\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/asset-types/a24a6ea4-ce75-4665-a070-57453082c25/assets\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"page\": 1,\n    \"limit\": 100\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/projects/{project_id}/asset-types/{asset_type_id}/assets/new": {
+      "post": {
+        "summary": "Create asset",
+        "description": "Create a new asset in a specific project with the given asset type and parameters.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/asset-types/a24a6ea4-ce75-4665-a070-57453082c25/assets/new\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"Character Name\",\n  \"description\": \"Main character\",\n  \"data\": [\n    {\n      \"difficulty\": \"easy\",\n      \"atmsophere\": \"sunny\"\n    }\n  ],\n  \"is_shared\": false,\n  \"source_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n  \"episode_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/asset-types/a24a6ea4-ce75-4665-a070-57453082c25/assets/new\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"Character Name\",\n    \"description\": \"Main character\",\n    \"data\": [\n        {\n            \"difficulty\": \"easy\",\n            \"atmsophere\": \"sunny\"\n        }\n    ],\n    \"is_shared\": false,\n    \"source_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"episode_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\"\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/projects/{project_id}/asset-types": {
+      "get": {
+        "summary": "Get project asset types",
+        "description": "Retrieve all asset types available for a specific project",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/asset-types\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/asset-types\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/projects/{project_id}/assets": {
+      "get": {
+        "summary": "Get project assets",
+        "description": "Retrieve all assets belonging to a specific project with filtering support",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/assets?asset_type_id=a24a6ea4-ce75-4665-a070-57453082c25&page=1&limit=100\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/assets\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"asset_type_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"page\": 1,\n    \"limit\": 100\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/actions/projects/{project_id}/assets/share": {
+      "post": {
+        "summary": "Set project assets shared",
+        "description": "Share or unshare all assets for a specific project or a list of specific assets.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/actions/projects/a24a6ea4-ce75-4665-a070-57453082c25/assets/share\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"is_shared\": true,\n  \"asset_ids\": [\n    \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"b35b7fb5-df86-5776-b181-68564193d36\"\n  ]\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/actions/projects/a24a6ea4-ce75-4665-a070-57453082c25/assets/share\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"is_shared\": true,\n    \"asset_ids\": [\n        \"a24a6ea4-ce75-4665-a070-57453082c25\",\n        \"b35b7fb5-df86-5776-b181-68564193d36\"\n    ]\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/actions/projects/{project_id}/asset-types/{asset_type_id}/assets/share": {
+      "post": {
+        "summary": "Set asset type assets shared",
+        "description": "Share or unshare all assets for a specific project and asset type.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/actions/projects/a24a6ea4-ce75-4665-a070-57453082c25/asset-types/a24a6ea4-ce75-4665-a070-57453082c25/assets/share\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"is_shared\": true\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/actions/projects/a24a6ea4-ce75-4665-a070-57453082c25/asset-types/a24a6ea4-ce75-4665-a070-57453082c25/assets/share\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"is_shared\": true\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/projects/{project_id}/assets/shared-used": {
+      "get": {
+        "summary": "Get shared assets used in project",
+        "description": "Retrieve all shared assets that are used in a specific project.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/assets/shared-used\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/assets/shared-used\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/projects/{project_id}/episodes/{episode_id}/assets/shared-used": {
+      "get": {
+        "summary": "Get shared assets used in episode",
+        "description": "Retrieve all shared assets that are used in a specific project episode.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/episodes/a24a6ea4-ce75-4665-a070-57453082c25/assets/shared-used\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/episodes/a24a6ea4-ce75-4665-a070-57453082c25/assets/shared-used\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/projects/{project_id}/entities/{entity_id}/casting": {
+      "put": {
+        "summary": "Update entity casting",
+        "description": "Modify the casting relationships for a specific entity by updating which assets are linked to it.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X PUT \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/entities/a24a6ea4-ce75-4665-a070-57453082c25/casting\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"casting\": [\n    {\n      \"asset_id\": \"c46c8gc6-eg97-6887-c292-79675204e47\",\n      \"asset_name\": \"Main Character\"\n    }\n  ]\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/entities/a24a6ea4-ce75-4665-a070-57453082c25/casting\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"casting\": [\n        {\n            \"asset_id\": \"c46c8gc6-eg97-6887-c292-79675204e47\",\n            \"asset_name\": \"Main Character\"\n        }\n    ]\n}\n\nresponse = requests.put(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "get": {
+        "summary": "Get entity casting",
+        "description": "Retrieve the casting information for a specific entity showing which assets are linked to it.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/entities/a24a6ea4-ce75-4665-a070-57453082c25/casting\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/entities/a24a6ea4-ce75-4665-a070-57453082c25/casting\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/projects/{project_id}/asset-types/{asset_type_id}/casting": {
+      "get": {
+        "summary": "Get asset type casting",
+        "description": "Retrieve the casting information for all assets of a specific asset type in a project.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/asset-types/g80g2kg0-ik31-0221-g736-13019648i81/casting\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/asset-types/g80g2kg0-ik31-0221-g736-13019648i81/casting\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/projects/{project_id}/episodes/casting": {
+      "get": {
+        "summary": "Get episodes casting",
+        "description": "Retrieve the casting information for all episodes in a specific project.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/episodes/casting\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/episodes/casting\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/projects/{project_id}/sequences/{sequence_id}/casting": {
+      "get": {
+        "summary": "Get sequence shots casting",
+        "description": "Retrieve the casting information for all shots from a specific sequence.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/sequences/f79f1jf9-hj20-9110-f625-02908537h70/casting\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/sequences/f79f1jf9-hj20-9110-f625-02908537h70/casting\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/projects/{project_id}/episodes/{episode_id}/sequences/all/casting": {
+      "get": {
+        "summary": "Get episode shots casting",
+        "description": "Retrieve the casting information for all shots from a specific episode.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/episodes/d57d9hd7-fh08-7998-d403-80786315f58/sequences/all/casting\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/episodes/d57d9hd7-fh08-7998-d403-80786315f58/sequences/all/casting\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/projects/{project_id}/sequences/all/casting": {
+      "get": {
+        "summary": "Get project shots casting",
+        "description": "Retrieve the casting information for all shots from all sequences in a specific project.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/sequences/all/casting\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/sequences/all/casting\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/projects/{project_id}/entity-links": {
+      "get": {
+        "summary": "Get project entity links",
+        "description": "Retrieve all entity links related to a specific project. Results can be paginated using page and limit query parameters. If you prefer a more accurate pagination, you can use cursor_created_at to get the next page. It's mainly used for synchronisation purpose.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/entity-links?page=2&limit=100&cursor_created_at=2020-01-01T00%3A00%3A00\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/entity-links\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"page\": 2,\n    \"limit\": 100,\n    \"cursor_created_at\": \"2020-01-01T00:00:00\"\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/projects/{project_id}/entity-links/{entity_link_id}": {
+      "delete": {
+        "summary": "Delete entity link",
+        "description": "Delete a specific entity link. It's mainly used for synchronisation purpose.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/entity-links/m46m8qm6-oq97-6887-m403-80786315o47\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/entity-links/m46m8qm6-oq97-6887-m403-80786315o47\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/projects/{project_id}/attachment-files": {
+      "get": {
+        "summary": "Get project attachment files",
+        "description": "Retrieve all attachment files related to a specific project. Requires administrator permissions.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/attachment-files\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/attachment-files\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/actions/projects/{project_id}/tasks/comment-many": {
+      "post": {
+        "summary": "Create multiple comments",
+        "description": "Create several comments at once for a specific project. Each comment requires a text, a task id, a task_status and a person as arguments. This way, comments keep history of status changes. When the comment is created, it updates the task status with the given task status.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/actions/projects/a24a6ea4-ce75-4665-a070-57453082c25/tasks/comment-many\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '[\n  {\n    \"task_status_id\": \"c46c8gc6-eg97-6887-c292-79675204e47\",\n    \"comment\": \"This looks great! Ready for review.\",\n    \"person_id\": \"d57d9hd7-fh08-7998-d403-80786315f58\",\n    \"object_id\": \"e68e0ie8-gi19-8009-e514-91897426g69\",\n    \"created_at\": \"2023-01-01T12:00:00Z\",\n    \"checklist\": {\n      \"item1\": \"Check lighting\",\n      \"item2\": \"Verify textures\"\n    },\n    \"links\": [\n      \"https://example.com/reference1\",\n      \"https://example.com/reference2\"\n    ]\n  }\n]'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/actions/projects/a24a6ea4-ce75-4665-a070-57453082c25/tasks/comment-many\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = [\n    {\n        \"task_status_id\": \"c46c8gc6-eg97-6887-c292-79675204e47\",\n        \"comment\": \"This looks great! Ready for review.\",\n        \"person_id\": \"d57d9hd7-fh08-7998-d403-80786315f58\",\n        \"object_id\": \"e68e0ie8-gi19-8009-e514-91897426g69\",\n        \"created_at\": \"2023-01-01T12:00:00Z\",\n        \"checklist\": {\n            \"item1\": \"Check lighting\",\n            \"item2\": \"Verify textures\"\n        },\n        \"links\": [\n            \"https://example.com/reference1\",\n            \"https://example.com/reference2\"\n        ]\n    }\n]\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/projects": {
+      "get": {
+        "summary": "Get projects",
+        "description": "Retrieve all projects. Supports filtering via query parameters and pagination. Includes project permission filtering for non-admin users.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/projects?page=1&limit=50&relations=false\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"page\": 1,\n    \"limit\": 50,\n    \"relations\": false\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Create project",
+        "description": "Create a new project with data provided in the request body. JSON format is expected. Validates production_style. For tvshow production type, automatically creates first episode.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/projects\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"Project Name\",\n  \"production_type\": \"feature\",\n  \"production_style\": \"2d3d\",\n  \"project_status_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"Project Name\",\n    \"production_type\": \"feature\",\n    \"production_style\": \"2d3d\",\n    \"project_status_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\"\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/projects/{instance_id}": {
+      "delete": {
+        "summary": "Delete project",
+        "description": "Delete a project by its ID. Only closed projects can be deleted. Returns empty response on success.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25?force=false\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"force\": false\n}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "get": {
+        "summary": "Get project",
+        "description": "Retrieve a project by its ID and return it as a JSON object. Supports including relations. Requires project access.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25?relations=true\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"relations\": true\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "put": {
+        "summary": "Update project",
+        "description": "Update a project with data provided in the request body. JSON format is expected. Requires manager access to the project. Validates production_style.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X PUT \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"Updated Project Name\",\n  \"production_style\": \"2d\",\n  \"preview_background_file_id\": \"b24a6ea4-ce75-4665-a070-57453082c25\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"Updated Project Name\",\n    \"production_style\": \"2d\",\n    \"preview_background_file_id\": \"b24a6ea4-ce75-4665-a070-57453082c25\"\n}\n\nresponse = requests.put(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/projects/{project_id}/output-files": {
+      "get": {
+        "summary": "Get project output files",
+        "description": "Retrieve all output files for a given project with optional filtering by output type, task type, representation, file status, and name.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/output-files?output_type_id=b35b7fb5-df86-5776-b181-68564193d36&task_type_id=c46c8gc6-eg97-6887-c292-79675204e47&file_status_id=d57d9hd7-fh08-7998-d403-80786315f58&representation=cache&name=main\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/output-files\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"output_type_id\": \"b35b7fb5-df86-5776-b181-68564193d36\",\n    \"task_type_id\": \"c46c8gc6-eg97-6887-c292-79675204e47\",\n    \"file_status_id\": \"d57d9hd7-fh08-7998-d403-80786315f58\",\n    \"representation\": \"cache\",\n    \"name\": \"main\"\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/actions/projects/{project_id}/set-file-tree": {
+      "post": {
+        "summary": "Set project file tree",
+        "description": "Define a template file to use for a given project. Template files are located on the server side and each template has a name for selection.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/actions/projects/a24a6ea4-ce75-4665-a070-57453082c25/set-file-tree\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"tree_name\": \"default\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/actions/projects/a24a6ea4-ce75-4665-a070-57453082c25/set-file-tree\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"tree_name\": \"default\"\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/projects/news": {
+      "get": {
+        "summary": "Get open projects news",
+        "description": "Returns the latest news and activity feed from all projects the user has access to.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/projects/news?project_id=a24a6ea4-ce75-4665-a070-57453082c25&before=2022-07-12&after=2022-07-12&page=1&limit=50&person_id=a24a6ea4-ce75-4665-a070-57453082c25&task_type_id=a24a6ea4-ce75-4665-a070-57453082c25&task_status_id=a24a6ea4-ce75-4665-a070-57453082c25&episode_id=a24a6ea4-ce75-4665-a070-57453082c25&only_preview=false\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/news\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"project_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"before\": \"2022-07-12\",\n    \"after\": \"2022-07-12\",\n    \"page\": 1,\n    \"limit\": 50,\n    \"person_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"task_type_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"task_status_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"episode_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"only_preview\": false\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/projects/{project_id}/news": {
+      "get": {
+        "summary": "Get project latest news",
+        "description": "Get the 50 latest news object (activity feed) for a project",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/news?before=2022-07-12&after=2022-07-12&page=1&limit=50&person_id=a24a6ea4-ce75-4665-a070-57453082c25&task_type_id=a24a6ea4-ce75-4665-a070-57453082c25&task_status_id=a24a6ea4-ce75-4665-a070-57453082c25&episode_id=a24a6ea4-ce75-4665-a070-57453082c25&only_preview=false\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/news\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"before\": \"2022-07-12\",\n    \"after\": \"2022-07-12\",\n    \"page\": 1,\n    \"limit\": 50,\n    \"person_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"task_type_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"task_status_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"episode_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"only_preview\": false\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/projects/{project_id}/news/{news_id}": {
+      "get": {
+        "summary": "Get news item",
+        "description": "Retrieves detailed information about a specific news item from a givenproject.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/news/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/news/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/projects/{project_id}/playlists": {
+      "get": {
+        "summary": "Get project playlists",
+        "description": "Retrieve all playlists related to given project. Result is paginated and can be sorted.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/playlists?page=1&sort_by=updated_at&task_type_id=b35b7fb5-df86-5776-b181-68564193d36\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/playlists\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"page\": 1,\n    \"sort_by\": \"updated_at\",\n    \"task_type_id\": \"b35b7fb5-df86-5776-b181-68564193d36\"\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/projects/{project_id}/playlists/all": {
+      "get": {
+        "summary": "Get all project playlists",
+        "description": "Retrieve all playlists related to given project. It's mainly used for synchronisation purpose.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/playlists/all\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/playlists/all\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/projects/{project_id}/episodes/{episode_id}/playlists": {
+      "get": {
+        "summary": "Get episode playlists",
+        "description": "Retrieve all playlists related to given episode. The full list is returned because the number of playlists in an episode is not that big.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/episodes/a24a6ea4-ce75-4665-a070-57453082c25/playlists\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/episodes/a24a6ea4-ce75-4665-a070-57453082c25/playlists\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/projects/{project_id}/playlists/{playlist_id}": {
+      "get": {
+        "summary": "Get playlist",
+        "description": "Retrieve a specific playlist by ID with preview file revisions.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/playlists/b35b7fb5-df86-5776-b181-68564193d36\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/playlists/b35b7fb5-df86-5776-b181-68564193d36\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/projects/{project_id}/build-jobs": {
+      "get": {
+        "summary": "Get project build jobs",
+        "description": "Retrieve all build jobs related to given project. It's mainly used for synchronisation purpose.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/build-jobs\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/build-jobs\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/projects/{project_id}/playlists/temp": {
+      "post": {
+        "summary": "Generate temp playlist",
+        "description": "Generate a temporary playlist from task IDs. It's mainly used for synchronisation purpose.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/playlists/temp?sort=true\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"task_ids\": [\n    \"a24a6ea4-ce75-4665-a070-57453082c25\"\n  ]\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/playlists/temp\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {\n    \"sort\": true\n}\npayload = {\n    \"task_ids\": [\n        \"a24a6ea4-ce75-4665-a070-57453082c25\"\n    ]\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/projects/open": {
+      "get": {
+        "summary": "Get open projects",
+        "description": "Return the list of projects currently running. Most of the time, past projects are not needed.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/projects/open?name=My%20Project\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/open\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"name\": \"My Project\"\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/projects/all": {
+      "get": {
+        "summary": "Get all projects",
+        "description": "Return all projects listed in database. Ensure that user has at least the manager level before that.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/projects/all?name=My%20Project\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/all\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"name\": \"My Project\"\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/projects/{project_id}/team": {
+      "get": {
+        "summary": "Get production team",
+        "description": "Return the people listed in a production team.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/team\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/team\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Add person to production team",
+        "description": "Add a person to a production team.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/team\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"person_id\": \"b35b7fb5-df86-5776-b181-68564193d36\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/team\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"person_id\": \"b35b7fb5-df86-5776-b181-68564193d36\"\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/projects/{project_id}/task-types": {
+      "get": {
+        "summary": "Get production task types",
+        "description": "Retrieve task types linked to the production.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/task-types\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/task-types\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/projects/{project_id}/task-types/{task_type_id}/time-spents": {
+      "get": {
+        "summary": "Get production task type time spents",
+        "description": "Retrieve time spents for a task type in the production.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/task-types/b35b7fb5-df86-5776-b181-68564193d36/time-spents?start_date=2022-07-01&end_date=2022-07-31\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/task-types/b35b7fb5-df86-5776-b181-68564193d36/time-spents\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"start_date\": \"2022-07-01\",\n    \"end_date\": \"2022-07-31\"\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/projects/{project_id}/day-offs": {
+      "get": {
+        "summary": "Get production day offs",
+        "description": "Retrieve all day offs for a production.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/day-offs?start_date=2022-07-01&end_date=2022-07-31\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/day-offs\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"start_date\": \"2022-07-01\",\n    \"end_date\": \"2022-07-31\"\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/projects/{project_id}/team/{person_id}": {
+      "delete": {
+        "summary": "Remove person from production team",
+        "description": "Remove people listed in a production team.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/team/b35b7fb5-df86-5776-b181-68564193d36\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/team/b35b7fb5-df86-5776-b181-68564193d36\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/projects/{project_id}/settings/asset-types": {
+      "post": {
+        "summary": "Add asset type to production",
+        "description": "Add an asset type linked to a production.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/settings/asset-types\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"asset_type_id\": \"b35b7fb5-df86-5776-b181-68564193d36\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/settings/asset-types\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"asset_type_id\": \"b35b7fb5-df86-5776-b181-68564193d36\"\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/projects/{project_id}/settings/asset-types/{asset_type_id}": {
+      "delete": {
+        "summary": "Remove asset type from production",
+        "description": "Remove an asset type from a production.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/settings/asset-types/b35b7fb5-df86-5776-b181-68564193d36\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/settings/asset-types/b35b7fb5-df86-5776-b181-68564193d36\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/projects/{project_id}/settings/task-types": {
+      "post": {
+        "summary": "Add task type to production",
+        "description": "Add a task type linked to a production.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/settings/task-types\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"task_type_id\": \"b35b7fb5-df86-5776-b181-68564193d36\",\n  \"priority\": \"None\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/settings/task-types\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"task_type_id\": \"b35b7fb5-df86-5776-b181-68564193d36\",\n    \"priority\": \"None\"\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/projects/{project_id}/settings/task-types/{task_type_id}": {
+      "delete": {
+        "summary": "Remove task type from production",
+        "description": "Remove a task type from a production.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/settings/task-types/b35b7fb5-df86-5776-b181-68564193d36\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/settings/task-types/b35b7fb5-df86-5776-b181-68564193d36\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/projects/{project_id}/settings/task-status": {
+      "get": {
+        "summary": "Get production task statuses",
+        "description": "Return task statuses linked to a production.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/settings/task-status\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/settings/task-status\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Add task status to production",
+        "description": "Add a task status linked to a production.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/settings/task-status\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"task_status_id\": \"b35b7fb5-df86-5776-b181-68564193d36\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/settings/task-status\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"task_status_id\": \"b35b7fb5-df86-5776-b181-68564193d36\"\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/projects/{project_id}/settings/task-status/{task_status_id}": {
+      "delete": {
+        "summary": "Remove task status from production",
+        "description": "Remove a task status from a production.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/settings/task-status/b35b7fb5-df86-5776-b181-68564193d36\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/settings/task-status/b35b7fb5-df86-5776-b181-68564193d36\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/projects/{project_id}/settings/status-automations": {
+      "get": {
+        "summary": "Get production status automations",
+        "description": "Get status automations linked to a production.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/settings/status-automations\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/settings/status-automations\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Add status automation to production",
+        "description": "Add a status automation linked to a production.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/settings/status-automations\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"status_automation_id\": \"b35b7fb5-df86-5776-b181-68564193d36\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/settings/status-automations\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"status_automation_id\": \"b35b7fb5-df86-5776-b181-68564193d36\"\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/projects/{project_id}/settings/status-automations/{status_automation_id}": {
+      "delete": {
+        "summary": "Remove status automation from production",
+        "description": "Remove a status automation from a production.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/settings/status-automations/b35b7fb5-df86-5776-b181-68564193d36\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/settings/status-automations/b35b7fb5-df86-5776-b181-68564193d36\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/projects/{project_id}/settings/preview-background-files/{preview_background_file_id}": {
+      "delete": {
+        "summary": "Remove preview background file from production",
+        "description": "Remove a preview background file from a production.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/settings/preview-background-files/b35b7fb5-df86-5776-b181-68564193d36\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/settings/preview-background-files/b35b7fb5-df86-5776-b181-68564193d36\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/projects/{project_id}/settings/preview-background-files": {
+      "get": {
+        "summary": "Get production preview background files",
+        "description": "Return preview background files linked to a production.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/settings/preview-background-files\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/settings/preview-background-files\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Add preview background file to production",
+        "description": "Add a preview background file linked to a production.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/settings/preview-background-files\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"preview_background_file_id\": \"b35b7fb5-df86-5776-b181-68564193d36\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/settings/preview-background-files\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"preview_background_file_id\": \"b35b7fb5-df86-5776-b181-68564193d36\"\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/projects/{project_id}/metadata-descriptors": {
+      "get": {
+        "summary": "Get metadata descriptors",
+        "description": "Get all metadata descriptors. It serves to describe extra fields listed in the data attribute of entities.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/metadata-descriptors\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/metadata-descriptors\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Create metadata descriptor",
+        "description": "Create a new metadata descriptor. It serves to describe extra fields listed in the data attribute of entities.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/metadata-descriptors\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"entity_type\": \"Asset\",\n  \"name\": \"Custom Field\",\n  \"data_type\": \"string\",\n  \"for_client\": \"True\",\n  \"choices\": [\n    \"option1\",\n    \"option2\"\n  ],\n  \"departments\": [\n    \"department1\",\n    \"department2\"\n  ]\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/metadata-descriptors\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"entity_type\": \"Asset\",\n    \"name\": \"Custom Field\",\n    \"data_type\": \"string\",\n    \"for_client\": \"True\",\n    \"choices\": [\n        \"option1\",\n        \"option2\"\n    ],\n    \"departments\": [\n        \"department1\",\n        \"department2\"\n    ]\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/projects/{project_id}/metadata-descriptors/{descriptor_id}": {
+      "delete": {
+        "summary": "Delete metadata descriptor",
+        "description": "Delete a metadata descriptor. Descriptors serve to describe extra fields listed in the data attribute of entities.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/metadata-descriptors/b35b7fb5-df86-5776-b181-68564193d36\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/metadata-descriptors/b35b7fb5-df86-5776-b181-68564193d36\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "get": {
+        "summary": "Get metadata descriptor",
+        "description": "Get a metadata descriptor. Descriptors serve to describe extra fields listed in the data attribute of entities.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/metadata-descriptors/b35b7fb5-df86-5776-b181-68564193d36\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/metadata-descriptors/b35b7fb5-df86-5776-b181-68564193d36\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "put": {
+        "summary": "Update metadata descriptor",
+        "description": "Update a metadata descriptor. Descriptors serve to describe extra fields listed in the data attribute of entities.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X PUT \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/metadata-descriptors/b35b7fb5-df86-5776-b181-68564193d36\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"Custom Field\",\n  \"for_client\": \"True\",\n  \"choices\": [\n    \"option1\",\n    \"option2\"\n  ],\n  \"departments\": [\n    \"department1\",\n    \"department2\"\n  ]\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/metadata-descriptors/b35b7fb5-df86-5776-b181-68564193d36\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"Custom Field\",\n    \"for_client\": \"True\",\n    \"choices\": [\n        \"option1\",\n        \"option2\"\n    ],\n    \"departments\": [\n        \"department1\",\n        \"department2\"\n    ]\n}\n\nresponse = requests.put(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/projects/{project_id}/metadata-descriptors/reorder": {
+      "post": {
+        "summary": "Reorder metadata descriptors",
+        "description": "Reorder metadata descriptors for a specific entity type and project. Descriptors are reordered based on the list of descriptor IDs provided in the request body. Position is set according to the order in the list.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/metadata-descriptors/reorder\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"entity_type\": \"Asset\",\n  \"descriptor_ids\": [\n    \"b35b7fb5-df86-5776-b181-68564193d36\",\n    \"c46c8gc6-eg97-6887-c292-79675204e47\"\n  ]\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/metadata-descriptors/reorder\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"entity_type\": \"Asset\",\n    \"descriptor_ids\": [\n        \"b35b7fb5-df86-5776-b181-68564193d36\",\n        \"c46c8gc6-eg97-6887-c292-79675204e47\"\n    ]\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/projects/{project_id}/milestones": {
+      "get": {
+        "summary": "Get production milestones",
+        "description": "Retrieve milestones for given production.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/milestones\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/milestones\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/projects/{project_id}/schedule-items": {
+      "get": {
+        "summary": "Get production schedule items",
+        "description": "Retrieve schedule items for given production.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/schedule-items\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/schedule-items\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/projects/{project_id}/schedule-items/task-types": {
+      "get": {
+        "summary": "Get production task type schedule items",
+        "description": "Retrieve task type schedule items for given production.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/schedule-items/task-types\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/schedule-items/task-types\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/projects/{project_id}/schedule-items/{task_type_id}/asset-types": {
+      "get": {
+        "summary": "Get asset types schedule items",
+        "description": "Retrieve asset types schedule items for given task type.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/schedule-items/b35b7fb5-df86-5776-b181-68564193d36/asset-types\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/schedule-items/b35b7fb5-df86-5776-b181-68564193d36/asset-types\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/projects/{project_id}/schedule-items/{task_type_id}/episodes": {
+      "get": {
+        "summary": "Get episodes schedule items",
+        "description": "Retrieve episodes schedule items for given task type.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/schedule-items/b35b7fb5-df86-5776-b181-68564193d36/episodes\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/schedule-items/b35b7fb5-df86-5776-b181-68564193d36/episodes\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/projects/{project_id}/schedule-items/{task_type_id}/sequences": {
+      "get": {
+        "summary": "Get sequences schedule items",
+        "description": "Retrieve sequences schedule items for given task type.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/schedule-items/b35b7fb5-df86-5776-b181-68564193d36/sequences\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/schedule-items/b35b7fb5-df86-5776-b181-68564193d36/sequences\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/projects/{project_id}/time-spents": {
+      "get": {
+        "summary": "Get production time spents",
+        "description": "Retrieve time spents for given production.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/time-spents\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/time-spents\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/projects/{project_id}/budgets": {
+      "get": {
+        "summary": "Get production budgets",
+        "description": "Retrieve budgets for given production.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/budgets\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/budgets\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Create budget",
+        "description": "Create a budget for given production.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/budgets\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"New Budget\",\n  \"currency\": \"USD\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/budgets\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"New Budget\",\n    \"currency\": \"USD\"\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/projects/{project_id}/budgets/{budget_id}": {
+      "delete": {
+        "summary": "Delete budget",
+        "description": "Delete a budget for given production.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/budgets/b35b7fb5-df86-5776-b181-68564193d36\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/budgets/b35b7fb5-df86-5776-b181-68564193d36\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "get": {
+        "summary": "Get budget",
+        "description": "Retrieve a budget for given production.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/budgets/b35b7fb5-df86-5776-b181-68564193d36\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/budgets/b35b7fb5-df86-5776-b181-68564193d36\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "put": {
+        "summary": "Update budget",
+        "description": "Update a budget for given production.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X PUT \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/budgets/b35b7fb5-df86-5776-b181-68564193d36\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"New Budget\",\n  \"currency\": \"USD\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/budgets/b35b7fb5-df86-5776-b181-68564193d36\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"New Budget\",\n    \"currency\": \"USD\"\n}\n\nresponse = requests.put(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/projects/{project_id}/budgets/{budget_id}/entries": {
+      "get": {
+        "summary": "Get budget entries",
+        "description": "Retrieve budget entries for given production.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/budgets/b35b7fb5-df86-5776-b181-68564193d36/entries\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/budgets/b35b7fb5-df86-5776-b181-68564193d36/entries\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Create budget entry",
+        "description": "Create a budget entry for given production and budget.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/budgets/b35b7fb5-df86-5776-b181-68564193d36/entries\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"department_id\": \"c46c8gc6-eg97-6887-c292-79675204e47\",\n  \"person_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n  \"start_date\": \"2025-01-01\",\n  \"months_duration\": 12,\n  \"daily_salary\": 100,\n  \"position\": \"Artist\",\n  \"seniority\": \"Mid\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/budgets/b35b7fb5-df86-5776-b181-68564193d36/entries\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"department_id\": \"c46c8gc6-eg97-6887-c292-79675204e47\",\n    \"person_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"start_date\": \"2025-01-01\",\n    \"months_duration\": 12,\n    \"daily_salary\": 100,\n    \"position\": \"Artist\",\n    \"seniority\": \"Mid\"\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/projects/{project_id}/budgets/{budget_id}/entries/{entry_id}": {
+      "delete": {
+        "summary": "Delete budget entry",
+        "description": "Delete a budget entry for given production and budget.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/budgets/b35b7fb5-df86-5776-b181-68564193d36/entries/c46c8gc6-eg97-6887-c292-79675204e47\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/budgets/b35b7fb5-df86-5776-b181-68564193d36/entries/c46c8gc6-eg97-6887-c292-79675204e47\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "get": {
+        "summary": "Get budget entry",
+        "description": "Retrieve a budget entry for given production and budget.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/budgets/b35b7fb5-df86-5776-b181-68564193d36/entries/c46c8gc6-eg97-6887-c292-79675204e47\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/budgets/b35b7fb5-df86-5776-b181-68564193d36/entries/c46c8gc6-eg97-6887-c292-79675204e47\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "put": {
+        "summary": "Update budget entry",
+        "description": "Update a budget entry for given production and budget.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X PUT \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/budgets/b35b7fb5-df86-5776-b181-68564193d36/entries/c46c8gc6-eg97-6887-c292-79675204e47\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"department_id\": \"c46c8gc6-eg97-6887-c292-79675204e47\",\n  \"person_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n  \"start_date\": \"2025-01-01\",\n  \"months_duration\": 12,\n  \"daily_salary\": 100,\n  \"position\": \"Artist\",\n  \"seniority\": \"Mid\",\n  \"exceptions\": {\n    \"2025-01-01\": 1000,\n    \"2025-02-01\": 2000\n  }\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/budgets/b35b7fb5-df86-5776-b181-68564193d36/entries/c46c8gc6-eg97-6887-c292-79675204e47\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"department_id\": \"c46c8gc6-eg97-6887-c292-79675204e47\",\n    \"person_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"start_date\": \"2025-01-01\",\n    \"months_duration\": 12,\n    \"daily_salary\": 100,\n    \"position\": \"Artist\",\n    \"seniority\": \"Mid\",\n    \"exceptions\": {\n        \"2025-01-01\": 1000,\n        \"2025-02-01\": 2000\n    }\n}\n\nresponse = requests.put(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/projects/{project_id}/budgets/time-spents": {
+      "get": {
+        "summary": "Get production month time spents",
+        "description": "Get aggregated time spents by month for given project.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/budgets/time-spents\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/budgets/time-spents\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/projects/{project_id}/shots": {
+      "get": {
+        "summary": "Get project shots",
+        "description": "Get shots for a project. May limit to assigned shots for vendor users.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/shots\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/shots\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Create project shot",
+        "description": "Create a shot in a project. Provide name and optional fields like description, sequence_id and nb_frames.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/shots\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"SH010\",\n  \"description\": \"A short description of the shot\",\n  \"sequence_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n  \"nb_frames\": 24\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/shots\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"SH010\",\n    \"description\": \"A short description of the shot\",\n    \"sequence_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"nb_frames\": 24\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/projects/{project_id}/scenes": {
+      "get": {
+        "summary": "Get project scenes",
+        "description": "Get all scenes for a project.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/scenes\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/scenes\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Create project scene",
+        "description": "Create a new scene in a project. Provide a name and the related sequence id.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/scenes\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"Name of scene\",\n  \"sequence_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/scenes\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"Name of scene\",\n    \"sequence_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\"\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/projects/{project_id}/sequences": {
+      "get": {
+        "summary": "Get project sequences",
+        "description": "Get sequences for a project. May limit to assigned items for vendor users.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/sequences\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/sequences\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Create project sequence",
+        "description": "Create a sequence in a project. Provide name and optional episode_id.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/sequences\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"SQ01\",\n  \"episode_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/sequences\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"SQ01\",\n    \"episode_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\"\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/projects/{project_id}/episodes": {
+      "get": {
+        "summary": "Get project episodes",
+        "description": "Get episodes for a project. May limit to assigned items for vendor users.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/episodes\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/episodes\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Create project episode",
+        "description": "Create an episode in a project. Provide name and description. Status is optional.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/episodes\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"EP01\",\n  \"description\": \"A short description of the episode\",\n  \"status\": \"running\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/episodes\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"EP01\",\n    \"description\": \"A short description of the episode\",\n    \"status\": \"running\"\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/projects/{project_id}/episodes/stats": {
+      "get": {
+        "summary": "Get episode stats",
+        "description": "Return number of tasks by status, task type and episode for the project.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/episodes/stats\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/episodes/stats\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/projects/{project_id}/episodes/retake-stats": {
+      "get": {
+        "summary": "Get episode retake stats",
+        "description": "Return retake and done counts by task type and episode. Includes evolution data and max retake count.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/episodes/retake-stats\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/episodes/retake-stats\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/projects/{project_id}/quotas/{task_type_id}": {
+      "get": {
+        "summary": "Get project quotas",
+        "description": "Get quotas statistics for a project and task type. Supports weighted and raw modes with optional feedback filtering.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/quotas/a24a6ea4-ce75-4665-a070-57453082c25?count_mode=weighted&studio_id=a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/quotas/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"count_mode\": \"weighted\",\n    \"studio_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\"\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/projects/{project_id}/quotas/persons/{person_id}": {
+      "get": {
+        "summary": "Get project person quotas",
+        "description": "Get quotas statistics for a person in a project. Supports weighted and raw modes with optional feedback filtering.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/quotas/persons/a24a6ea4-ce75-4665-a070-57453082c25?count_mode=weighted&studio_id=a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/quotas/persons/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"count_mode\": \"weighted\",\n    \"studio_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\"\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/actions/projects/{project_id}/task-types/{task_type_id}/set-shot-nb-frames": {
+      "post": {
+        "summary": "Set shots frames",
+        "description": "Set number of frames on shots based on latest preview files for a task type. Optionally scope by episode via query param.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/actions/projects/{project_id}/task-types/{task_type_id}/set-shot-nb-frames\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"shots\": [\n    {\n      \"shot_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n      \"nb_frames\": 24\n    }\n  ]\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/actions/projects/{project_id}/task-types/{task_type_id}/set-shot-nb-frames\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"shots\": [\n        {\n            \"shot_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n            \"nb_frames\": 24\n        }\n    ]\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/projects/{project_id}/comments": {
+      "get": {
+        "summary": "Get project comments",
+        "description": "Retrieve comments for tasks related to a project. Useful for sync.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/comments?limit=100\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/comments\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"limit\": 100\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/projects/{project_id}/notifications": {
+      "get": {
+        "summary": "Get project notifications",
+        "description": "Retrieve notifications for tasks related to a project. Useful for sync.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/notifications\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/notifications\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/projects/{project_id}/preview-files": {
+      "get": {
+        "summary": "Get project preview files",
+        "description": "Retrieve all preview files that are linked to a specific project. This includes images, videos, and other preview media associated with the project.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/preview-files\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/preview-files\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/projects/{project_id}/subscriptions": {
+      "get": {
+        "summary": "Get project subscriptions",
+        "description": "Retrieve all subscriptions to tasks related to a project. Useful for sync.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/subscriptions\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/subscriptions\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/projects/{project_id}/tasks": {
+      "get": {
+        "summary": "Get project tasks",
+        "description": "Retrieve tasks related to a project. Useful for sync.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/tasks?page=1&task_type_id=a24a6ea4-ce75-4665-a070-57453082c25&episode_id=a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/tasks\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"page\": 1,\n    \"task_type_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"episode_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\"\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/actions/projects/{project_id}/task-types/{task_type_id}/delete-tasks": {
+      "delete": {
+        "summary": "Delete tasks for type",
+        "description": "Delete all tasks for a task type in a project. Useful when tasks were created by mistake at project start.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/actions/projects/a24a6ea4-ce75-4665-a070-57453082c25/task-types/a24a6ea4-ce75-4665-a070-57453082c25/delete-tasks\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/actions/projects/a24a6ea4-ce75-4665-a070-57453082c25/task-types/a24a6ea4-ce75-4665-a070-57453082c25/delete-tasks\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/actions/projects/{project_id}/delete-tasks": {
+      "post": {
+        "summary": "Delete tasks batch",
+        "description": "Delete tasks given by id list. Useful for batch deletions.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/actions/projects/a24a6ea4-ce75-4665-a070-57453082c25/delete-tasks\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/actions/projects/a24a6ea4-ce75-4665-a070-57453082c25/delete-tasks\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/actions/projects/{project_id}/task-types/{task_type_id}/shots/create-tasks": {
+      "post": {
+        "summary": "Create shot tasks",
+        "description": "Create tasks for shots. Provide a list of shot IDs in the JSON body, or omit for all shots in the project.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/actions/projects/a24a6ea4-ce75-4665-a070-57453082c25/task-types/a24a6ea4-ce75-4665-a070-57453082c25/shots/create-tasks\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '[\n  \"\"\n]'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/actions/projects/a24a6ea4-ce75-4665-a070-57453082c25/task-types/a24a6ea4-ce75-4665-a070-57453082c25/shots/create-tasks\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = [\n    \"\"\n]\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/actions/projects/{project_id}/task-types/{task_type_id}/assets/create-tasks": {
+      "post": {
+        "summary": "Create asset tasks",
+        "description": "Create tasks for assets. Provide a list of asset IDs in the JSON body, or omit for all assets in the project.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/actions/projects/a24a6ea4-ce75-4665-a070-57453082c25/task-types/a24a6ea4-ce75-4665-a070-57453082c25/assets/create-tasks\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '[\n  \"\"\n]'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/actions/projects/a24a6ea4-ce75-4665-a070-57453082c25/task-types/a24a6ea4-ce75-4665-a070-57453082c25/assets/create-tasks\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = [\n    \"\"\n]\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/actions/projects/{project_id}/task-types/{task_type_id}/edits/create-tasks": {
+      "post": {
+        "summary": "Create edit tasks",
+        "description": "Create tasks for edits. Provide a list of edit IDs in the JSON body, or omit for all edits in the project.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/actions/projects/a24a6ea4-ce75-4665-a070-57453082c25/task-types/a24a6ea4-ce75-4665-a070-57453082c25/edits/create-tasks\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '[\n  \"\"\n]'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/actions/projects/a24a6ea4-ce75-4665-a070-57453082c25/task-types/a24a6ea4-ce75-4665-a070-57453082c25/edits/create-tasks\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = [\n    \"\"\n]\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/actions/projects/{project_id}/task-types/{task_type_id}/concepts/create-tasks": {
+      "post": {
+        "summary": "Create concept tasks",
+        "description": "Create tasks for concepts. Provide a list of concept IDs in the JSON body, or omit for all concepts in the project.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/actions/projects/a24a6ea4-ce75-4665-a070-57453082c25/task-types/a24a6ea4-ce75-4665-a070-57453082c25/concepts/create-tasks\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '[\n  \"\"\n]'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/actions/projects/a24a6ea4-ce75-4665-a070-57453082c25/task-types/a24a6ea4-ce75-4665-a070-57453082c25/concepts/create-tasks\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = [\n    \"\"\n]\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/actions/projects/{project_id}/task-types/{task_type_id}/create-tasks/{entity_type}/": {
+      "post": {
+        "summary": "Create entity tasks",
+        "description": "Create tasks for entities of a given type. Provide entity IDs in the JSON body, or omit for all entities in the project.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/actions/projects/a24a6ea4-ce75-4665-a070-57453082c25/task-types/a24a6ea4-ce75-4665-a070-57453082c25/create-tasks/Asset/\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '[\n  \"\"\n]'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/actions/projects/a24a6ea4-ce75-4665-a070-57453082c25/task-types/a24a6ea4-ce75-4665-a070-57453082c25/create-tasks/Asset/\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = [\n    \"\"\n]\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/projects/{project_id}/edits": {
+      "get": {
+        "summary": "Get project edits",
+        "description": "Retrieve all edits that are related to a specific project.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/edits\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/edits\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Create edit",
+        "description": "Create a new edit for a specific project with name, description, and optional episode association.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/edits\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"Opening Sequence\",\n  \"description\": \"Main opening sequence edit\",\n  \"data\": {\n    \"duration\": 120,\n    \"fps\": 24\n  },\n  \"episode_id\": \"b35b7fb5-df86-5776-b181-68564193d36\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/edits\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"Opening Sequence\",\n    \"description\": \"Main opening sequence edit\",\n    \"data\": {\n        \"duration\": 120,\n        \"fps\": 24\n    },\n    \"episode_id\": \"b35b7fb5-df86-5776-b181-68564193d36\"\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/projects/{project_id}/concepts": {
+      "get": {
+        "summary": "Get project concepts",
+        "description": "Retrieve all concepts that are related to a specific project.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/concepts\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/concepts\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Create concept",
+        "description": "Create a new concept for a specific project with name, description, and optional entity concept links.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/concepts\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"Character Design\",\n  \"description\": \"Main character concept art\",\n  \"data\": {\n    \"style\": \"realistic\",\n    \"mood\": \"heroic\"\n  },\n  \"entity_concept_links\": [\n    \"b35b7fb5-df86-5776-b181-68564193d36\",\n    \"c46c8gc6-eg97-6887-c292-79675204e47\"\n  ]\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/projects/a24a6ea4-ce75-4665-a070-57453082c25/concepts\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"Character Design\",\n    \"description\": \"Main character concept art\",\n    \"data\": {\n        \"style\": \"realistic\",\n        \"mood\": \"heroic\"\n    },\n    \"entity_concept_links\": [\n        \"b35b7fb5-df86-5776-b181-68564193d36\",\n        \"c46c8gc6-eg97-6887-c292-79675204e47\"\n    ]\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/salary-scales": {
+      "get": {
+        "summary": "Get salary scales",
+        "description": "Retrieve all salary scale entries. Automatically creates missing combinations of department, position, and seniority.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/salary-scales\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/salary-scales\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Create model",
+        "description": "Create a new model instance with data provided in the request body. JSON format is expected. The model performs validation automatically when instantiated.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/salary-scales\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"Model Name\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/salary-scales\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"Model Name\"\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/salary-scales/{instance_id}": {
+      "delete": {
+        "summary": "Delete salary scale",
+        "description": "Delete a salary scale by its ID. Returns empty response on success.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/data/salary-scales/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/salary-scales/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "get": {
+        "summary": "Get salary scale",
+        "description": "Retrieve a salary scale by its ID and return it as a JSON object. Supports including relations.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/salary-scales/a24a6ea4-ce75-4665-a070-57453082c25?relations=true\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/salary-scales/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"relations\": true\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "put": {
+        "summary": "Update salary scale",
+        "description": "Update a salary scale with data provided in the request body. JSON format is expected. Department ID cannot be changed.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X PUT \"http://api.example.com/data/salary-scales/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"rate\": 55\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/salary-scales/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"rate\": 55\n}\n\nresponse = requests.put(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/scenes/{scene_id}/asset-instances": {
+      "get": {
+        "summary": "Get scene asset instances",
+        "description": "Retrieve all asset instances that are linked to a specific scene.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/scenes/i02i4mi2-km53-2443-i958-35231870k03/asset-instances\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/scenes/i02i4mi2-km53-2443-i958-35231870k03/asset-instances\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Create scene asset instance",
+        "description": "Create an asset instance on a specific scene.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/scenes/i02i4mi2-km53-2443-i958-35231870k03/asset-instances\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"asset_id\": \"c46c8gc6-eg97-6887-c292-79675204e47\",\n  \"description\": \"Main character instance\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/scenes/i02i4mi2-km53-2443-i958-35231870k03/asset-instances\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"asset_id\": \"c46c8gc6-eg97-6887-c292-79675204e47\",\n    \"description\": \"Main character instance\"\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/scenes/{scene_id}/camera-instances": {
+      "get": {
+        "summary": "Get scene camera instances",
+        "description": "Retrieve all camera instances that are linked to a specific scene.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/scenes/i02i4mi2-km53-2443-i958-35231870k03/camera-instances\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/scenes/i02i4mi2-km53-2443-i958-35231870k03/camera-instances\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/scenes/all": {
+      "get": {
+        "summary": "Get scenes",
+        "description": "Get scenes with optional filters. Use project_id to filter by project.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/scenes/all?project_id=a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/scenes/all\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"project_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\"\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/scenes/with-tasks": {
+      "get": {
+        "summary": "Get scenes and tasks",
+        "description": "Get scenes and their related tasks. Optionally filter by project.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/scenes/with-tasks?project_id=a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/scenes/with-tasks\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"project_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\"\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/scenes/{scene_id}": {
+      "delete": {
+        "summary": "Delete scene",
+        "description": "Delete a scene by id. Requires manager access or ownership.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/data/scenes/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/scenes/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "get": {
+        "summary": "Get scene",
+        "description": "Get a scene by id. Returns full scene data needed by clients.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/scenes/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/scenes/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/scenes/{scene_id}/tasks": {
+      "get": {
+        "summary": "Get scene tasks",
+        "description": "Get tasks for a scene.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/scenes/a24a6ea4-ce75-4665-a070-57453082c25/tasks\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/scenes/a24a6ea4-ce75-4665-a070-57453082c25/tasks\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/scenes/{scene_id}/task-types": {
+      "get": {
+        "summary": "Get scene task types",
+        "description": "Get task types for a scene.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/scenes/a24a6ea4-ce75-4665-a070-57453082c25/task-types\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/scenes/a24a6ea4-ce75-4665-a070-57453082c25/task-types\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/scenes/{scene_id}/shots": {
+      "get": {
+        "summary": "Get scene shots",
+        "description": "Get shots that come from a scene.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/scenes/a24a6ea4-ce75-4665-a070-57453082c25/shots\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/scenes/a24a6ea4-ce75-4665-a070-57453082c25/shots\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Link shot to scene",
+        "description": "Link a shot to a scene as its source.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/scenes/a24a6ea4-ce75-4665-a070-57453082c25/shots\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"shot_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/scenes/a24a6ea4-ce75-4665-a070-57453082c25/shots\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"shot_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\"\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/scenes/{scene_id}/shots/{shot_id}": {
+      "delete": {
+        "summary": "Delete given shot from given scene.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/data/scenes/a24a6ea4-ce75-4665-a070-57453082c25/shots/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/scenes/a24a6ea4-ce75-4665-a070-57453082c25/shots/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/schedule-items/": {
+      "get": {
+        "summary": "Get schedule items",
+        "description": "Retrieve all schedule items. Supports filtering via query parameters and pagination.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/schedule-items/?page=1&limit=50&relations=false\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/schedule-items/\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"page\": 1,\n    \"limit\": 50,\n    \"relations\": false\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Create schedule item",
+        "description": "Create a new schedule item with data provided in the request body. JSON format is expected. Similar schedule items cannot exist with same project, task type, and object.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/schedule-items/\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"project_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n  \"task_type_id\": \"b24a6ea4-ce75-4665-a070-57453082c25\",\n  \"object_id\": \"c24a6ea4-ce75-4665-a070-57453082c25\",\n  \"man_days\": 10.5\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/schedule-items/\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"project_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"task_type_id\": \"b24a6ea4-ce75-4665-a070-57453082c25\",\n    \"object_id\": \"c24a6ea4-ce75-4665-a070-57453082c25\",\n    \"man_days\": 10.5\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/schedule-items/{instance_id}": {
+      "delete": {
+        "summary": "Delete schedule item",
+        "description": "Delete a schedule item by its ID. Returns empty response on success.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/data/schedule-items/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/schedule-items/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "get": {
+        "summary": "Get schedule item",
+        "description": "Retrieve a schedule item by its ID and return it as a JSON object. Supports including relations.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/schedule-items/a24a6ea4-ce75-4665-a070-57453082c25?relations=true\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/schedule-items/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"relations\": true\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "put": {
+        "summary": "Update schedule item",
+        "description": "Update a schedule item with data provided in the request body. JSON format is expected. Requires supervisor access to project and task type.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X PUT \"http://api.example.com/data/schedule-items/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"man_days\": 12\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/schedule-items/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"man_days\": 12\n}\n\nresponse = requests.put(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/search": {
+      "post": {
+        "summary": "Search entities",
+        "description": "Search across indexes for persons, assets and shots. Use optional filters to limit results to a project and specific indexes. Results are paginated with limit and offset.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/search\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"query\": \"kitsu\",\n  \"project_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n  \"limit\": 3,\n  \"offset\": 0,\n  \"index_names\": [\n    \"assets\"\n  ]\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/search\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"query\": \"kitsu\",\n    \"project_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"limit\": 3,\n    \"offset\": 0,\n    \"index_names\": [\n        \"assets\"\n    ]\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/search-filter-groups/": {
+      "get": {
+        "summary": "Get search filter groups",
+        "description": "Retrieve all search filter groups. Supports filtering via query parameters and pagination.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/search-filter-groups/?page=1&limit=50&relations=false\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/search-filter-groups/\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"page\": 1,\n    \"limit\": 50,\n    \"relations\": false\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Create search filter group",
+        "description": "Create a new search filter group with data provided in the request body. JSON format is expected.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/search-filter-groups/\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"My Filter Group\",\n  \"person_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/search-filter-groups/\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"My Filter Group\",\n    \"person_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\"\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/search-filter-groups/{instance_id}": {
+      "delete": {
+        "summary": "Delete search filter group",
+        "description": "Delete a search filter group by its ID. Returns empty response on success.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/data/search-filter-groups/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/search-filter-groups/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "get": {
+        "summary": "Get search filter group",
+        "description": "Retrieve a search filter group by its ID and return it as a JSON object. Supports including relations.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/search-filter-groups/a24a6ea4-ce75-4665-a070-57453082c25?relations=true\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/search-filter-groups/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"relations\": true\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "put": {
+        "summary": "Update search filter group",
+        "description": "Update a search filter group with data provided in the request body. JSON format is expected.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X PUT \"http://api.example.com/data/search-filter-groups/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"Updated Filter Group Name\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/search-filter-groups/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"Updated Filter Group Name\"\n}\n\nresponse = requests.put(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/search-filters/": {
+      "get": {
+        "summary": "Get search filters",
+        "description": "Retrieve all search filters. Supports filtering via query parameters and pagination.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/search-filters/?page=1&limit=50&relations=false\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/search-filters/\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"page\": 1,\n    \"limit\": 50,\n    \"relations\": false\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Create search filter",
+        "description": "Create a new search filter with data provided in the request body. JSON format is expected.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/search-filters/\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"My Filter\",\n  \"person_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n  \"search_filter_group_id\": \"b24a6ea4-ce75-4665-a070-57453082c25\",\n  \"list_type\": \"assets\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/search-filters/\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"My Filter\",\n    \"person_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"search_filter_group_id\": \"b24a6ea4-ce75-4665-a070-57453082c25\",\n    \"list_type\": \"assets\"\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/search-filters/{instance_id}": {
+      "delete": {
+        "summary": "Delete search filter",
+        "description": "Delete a search filter by its ID. Returns empty response on success.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/data/search-filters/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/search-filters/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "get": {
+        "summary": "Get search filter",
+        "description": "Retrieve a search filter by its ID and return it as a JSON object. Supports including relations.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/search-filters/a24a6ea4-ce75-4665-a070-57453082c25?relations=true\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/search-filters/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"relations\": true\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "put": {
+        "summary": "Update search filter",
+        "description": "Update a search filter with data provided in the request body. JSON format is expected.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X PUT \"http://api.example.com/data/search-filters/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"Updated Filter Name\",\n  \"list_type\": \"shots\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/search-filters/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"Updated Filter Name\",\n    \"list_type\": \"shots\"\n}\n\nresponse = requests.put(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/sequences": {
+      "get": {
+        "summary": "Get sequences",
+        "description": "Get sequences with optional filters. Use episode_id to filter by episode.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/sequences?episode_id=a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/sequences\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"episode_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\"\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/sequences/with-tasks": {
+      "get": {
+        "summary": "Get sequences and tasks",
+        "description": "Get sequences and their related tasks. Optionally filter by project.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/sequences/with-tasks?project_id=a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/sequences/with-tasks\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"project_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\"\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/sequences/{sequence_id}": {
+      "delete": {
+        "summary": "Delete sequence",
+        "description": "Delete a sequence by id. Requires manager access or ownership.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/data/sequences/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/sequences/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "get": {
+        "summary": "Get sequence",
+        "description": "Get a sequence by id.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/sequences/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/sequences/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/sequences/{sequence_id}/shots": {
+      "get": {
+        "summary": "Get sequence shots",
+        "description": "Get shots for a sequence. Supports filtering using query params.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/sequences/a24a6ea4-ce75-4665-a070-57453082c25/shots?project_id=a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/sequences/a24a6ea4-ce75-4665-a070-57453082c25/shots\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"project_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\"\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/sequences/{sequence_id}/scenes": {
+      "get": {
+        "summary": "Get sequence scenes",
+        "description": "Get scenes that belong to a sequence.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/sequences/a24a6ea4-ce75-4665-a070-57453082c25/scenes\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/sequences/a24a6ea4-ce75-4665-a070-57453082c25/scenes\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/sequences/{sequence_id}/tasks": {
+      "get": {
+        "summary": "Get sequence tasks",
+        "description": "Get tasks for a sequence. Optionally include relations using query params.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/sequences/a24a6ea4-ce75-4665-a070-57453082c25/tasks\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/sequences/a24a6ea4-ce75-4665-a070-57453082c25/tasks\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/sequences/{sequence_id}/task-types": {
+      "get": {
+        "summary": "Get sequence task types",
+        "description": "Get task types for a sequence.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/sequences/a24a6ea4-ce75-4665-a070-57453082c25/task-types\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/sequences/a24a6ea4-ce75-4665-a070-57453082c25/task-types\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/sequences/{sequence_id}/shot-tasks": {
+      "get": {
+        "summary": "Get sequence shot tasks",
+        "description": "Get shot tasks for a sequence. Restricted for vendor permissions.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/sequences/a24a6ea4-ce75-4665-a070-57453082c25/shot-tasks\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/sequences/a24a6ea4-ce75-4665-a070-57453082c25/shot-tasks\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/shots/{shot_id}/asset-types": {
+      "get": {
+        "summary": "Get shot asset types",
+        "description": "Retrieve all asset types of assets that are casted in a specific shot",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/shots/a24a6ea4-ce75-4665-a070-57453082c25/asset-types\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/shots/a24a6ea4-ce75-4665-a070-57453082c25/asset-types\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/shots/{shot_id}/asset-instances": {
+      "get": {
+        "summary": "Get shot asset instances",
+        "description": "Retrieve all asset instances that are linked to a specific shot.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/shots/e68e0ie8-gi19-8009-e514-91897426g69/asset-instances\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/shots/e68e0ie8-gi19-8009-e514-91897426g69/asset-instances\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Add shot asset instance",
+        "description": "Add an asset instance to a specific shot.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/shots/e68e0ie8-gi19-8009-e514-91897426g69/asset-instances\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"asset_instance_id\": \"h91h3lh1-jl42-1332-h847-24120759j92\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/shots/e68e0ie8-gi19-8009-e514-91897426g69/asset-instances\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"asset_instance_id\": \"h91h3lh1-jl42-1332-h847-24120759j92\"\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/shots/{shot_id}/asset-instances/{asset_instance_id}": {
+      "delete": {
+        "summary": "Remove shot asset instance",
+        "description": "Remove an asset instance from a specific shot.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/data/shots/e68e0ie8-gi19-8009-e514-91897426g69/asset-instances/h91h3lh1-jl42-1332-h847-24120759j92\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/shots/e68e0ie8-gi19-8009-e514-91897426g69/asset-instances/h91h3lh1-jl42-1332-h847-24120759j92\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/shots": {
+      "get": {
+        "summary": "Get all shots",
+        "description": "Get all shots across projects with optional filters. Use sequence_id, project_id, or parent_id to filter.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/shots?sequence_id=a24a6ea4-ce75-4665-a070-57453082c25&project_id=a24a6ea4-ce75-4665-a070-57453082c25&parent_id=a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/shots\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"sequence_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"project_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"parent_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\"\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/shots/all": {
+      "get": {
+        "summary": "Get shots",
+        "description": "Get shots with optional filters. Use query params like project_id, sequence_id or parent_id to filter results.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/shots/all?sequence_id=a24a6ea4-ce75-4665-a070-57453082c25&project_id=a24a6ea4-ce75-4665-a070-57453082c25&parent_id=a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/shots/all\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"sequence_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"project_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"parent_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\"\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/shots/with-tasks": {
+      "get": {
+        "summary": "Get shots and tasks",
+        "description": "Get shots and their related tasks. Optionally filter by project.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/shots/with-tasks?project_id=a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/shots/with-tasks\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"project_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\"\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/shots/{shot_id}": {
+      "delete": {
+        "summary": "Delete shot",
+        "description": "Delete a shot by id. Requires manager access or ownership of the shot.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/data/shots/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/shots/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "get": {
+        "summary": "Get shot",
+        "description": "Get a shot by id. Returns full shot data. Use this to fetch a single shot with all fields needed by the UI.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/shots/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/shots/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "put": {
+        "summary": "Update shot",
+        "description": "Update a shot by id. Only mutable fields are allowed. Send a JSON body with the fields to change.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X PUT \"http://api.example.com/data/shots/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"SH010 new name\",\n  \"description\": \"Update description for the shot\",\n  \"nb_frames\": 24,\n  \"data\": {\n    \"camera\": \"camA\",\n    \"cut_in\": 1001\n  }\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/shots/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"SH010 new name\",\n    \"description\": \"Update description for the shot\",\n    \"nb_frames\": 24,\n    \"data\": {\n        \"camera\": \"camA\",\n        \"cut_in\": 1001\n    }\n}\n\nresponse = requests.put(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/shots/{shot_id}/assets": {
+      "get": {
+        "summary": "Get shot assets",
+        "description": "Get assets linked to a shot. Returns the breakdown casting for the shot.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/shots/a24a6ea4-ce75-4665-a070-57453082c25/assets\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/shots/a24a6ea4-ce75-4665-a070-57453082c25/assets\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/shots/{shot_id}/task-types": {
+      "get": {
+        "summary": "Get shot task types",
+        "description": "Get task types for a shot.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/shots/a24a6ea4-ce75-4665-a070-57453082c25/task-types\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/shots/a24a6ea4-ce75-4665-a070-57453082c25/task-types\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/shots/{shot_id}/tasks": {
+      "get": {
+        "summary": "Get shot tasks",
+        "description": "Get tasks for a shot. Optionally include relations using query params.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/shots/a24a6ea4-ce75-4665-a070-57453082c25/tasks\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/shots/a24a6ea4-ce75-4665-a070-57453082c25/tasks\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/shots/{shot_id}/preview-files": {
+      "get": {
+        "summary": "Get shot previews",
+        "description": "Return previews for a shot as a dict keyed by task type id. Each value is an array of previews for that task type.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/shots/a24a6ea4-ce75-4665-a070-57453082c25/preview-files\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/shots/a24a6ea4-ce75-4665-a070-57453082c25/preview-files\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/shots/{shot_id}/versions": {
+      "get": {
+        "summary": "Get shot versions",
+        "description": "Get data versions of a shot. Use this to inspect version history.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/shots/a24a6ea4-ce75-4665-a070-57453082c25/versions\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/shots/a24a6ea4-ce75-4665-a070-57453082c25/versions\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/softwares": {
+      "get": {
+        "summary": "Get models",
+        "description": "Retrieve all entries for the given model. Supports filtering via query parameters and pagination.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/softwares?page=1&limit=50&relations=false\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/softwares\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"page\": 1,\n    \"limit\": 50,\n    \"relations\": false\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Create model",
+        "description": "Create a new model instance with data provided in the request body. JSON format is expected. The model performs validation automatically when instantiated.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/softwares\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"Model Name\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/softwares\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"Model Name\"\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/softwares/{instance_id}": {
+      "delete": {
+        "summary": "Delete model",
+        "description": "Delete a model instance by its ID. Returns empty response on success.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/data/softwares/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/softwares/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "get": {
+        "summary": "Get software",
+        "description": "Retrieve a software instance by its ID and return it as a JSON object.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/softwares/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/softwares/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "put": {
+        "summary": "Update model",
+        "description": "Update a model instance with data provided in the request body. JSON format is expected. Model performs validation automatically when fields are modified.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X PUT \"http://api.example.com/data/softwares/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"Updated Model Name\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/softwares/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"Updated Model Name\"\n}\n\nresponse = requests.put(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/stats": {
+      "get": {
+        "summary": "Get usage stats",
+        "description": "Get the amount of projects, assets, shots, tasks, and persons.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/stats\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/stats\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/status": {
+      "get": {
+        "summary": "Get status of the API services",
+        "description": " ",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/status\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/status\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/status/influx": {
+      "get": {
+        "summary": "Get status of the API services for InfluxDB",
+        "description": "Get status of the database, key value store, event stream, job queue, indexer as a JSON object.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/status/influx\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/status/influx\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/status/resources": {
+      "get": {
+        "summary": "Get resource usage stats",
+        "description": "Get CPU usage for each core, memory repartition and number of jobs in the job queue.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/status/resources\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/status/resources\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/status/test-event": {
+      "get": {
+        "summary": "Generate a test event",
+        "description": "Generate a `main:test` event to test the event stream with the Python client or similar.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/status/test-event\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/status/test-event\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/status-automations/": {
+      "get": {
+        "summary": "Get status automations",
+        "description": "Retrieve all status automations. Supports filtering via query parameters and pagination. Vendor access is blocked.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/status-automations/?page=1&limit=50&relations=false\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/status-automations/\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"page\": 1,\n    \"limit\": 50,\n    \"relations\": false\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Create status automation",
+        "description": "Create a new status automation with data provided in the request body. JSON format is expected.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/status-automations/\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"source_task_status_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n  \"target_task_status_id\": \"b24a6ea4-ce75-4665-a070-57453082c25\",\n  \"field_name\": \"ready_for\",\n  \"field_value\": \"production\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/status-automations/\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"source_task_status_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"target_task_status_id\": \"b24a6ea4-ce75-4665-a070-57453082c25\",\n    \"field_name\": \"ready_for\",\n    \"field_value\": \"production\"\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/status-automations/{instance_id}": {
+      "delete": {
+        "summary": "Delete status automation",
+        "description": "Delete a status automation by its ID. Returns empty response on success. Cannot delete if automation is used in a project.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/data/status-automations/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/status-automations/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "get": {
+        "summary": "Get status automation",
+        "description": "Retrieve a status automation by its ID and return it as a JSON object. Supports including relations.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/status-automations/a24a6ea4-ce75-4665-a070-57453082c25?relations=true\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/status-automations/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"relations\": true\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "put": {
+        "summary": "Update status automation",
+        "description": "Update a status automation with data provided in the request body. JSON format is expected.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X PUT \"http://api.example.com/data/status-automations/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"field_name\": \"ready_for\",\n  \"field_value\": \"approved\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/status-automations/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"field_name\": \"ready_for\",\n    \"field_value\": \"approved\"\n}\n\nresponse = requests.put(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/status.txt": {
+      "get": {
+        "summary": "Get status of the API services as text",
+        "description": "Get status of the database, key value store, event stream, job queue, the indexer as a text.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/status.txt\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/status.txt\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/studios": {
+      "get": {
+        "summary": "Get studios",
+        "description": "Retrieve all studios. Supports filtering via query parameters and pagination.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/studios?page=1&limit=50&relations=false\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/studios\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"page\": 1,\n    \"limit\": 50,\n    \"relations\": false\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Create studio",
+        "description": "Create a new studio with data provided in the request body. JSON format is expected.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/studios\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"Studio Name\",\n  \"hours_by_day\": 8\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/studios\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"Studio Name\",\n    \"hours_by_day\": 8\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/studios/{instance_id}": {
+      "delete": {
+        "summary": "Delete studio",
+        "description": "Delete a studio by its ID. Returns empty response on success.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/data/studios/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/studios/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "get": {
+        "summary": "Get studio",
+        "description": "Retrieve a studio by its ID and return it as a JSON object. Supports including relations.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/studios/a24a6ea4-ce75-4665-a070-57453082c25?relations=true\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/studios/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"relations\": true\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "put": {
+        "summary": "Update studio",
+        "description": "Update a studio with data provided in the request body. JSON format is expected.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X PUT \"http://api.example.com/data/studios/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"Updated Studio Name\",\n  \"hours_by_day\": 7.5\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/studios/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"Updated Studio Name\",\n    \"hours_by_day\": 7.5\n}\n\nresponse = requests.put(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/subscriptions/": {
+      "get": {
+        "summary": "Get subscriptions",
+        "description": "Retrieve all subscriptions. Supports filtering via query parameters and pagination.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/subscriptions/?page=1&limit=50&relations=false\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/subscriptions/\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"page\": 1,\n    \"limit\": 50,\n    \"relations\": false\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Create subscription",
+        "description": "Create a new subscription with data provided in the request body. JSON format is expected.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/subscriptions/\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"person_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n  \"entity_id\": \"b24a6ea4-ce75-4665-a070-57453082c25\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/subscriptions/\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"person_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"entity_id\": \"b24a6ea4-ce75-4665-a070-57453082c25\"\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/subscriptions/{instance_id}": {
+      "delete": {
+        "summary": "Delete subscription",
+        "description": "Delete a subscription by its ID. Returns empty response on success.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/data/subscriptions/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/subscriptions/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "get": {
+        "summary": "Get subscription",
+        "description": "Retrieve a subscription by its ID and return it as a JSON object. Supports including relations.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/subscriptions/a24a6ea4-ce75-4665-a070-57453082c25?relations=true\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/subscriptions/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"relations\": true\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "put": {
+        "summary": "Update subscription",
+        "description": "Update a subscription with data provided in the request body. JSON format is expected.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X PUT \"http://api.example.com/data/subscriptions/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"person_id\": \"b24a6ea4-ce75-4665-a070-57453082c25\",\n  \"entity_id\": \"c24a6ea4-ce75-4665-a070-57453082c25\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/subscriptions/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"person_id\": \"b24a6ea4-ce75-4665-a070-57453082c25\",\n    \"entity_id\": \"c24a6ea4-ce75-4665-a070-57453082c25\"\n}\n\nresponse = requests.put(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/task-status": {
+      "get": {
+        "summary": "Get task statuses",
+        "description": "Retrieve all task statuses. Supports filtering via query parameters and pagination.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/task-status?page=1&limit=50&relations=false\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/task-status\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"page\": 1,\n    \"limit\": 50,\n    \"relations\": false\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Create task status",
+        "description": "Create a new task status with data provided in the request body. JSON format is expected. If is_default is true, sets all other statuses to non-default.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/task-status\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"To Do\",\n  \"short_name\": \"TODO\",\n  \"color\": \"#FF5733\",\n  \"is_default\": false\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/task-status\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"To Do\",\n    \"short_name\": \"TODO\",\n    \"color\": \"#FF5733\",\n    \"is_default\": false\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/task-status/{instance_id}": {
+      "delete": {
+        "summary": "Delete task status",
+        "description": "Delete a task status by its ID. Returns empty response on success.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/data/task-status/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/task-status/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "get": {
+        "summary": "Get task status",
+        "description": "Retrieve a task status by its ID and return it as a JSON object. Supports including relations.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/task-status/a24a6ea4-ce75-4665-a070-57453082c25?relations=true\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/task-status/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"relations\": true\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "put": {
+        "summary": "Update task status",
+        "description": "Update a task status with data provided in the request body. JSON format is expected. If is_default is set to true, sets all other statuses to non-default.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X PUT \"http://api.example.com/data/task-status/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"In Progress\",\n  \"short_name\": \"WIP\",\n  \"color\": \"#00FF00\",\n  \"is_default\": true\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/task-status/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"In Progress\",\n    \"short_name\": \"WIP\",\n    \"color\": \"#00FF00\",\n    \"is_default\": true\n}\n\nresponse = requests.put(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/task-status-links": {
+      "post": {
+        "summary": "Create project task status link",
+        "description": "Create a link between a project and a task status. Sets the priority and roles that can view it on the board.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/task-status-links\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"project_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n  \"task_status_id\": \"b24a6ea4-ce75-4665-a070-57453082c25\",\n  \"priority\": 1,\n  \"roles_for_board\": [\n    \"admin\",\n    \"manager\"\n  ]\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/task-status-links\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"project_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"task_status_id\": \"b24a6ea4-ce75-4665-a070-57453082c25\",\n    \"priority\": 1,\n    \"roles_for_board\": [\n        \"admin\",\n        \"manager\"\n    ]\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/task-type-links": {
+      "post": {
+        "summary": "Create project task type link",
+        "description": "Create a link between a project and a task type. Sets the priority of the task type within the project.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/task-type-links\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"project_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n  \"task_type_id\": \"b24a6ea4-ce75-4665-a070-57453082c25\",\n  \"priority\": 1\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/task-type-links\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"project_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"task_type_id\": \"b24a6ea4-ce75-4665-a070-57453082c25\",\n    \"priority\": 1\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/task-types": {
+      "get": {
+        "summary": "Get task types",
+        "description": "Retrieve all task types. Supports filtering via query parameters and pagination.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/task-types?page=1&limit=50&relations=false\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/task-types\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"page\": 1,\n    \"limit\": 50,\n    \"relations\": false\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Create task type",
+        "description": "Create a new task type with data provided in the request body. JSON format is expected. Task type names must be unique.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/task-types\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"Animation\",\n  \"for_entity\": \"Shot\",\n  \"color\": \"#FF5733\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/task-types\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"Animation\",\n    \"for_entity\": \"Shot\",\n    \"color\": \"#FF5733\"\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/task-types/{instance_id}": {
+      "delete": {
+        "summary": "Delete task type",
+        "description": "Delete a task type by its ID. Returns empty response on success.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/data/task-types/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/task-types/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "get": {
+        "summary": "Get task type",
+        "description": "Retrieve a task type by its ID and return it as a JSON object. Supports including relations.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/task-types/a24a6ea4-ce75-4665-a070-57453082c25?relations=true\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/task-types/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"relations\": true\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "put": {
+        "summary": "Update task type",
+        "description": "Update a task type with data provided in the request body. JSON format is expected. Task type names must be unique.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X PUT \"http://api.example.com/data/task-types/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"Updated Animation\",\n  \"color\": \"#FF5734\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/task-types/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"Updated Animation\",\n    \"color\": \"#FF5734\"\n}\n\nresponse = requests.put(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/tasks/{task_id}/comments/{comment_id}/ack": {
+      "post": {
+        "summary": "Acknowledge comment",
+        "description": "Acknowledge a specific comment. If it's already acknowledged, remove the acknowledgement.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/tasks/a24a6ea4-ce75-4665-a070-57453082c25/comments/b35b7fb5-df86-5776-b181-68564193d36/ack\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/tasks/a24a6ea4-ce75-4665-a070-57453082c25/comments/b35b7fb5-df86-5776-b181-68564193d36/ack\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/tasks/{task_id}/comments/{comment_id}/reply": {
+      "post": {
+        "summary": "Reply to comment",
+        "description": "Add a reply to a specific comment. The reply will be added to the comment's replies list.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/tasks/a24a6ea4-ce75-4665-a070-57453082c25/comments/b35b7fb5-df86-5776-b181-68564193d36/reply\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/tasks/a24a6ea4-ce75-4665-a070-57453082c25/comments/b35b7fb5-df86-5776-b181-68564193d36/reply\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/tasks/{task_id}/comments/{comment_id}/attachments/{attachment_id}": {
+      "delete": {
+        "summary": "Delete comment attachment",
+        "description": "Delete a specific attachment file linked to a comment. Only the comment author or project managers can delete attachments.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/data/tasks/a24a6ea4-ce75-4665-a070-57453082c25/comments/b35b7fb5-df86-5776-b181-68564193d36/attachments/c46c8gc6-eg97-6887-c292-79675204e47\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/tasks/a24a6ea4-ce75-4665-a070-57453082c25/comments/b35b7fb5-df86-5776-b181-68564193d36/attachments/c46c8gc6-eg97-6887-c292-79675204e47\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/tasks/{task_id}/comments/{comment_id}/reply/{reply_id}": {
+      "delete": {
+        "summary": "Delete comment reply",
+        "description": "Delete a specific reply from a comment. Only the reply author or administrators can delete replies.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/data/tasks/a24a6ea4-ce75-4665-a070-57453082c25/comments/b35b7fb5-df86-5776-b181-68564193d36/reply/c46c8gc6-eg97-6887-c292-79675204e47\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/tasks/a24a6ea4-ce75-4665-a070-57453082c25/comments/b35b7fb5-df86-5776-b181-68564193d36/reply/c46c8gc6-eg97-6887-c292-79675204e47\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/actions/tasks/{task_id}/comments/{comment_id}/add-attachment": {
+      "post": {
+        "summary": "Add comment attachments",
+        "description": "Add one or more files as attachments to a specific comment. Supports various file types including images and documents.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/actions/tasks/a24a6ea4-ce75-4665-a070-57453082c25/comments/b35b7fb5-df86-5776-b181-68564193d36/add-attachment\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/actions/tasks/a24a6ea4-ce75-4665-a070-57453082c25/comments/b35b7fb5-df86-5776-b181-68564193d36/add-attachment\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/tasks/{task_id}/attachment-files": {
+      "get": {
+        "summary": "Get task attachment files",
+        "description": "Retrieve all attachment files related to a specific task. Requires administrator permissions.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/tasks/a24a6ea4-ce75-4665-a070-57453082c25/attachment-files\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/tasks/a24a6ea4-ce75-4665-a070-57453082c25/attachment-files\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/actions/tasks/{task_id}/comment": {
+      "post": {
+        "summary": "Create task comment",
+        "description": "Create a new comment for a specific task. It requires a text, a task_status and a person as arguments. This way, comments keep history of status changes. When the comment is created, it updates the task status with the given task status.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/actions/tasks/a24a6ea4-ce75-4665-a070-57453082c25/comment\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"task_status_id\": \"c46c8gc6-eg97-6887-c292-79675204e47\",\n  \"comment\": \"This looks great! Ready for review.\",\n  \"person_id\": \"d57d9hd7-fh08-7998-d403-80786315f58\",\n  \"created_at\": \"2023-01-01T12:00:00Z\",\n  \"checklist\": {\n    \"item1\": \"Check lighting\",\n    \"item2\": \"Verify textures\"\n  },\n  \"links\": [\n    \"https://example.com/reference1\",\n    \"https://example.com/reference2\"\n  ]\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/actions/tasks/a24a6ea4-ce75-4665-a070-57453082c25/comment\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"task_status_id\": \"c46c8gc6-eg97-6887-c292-79675204e47\",\n    \"comment\": \"This looks great! Ready for review.\",\n    \"person_id\": \"d57d9hd7-fh08-7998-d403-80786315f58\",\n    \"created_at\": \"2023-01-01T12:00:00Z\",\n    \"checklist\": {\n        \"item1\": \"Check lighting\",\n        \"item2\": \"Verify textures\"\n    },\n    \"links\": [\n        \"https://example.com/reference1\",\n        \"https://example.com/reference2\"\n    ]\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/tasks": {
+      "get": {
+        "summary": "Get tasks",
+        "description": "Retrieve all tasks. Supports filtering via query parameters and pagination. Includes project permission filtering for non-admin users. Vendor users only see assigned tasks.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/tasks?page=1&limit=50&relations=false&episode_id=a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/tasks\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"page\": 1,\n    \"limit\": 50,\n    \"relations\": false,\n    \"episode_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\"\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Create task",
+        "description": "Create a task with data provided in the request body. JSON format is expected. The task type must match the entity type.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/tasks\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"task_type_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n  \"entity_id\": \"b24a6ea4-ce75-4665-a070-57453082c25\",\n  \"assignees\": [\n    \"c24a6ea4-ce75-4665-a070-57453082c25\"\n  ]\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/tasks\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"task_type_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"entity_id\": \"b24a6ea4-ce75-4665-a070-57453082c25\",\n    \"assignees\": [\n        \"c24a6ea4-ce75-4665-a070-57453082c25\"\n    ]\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/tasks/{instance_id}": {
+      "delete": {
+        "summary": "Delete task",
+        "description": "Delete a task by its ID. Returns empty response on success. May require force flag if task has associated data.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/data/tasks/a24a6ea4-ce75-4665-a070-57453082c25?force=false\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/tasks/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"force\": false\n}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "get": {
+        "summary": "Get task",
+        "description": "Retrieve a task by its ID and return it as a JSON object. Supports including relations. Requires project and entity access.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/tasks/a24a6ea4-ce75-4665-a070-57453082c25?relations=true\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/tasks/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"relations\": true\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "put": {
+        "summary": "Update task",
+        "description": "Update a task with data provided in the request body. JSON format is expected. Requires supervisor access.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X PUT \"http://api.example.com/data/tasks/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"task_status_id\": \"b24a6ea4-ce75-4665-a070-57453082c25\",\n  \"assignees\": [\n    \"c24a6ea4-ce75-4665-a070-57453082c25\"\n  ],\n  \"duration\": 8.5\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/tasks/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"task_status_id\": \"b24a6ea4-ce75-4665-a070-57453082c25\",\n    \"assignees\": [\n        \"c24a6ea4-ce75-4665-a070-57453082c25\"\n    ],\n    \"duration\": 8.5\n}\n\nresponse = requests.put(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/tasks/{task_id}/working-files": {
+      "get": {
+        "summary": "Get task working files",
+        "description": "Retrieve all working file revisions for a given task. Returns complete list of working files with their revisions.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/tasks/a24a6ea4-ce75-4665-a070-57453082c25/working-files\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/tasks/a24a6ea4-ce75-4665-a070-57453082c25/working-files\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/tasks/{task_id}/working-files/new": {
+      "post": {
+        "summary": "Create new working file",
+        "description": "Create a new working file for a task. Working files are versioned files used by artists to produce output files. Each file requires a comment and generates a path based on file tree template.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/tasks/a24a6ea4-ce75-4665-a070-57453082c25/working-files/new\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"main\",\n  \"mode\": \"working\",\n  \"description\": \"Main character model\",\n  \"comment\": \"Updated lighting and materials\",\n  \"person_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n  \"software_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n  \"revision\": 1,\n  \"sep\": \"/\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/tasks/a24a6ea4-ce75-4665-a070-57453082c25/working-files/new\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"main\",\n    \"mode\": \"working\",\n    \"description\": \"Main character model\",\n    \"comment\": \"Updated lighting and materials\",\n    \"person_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"software_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"revision\": 1,\n    \"sep\": \"/\"\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/tasks/{task_id}/working-files/last-revisions": {
+      "get": {
+        "summary": "Get last working files",
+        "description": "Retrieve the last working file revisions for each file name for a given task. Returns the most recent version of each working file.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/tasks/a24a6ea4-ce75-4665-a070-57453082c25/working-files/last-revisions\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/tasks/a24a6ea4-ce75-4665-a070-57453082c25/working-files/last-revisions\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/tasks/{task_id}/working-file-path": {
+      "post": {
+        "summary": "Generate working file path",
+        "description": "Generate a working file path from file tree template based on task parameters. Revision can be computed automatically if not provided.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/tasks/a24a6ea4-ce75-4665-a070-57453082c25/working-file-path\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"main\",\n  \"mode\": \"working\",\n  \"software_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n  \"comment\": \"Updated lighting\",\n  \"revision\": 1,\n  \"separator\": \"/\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/tasks/a24a6ea4-ce75-4665-a070-57453082c25/working-file-path\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"main\",\n    \"mode\": \"working\",\n    \"software_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"comment\": \"Updated lighting\",\n    \"revision\": 1,\n    \"separator\": \"/\"\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/tasks/open-tasks": {
+      "get": {
+        "summary": "Get open tasks",
+        "description": "Return tasks for open projects with optional filters and pagination. Includes statistics.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/tasks/open-tasks?project_id=a24a6ea4-ce75-4665-a070-57453082c25&task_status_id=a24a6ea4-ce75-4665-a070-57453082c25&task_type_id=a24a6ea4-ce75-4665-a070-57453082c25&person_id=a24a6ea4-ce75-4665-a070-57453082c25&start_date=2022-07-12&due_date=2022-07-12&priority=3&page=1&limit=100\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/tasks/open-tasks\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"project_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"task_status_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"task_type_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"person_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"start_date\": \"2022-07-12\",\n    \"due_date\": \"2022-07-12\",\n    \"priority\": 3,\n    \"page\": 1,\n    \"limit\": 100\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/tasks/open-tasks/stats": {
+      "get": {
+        "summary": "Get open tasks stats",
+        "description": "Return totals and aggregates by status and task type per project for open projects.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/tasks/open-tasks/stats\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/tasks/open-tasks/stats\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/tasks/{task_id}/comments": {
+      "get": {
+        "summary": "Get task comments",
+        "description": "Return comments linked to a task.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/tasks/a24a6ea4-ce75-4665-a070-57453082c25/comments\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/tasks/a24a6ea4-ce75-4665-a070-57453082c25/comments\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/tasks/{task_id}/comments/{comment_id}": {
+      "delete": {
+        "summary": "Delete comment",
+        "description": "Delete a comment by id for a task.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/data/tasks/a24a6ea4-ce75-4665-a070-57453082c25/comments/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/tasks/a24a6ea4-ce75-4665-a070-57453082c25/comments/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "get": {
+        "summary": "Get comment",
+        "description": "Get a comment by id for a task.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/tasks/a24a6ea4-ce75-4665-a070-57453082c25/comments/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/tasks/a24a6ea4-ce75-4665-a070-57453082c25/comments/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/tasks/{task_id}/previews": {
+      "get": {
+        "summary": "Get task previews",
+        "description": "Return previews linked to a task.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/tasks/a24a6ea4-ce75-4665-a070-57453082c25/previews\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/tasks/a24a6ea4-ce75-4665-a070-57453082c25/previews\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/tasks/{task_id}/full": {
+      "get": {
+        "summary": "Get task full",
+        "description": "Return a task with many information. Includes full details for assignees, task type, and task status.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/tasks/a24a6ea4-ce75-4665-a070-57453082c25/full\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/tasks/a24a6ea4-ce75-4665-a070-57453082c25/full\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/actions/tasks/{task_id}/assign": {
+      "put": {
+        "summary": "Assign task to person",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X PUT \"http://api.example.com/actions/tasks/a24a6ea4-ce75-4665-a070-57453082c25/assign\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"person_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/actions/tasks/a24a6ea4-ce75-4665-a070-57453082c25/assign\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"person_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\"\n}\n\nresponse = requests.put(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/actions/tasks/clear-assignation": {
+      "put": {
+        "summary": "Clear task assignations",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X PUT \"http://api.example.com/actions/tasks/clear-assignation\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"task_ids\": [\n    \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"b24a6ea4-ce75-4665-a070-57453082c25\"\n  ],\n  \"person_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/actions/tasks/clear-assignation\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"task_ids\": [\n        \"a24a6ea4-ce75-4665-a070-57453082c25\",\n        \"b24a6ea4-ce75-4665-a070-57453082c25\"\n    ],\n    \"person_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\"\n}\n\nresponse = requests.put(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/actions/tasks/{task_id}/time-spents/{date}": {
+      "get": {
+        "summary": "Get task time spent for date",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/actions/tasks/a24a6ea4-ce75-4665-a070-57453082c25/time-spents/2022-07-12\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/actions/tasks/a24a6ea4-ce75-4665-a070-57453082c25/time-spents/2022-07-12\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/actions/tasks/{task_id}/time-spents": {
+      "get": {
+        "summary": "Get task time spent",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/actions/tasks/a24a6ea4-ce75-4665-a070-57453082c25/time-spents\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/actions/tasks/a24a6ea4-ce75-4665-a070-57453082c25/time-spents\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/actions/tasks/{task_id}/time-spents/{date}/persons/{person_id}": {
+      "delete": {
+        "summary": "Delete time spent",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/actions/tasks/a24a6ea4-ce75-4665-a070-57453082c25/time-spents/2022-07-12/persons/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/actions/tasks/a24a6ea4-ce75-4665-a070-57453082c25/time-spents/2022-07-12/persons/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Set time spent",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/actions/tasks/a24a6ea4-ce75-4665-a070-57453082c25/time-spents/2022-07-12/persons/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"duration\": 120\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/actions/tasks/a24a6ea4-ce75-4665-a070-57453082c25/time-spents/2022-07-12/persons/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"duration\": 120\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/actions/tasks/{task_id}/time-spents/{date}/persons/{person_id}/add": {
+      "post": {
+        "summary": "Add time spent",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/actions/tasks/a24a6ea4-ce75-4665-a070-57453082c25/time-spents/2022-07-12/persons/a24a6ea4-ce75-4665-a070-57453082c25/add\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"duration\": 30\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/actions/tasks/a24a6ea4-ce75-4665-a070-57453082c25/time-spents/2022-07-12/persons/a24a6ea4-ce75-4665-a070-57453082c25/add\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"duration\": 30\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/actions/tasks/{task_id}/comments/{comment_id}/add-preview": {
+      "post": {
+        "summary": "Add task preview",
+        "description": "Add preview metadata to a task. The preview file is uploaded after. Revision is auto set to last + 1. It can also be set manually.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/actions/tasks/a24a6ea4-ce75-4665-a070-57453082c25/comments/a24a6ea4-ce75-4665-a070-57453082c25/add-preview\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"revision\": 1\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/actions/tasks/a24a6ea4-ce75-4665-a070-57453082c25/comments/a24a6ea4-ce75-4665-a070-57453082c25/add-preview\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"revision\": 1\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/actions/tasks/{task_id}/comments/{comment_id}/preview-files/{preview_file_id}": {
+      "delete": {
+        "summary": "Delete preview from comment",
+        "description": "Delete a preview from a comment. Use force query to delete even if there are dependencies.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/actions/tasks/a24a6ea4-ce75-4665-a070-57453082c25/comments/a24a6ea4-ce75-4665-a070-57453082c25/preview-files/a24a6ea4-ce75-4665-a070-57453082c25?force=\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/actions/tasks/a24a6ea4-ce75-4665-a070-57453082c25/comments/a24a6ea4-ce75-4665-a070-57453082c25/preview-files/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"force\": \"\"\n}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Add preview to comment",
+        "description": "Add a preview to a comment by uploading a file in multipart form data.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/actions/tasks/a24a6ea4-ce75-4665-a070-57453082c25/comments/a24a6ea4-ce75-4665-a070-57453082c25/preview-files/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/actions/tasks/a24a6ea4-ce75-4665-a070-57453082c25/comments/a24a6ea4-ce75-4665-a070-57453082c25/preview-files/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/actions/tasks/{task_id}/to-review": {
+      "put": {
+        "summary": "Set task to review",
+        "description": "Create a new preview file entry and set the path from the disk. Optionally change the task status.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X PUT \"http://api.example.com/actions/tasks/a24a6ea4-ce75-4665-a070-57453082c25/to-review\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"person_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n  \"comment\": \"Please check this version\",\n  \"name\": \"main\",\n  \"revision\": 1,\n  \"change_status\": true\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/actions/tasks/a24a6ea4-ce75-4665-a070-57453082c25/to-review\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"person_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"comment\": \"Please check this version\",\n    \"name\": \"main\",\n    \"revision\": 1,\n    \"change_status\": true\n}\n\nresponse = requests.put(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/actions/tasks/{task_id}/set-main-preview": {
+      "put": {
+        "summary": "Set main preview from task",
+        "description": "Set the last preview of a task as the main preview of the related entity.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X PUT \"http://api.example.com/actions/tasks/a24a6ea4-ce75-4665-a070-57453082c25/set-main-preview\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/actions/tasks/a24a6ea4-ce75-4665-a070-57453082c25/set-main-preview\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.put(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/actions/tasks/{task_id}/batch-comment": {
+      "post": {
+        "summary": "Add task batch comments",
+        "description": "Creates new comments for given task. Each comment requires a text, a task_status and a person as arguments. Can include preview files and attachments.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/actions/tasks/a24a6ea4-ce75-4665-a070-57453082c25/batch-comment\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/actions/tasks/a24a6ea4-ce75-4665-a070-57453082c25/batch-comment\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/actions/tasks/batch-comment": {
+      "post": {
+        "summary": "Add tasks batch comments",
+        "description": "Creates new comments for given tasks. Each comment requires a task_id, text, a task_status and a person as arguments. Can include preview files and attachments.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/actions/tasks/batch-comment\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/actions/tasks/batch-comment\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/time-spents/": {
+      "get": {
+        "summary": "Get time spents",
+        "description": "Retrieve all time spent records. Supports filtering via query parameters and pagination. Supports date range filtering with start_date and end_date.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/time-spents/?page=1&limit=50&relations=false&start_date=2024-01-01&end_date=2024-01-31\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/time-spents/\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"page\": 1,\n    \"limit\": 50,\n    \"relations\": false,\n    \"start_date\": \"2024-01-01\",\n    \"end_date\": \"2024-01-31\"\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Create time spent",
+        "description": "Create a new time spent record with data provided in the request body. JSON format is expected. Updates task duration automatically.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/time-spents/\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"task_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n  \"person_id\": \"b24a6ea4-ce75-4665-a070-57453082c25\",\n  \"date\": \"2024-01-15\",\n  \"duration\": 8.5\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/time-spents/\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"task_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"person_id\": \"b24a6ea4-ce75-4665-a070-57453082c25\",\n    \"date\": \"2024-01-15\",\n    \"duration\": 8.5\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/time-spents/{instance_id}": {
+      "delete": {
+        "summary": "Delete time spent",
+        "description": "Delete a time spent record by its ID. Returns empty response on success. Updates task duration automatically.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/data/time-spents/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/time-spents/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "get": {
+        "summary": "Get time spent",
+        "description": "Retrieve a time spent record by its ID and return it as a JSON object. Supports including relations.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/time-spents/a24a6ea4-ce75-4665-a070-57453082c25?relations=true\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/time-spents/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"relations\": true\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "put": {
+        "summary": "Update time spent",
+        "description": "Update a time spent record with data provided in the request body. JSON format is expected. Updates task duration automatically.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X PUT \"http://api.example.com/data/time-spents/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"date\": \"2024-01-16\",\n  \"duration\": 7.5\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/time-spents/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"date\": \"2024-01-16\",\n    \"duration\": 7.5\n}\n\nresponse = requests.put(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/": {
+      "get": {
+        "summary": "Get API name and version",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/user/context": {
+      "get": {
+        "summary": "Get context",
+        "description": "Retrieve context information required to properly run a full application connected to the API. Returns user, project, and system configuration data.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/user/context\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/user/context\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/user/assets/{asset_id}/tasks": {
+      "get": {
+        "summary": "Get asset tasks",
+        "description": "Return tasks related to given asset for current user.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/user/assets/a24a6ea4-ce75-4665-a070-57453082c25/tasks\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/user/assets/a24a6ea4-ce75-4665-a070-57453082c25/tasks\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/user/shots/{shot_id}/tasks": {
+      "get": {
+        "summary": "Get shot tasks",
+        "description": "Retrieve tasks related to a specific shot for the current user. Returns all tasks assigned to the user for the given shot.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/user/shots/a24a6ea4-ce75-4665-a070-57453082c25/tasks\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/user/shots/a24a6ea4-ce75-4665-a070-57453082c25/tasks\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/user/scenes/{scene_id}/tasks": {
+      "get": {
+        "summary": "Get scene tasks",
+        "description": "Retrieve tasks related to a specific scene for the current user.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/user/scenes/a24a6ea4-ce75-4665-a070-57453082c25/tasks\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/user/scenes/a24a6ea4-ce75-4665-a070-57453082c25/tasks\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/user/sequences/{sequence_id}/tasks": {
+      "get": {
+        "summary": "Get sequence tasks",
+        "description": "Retrieve tasks related to a specific sequence for the current user. sequence.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/user/sequences/a24a6ea4-ce75-4665-a070-57453082c25/tasks\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/user/sequences/a24a6ea4-ce75-4665-a070-57453082c25/tasks\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/user/assets/{asset_id}/task-types": {
+      "get": {
+        "summary": "Get asset task types",
+        "description": "Retrieve task types related to a specific asset for the current user. Returns all task types available for the given asset.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/user/assets/a24a6ea4-ce75-4665-a070-57453082c25/task-types\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/user/assets/a24a6ea4-ce75-4665-a070-57453082c25/task-types\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/user/shots/{shot_id}/task-types": {
+      "get": {
+        "summary": "Get shot task types",
+        "description": "Retrieve task types related to a specific shot for the current user. Returns all task types available for the given shot.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/user/shots/a24a6ea4-ce75-4665-a070-57453082c25/task-types\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/user/shots/a24a6ea4-ce75-4665-a070-57453082c25/task-types\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/user/scenes/{scene_id}/task-types": {
+      "get": {
+        "summary": "Get scene task types",
+        "description": "Retrieve task types related to a specific scene for the current user.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/user/scenes/a24a6ea4-ce75-4665-a070-57453082c25/task-types\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/user/scenes/a24a6ea4-ce75-4665-a070-57453082c25/task-types\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/user/sequences/{sequence_id}/task-types": {
+      "get": {
+        "summary": "Get sequence task types",
+        "description": "Retrieve task types related to a specific sequence for the current user.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/user/sequences/a24a6ea4-ce75-4665-a070-57453082c25/task-types\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/user/sequences/a24a6ea4-ce75-4665-a070-57453082c25/task-types\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/user/projects/open": {
+      "get": {
+        "summary": "Get open projects",
+        "description": "Retrieve open projects for which the current user has at least one task assigned. Optionally filter by project name.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/user/projects/open?name=My%20Project\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/user/projects/open\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"name\": \"My Project\"\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/user/projects/{project_id}/asset-types": {
+      "get": {
+        "summary": "Get project asset types",
+        "description": "Retrieve asset types related to a specific project for the current user.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/user/projects/a24a6ea4-ce75-4665-a070-57453082c25/asset-types\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/user/projects/a24a6ea4-ce75-4665-a070-57453082c25/asset-types\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/user/projects/{project_id}/asset-types/{asset_type_id}/assets": {
+      "get": {
+        "summary": "Get project assets",
+        "description": "Retrieve assets of a specific type within a project matching the asset type in the given project if the user has access.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/user/projects/a24a6ea4-ce75-4665-a070-57453082c25/asset-types/b35b7fb5-df86-5776-b181-68564193d36/assets\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/user/projects/a24a6ea4-ce75-4665-a070-57453082c25/asset-types/b35b7fb5-df86-5776-b181-68564193d36/assets\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/user/projects/{project_id}/sequences": {
+      "get": {
+        "summary": "Get project sequences",
+        "description": "Retrieve sequences related to a specific project for the current user. Returns all sequences in the project if the user has access.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/user/projects/a24a6ea4-ce75-4665-a070-57453082c25/sequences\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/user/projects/a24a6ea4-ce75-4665-a070-57453082c25/sequences\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/user/projects/{project_id}/episodes": {
+      "get": {
+        "summary": "Get project episodes",
+        "description": "Retrieve episodes related to a specific project for the current user. Returns all episodes in the project if the user has access.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/user/projects/a24a6ea4-ce75-4665-a070-57453082c25/episodes\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/user/projects/a24a6ea4-ce75-4665-a070-57453082c25/episodes\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/user/sequences/{sequence_id}/shots": {
+      "get": {
+        "summary": "Get sequence shots",
+        "description": "Retrieve shots related to a specific sequence for the current user.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/user/sequences/a24a6ea4-ce75-4665-a070-57453082c25/shots\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/user/sequences/a24a6ea4-ce75-4665-a070-57453082c25/shots\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/user/sequences/{sequence_id}/scenes": {
+      "get": {
+        "summary": "Get sequence scenes",
+        "description": "Retrieve scenes related to a specific sequence for the current user.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/user/sequences/a24a6ea4-ce75-4665-a070-57453082c25/scenes\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/user/sequences/a24a6ea4-ce75-4665-a070-57453082c25/scenes\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/user/tasks": {
+      "get": {
+        "summary": "Get my tasks",
+        "description": "Retrieve ttasks currently assigned to current user and of which status has is_done attribute set to false.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/user/tasks\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/user/tasks\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/user/tasks-to-check": {
+      "get": {
+        "summary": "Get tasks requiring feedback",
+        "description": "Retrieve tasks requiring feedback for departments where the current user is a supervisor. Returns empty list if user is not a supervisor.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/user/tasks-to-check\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/user/tasks-to-check\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/user/done-tasks": {
+      "get": {
+        "summary": "Get done tasks",
+        "description": "Retrieve tasks currently assigned to the current user with status marked as done. Returns only tasks from open projects.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/user/done-tasks\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/user/done-tasks\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/user/filters": {
+      "get": {
+        "summary": "Get filters",
+        "description": "Retrieve filters for the current user limited to open projects only.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/user/filters\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/user/filters\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Create filter",
+        "description": "Create a new filter for the current user limited to open projects only.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/user/filters\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"My Custom Filter\",\n  \"query\": \"{\\\"project_id\\\": \\\"uuid\\\"}\",\n  \"list_type\": \"todo\",\n  \"entity_type\": \"Asset\",\n  \"project_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n  \"is_shared\": false,\n  \"search_filter_group_id\": \"b35b7fb5-df86-5776-b181-68564193d36\",\n  \"department_id\": \"c46c8gc6-eg97-6887-c292-79675204e47\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/user/filters\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"My Custom Filter\",\n    \"query\": \"{\\\"project_id\\\": \\\"uuid\\\"}\",\n    \"list_type\": \"todo\",\n    \"entity_type\": \"Asset\",\n    \"project_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"is_shared\": false,\n    \"search_filter_group_id\": \"b35b7fb5-df86-5776-b181-68564193d36\",\n    \"department_id\": \"c46c8gc6-eg97-6887-c292-79675204e47\"\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/user/filters/{filter_id}": {
+      "delete": {
+        "summary": "Delete filter",
+        "description": "Delete a specific filter if it is owned by the current user.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/data/user/filters/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/user/filters/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "put": {
+        "summary": "Update filter",
+        "description": "Update an existing filter if it is owned by the current user.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X PUT \"http://api.example.com/data/user/filters/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"Updated Filter Name\",\n  \"search_query\": \"{\\\"status\\\": \\\"active\\\"}\",\n  \"search_filter_group_id\": \"b35b7fb5-df86-5776-b181-68564193d36\",\n  \"is_shared\": true,\n  \"project_id\": \"c46c8gc6-eg97-6887-c292-79675204e47\",\n  \"department_id\": \"d57d9hd7-fh08-7998-d403-80786315f58\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/user/filters/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"Updated Filter Name\",\n    \"search_query\": \"{\\\"status\\\": \\\"active\\\"}\",\n    \"search_filter_group_id\": \"b35b7fb5-df86-5776-b181-68564193d36\",\n    \"is_shared\": true,\n    \"project_id\": \"c46c8gc6-eg97-6887-c292-79675204e47\",\n    \"department_id\": \"d57d9hd7-fh08-7998-d403-80786315f58\"\n}\n\nresponse = requests.put(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/user/filter-groups": {
+      "get": {
+        "summary": "Get filter groups",
+        "description": "Retrieve filter groups for the current user limited to open projects only.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/user/filter-groups\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/user/filter-groups\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Create filter group",
+        "description": "Create a new filter group for the current user limited to open projects only. The filter group can be shared with other users.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/user/filter-groups\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"My Filter Group\",\n  \"color\": \"#FF0000\",\n  \"list_type\": \"todo\",\n  \"entity_type\": \"Asset\",\n  \"is_shared\": false,\n  \"project_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n  \"department_id\": \"b35b7fb5-df86-5776-b181-68564193d36\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/user/filter-groups\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"My Filter Group\",\n    \"color\": \"#FF0000\",\n    \"list_type\": \"todo\",\n    \"entity_type\": \"Asset\",\n    \"is_shared\": false,\n    \"project_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"department_id\": \"b35b7fb5-df86-5776-b181-68564193d36\"\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/user/filter-groups/{filter_group_id}": {
+      "delete": {
+        "summary": "Delete filter group",
+        "description": "Delete a specific filter group if it is owned by the current user.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/data/user/filter-groups/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/user/filter-groups/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "get": {
+        "summary": "Get filter group",
+        "description": "Retrieve a specific filter group for the current user. Returns detailed information about the filter group.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/user/filter-groups/{filter_group_id}\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/user/filter-groups/{filter_group_id}\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "put": {
+        "summary": "Update filter group",
+        "description": "Update an existing filter group if it is owned by the current user. Allows modification of filter group properties.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X PUT \"http://api.example.com/data/user/filter-groups/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"Updated Filter Group\",\n  \"color\": \"#00FF00\",\n  \"is_shared\": true,\n  \"project_id\": \"b35b7fb5-df86-5776-b181-68564193d36\",\n  \"department_id\": \"c46c8gc6-eg97-6887-c292-79675204e47\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/user/filter-groups/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"Updated Filter Group\",\n    \"color\": \"#00FF00\",\n    \"is_shared\": true,\n    \"project_id\": \"b35b7fb5-df86-5776-b181-68564193d36\",\n    \"department_id\": \"c46c8gc6-eg97-6887-c292-79675204e47\"\n}\n\nresponse = requests.put(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/user/desktop-login-logs": {
+      "get": {
+        "summary": "Get desktop login logs",
+        "description": "Retrieve desktop login logs for the current user.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/user/desktop-login-logs\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/user/desktop-login-logs\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Create desktop login log",
+        "description": "Create a desktop login log entry for the current user.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/user/desktop-login-logs\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"date\": \"2023-01-01\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/user/desktop-login-logs\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"date\": \"2023-01-01\"\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/user/time-spents": {
+      "get": {
+        "summary": "Get time spents",
+        "description": "Retrieve all time spent entries for the current user. Optionally accepts date range parameters to filter results.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/user/time-spents?start_date=2023-01-01&end_date=2023-12-31\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/user/time-spents\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"start_date\": \"2023-01-01\",\n    \"end_date\": \"2023-12-31\"\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/user/time-spents/{date}": {
+      "get": {
+        "summary": "Get time spents by date",
+        "description": "Retrieve time spent entries for the current user on a specific date. Returns all time entries for the given date.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/user/time-spents/2023-01-01\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/user/time-spents/2023-01-01\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/user/tasks/{task_id}/time-spents/{date}": {
+      "get": {
+        "summary": "Get task time spent",
+        "description": "Retrieve time spent entries for the current user on a specific task and date. Returns detailed time tracking information.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/user/tasks/a24a6ea4-ce75-4665-a070-57453082c25/time-spents/2023-01-01\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/user/tasks/a24a6ea4-ce75-4665-a070-57453082c25/time-spents/2023-01-01\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/user/day-offs/{date}": {
+      "get": {
+        "summary": "Get day off",
+        "description": "Retrieve day off information for the current user on a specific date.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/user/day-offs/2023-01-01\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/user/day-offs/2023-01-01\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/user/notifications": {
+      "get": {
+        "summary": "Get notifications",
+        "description": "Retrieve the last 100 user notifications filtered by given parameters. Supports filtering by date range, task type, status, and other criteria.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/user/notifications?after=2023-01-01&before=2023-12-31&task_type_id=a24a6ea4-ce75-4665-a070-57453082c25&task_status_id=b35b7fb5-df86-5776-b181-68564193d36&type=comment&read=false&watching=true\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/user/notifications\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"after\": \"2023-01-01\",\n    \"before\": \"2023-12-31\",\n    \"task_type_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"task_status_id\": \"b35b7fb5-df86-5776-b181-68564193d36\",\n    \"type\": \"comment\",\n    \"read\": false,\n    \"watching\": true\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/user/notifications/{notification_id}": {
+      "put": {
+        "summary": "Update notification",
+        "description": "Change the read status of a specific notification. Only the notification owner can update their notifications.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X PUT \"http://api.example.com/data/user/notifications/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"read\": true\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/user/notifications/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"read\": true\n}\n\nresponse = requests.put(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "get": {
+        "summary": "Get notification",
+        "description": "Retrieve a specific notification by ID, only if it belongs to the current user.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/user/notifications/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/user/notifications/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/user/tasks/{task_id}/subscribed": {
+      "get": {
+        "summary": "Check task subscription",
+        "description": "Check if the current user has subscribed to a specific task.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/user/tasks/a24a6ea4-ce75-4665-a070-57453082c25/subscribed\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/user/tasks/a24a6ea4-ce75-4665-a070-57453082c25/subscribed\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/user/chats": {
+      "get": {
+        "summary": "Get chats",
+        "description": "Retrieve all chats where the current user is a participant. Returns list of chat conversations the user can access.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/user/chats\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/user/chats\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/actions/user/chats/{entity_id}/join": {
+      "delete": {
+        "summary": "Leave chat",
+        "description": "Leave a chat for a specific entity by removing the current user from participants. The user will no longer receive chat messages for this entity.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/actions/user/chats/a24a6ea4-ce75-4665-a070-57453082c25/join\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/actions/user/chats/a24a6ea4-ce75-4665-a070-57453082c25/join\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Join chat",
+        "description": "Join a chat for a specific entity by adding the current user as a participant. The user will be listed as a participant in the chat.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/actions/user/chats/a24a6ea4-ce75-4665-a070-57453082c25/join\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/actions/user/chats/a24a6ea4-ce75-4665-a070-57453082c25/join\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/actions/user/tasks/{task_id}/subscribe": {
+      "post": {
+        "summary": "Subscribe to task",
+        "description": "Create a subscription entry for the current user and given task. When subscribed, the user receives notifications for all comments posted on the task.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/actions/user/tasks/a24a6ea4-ce75-4665-a070-57453082c25/subscribe\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/actions/user/tasks/a24a6ea4-ce75-4665-a070-57453082c25/subscribe\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/actions/user/tasks/{task_id}/unsubscribe": {
+      "delete": {
+        "summary": "Unsubscribe from task",
+        "description": "Remove the subscription entry for the current user and given task. The user will no longer receive notifications for this task.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/actions/user/tasks/a24a6ea4-ce75-4665-a070-57453082c25/unsubscribe\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/actions/user/tasks/a24a6ea4-ce75-4665-a070-57453082c25/unsubscribe\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/actions/user/clear-avatar": {
+      "delete": {
+        "summary": "Clear avatar",
+        "description": "Set the has_avatar flag to false for the current user and remove the avatar file from storage. This action cannot be undone.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/actions/user/clear-avatar\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/actions/user/clear-avatar\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/user/entities/{sequence_id}/task-types/{task_type_id}/subscribed": {
+      "get": {
+        "summary": "Check sequence subscription",
+        "description": "Check if the current user has subscribed to a specific sequence and task type combination. Returns true if subscribed.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/user/entities/a24a6ea4-ce75-4665-a070-57453082c25/task-types/b35b7fb5-df86-5776-b181-68564193d36/subscribed\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/user/entities/a24a6ea4-ce75-4665-a070-57453082c25/task-types/b35b7fb5-df86-5776-b181-68564193d36/subscribed\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/user/projects/{project_id}/task-types/{task_type_id}/sequence-subscriptions": {
+      "get": {
+        "summary": "Get sequence subscriptions",
+        "description": "Retrieve list of sequence IDs to which the current user has subscribed for a given task type within a specific project.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/user/projects/a24a6ea4-ce75-4665-a070-57453082c25/task-types/b35b7fb5-df86-5776-b181-68564193d36/sequence-subscriptions\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/user/projects/a24a6ea4-ce75-4665-a070-57453082c25/task-types/b35b7fb5-df86-5776-b181-68564193d36/sequence-subscriptions\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/actions/user/sequences/{sequence_id}/task-types/{task_type_id}/subscribe": {
+      "post": {
+        "summary": "Subscribe to sequence",
+        "description": "Create a subscription entry for the current user, given sequence, and task type. When subscribed, the user receives notifications for all comments posted on tasks related to the sequence.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/actions/user/sequences/a24a6ea4-ce75-4665-a070-57453082c25/task-types/b35b7fb5-df86-5776-b181-68564193d36/subscribe\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/actions/user/sequences/a24a6ea4-ce75-4665-a070-57453082c25/task-types/b35b7fb5-df86-5776-b181-68564193d36/subscribe\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/actions/user/sequences/{sequence_id}/task-types/{task_type_id}/unsubscribe": {
+      "delete": {
+        "summary": "Unsubscribe from sequence",
+        "description": "Remove the subscription entry for the current user, given sequence, and task type. The user will no longer receive notifications for tasks related to this sequence.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/actions/user/sequences/a24a6ea4-ce75-4665-a070-57453082c25/task-types/b35b7fb5-df86-5776-b181-68564193d36/unsubscribe\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/actions/user/sequences/a24a6ea4-ce75-4665-a070-57453082c25/task-types/b35b7fb5-df86-5776-b181-68564193d36/unsubscribe\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/actions/user/notifications/mark-all-as-read": {
+      "post": {
+        "summary": "Mark all notifications as read",
+        "description": "Mark all notifications as read for the current user.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/actions/user/notifications/mark-all-as-read\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/actions/user/notifications/mark-all-as-read\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/working-files": {
+      "get": {
+        "summary": "Get working files",
+        "description": "Retrieve all working files. Supports filtering via query parameters and pagination. Vendor access is blocked. Includes project permission filtering for non-admin users.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/working-files?page=1&limit=50&relations=false\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/working-files\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {\n    \"page\": 1,\n    \"limit\": 50,\n    \"relations\": false\n}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Create working file",
+        "description": "Create a new working file with data provided in the request body. JSON format is expected.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/working-files\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"work_file_v001\",\n  \"task_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n  \"entity_id\": \"b24a6ea4-ce75-4665-a070-57453082c25\",\n  \"revision\": 1\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/working-files\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"work_file_v001\",\n    \"task_id\": \"a24a6ea4-ce75-4665-a070-57453082c25\",\n    \"entity_id\": \"b24a6ea4-ce75-4665-a070-57453082c25\",\n    \"revision\": 1\n}\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/working-files/{instance_id}": {
+      "delete": {
+        "summary": "Delete working file",
+        "description": "Delete a working file by its ID. Returns empty response on success.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X DELETE \"http://api.example.com/data/working-files/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/working-files/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.delete(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "get": {
+        "summary": "Get working file",
+        "description": "Retrieve a working file instance by its ID and return it as a JSON object.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/working-files/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/working-files/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "put": {
+        "summary": "Update working file",
+        "description": "Update a working file with data provided in the request body. JSON format is expected. Requires task action access.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X PUT \"http://api.example.com/data/working-files/a24a6ea4-ce75-4665-a070-57453082c25\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"name\": \"updated_work_file_v001\",\n  \"revision\": 2\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/working-files/a24a6ea4-ce75-4665-a070-57453082c25\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"name\": \"updated_work_file_v001\",\n    \"revision\": 2\n}\n\nresponse = requests.put(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/data/working-files/{working_file_id}/file": {
+      "get": {
+        "summary": "Download working file",
+        "description": "Download a working file from storage. Returns the file content with appropriate headers for caching and attachment.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X GET \"http://api.example.com/data/working-files/a24a6ea4-ce75-4665-a070-57453082c25/file\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/working-files/a24a6ea4-ce75-4665-a070-57453082c25/file\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.get(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Store working file",
+        "description": "Store a working file in the file storage system. Uploads the file content and associates it with the working file record.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X POST \"http://api.example.com/data/working-files/a24a6ea4-ce75-4665-a070-57453082c25/file\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/data/working-files/a24a6ea4-ce75-4665-a070-57453082c25/file\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.post(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/actions/working-files/{working_file_id}/comment": {
+      "put": {
+        "summary": "Update working file comment",
+        "description": "Update the comment on a specific working file. Comments provide context about changes made to the working file.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X PUT \"http://api.example.com/actions/working-files/a24a6ea4-ce75-4665-a070-57453082c25/comment\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"comment\": \"Updated lighting and materials\"\n}'"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/actions/working-files/a24a6ea4-ce75-4665-a070-57453082c25/comment\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\",\n    \"Content-Type\": \"application/json\"\n}\nparams = {}\npayload = {\n    \"comment\": \"Updated lighting and materials\"\n}\n\nresponse = requests.put(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    },
+    "/actions/working-files/{working_file_id}/modified": {
+      "put": {
+        "summary": "Update working file modification date",
+        "description": "Update the modification date of a working file to the current timestamp. Used to track when the file was last modified.",
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "curl",
+            "source": "curl -X PUT \"http://api.example.com/actions/working-files/a24a6ea4-ce75-4665-a070-57453082c25/modified\" \\\n  -H \"Authorization: Bearer YOUR_API_TOKEN\" \\\n  -H \"Accept: application/json\""
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nurl = \"http://api.example.com/actions/working-files/a24a6ea4-ce75-4665-a070-57453082c25/modified\"\nheaders = {\n    \"Authorization\": \"Bearer YOUR_API_TOKEN\",\n    \"Accept\": \"application/json\"\n}\nparams = {}\npayload = None\n\nresponse = requests.put(\n    url,\n    headers=headers,\n    params=params,\n    json=payload\n)\n\nresponse.raise_for_status()\n\nif response.content:\n    print(response.json())"
+          }
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
**Problem definition**

- Context: we need to add custom code samples to improve the DX of the OpenAPI spec document
- Problem: flasgger rewrites the standard x-codeSamples field Bump.sh needs

**Solution**

- This PR adds a new route to augment the existing OpenAPI spec with custom code samples and returns the combined JSON.
- The code samples are stored in a static-generated zou/app/openapi-code-samples.json file following the OpenAPI format. 
- The PR updates the Github Actions workflow for Bump.sh to use the new route

Staging test: https://bump.sh/basunako/doc/test/operation/operation-get-data-projects-parameter-asset-types-parameter-assets
Result:  all code samples use the new cURL examples

<img width="1713" height="531" alt="image" src="https://github.com/user-attachments/assets/20be9809-2563-4c52-91bf-aa7735ee6c27" />

**TODO**

- Need to add gazu code samples (can't auto-generate them for now)
- We'll need to find a way to generate openapi-code-samples.json via CI.