### PR TITLE
feat: sync JOB_QUEUE_NOMAD_HOST, JOB_QUEUE_NOMAD_NORMALIZE_JOB, and JOB_QUEUE_NOMAD_PLAYLIST_JOB via reload-config

### DIFF
--- a/tests/stores/test_config_store.py
+++ b/tests/stores/test_config_store.py
@@ -8,15 +8,24 @@ from zou.app.services import persons_service
 class ConfigStoreTestCase(ApiDBTestCase):
     def setUp(self):
         super().setUp()
-        config_store.config_store.delete(config_store.USER_LIMIT_KEY)
-        config_store.config_store.delete(config_store.DEFAULT_TIMEZONE_KEY)
-        config_store.config_store.delete(config_store.DEFAULT_LOCALE_KEY)
+        for key in self._all_keys():
+            config_store.config_store.delete(key)
 
     def tearDown(self):
-        config_store.config_store.delete(config_store.USER_LIMIT_KEY)
-        config_store.config_store.delete(config_store.DEFAULT_TIMEZONE_KEY)
-        config_store.config_store.delete(config_store.DEFAULT_LOCALE_KEY)
+        for key in self._all_keys():
+            config_store.config_store.delete(key)
         super().tearDown()
+
+    @staticmethod
+    def _all_keys():
+        return [
+            config_store.USER_LIMIT_KEY,
+            config_store.DEFAULT_TIMEZONE_KEY,
+            config_store.DEFAULT_LOCALE_KEY,
+            config_store.NOMAD_HOST_KEY,
+            config_store.NOMAD_NORMALIZE_JOB_KEY,
+            config_store.NOMAD_PLAYLIST_JOB_KEY,
+        ]
 
     # --- USER_LIMIT ---
 
@@ -127,6 +136,56 @@ class ConfigStoreTestCase(ApiDBTestCase):
         conf = self.get("config")
         self.assertEqual(conf["default_locale"], "ja_JP")
 
+    # --- NOMAD_HOST ---
+
+    def test_get_nomad_host_fallback(self):
+        """When Redis has no value, fall back to config."""
+        self.assertEqual(
+            config_store.get_nomad_host(),
+            config.JOB_QUEUE_NOMAD_HOST,
+        )
+
+    def test_get_nomad_host_from_redis(self):
+        """When Redis has a value, return it."""
+        config_store.config_store.set(
+            config_store.NOMAD_HOST_KEY, "nomad.example.com"
+        )
+        self.assertEqual(config_store.get_nomad_host(), "nomad.example.com")
+
+    # --- NOMAD_NORMALIZE_JOB ---
+
+    def test_get_nomad_normalize_job_fallback(self):
+        """When Redis has no value, fall back to config."""
+        self.assertEqual(
+            config_store.get_nomad_normalize_job(),
+            config.JOB_QUEUE_NOMAD_NORMALIZE_JOB,
+        )
+
+    def test_get_nomad_normalize_job_from_redis(self):
+        """When Redis has a value, return it."""
+        config_store.config_store.set(
+            config_store.NOMAD_NORMALIZE_JOB_KEY, "zou-norm-v2"
+        )
+        self.assertEqual(config_store.get_nomad_normalize_job(), "zou-norm-v2")
+
+    # --- NOMAD_PLAYLIST_JOB ---
+
+    def test_get_nomad_playlist_job_fallback(self):
+        """When Redis has no value, fall back to config."""
+        self.assertEqual(
+            config_store.get_nomad_playlist_job(),
+            config.JOB_QUEUE_NOMAD_PLAYLIST_JOB,
+        )
+
+    def test_get_nomad_playlist_job_from_redis(self):
+        """When Redis has a value, return it."""
+        config_store.config_store.set(
+            config_store.NOMAD_PLAYLIST_JOB_KEY, "zou-playlist-v2"
+        )
+        self.assertEqual(
+            config_store.get_nomad_playlist_job(), "zou-playlist-v2"
+        )
+
     # --- sync_config ---
 
     def test_sync_config_sets_all_values(self):
@@ -135,6 +194,15 @@ class ConfigStoreTestCase(ApiDBTestCase):
         self.assertEqual(values["user_limit"], config.USER_LIMIT)
         self.assertEqual(values["default_timezone"], config.DEFAULT_TIMEZONE)
         self.assertEqual(values["default_locale"], config.DEFAULT_LOCALE)
