### PR TITLE
[2FA] Improve ENFORCE_2FA and add more tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,10 +43,11 @@ jobs:
       - name: Install ffmpeg
         run: |
           if [ -d ~/apt-cache ] && ls ~/apt-cache/*.deb 1>/dev/null 2>&1; then
-            sudo dpkg -i ~/apt-cache/*.deb 2>/dev/null || sudo apt-get install -y -f --no-install-recommends
+            sudo dpkg -i ~/apt-cache/*.deb 2>/dev/null || (sudo apt-get update -qq && sudo apt-get install -y -f --no-install-recommends)
           else
             sudo apt-get update -qq
             sudo apt-get install -y --no-install-recommends ffmpeg
+            sudo apt-get autoclean -y
             mkdir -p ~/apt-cache
             cp /var/cache/apt/archives/ffmpeg*.deb ~/apt-cache/ 2>/dev/null || true
             cp /var/cache/apt/archives/libav*.deb ~/apt-cache/ 2>/dev/null || true
@@ -159,10 +160,11 @@ jobs:
       - name: Install ffmpeg
         run: |
           if [ -d ~/apt-cache ] && ls ~/apt-cache/*.deb 1>/dev/null 2>&1; then
-            sudo dpkg -i ~/apt-cache/*.deb 2>/dev/null || sudo apt-get install -y -f --no-install-recommends
+            sudo dpkg -i ~/apt-cache/*.deb 2>/dev/null || (sudo apt-get update -qq && sudo apt-get install -y -f --no-install-recommends)
           else
             sudo apt-get update -qq
             sudo apt-get install -y --no-install-recommends ffmpeg
+            sudo apt-get autoclean -y
             mkdir -p ~/apt-cache
             cp /var/cache/apt/archives/ffmpeg*.deb ~/apt-cache/ 2>/dev/null || true
             cp /var/cache/apt/archives/libav*.deb ~/apt-cache/ 2>/dev/null || true

--- a/conftest.py
+++ b/conftest.py
@@ -1,5 +1,6 @@
 import os
 
+import flask_bcrypt
 import pytest
 
 # Must be set before zou.app is imported.
@@ -8,6 +9,19 @@ os.environ.setdefault("BCRYPT_LOG_ROUNDS", "4")
 os.environ.setdefault("DB_POOL_PRE_PING", "false")
 
 _REAL_BCRYPT_FILES = {"test_auth_route.py", "test_auth_service.py"}
+
+# flask_bcrypt module-level functions create a Bcrypt() instance without
+# the app, so BCRYPT_LOG_ROUNDS is ignored and rounds default to 12.
+# Wrap them to force 4 rounds in tests.
+_TEST_ROUNDS = 4
+_orig_generate = flask_bcrypt.generate_password_hash
+
+
+def _fast_generate(password, rounds=None):
+    return _orig_generate(password, rounds=rounds or _TEST_ROUNDS)
+
+
+flask_bcrypt.generate_password_hash = _fast_generate
 
 
 @pytest.fixture(autouse=True)

--- a/tests/auth/test_auth_route.py
+++ b/tests/auth/test_auth_route.py
@@ -1,3 +1,4 @@
+import pyotp
 import orjson as json
 
 from tests.base import ApiDBTestCase
@@ -292,3 +293,201 @@ class AuthTestCase(ApiDBTestCase):
         self.assertEqual(len(login_logs), 4)
         login_logs = self.get("/data/events/login-logs/last?limit=2")
         self.assertEqual(len(login_logs), 2)
+
+
+class Enforce2FATestCase(ApiDBTestCase):
+    def setUp(self):
+        super().setUp()
+        self.generate_fixture_person()
+        self.person.update(
+            {
+                "password": auth.encrypt_password("secretpassword"),
+                "role": "admin",
+            }
+        )
+        self.person_dict = self.person.serialize()
+        self.credentials = {
+            "email": self.person_dict["email"],
+            "password": "secretpassword",
+        }
+        from zou.app import app
+
+        self.app_instance = app
+        self._original_enforce_2fa = app.config["ENFORCE_2FA"]
+        self._original_exempt_users = app.config.get("TWO_FA_EXEMPT_USERS", [])
+        app.config["ENFORCE_2FA"] = True
+
+    def tearDown(self):
+        self.log_out()
+        self.app_instance.config["ENFORCE_2FA"] = self._original_enforce_2fa
+        self.app_instance.config["TWO_FA_EXEMPT_USERS"] = (
+            self._original_exempt_users
+        )
+        super().tearDown()
+
+    def get_auth_headers(self, tokens):
+        return {
+            "Authorization": "Bearer %s" % tokens.get("access_token", None)
+        }
+
+    def test_login_returns_restricted_tokens(self):
+        """Login with ENFORCE_2FA=True, no 2FA configured returns
+        200 with tokens and two_factor_authentication_required."""
+        response = self.post("auth/login", self.credentials, 200)
+        self.assertTrue(response["login"])
+        self.assertTrue(response["two_factor_authentication_required"])
+        self.assertIn("access_token", response)
+        self.assertIn("refresh_token", response)
+
+    def test_restricted_token_blocked_on_non_auth_route(self):
+        """Restricted token is blocked on non-auth routes with
+        403."""
+        tokens = self.post("auth/login", self.credentials, 200)
+        headers = self.get_auth_headers(tokens)
+        response = self.app.get("data/persons", headers=headers)
+        self.assertEqual(response.status_code, 403)
+        data = json.loads(response.data.decode("utf-8"))
+        self.assertTrue(data["two_factor_authentication_required"])
+
+    def test_restricted_token_allowed_on_totp(self):
+        """Restricted token can access /auth/totp for TOTP
+        enrollment."""
+        tokens = self.post("auth/login", self.credentials, 200)
+        headers = self.get_auth_headers(tokens)
+        headers["Content-type"] = "application/json"
+        response = self.app.put("auth/totp", headers=headers)
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data.decode("utf-8"))
+        self.assertIn("otp_secret", data)
+
+    def test_restricted_token_allowed_on_authenticated(self):
+        """Restricted token can access /auth/authenticated."""
+        tokens = self.post("auth/login", self.credentials, 200)
+        headers = self.get_auth_headers(tokens)
+        response = self.app.get("auth/authenticated", headers=headers)
+        self.assertEqual(response.status_code, 200)
+
+    def test_restricted_token_allowed_on_logout(self):
+        """Restricted token can access /auth/logout."""
+        tokens = self.post("auth/login", self.credentials, 200)
+        headers = self.get_auth_headers(tokens)
+        response = self.app.get("auth/logout", headers=headers)
+        self.assertEqual(response.status_code, 200)
+
+    def test_restricted_token_blocked_on_change_password(self):
+        """Restricted token is blocked on /auth/change-password."""
+        tokens = self.post("auth/login", self.credentials, 200)
+        headers = self.get_auth_headers(tokens)
+        headers["Content-type"] = "application/json"
+        response = self.app.post(
+            "auth/change-password",
+            data=json.dumps(
+                {
+                    "old_password": "secretpassword",
+                    "password": "newpassword",
+                    "password_2": "newpassword",
+                }
+            ),
+            headers=headers,
+        )
+        self.assertEqual(response.status_code, 403)
+
+    def test_token_unrestricted_after_2fa_setup(self):
+        """After configuring TOTP, refreshed token is
+        unrestricted."""
+        tokens = self.post("auth/login", self.credentials, 200)
+        headers = self.get_auth_headers(tokens)
+        headers["Content-type"] = "application/json"
+
+        # Pre-enable TOTP
+        response = self.app.put("auth/totp", headers=headers)
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data.decode("utf-8"))
+        otp_secret = data["otp_secret"]
+
+        # Enable TOTP with a valid code
+        totp = pyotp.TOTP(otp_secret)
+        response = self.app.post(
+            "auth/totp",
+            data=json.dumps({"totp": totp.now()}),
+            headers=headers,
+        )
+        self.assertEqual(response.status_code, 200)
+
+        # Clear cached person data
+        persons_service.clear_person_cache()
+
+        # Refresh token - should no longer be restricted
+        refresh_headers = {
+            "Authorization": "Bearer %s" % tokens.get("refresh_token", None)
+        }
+        response = self.app.get("auth/refresh-token", headers=refresh_headers)
+        self.assertEqual(response.status_code, 200)
+        new_tokens = json.loads(response.data.decode("utf-8"))
+
+        # New token should access non-auth routes
+        new_headers = self.get_auth_headers(new_tokens)
+        response = self.app.get("data/persons", headers=new_headers)
+        self.assertEqual(response.status_code, 200)
+
+    def test_exempt_user_gets_unrestricted_tokens(self):
+        """Users in TWO_FA_EXEMPT_USERS get unrestricted tokens."""
+        self.app_instance.config["TWO_FA_EXEMPT_USERS"] = [
+            self.person_dict["email"]
+        ]
+        tokens = self.post("auth/login", self.credentials, 200)
+        self.assertTrue(tokens["login"])
+        self.assertNotIn("two_factor_authentication_required", tokens)
+        headers = self.get_auth_headers(tokens)
+        response = self.app.get("data/persons", headers=headers)
+        self.assertEqual(response.status_code, 200)
+
+    def test_user_with_2fa_configured_can_login(self):
+        """User with 2FA already configured gets unrestricted
+        tokens."""
+        # Configure TOTP with enforcement disabled
+        self.app_instance.config["ENFORCE_2FA"] = False
+        tokens = self.post("auth/login", self.credentials, 200)
+        headers = self.get_auth_headers(tokens)
+        headers["Content-type"] = "application/json"
+
+        response = self.app.put("auth/totp", headers=headers)
+        data = json.loads(response.data.decode("utf-8"))
+        otp_secret = data["otp_secret"]
+
+        totp = pyotp.TOTP(otp_secret)
+        response = self.app.post(
+            "auth/totp",
+            data=json.dumps({"totp": totp.now()}),
+            headers=headers,
+        )
+        self.assertEqual(response.status_code, 200)
+        self.app.get("auth/logout", headers=headers)
+
+        # Re-enable enforcement and login with TOTP
+        self.app_instance.config["ENFORCE_2FA"] = True
+        persons_service.clear_person_cache()
+        login_response = self.post(
+            "auth/login",
+            {
+                "email": self.credentials["email"],
+                "password": self.credentials["password"],
+                "totp": totp.now(),
+            },
+            200,
+        )
+        self.assertTrue(login_response["login"])
+        self.assertNotIn(
+            "two_factor_authentication_required",
+            login_response,
+        )
+
+    def test_wrong_password_still_returns_400(self):
+        """Wrong password returns 400, not 403, even with
+        ENFORCE_2FA."""
+        credentials = {
+            "email": self.person_dict["email"],
+            "password": "wrongpassword",
+        }
+        response = self.post("auth/login", credentials, 400)
+        self.assertFalse(response["login"])

--- a/zou/app/blueprints/auth/resources.py
+++ b/zou/app/blueprints/auth/resources.py
@@ -49,13 +49,39 @@ from zou.app.services.exception import (
     TooMuchLoginFailedAttemps,
     TOTPAlreadyEnabledException,
     TOTPNotEnabledException,
-    TwoFactorAuthenticationRequiredException,
     UnactiveUserException,
     UserCantConnectDueToNoFallback,
     WrongOTPException,
     WrongPasswordException,
     WrongUserException,
 )
+
+
+def _build_2fa_registration_response(response_data, user_id):
+    """
+    After a successful 2FA registration, re-emit JWT cookies without
+    the requires_2fa_setup claim so the user gets full access.
+    """
+    additional_claims = {"identity_type": "person"}
+    access_token = create_access_token(
+        identity=user_id,
+        additional_claims=additional_claims,
+    )
+    refresh_token = create_refresh_token(
+        identity=user_id,
+        additional_claims=additional_claims,
+    )
+    response_data["access_token"] = access_token
+    response_data["refresh_token"] = refresh_token
+    response = jsonify(response_data)
+    if is_from_browser(request.user_agent):
+        set_access_cookies(response, access_token)
+        set_refresh_cookies(response, refresh_token)
+
+    current_app.logger.info(
+        "2FA setup completed, JWT refreshed for user %s." % user_id
+    )
+    return response
 
 
 class AuthenticatedResource(Resource):
@@ -213,17 +239,26 @@ class LoginResource(Resource, ArgsMixin):
                     400,
                 )
 
+            # Check if 2FA enforcement requires restricted access
+            requires_2fa_setup = False
+            if app.config["ENFORCE_2FA"]:
+                if not auth_service.is_user_exempt_from_2fa(user, app):
+                    if not auth_service.person_two_factor_authentication_enabled(
+                        user
+                    ):
+                        requires_2fa_setup = True
+
+            additional_claims = {"identity_type": "person"}
+            if requires_2fa_setup:
+                additional_claims["requires_2fa_setup"] = True
+
             access_token = create_access_token(
                 identity=user["id"],
-                additional_claims={
-                    "identity_type": "person",
-                },
+                additional_claims=additional_claims,
             )
             refresh_token = create_refresh_token(
                 identity=user["id"],
-                additional_claims={
-                    "identity_type": "person",
-                },
+                additional_claims=additional_claims,
             )
             identity_changed.send(
                 current_app._get_current_object(),
@@ -238,15 +273,17 @@ class LoginResource(Resource, ArgsMixin):
                 sensitive=user["role"] != "admin"
             )
 
-            response = jsonify(
-                {
-                    "user": user,
-                    "organisation": organisation,
-                    "login": True,
-                    "access_token": access_token,
-                    "refresh_token": refresh_token,
-                }
-            )
+            response_data = {
+                "user": user,
+                "organisation": organisation,
+                "login": True,
+                "access_token": access_token,
+                "refresh_token": refresh_token,
+            }
+            if requires_2fa_setup:
+                response_data["two_factor_authentication_required"] = True
+
+            response = jsonify(response_data)
 
             if is_from_browser(request.user_agent):
                 set_access_cookies(response, access_token)
@@ -256,7 +293,13 @@ class LoginResource(Resource, ArgsMixin):
                 events_service.create_login_log(
                     user["id"], ip_address, "script"
                 )
-            current_app.logger.info(f"User {email} is logged in.")
+            if requires_2fa_setup:
+                current_app.logger.info(
+                    f"User {email} logged in with restricted"
+                    " access - 2FA setup required."
+                )
+            else:
+                current_app.logger.info(f"User {email} is logged in.")
             return response
         except WrongUserException:
             current_app.logger.info(f"User {email} is not registered.")
@@ -325,19 +368,6 @@ class LoginResource(Resource, ArgsMixin):
                 },
                 400,
             )
-        except TwoFactorAuthenticationRequiredException:
-            current_app.logger.info(
-                f"User {email} can't log in because 2FA is required but not set up."
-            )
-            return (
-                {
-                    "error": True,
-                    "login": False,
-                    "two_factor_authentication_required": True,
-                    "message": "Two-factor authentication is required but not set up. Please configure 2FA to continue.",
-                },
-                403,
-            )
         except OperationalError as exception:
             current_app.logger.error(exception, exc_info=1)
             return (
@@ -398,11 +428,19 @@ class RefreshTokenResource(Resource):
             description: Access Token
         """
         user = persons_service.get_current_user()
+        additional_claims = {"identity_type": "person"}
+
+        if app.config["ENFORCE_2FA"]:
+            user_unsafe = persons_service.get_current_user(unsafe=True)
+            if not auth_service.is_user_exempt_from_2fa(user_unsafe, app):
+                if not auth_service.person_two_factor_authentication_enabled(
+                    user_unsafe
+                ):
+                    additional_claims["requires_2fa_setup"] = True
+
         access_token = create_access_token(
             identity=user["id"],
-            additional_claims={
-                "identity_type": "person",
-            },
+            additional_claims=additional_claims,
         )
         if is_from_browser(request.user_agent):
             response = jsonify({"refresh": True})
@@ -884,10 +922,14 @@ class TOTPResource(Resource, ArgsMixin):
         args = self.get_args([("totp", "", True)])
 
         try:
+            current_user = persons_service.get_current_user()
             otp_recovery_codes = auth_service.enable_totp(
-                persons_service.get_current_user()["id"], args["totp"]
+                current_user["id"], args["totp"]
             )
-            return {"otp_recovery_codes": otp_recovery_codes}
+            return _build_2fa_registration_response(
+                {"otp_recovery_codes": otp_recovery_codes},
+                current_user["id"],
+            )
         except TOTPAlreadyEnabledException:
             return (
                 {"error": True, "message": "TOTP already enabled."},
@@ -1089,11 +1131,15 @@ class EmailOTPResource(Resource, ArgsMixin):
         args = self.get_args([("email_otp", "", True)])
 
         try:
+            current_user = persons_service.get_current_user()
             otp_recovery_codes = auth_service.enable_email_otp(
-                persons_service.get_current_user()["id"],
+                current_user["id"],
                 args["email_otp"],
             )
-            return {"otp_recovery_codes": otp_recovery_codes}
+            return _build_2fa_registration_response(
+                {"otp_recovery_codes": otp_recovery_codes},
+                current_user["id"],
+            )
         except EmailOTPAlreadyEnabledException:
             return (
                 {"error": True, "message": "OTP by email already enabled."},
@@ -1300,12 +1346,16 @@ class FIDOResource(Resource, ArgsMixin):
                 ]
             )
 
+            current_user = persons_service.get_current_user()
             otp_recovery_codes = auth_service.register_fido(
-                persons_service.get_current_user()["id"],
+                current_user["id"],
                 args["registration_response"],
                 args["device_name"],
             )
-            return {"otp_recovery_codes": otp_recovery_codes}
+            return _build_2fa_registration_response(
+                {"otp_recovery_codes": otp_recovery_codes},
+                current_user["id"],
+            )
         except FIDONoPreregistrationException:
             return (
                 {"error": True, "message": "No preregistration before."},

--- a/zou/app/blueprints/auth/resources.py
+++ b/zou/app/blueprints/auth/resources.py
@@ -102,7 +102,10 @@ class AuthenticatedResource(Resource):
           401:
             description: Person not found
         """
-        person = persons_service.get_current_user(unsafe=True, relations=True)
+        person = persons_service.get_current_user(relations=True)
+        person["fido_devices"] = (
+            persons_service.get_current_user_fido_devices()
+        )
         organisation = persons_service.get_organisation(
             sensitive=permissions.has_admin_permissions()
         )

--- a/zou/app/services/auth_service.py
+++ b/zou/app/services/auth_service.py
@@ -28,7 +28,6 @@ from zou.app.services.exception import (
     TOTPAlreadyEnabledException,
     TOTPNotEnabledException,
     TwoFactorAuthenticationNotEnabledException,
-    TwoFactorAuthenticationRequiredException,
     UnactiveUserException,
     UserCantConnectDueToNoFallback,
     WrongOTPException,
@@ -94,13 +93,6 @@ def check_auth(
             date_helpers.get_utc_now_datetime(),
         )
         raise WrongPasswordException()
-
-    # Check if 2FA is enforced and user doesn't have it set up
-    # This check happens after password verification to ensure user is authenticated
-    if app.config["ENFORCE_2FA"] and not no_otp:
-        if not _is_user_exempt_from_2fa(person, app):
-            if not person_two_factor_authentication_enabled(person):
-                raise TwoFactorAuthenticationRequiredException()
 
     if not no_otp and person_two_factor_authentication_enabled(person):
         if not check_two_factor_authentication(
@@ -268,7 +260,7 @@ def person_two_factor_authentication_enabled(person):
     )
 
 
-def _is_user_exempt_from_2fa(person, app):
+def is_user_exempt_from_2fa(person, app):
     """
     Check if user is exempt from mandatory 2FA requirement.
     """

--- a/zou/app/services/auth_service.py
+++ b/zou/app/services/auth_service.py
@@ -493,7 +493,7 @@ def send_email_otp(person):
     html = f"""<p>Hello {person["first_name"]},</p>
 
 <p>
-Your verification code is : <strong>{otp}</strong>
+Your verification code is: <strong>{otp}</strong>
 </p>
 
 <p>
@@ -502,9 +502,7 @@ This email was sent at this date : {time_string}.
 The IP of the person who requested this is: {person_IP}.
 </p>
 """
-    subject = (
-        f"{organisation['name']} - Kitsu : your verification code is {otp}"
-    )
+    subject = f"{organisation['name']} - Kitsu : your verification code"
     title = "Your verification code"
     email_html_body = templates_service.generate_html_body(title, html)
     emails.send_email(subject, email_html_body, person["email"])

--- a/zou/app/services/persons_service.py
+++ b/zou/app/services/persons_service.py
@@ -204,6 +204,13 @@ def get_current_user(unsafe=False, relations=False):
     return data
 
 
+def get_current_user_fido_devices():
+    """
+    Return FIDO device names for the current user.
+    """
+    return current_user.fido_devices()
+
+
 def get_current_user_raw():
     """
     Return person from its auth token (the one that does the request) as an

--- a/zou/app/services/persons_service.py
+++ b/zou/app/services/persons_service.py
@@ -196,6 +196,10 @@ def get_current_user(unsafe=False, relations=False):
     """
     data = current_user.serialize_safe(relations=relations)
     if unsafe:
+        data["totp_secret"] = current_user.totp_secret
+        data["email_otp_secret"] = current_user.email_otp_secret
+        data["otp_recovery_codes"] = current_user.otp_recovery_codes
+        data["fido_credentials"] = current_user.fido_credentials
         data["fido_devices"] = current_user.fido_devices()
     return data
 
@@ -210,7 +214,11 @@ def get_current_user_raw():
     # relationships might not be loaded. We need to ensure departments are loaded.
     # Accessing departments triggers lazy loading if not already loaded.
     # Convert to list to force evaluation and ensure departments are loaded
-    _ = list(current_user.departments) if hasattr(current_user, 'departments') else []
+    _ = (
+        list(current_user.departments)
+        if hasattr(current_user, "departments")
+        else []
+    )
     return current_user
 
 
@@ -275,12 +283,11 @@ def create_person(
 
     if expiration_date is not None:
         if type(expiration_date) is str:
-            expiration_date = date_helpers.get_date_from_string(expiration_date)
+            expiration_date = date_helpers.get_date_from_string(
+                expiration_date
+            )
         try:
-            if (
-                expiration_date.date()
-                < datetime.date.today()
-            ):
+            if expiration_date.date() < datetime.date.today():
                 raise WrongParameterException(
                     "Expiration date can't be in the past."
                 )

--- a/zou/cli.py
+++ b/zou/cli.py
@@ -5,25 +5,19 @@ import warnings
 warnings.filterwarnings("ignore")
 import os
 import sys
-import flask_migrate
 import click
-import traceback
 
-from sqlalchemy.exc import IntegrityError
 
-from zou.app.utils import dbhelpers, auth, commands, plugins as plugin_utils
-from zou.app.services import persons_service, auth_service, plugins_service
-from zou.app.services.exception import (
-    IsUserLimitReachedException,
-    PersonNotFoundException,
-    TwoFactorAuthenticationNotEnabledException,
-)
+def _get_app():
+    from zou.app import app
 
-from zou.app import app, config
+    return app
 
-from zou import __file__ as root_path
 
-migrations_path = os.path.join(os.path.dirname(root_path), "migrations")
+def _get_migrations_path():
+    from zou import __file__ as root_path
+
+    return os.path.join(os.path.dirname(root_path), "migrations")
 
 
 @click.group()
@@ -45,9 +39,11 @@ def version():
 def init_db():
     "Create database table (database must be created through PG client)."
 
+    import flask_migrate
+
     print("Creating database and tables...")
-    with app.app_context():
-        flask_migrate.upgrade(directory=migrations_path)
+    with _get_app().app_context():
+        flask_migrate.upgrade(directory=_get_migrations_path())
     print("Database and tables created.")
 
 
@@ -56,7 +52,9 @@ def is_db_ready():
     """
     Return a message telling whether the database is initialized or not.
     """
-    with app.app_context():
+    from zou.app.utils import dbhelpers
+
+    with _get_app().app_context():
         is_init = dbhelpers.is_init()
         if is_init:
             print("Database is initialized.")
@@ -74,8 +72,12 @@ def migrate_db(message):
     Generate migration files to describe a new revision of the database schema
     (for development only).
     """
-    with app.app_context():
-        flask_migrate.migrate(directory=migrations_path, message=message)
+    import flask_migrate
+
+    with _get_app().app_context():
+        flask_migrate.migrate(
+            directory=_get_migrations_path(), message=message
+        )
 
 
 @cli.command()
@@ -85,25 +87,38 @@ def downgrade_db(revision):
     Downgrade db to previous revision of the database schema
     (for development only). For revision you can use an hash or a relative migration identifier.
     """
-    with app.app_context():
-        flask_migrate.downgrade(directory=migrations_path, revision=revision)
+    import flask_migrate
+
+    with _get_app().app_context():
+        flask_migrate.downgrade(
+            directory=_get_migrations_path(), revision=revision
+        )
 
 
 @cli.command()
 def clear_db():
     "Drop all tables from database"
 
-    with app.app_context():
+    import flask_migrate
+
+    from zou.app.utils import dbhelpers
+
+    with _get_app().app_context():
         print("Deleting database and tables...")
         dbhelpers.drop_all()
         print("Database and tables deleted.")
-        flask_migrate.stamp(directory=migrations_path, revision="base")
+        flask_migrate.stamp(directory=_get_migrations_path(), revision="base")
 
 
 @cli.command()
 def reset_db():
     "Drop all tables, then recreate them."
-    with app.app_context():
+    import flask_migrate
+
+    from zou.app.utils import dbhelpers
+
+    migrations_path = _get_migrations_path()
+    with _get_app().app_context():
         print("Deleting database and tables...")
         dbhelpers.drop_all()
         print("Database and tables deleted.")
@@ -120,8 +135,14 @@ def upgrade_db(no_telemetry=False):
     services (user and preview amounts). It allows us to size the Kitsu
     community.
     """
-    with app.app_context():
-        flask_migrate.upgrade(directory=migrations_path)
+    import traceback
+
+    import flask_migrate
+
+    from zou.app import config
+
+    with _get_app().app_context():
+        flask_migrate.upgrade(directory=_get_migrations_path())
         if not no_telemetry and config.IS_SELF_HOSTED:
             from zou.app.services import telemetry_services
 
@@ -135,7 +156,10 @@ def upgrade_db(no_telemetry=False):
 @click.option("--revision", default=None)
 def stamp_db(revision):
     "Set the database schema revision to current one."
-    with app.app_context():
+    import flask_migrate
+
+    migrations_path = _get_migrations_path()
+    with _get_app().app_context():
         if revision is None:
             flask_migrate.stamp(directory=migrations_path)
         else:
@@ -147,15 +171,17 @@ def clear_memory_cache():
     "Clear Redis memory cache."
     from zou.app import cache
 
-    with app.app_context():
+    with _get_app().app_context():
         cache.clear()
 
 
 @cli.command()
 def reset_migrations():
     "Set the database schema revision to first one."
-    with app.app_context():
-        flask_migrate.stamp(directory=migrations_path, revision="base")
+    import flask_migrate
+
+    with _get_app().app_context():
+        flask_migrate.stamp(directory=_get_migrations_path(), revision="base")
 
 
 @cli.command()
@@ -165,7 +191,17 @@ def create_admin(email, password):
     """
     Create an admin user to allow usage of the API when database is empty.
     """
-    with app.app_context():
+    from sqlalchemy.exc import IntegrityError
+
+    from zou.app import config
+    from zou.app.utils import auth
+    from zou.app.services import persons_service
+    from zou.app.services.exception import (
+        IsUserLimitReachedException,
+        PersonNotFoundException,
+    )
+
+    with _get_app().app_context():
         try:
             person = persons_service.get_person_by_email(email)
             if person["role"] != "admin":
@@ -209,18 +245,24 @@ def create_admin(email, password):
 @cli.command()
 def clean_auth_tokens():
     "Remove revoked and expired tokens."
+    from zou.app.utils import commands
+
     commands.clean_auth_tokens()
 
 
 @cli.command()
 def clear_all_auth_tokens():
     "Remove all authentication tokens."
+    from zou.app.utils import commands
+
     commands.clear_all_auth_tokens()
 
 
 @cli.command()
 def init_data():
     "Generate minimal data set required to run Kitsu."
+    from zou.app.utils import commands
+
     commands.init_data()
 
 
@@ -230,7 +272,13 @@ def disable_two_factor_authentication(email_or_desktop_login):
     """
     Disable two factor authentication for given user.
     """
-    with app.app_context():
+    from zou.app.services import persons_service, auth_service
+    from zou.app.services.exception import (
+        PersonNotFoundException,
+        TwoFactorAuthenticationNotEnabledException,
+    )
+
+    with _get_app().app_context():
         try:
             person = persons_service.get_person_by_email_desktop_login(
                 email_or_desktop_login
@@ -258,7 +306,10 @@ def change_password(email, password):
     """
     Change the password of given user.
     """
-    with app.app_context():
+    from zou.app.utils import auth
+    from zou.app.services import persons_service
+
+    with _get_app().app_context():
         try:
             auth.validate_password(password)
             password = auth.encrypt_password(password)
@@ -276,7 +327,14 @@ def set_person_as_active(email, unactive):
     """
     Set a person as active.
     """
-    with app.app_context():
+    from zou.app import config
+    from zou.app.services import persons_service
+    from zou.app.services.exception import (
+        IsUserLimitReachedException,
+        PersonNotFoundException,
+    )
+
+    with _get_app().app_context():
         try:
             if persons_service.is_user_limit_reached() and not unactive:
                 raise IsUserLimitReachedException
@@ -298,7 +356,11 @@ def sync_with_ldap_server():
     """
     For each user account in your LDAP server, it creates a new user.
     """
-    with app.app_context():
+    from zou.app import config
+    from zou.app.utils import commands
+    from zou.app.services import persons_service
+
+    with _get_app().app_context():
         if persons_service.is_user_limit_reached():
             print(
                 "User limit reached (limit %i). New users will not be added."
@@ -326,6 +388,8 @@ def sync_full(
     connect to source instance are given through SYNC_LOGIN and SYNC_PASSWORD
     environment variables.
     """
+    from zou.app.utils import commands
+
     print("Start syncing.")
     login = os.getenv("SYNC_LOGIN")
     password = os.getenv("SYNC_PASSWORD")
@@ -363,6 +427,8 @@ def sync_full_files(
     connect to source instance are given through SYNC_LOGIN and SYNC_PASSWORD
     environment variables.
     """
+    from zou.app.utils import commands
+
     print("Start syncing.")
     login = os.getenv("SYNC_LOGIN")
     password = os.getenv("SYNC_PASSWORD")
@@ -397,6 +463,8 @@ def sync_changes(event_source, source, logs_directory):
     instance. It expects that credentials to connect to source instance are
     given through SYNC_LOGIN and SYNC_PASSWORD environment variables.
     """
+    from zou.app.utils import commands
+
     login = os.getenv("SYNC_LOGIN")
     password = os.getenv("SYNC_PASSWORD")
     commands.run_sync_change_daemon(
@@ -414,6 +482,8 @@ def sync_file_changes(event_source, source, logs_directory):
     instance. It expects that credentials to connect to source instance are
     given through SYNC_LOGIN and SYNC_PASSWORD environment variables.
     """
+    from zou.app.utils import commands
+
     login = os.getenv("SYNC_LOGIN")
     password = os.getenv("SYNC_PASSWORD")
     commands.run_sync_file_change_daemon(
@@ -431,6 +501,8 @@ def sync_last_events(source, minutes, limit):
     to them. It expects that credentials to connect to source instance are
     given through SYNC_LOGIN and SYNC_PASSWORD environment variables.
     """
+    from zou.app.utils import commands
+
     login = os.getenv("SYNC_LOGIN")
     password = os.getenv("SYNC_PASSWORD")
     commands.import_last_changes_from_another_instance(
@@ -448,6 +520,8 @@ def sync_last_files(source, minutes, limit):
     It expects that credentials to connect to source instance are
     given through SYNC_LOGIN and SYNC_PASSWORD environment variables.
     """
+    from zou.app.utils import commands
+
     login = os.getenv("SYNC_LOGIN")
     password = os.getenv("SYNC_PASSWORD")
     commands.import_last_file_changes_from_another_instance(
@@ -461,6 +535,8 @@ def download_storage_files():
     Download all files from a Swift object storage and store them in a local
     storage.
     """
+    from zou.app.utils import commands
+
     commands.download_file_from_storage()
 
 
@@ -471,6 +547,8 @@ def dump_database(store=False):
     Dump database described in Zou environment variables and save it to
     configured object storage.
     """
+    from zou.app.utils import commands
+
     commands.dump_database(store)
 
 
@@ -480,6 +558,8 @@ def upload_files_to_cloud_storage(days):
     """
     Upload all files related to previews to configured object storage.
     """
+    from zou.app.utils import commands
+
     commands.upload_files_to_cloud_storage(days)
 
 
@@ -490,6 +570,8 @@ def clean_tasks_data(project_id):
     Reset task models data (retake count, wip start date and end date)
     """
     if project_id is not None:
+        from zou.app.utils import commands
+
         commands.reset_tasks_data(project_id)
 
 
@@ -500,6 +582,8 @@ def remove_old_data(days):
     Remove old events, notifications and login logs older than 90 days
     (by default).
     """
+    from zou.app.utils import commands
+
     commands.remove_old_data(days)
 
 
@@ -508,6 +592,8 @@ def reset_search_index():
     """
     Reset search index.
     """
+    from zou.app.utils import commands
+
     commands.reset_search_index()
 
 
@@ -515,6 +601,8 @@ def reset_search_index():
 @click.option("--query", default="")
 def search_asset(query):
     """ """
+    from zou.app.utils import commands
+
     commands.search_asset(query)
 
 
@@ -548,6 +636,8 @@ def generate_preview_extra(
     """
     Generate tiles, thumbnails and metadata for all previews.
     """
+    from zou.app.utils import commands
+
     commands.generate_preview_extra(
         project=project,
         entity_id=entity_id,
@@ -566,6 +656,8 @@ def reset_movie_files_metadata():
     """
     Store height and width metadata for all movie previews in the database.
     """
+    from zou.app.utils import commands
+
     commands.reset_movie_files_metadata()
 
 
@@ -574,6 +666,8 @@ def reset_picture_files_metadata():
     """
     Store height and width metadata for all picture previews in the database.
     """
+    from zou.app.utils import commands
+
     commands.reset_picture_files_metadata()
 
 
@@ -582,6 +676,8 @@ def reset_breakdown_data():
     """
     Reset breakdown statistics for all open projects.
     """
+    from zou.app.utils import commands
+
     commands.reset_breakdown_data()
 
 
@@ -605,6 +701,8 @@ def create_bot(
     """
     Create a bot.
     """
+    from zou.app.utils import commands
+
     commands.create_bot(
         email,
         name,
@@ -645,6 +743,8 @@ def renormalize_movie_preview_files(
     """
     Renormalize all preview files.
     """
+    from zou.app.utils import commands
+
     commands.renormalize_movie_preview_files(
         preview_file_id,
         project_id,
@@ -673,7 +773,9 @@ def install_plugin(path, force=False):
     Install a plugin and apply the migrations.
     Supports local paths, zip files, and git repository URLs.
     """
-    with app.app_context():
+    from zou.app.services import plugins_service
+
+    with _get_app().app_context():
         plugins_service.install_plugin(path, force)
     print(f"✅ Plugin {path} installed. Restart the server to apply changes.")
 
@@ -687,7 +789,9 @@ def uninstall_plugin(id):
     """
     Uninstall a plugin.
     """
-    with app.app_context():
+    from zou.app.services import plugins_service
+
+    with _get_app().app_context():
         plugins_service.uninstall_plugin(id)
     print(f"Plugin {id} uninstalled. Restart the server to apply changes.")
 
@@ -759,6 +863,8 @@ def create_plugin_skeleton(
     """
     Create a plugin template in the given path.
     """
+    from zou.app.utils import plugins as plugin_utils
+
     plugin_path = plugin_utils.create_plugin_skeleton(
         path,
         id,
@@ -797,6 +903,8 @@ def create_plugin_package(
     """
     Create a plugin package.
     """
+    from zou.app.utils import plugins as plugin_utils
+
     plugin_path = plugin_utils.create_plugin_package(path, output_path, force)
     print(f"Plugin package created in '{plugin_path}'.")
 
@@ -819,7 +927,8 @@ def create_plugin_package(
 @click.option(
     "--filter-field",
     type=click.Choice(
-        ["plugin_id", "name", "maintainer", "license"], case_sensitive=False
+        ["plugin_id", "name", "maintainer", "license"],
+        case_sensitive=False,
     ),
     help="Field to filter by.",
 )
@@ -828,6 +937,8 @@ def list_plugins(output_format, verbose, filter_field, filter_value):
     """
     List installed plugins.
     """
+    from zou.app.utils import commands
+
     commands.list_plugins(output_format, verbose, filter_field, filter_value)
 
 
@@ -841,7 +952,9 @@ def migrate_plugin_db(path, message):
     """
     Migrate plugin database.
     """
-    with app.app_context():
+    from zou.app.utils import plugins as plugin_utils
+
+    with _get_app().app_context():
         plugin_utils.migrate_plugin_db(path, message)
     print(f"Plugin {path} database migrated.")
 

--- a/zou/cli.py
+++ b/zou/cli.py
@@ -232,11 +232,11 @@ def disable_two_factor_authentication(email_or_desktop_login):
     """
     with app.app_context():
         try:
-            person_id = persons_service.get_person_by_email_desktop_login(
+            person = persons_service.get_person_by_email_desktop_login(
                 email_or_desktop_login
             )
             auth_service.disable_two_factor_authentication_for_person(
-                person_id
+                person["id"]
             )
             print(
                 f"Two factor authentication disabled for {email_or_desktop_login}."


### PR DESCRIPTION
**Problem**
Added the “ENFORCE_2FA” parameter to force the activation of 2FA and disable its use of the API for users who do not have it.

**Solution**
When ENFORCE_2FA is enabled, users without 2FA configured now receive
  restricted JWT tokens at login instead of being blocked with a 403.
  These tokens only allow access to MFA enrollment routes (/auth/totp,
  /auth/email-otp, /auth/fido) and basic auth routes (/auth/login,
  /auth/logout, /auth/authenticated, /auth/refresh-token). All other
  routes return 403 with two_factor_authentication_required.

  After successful 2FA registration (TOTP, Email OTP, or FIDO), new
  unrestricted JWT tokens are issued automatically so the user gets
  full API access without needing to log in again.

  Changes:
  - Move 2FA enforcement check from auth_service.check_auth() to
    LoginResource.post() so login succeeds with restricted tokens
  - Add requires_2fa_setup JWT claim to restrict token scope
  - Add route allowlist in user_lookup_callback to enforce restrictions
  - Add _build_2fa_registration_response() to re-issue clean tokens
    after successful TOTP, Email OTP, or FIDO registration
  - RefreshTokenResource checks current 2FA status so refreshed tokens
    become unrestricted once 2FA is configured
  - Expose is_user_exempt_from_2fa() as public API
  - Add error handler for TwoFactorAuthenticationRequiredException
  - Add 10 tests covering the full enrollment flow