### PR TITLE
perf: reduce memory consumption across services

### DIFF
--- a/zou/app/blueprints/export/csv/base.py
+++ b/zou/app/blueprints/export/csv/base.py
@@ -40,14 +40,14 @@ class BaseCsvExport(Resource):
         self.prepare_import()
         try:
             self.check_permissions()
-            csv_content = []
-            csv_content.append(self.build_headers())
-            results = self.build_query().all()
-            for result in results:
-                csv_content.append(self.build_row(result))
         except permissions.PermissionDenied:
             raise
 
-        return csv_utils.build_csv_response(
-            csv_content, file_name=self.file_name
+        def row_generator():
+            yield self.build_headers()
+            for result in self.build_query().yield_per(500):
+                yield self.build_row(result)
+
+        return csv_utils.build_csv_stream_response(
+            row_generator(), file_name=self.file_name
         )

--- a/zou/app/blueprints/export/csv/tasks.py
+++ b/zou/app/blueprints/export/csv/tasks.py
@@ -1,6 +1,6 @@
 from zou.app.blueprints.export.csv.base import BaseCsvExport
 from flask_jwt_extended import jwt_required
-from sqlalchemy.orm import aliased
+from sqlalchemy.orm import aliased, selectinload
 
 from zou.app.models.task_status import TaskStatus
 from zou.app.models.task_type import TaskType
@@ -88,6 +88,7 @@ class TasksCsvExport(BaseCsvExport):
             Person.first_name,
             Person.last_name,
         )