+        self.assertEqual(values["nomad_host"], config.JOB_QUEUE_NOMAD_HOST)
+        self.assertEqual(
+            values["nomad_normalize_job"],
+            config.JOB_QUEUE_NOMAD_NORMALIZE_JOB,
+        )
+        self.assertEqual(
+            values["nomad_playlist_job"],
+            config.JOB_QUEUE_NOMAD_PLAYLIST_JOB,
+        )
         self.assertEqual(
             config_store.config_store.get(config_store.USER_LIMIT_KEY),
             str(config.USER_LIMIT),
@@ -147,6 +215,20 @@ class ConfigStoreTestCase(ApiDBTestCase):
             config_store.config_store.get(config_store.DEFAULT_LOCALE_KEY),
             config.DEFAULT_LOCALE,
         )
+        self.assertEqual(
+            config_store.config_store.get(config_store.NOMAD_HOST_KEY),
+            config.JOB_QUEUE_NOMAD_HOST,
+        )
+        self.assertEqual(
+            config_store.config_store.get(
+                config_store.NOMAD_NORMALIZE_JOB_KEY
+            ),
+            config.JOB_QUEUE_NOMAD_NORMALIZE_JOB,
+        )
+        self.assertEqual(
+            config_store.config_store.get(config_store.NOMAD_PLAYLIST_JOB_KEY),
+            config.JOB_QUEUE_NOMAD_PLAYLIST_JOB,
+        )
 
     def test_sync_config_updates_when_different(self):
         """sync_config overwrites Redis when values differ."""
@@ -154,14 +236,19 @@ class ConfigStoreTestCase(ApiDBTestCase):
         config_store.config_store.set(
             config_store.DEFAULT_TIMEZONE_KEY, "Old/Zone"
         )
+        config_store.config_store.set(config_store.NOMAD_HOST_KEY, "old-host")
         original_limit = config.USER_LIMIT
         original_tz = config.DEFAULT_TIMEZONE
+        original_host = config.JOB_QUEUE_NOMAD_HOST
         config.USER_LIMIT = 50
         config.DEFAULT_TIMEZONE = "UTC"
+        config.JOB_QUEUE_NOMAD_HOST = "new-nomad-host"
         try:
             config_store.sync_config()
             self.assertEqual(config_store.get_user_limit(), 50)
             self.assertEqual(config_store.get_default_timezone(), "UTC")
+            self.assertEqual(config_store.get_nomad_host(), "new-nomad-host")
         finally:
             config.USER_LIMIT = original_limit
             config.DEFAULT_TIMEZONE = original_tz
+            config.JOB_QUEUE_NOMAD_HOST = original_host

--- a/zou/app/services/playlists_service.py
+++ b/zou/app/services/playlists_service.py
@@ -16,8 +16,8 @@ from slugify import slugify
 from sqlalchemy import or_
 from sqlalchemy.orm import joinedload
 
-from zou.app import config, db
-from zou.app.stores import file_store
+from zou.app import config
+from zou.app.stores import config_store, file_store
 
 from zou.app.models.build_job import BuildJob
 from zou.app.models.playlist import Playlist
@@ -196,7 +196,7 @@ def get_playlist_with_preview_file_revisions(playlist_id):
 
     if playlist_dict["shots"] is None:
         playlist_dict["shots"] = []
-    (playlist_dict, preview_file_map) = set_preview_files_for_entities(
+    playlist_dict, preview_file_map = set_preview_files_for_entities(
         playlist_dict
     )
 
@@ -716,7 +716,7 @@ def _run_remote_job_build_playlist(
         "fps": params.fps,
         "full": str(full).lower(),
     }
-    nomad_job = config.JOB_QUEUE_NOMAD_PLAYLIST_JOB
+    nomad_job = config_store.get_nomad_playlist_job()
     remote_job.run_job(app, config, nomad_job, params)
 
     with open(movie_file_path, "wb") as movie_file:

--- a/zou/app/services/preview_files_service.py
+++ b/zou/app/services/preview_files_service.py
@@ -11,7 +11,7 @@ from sqlalchemy.orm import aliased
 from sqlalchemy.orm.exc import ObjectDeletedError, StaleDataError
 
 from zou.app import config
-from zou.app.stores import file_store
+from zou.app.stores import config_store, file_store
 from zou.app.stores.redis_lock import with_preview_file_lock
 
 from zou.app.models.entity import Entity
@@ -224,7 +224,7 @@ def prepare_and_store_movie(
 
         is_remote = (
             config.ENABLE_JOB_QUEUE_REMOTE
-            and len(config.JOB_QUEUE_NOMAD_NORMALIZE_JOB) > 0
+            and len(config_store.get_nomad_normalize_job()) > 0
         )
 
         if normalize:
@@ -363,7 +363,7 @@ def _run_remote_normalize_movie(app, preview_file_id, fps, width, height):
         "height": height,
         "fps": fps,
     }
-    nomad_job = app.config["JOB_QUEUE_NOMAD_NORMALIZE_JOB"]
+    nomad_job = config_store.get_nomad_normalize_job()
     result = remote_job.run_job(app, config, nomad_job, params)
     return result
 

--- a/zou/app/stores/config_store.py
+++ b/zou/app/stores/config_store.py
@@ -7,6 +7,9 @@ from zou.app import config
 USER_LIMIT_KEY = "config:user_limit"
 DEFAULT_TIMEZONE_KEY = "config:default_timezone"
 DEFAULT_LOCALE_KEY = "config:default_locale"
+NOMAD_HOST_KEY = "config:nomad_host"
+NOMAD_NORMALIZE_JOB_KEY = "config:nomad_normalize_job"
+NOMAD_PLAYLIST_JOB_KEY = "config:nomad_playlist_job"
 
 try:
     config_store = redis.StrictRedis(
@@ -57,6 +60,18 @@ def get_default_locale():
     return _get(DEFAULT_LOCALE_KEY, config.DEFAULT_LOCALE)
 
 
+def get_nomad_host():
+    return _get(NOMAD_HOST_KEY, config.JOB_QUEUE_NOMAD_HOST)
+
+
+def get_nomad_normalize_job():
+    return _get(NOMAD_NORMALIZE_JOB_KEY, config.JOB_QUEUE_NOMAD_NORMALIZE_JOB)
+
+
+def get_nomad_playlist_job():
+    return _get(NOMAD_PLAYLIST_JOB_KEY, config.JOB_QUEUE_NOMAD_PLAYLIST_JOB)
+
+
 def sync_config():
     """
     Read config values from environment variables and push them to
@@ -70,4 +85,13 @@ def sync_config():
             DEFAULT_TIMEZONE_KEY, config.DEFAULT_TIMEZONE
         ),
         "default_locale": _sync(DEFAULT_LOCALE_KEY, config.DEFAULT_LOCALE),
+        "nomad_host": _sync(NOMAD_HOST_KEY, config.JOB_QUEUE_NOMAD_HOST),
+        "nomad_normalize_job": _sync(
+            NOMAD_NORMALIZE_JOB_KEY,
+            config.JOB_QUEUE_NOMAD_NORMALIZE_JOB,
+        ),
+        "nomad_playlist_job": _sync(
+            NOMAD_PLAYLIST_JOB_KEY,
+            config.JOB_QUEUE_NOMAD_PLAYLIST_JOB,
+        ),
     }

--- a/zou/app/utils/remote_job.py
+++ b/zou/app/utils/remote_job.py
@@ -4,9 +4,11 @@ import orjson as json
 import textwrap
 import time
 
+from zou.app.stores import config_store
+
 
 def run_job(app, config, nomad_job_name, params):
-    nomad_host = config.JOB_QUEUE_NOMAD_HOST
+    nomad_host = config_store.get_nomad_host()
 
     params.update(
         {

--- a/zou/cli.py
+++ b/zou/cli.py
@@ -400,9 +400,11 @@ def sync_with_ldap_server():
 @cli.command()
 def reload_config():
     """
-    Read USER_LIMIT, DEFAULT_TIMEZONE, and DEFAULT_LOCALE from
-    environment variables and push them to Redis so that all workers
-    pick up the new values immediately.
+    Read USER_LIMIT, DEFAULT_TIMEZONE, DEFAULT_LOCALE,
+    JOB_QUEUE_NOMAD_HOST, JOB_QUEUE_NOMAD_NORMALIZE_JOB, and
+    JOB_QUEUE_NOMAD_PLAYLIST_JOB from environment variables and push
+    them to Redis so that all workers pick up the new values
+    immediately.
     """
     from zou.app.stores.config_store import sync_config
 


### PR DESCRIPTION
**Problem**
The Nomad job queue settings (JOB_QUEUE_NOMAD_HOST, JOB_QUEUE_NOMAD_NORMALIZE_JOB, JOB_QUEUE_NOMAD_PLAYLIST_JOB) are read once from environment variables at import time.
Changing them requires restarting all workers, unlike USER_LIMIT, DEFAULT_TIMEZONE, and DEFAULT_LOCALE which can be hot-reloaded via Redis with `zou reload-config`.

**Solution**
Store the three Nomad settings in Redis alongside the existing config keys. Add getters (`get_nomad_host`, `get_nomad_normalize_job`, `get_nomad_playlist_job`) to `config_store` and update all consumers (`remote_job.py`, `preview_files_service.py`, `playlists_service.py`) to read from Redis instead of `config` directly. The `sync_config()` function and `reload-config` CLI command now handle all six settings.