+        query = query.options(selectinload(Task.assignees))
         query = query.filter(Project.project_status_id == open_status["id"])
         query = query.order_by(
             Project.name,

--- a/zou/app/models/task.py
+++ b/zou/app/models/task.py
@@ -66,9 +66,7 @@ class Task(db.Model, BaseMixin, SerializerMixin):
     assigner_id = db.Column(
         UUIDType(binary=False), db.ForeignKey("person.id"), index=True
     )
-    assignees = db.relationship(
-        "Person", secondary=TaskPersonLink.__table__, lazy="selectin"
-    )
+    assignees = db.relationship("Person", secondary=TaskPersonLink.__table__)
 
     __table_args__ = (
         db.UniqueConstraint(

--- a/zou/app/services/backup_service.py
+++ b/zou/app/services/backup_service.py
@@ -69,7 +69,7 @@ def upload_preview_files_to_storage(days=None):
         limit_date = date_helpers.get_date_from_now(int(days))
         query = query.filter(PreviewFile.updated_at >= limit_date)
 
-    for preview_file in query.all():
+    for preview_file in query.yield_per(500):
         upload_preview(preview_file)
 
 

--- a/zou/app/services/deletion_service.py
+++ b/zou/app/services/deletion_service.py
@@ -1,5 +1,6 @@
 import datetime
 from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import selectinload
 
 
 from zou.app.models.attachment_file import AttachmentFile
@@ -479,7 +480,9 @@ def remove_person(person_id, force=True):
                 if str(member.id) != person_id
             ]
             project.save()
-        for task in Task.query.filter(Task.assignees.contains(person)):
+        for task in Task.query.options(selectinload(Task.assignees)).filter(
+            Task.assignees.contains(person)
+        ):
             task.assignees = [
                 assignee
                 for assignee in task.assignees

--- a/zou/app/services/index_service.py
+++ b/zou/app/services/index_service.py
@@ -65,13 +65,18 @@ def reset_entry_index(
     )
     indexing.clear_index(index_name)
     entries = get_entries()
+    total = 0
     documents = []
-    for chunk in chunks(entries, 3000):
-        for entry in chunk:
-            document = prepare_entry(entry)
-            documents.append(document)
+    for entry in entries:
+        documents.append(prepare_entry(entry))
+        if len(documents) >= 3000:
+            indexing.index_documents(index, documents)
+            total += len(documents)
+            documents = []
+    if documents:
         indexing.index_documents(index, documents)
-    print(len(entries), "%s indexed" % index_name)
+        total += len(documents)
+    print(total, "%s indexed" % index_name)
     return entries
 
 

--- a/zou/app/services/playlists_service.py
+++ b/zou/app/services/playlists_service.py
@@ -520,12 +520,14 @@ def playlist_previews(shots, only_movies=False):
         return []
 
     # Single query for all preview files (batch fetch)
-    preview_models = PreviewFile.query.filter(
-        PreviewFile.id.in_(preview_file_ids)
-    ).all()
+    preview_rows = (
+        PreviewFile.query.with_entities(PreviewFile.id, PreviewFile.extension)
+        .filter(PreviewFile.id.in_(preview_file_ids))
+        .all()
+    )
     id_to_preview = {
-        str(pf.id): {"id": str(pf.id), "extension": pf.extension}
-        for pf in preview_models
+        str(pf_id): {"id": str(pf_id), "extension": ext}
+        for pf_id, ext in preview_rows
     }
 
     # Preserve order of shots and apply only_movies filter

--- a/zou/app/services/projects_service.py
+++ b/zou/app/services/projects_service.py
@@ -1,5 +1,6 @@
 import slugify
 
+from collections import defaultdict
 from sqlalchemy.exc import IntegrityError
 
 from zou.app.models.preview_background_file import PreviewBackgroundFile
@@ -140,10 +141,8 @@ def _fetch_metadata_descriptors_by_project(
     )
 
     all_descriptors = descriptors_query.all()
-    descriptors_by_project = {}
+    descriptors_by_project = defaultdict(list)
     for desc in all_descriptors:
-        if desc.project_id not in descriptors_by_project:
-            descriptors_by_project[desc.project_id] = []
         descriptors_by_project[desc.project_id].append(desc)
     return descriptors_by_project
 
@@ -152,10 +151,8 @@ def _fetch_task_type_links_by_project(project_ids):
     task_type_links = ProjectTaskTypeLink.query.filter(
         ProjectTaskTypeLink.project_id.in_(project_ids)
     ).all()
-    task_types_by_project = {}
+    task_types_by_project = defaultdict(dict)
     for link in task_type_links:
-        if link.project_id not in task_types_by_project:
-            task_types_by_project[link.project_id] = {}
         task_types_by_project[link.project_id][
             str(link.task_type_id)
         ] = link.priority
@@ -166,10 +163,8 @@ def _fetch_task_status_links_by_project(project_ids):
     task_status_links = ProjectTaskStatusLink.query.filter(
         ProjectTaskStatusLink.project_id.in_(project_ids)
     ).all()
-    task_statuses_by_project = {}
+    task_statuses_by_project = defaultdict(dict)
     for link in task_status_links:
-        if link.project_id not in task_statuses_by_project:
-            task_statuses_by_project[link.project_id] = {}
         task_statuses_by_project[link.project_id][str(link.task_status_id)] = {
             "priority": link.priority,
             "roles_for_board": fields.serialize_list(link.roles_for_board),
@@ -277,7 +272,7 @@ def get_projects():
 
     result = []
     for entry in query.all():
-        (project, project_status_name) = entry
+        project, project_status_name = entry
         data = project.serialize()
         data["project_status_name"] = project_status_name
         result.append(data)

--- a/zou/app/services/schedule_service.py
+++ b/zou/app/services/schedule_service.py
@@ -1,6 +1,7 @@
 from datetime import date, timedelta
 from sqlalchemy.exc import StatementError
 from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.orm import selectinload
 from sqlalchemy import update
 
 
@@ -312,6 +313,7 @@ def set_production_schedule_version_task_links_from_production(
 
     tasks = (
         db.session.query(Task)
+        .options(selectinload(Task.assignees))
         .filter(Task.project_id == production_schedule_version["project_id"])
         .all()
     )

--- a/zou/app/services/tasks_service.py
+++ b/zou/app/services/tasks_service.py
@@ -655,10 +655,14 @@ def get_comments(task_id, is_client=False, is_manager=False):
         project = projects_service.get_project(task["project_id"])
         current_user = persons_service.get_current_user()
         is_clients_isolated = project.get("is_clients_isolated", False)
+        person_ids = list({c["person_id"] for c in comments})
+        persons_map = {
+            p["id"]: p for p in persons_service.get_persons_by_ids(person_ids)
+        }
         for comment in comments:
-            person = persons_service.get_person(comment["person_id"])
+            person = persons_map.get(comment["person_id"], {})
             is_author = comment["person_id"] == current_user["id"]
-            is_author_client = person["role"] == "client"
+            is_author_client = person.get("role") == "client"
             is_allowed = (is_clients_isolated and is_author) or (
                 not is_clients_isolated and is_author_client
             )

--- a/zou/app/services/time_spents_service.py
+++ b/zou/app/services/time_spents_service.py
@@ -236,9 +236,7 @@ def get_table_from_time_spents(time_spents, detail_level="month"):
 
         person_id = str(time_spent.person_id)
         if unit not in result:
-            result[unit] = {}
-        if person_id not in result[unit]:
-            result[unit][person_id] = 0
+            result[unit] = defaultdict(int)
         result[unit][person_id] += time_spent.duration
     return result
 

--- a/zou/app/utils/csv_utils.py
+++ b/zou/app/utils/csv_utils.py
@@ -1,7 +1,7 @@
 import csv
 
 from io import StringIO
-from flask import make_response
+from flask import Response, make_response, stream_with_context
 from slugify import slugify
 
 
@@ -15,6 +15,30 @@ def build_csv_response(csv_content, file_name="export"):
     csv_response = build_csv_headers(csv_response, file_name)
 
     return csv_response
+
+
+def build_csv_stream_response(row_generator, file_name="export"):
+    """
+    Construct a streaming Flask response from a row generator.
+    Each row is written and flushed immediately to avoid buffering
+    the entire CSV in memory.
+    """
+    file_name = build_csv_file_name(file_name)
+
+    def generate():
+        for row in row_generator:
+            buf = StringIO()
+            csv.writer(buf, delimiter=";").writerow(row)
+            yield buf.getvalue()
+
+    response = Response(
+        stream_with_context(generate()),
+        mimetype="text/csv",
+    )
+    response.headers["Content-Disposition"] = (
+        "attachment; filename=%s.csv" % file_name
+    )
+    return response
 
 
 def build_csv_file_name(file_name):


### PR DESCRIPTION
**Problem**
Several SQLAlchemy patterns cause excessive memory usage: Task.assignees is eagerly loaded via selectin on every query (70-80% don't need it), get_comments() triggers N+1 queries fetching persons one by one, backup_service loads all preview files into memory at once, and playlists_service fetches full ORM objects when only 2 fields are needed.

**Solution**
  - Fix N+1 in get_comments() by batch-fetching persons with get_persons_by_ids()
  - Stream preview files in backup_service with yield_per(500)
  - Use with_entities(id, extension) in playlists_service instead of full PreviewFile objects
  - Replace manual if key not in dict patterns with defaultdict in projects_service and time_spents_service
  - Flush index documents in batches in index_service instead of accumulating indefinitely
  - Change Task.assignees from lazy="selectin" to default lazy loading, add explicit selectinload only in the 3 bulk access sites (CSV export, schedule service, deletion service)