### PR TITLE
Fix Sentry crashes and restore casting/to-review event payloads

### DIFF
--- a/tests/services/test_breakdown_service.py
+++ b/tests/services/test_breakdown_service.py
@@ -6,6 +6,7 @@ from zou.app.services import (
     projects_service,
     tasks_service,
 )
+from zou.app.utils import events
 
 
 class BreakdownServiceTestCase(ApiDBTestCase):
@@ -157,6 +158,61 @@ class BreakdownServiceTestCase(ApiDBTestCase):
         self.assertEqual(cast_in[0]["shot_name"], self.shot.name)
         self.assertEqual(cast_in[0]["sequence_name"], self.sequence.name)
         self.assertEqual(cast_in[0]["episode_name"], self.episode.name)
+
+    def test_update_casting_event_payload_diff(self):
+        """
+        casting-update events must include added_asset_ids and
+        removed_asset_ids so listeners know what changed without having
+        to keep a client-side snapshot (cgwire/gazu#393).
+        """
+        captured = []
+
+        class _Handler:
+            __name__ = "casting_update_handler"
+
+            def __init__(self, sink):
+                self.sink = sink
+
+            def handle_event(self, data=None):
+                self.sink.append(data or {})
+
+        events.unregister_all()
+        handler = _Handler(captured)
+        events.register("shot:casting-update", "casting_update_handler", handler)
+
+        shot_id = str(self.shot.id)
+        asset_id = str(self.asset.id)
+        asset_character_id = str(self.asset_character.id)
+
+        # Initial casting: both assets added.
+        breakdown_service.update_casting(
+            self.shot.id,
+            [
+                {"asset_id": asset_id, "nb_occurences": 1},
+                {"asset_id": asset_character_id, "nb_occurences": 3},
+            ],
+        )
+        self.assertEqual(len(captured), 1)
+        first = captured[0]
+        self.assertEqual(first["shot_id"], shot_id)
+        self.assertEqual(first["nb_entities_out"], 2)
+        self.assertEqual(
+            sorted(first["added_asset_ids"]),
+            sorted([asset_id, asset_character_id]),
+        )
+        self.assertEqual(first["removed_asset_ids"], [])
+
+        # Replace casting: drop asset_character, keep asset.
+        breakdown_service.update_casting(
+            self.shot.id,
+            [{"asset_id": asset_id, "nb_occurences": 1}],
+        )
+        self.assertEqual(len(captured), 2)
+        second = captured[1]
+        self.assertEqual(second["shot_id"], shot_id)
+        self.assertEqual(second["nb_entities_out"], 1)
+        self.assertEqual(second["added_asset_ids"], [])
+        self.assertEqual(second["removed_asset_ids"], [asset_character_id])
 
     def test_add_instance_to_shot(self):
         instances = breakdown_service.get_asset_instances_for_shot(

--- a/tests/services/test_comments_service.py
+++ b/tests/services/test_comments_service.py
@@ -7,6 +7,7 @@ from zou.app.services import (
     tasks_service,
     exception,
 )
+from zou.app.utils import events
 
 
 class CommentsServiceTestCase(ApiDBTestCase):
@@ -123,6 +124,42 @@ class CommentsServiceTestCase(ApiDBTestCase):
             self.wfa_status, task, comment
         )
         self.assertTrue(task["end_date"] is not None)
+
+    def test_manage_status_change_emits_to_review(self):
+        """
+        Moving a task to a feedback-request status via a comment must
+        re-emit the legacy task:to-review event so existing gazu listeners
+        keep working after the deprecation of /actions/tasks/<id>/to-review.
+        """
+        self.fired_events = []
+
+        class _Handler:
+            __name__ = "to_review_handler"
+
+            def __init__(self, sink):
+                self.sink = sink
+
+            def handle_event(self, data=None):
+                self.sink.append(data or {})
+
+        events.unregister_all()
+        handler = _Handler(self.fired_events)
+        events.register("task:to-review", "to_review_handler", handler)
+
+        comment = comments_service.new_comment(
+            self.task.id, self.task_status.id, self.user["id"], "to wfa"
+        )
+        task = self.task.serialize()
+
+        comments_service._manage_status_change(self.wfa_status, task, comment)
+
+        self.assertEqual(len(self.fired_events), 1)
+        payload = self.fired_events[0]
+        self.assertEqual(payload["task_id"], str(self.task.id))
+        self.assertEqual(
+            payload["new_task_status_id"], self.wfa_status["id"]
+        )
+        self.assertEqual(payload["comment_id"], comment["id"])
 
     def test_manage_subscriptions(self):
         # TODO

--- a/zou/app/blueprints/crud/project.py
+++ b/zou/app/blueprints/crud/project.py
@@ -13,6 +13,7 @@ from zou.app.services import (
     user_service,
     persons_service,
     files_service,
+    preview_files_service,
 )
 from zou.app.utils import events, permissions, fields
 
@@ -181,7 +182,8 @@ class ProjectsResource(BaseModelsResource):
 
     def check_creation_integrity(self, data):
         """
-        Check if the data descriptor has a valid production_style.
+        Check if the data descriptor has a valid production_style and
+        resolution.
         """
         if "production_style" in data:
             if data["production_style"] is None:
@@ -190,6 +192,8 @@ class ProjectsResource(BaseModelsResource):
                 type_name for type_name, _ in PROJECT_STYLES
             ]:
                 raise WrongParameterException("Invalid production_style")
+        if "resolution" in data:
+            preview_files_service.validate_resolution(data["resolution"])
         return True
 
     def update_data(self, data):
@@ -392,6 +396,9 @@ class ProjectResource(BaseModelResource, ArgsMixin):
         return user_service.check_manager_project_access(project["id"])
 
     def pre_update(self, project_dict, data):
+        if "resolution" in data:
+            preview_files_service.validate_resolution(data["resolution"])
+
         if "preview_background_files" in data:
             data["preview_background_files"] = [
                 files_service.get_preview_background_file_raw(

--- a/zou/app/services/breakdown_service.py
+++ b/zou/app/services/breakdown_service.py
@@ -274,6 +274,21 @@ def update_casting(entity_id, casting):
 
     entity = entities_service.get_entity_raw(entity_id)
     entity_dict = entity.serialize(relations=True)
+
+    # Snapshot the casting before mutating so the emitted event can carry
+    # an explicit added/removed diff. Listeners would otherwise have to
+    # keep their own client-side snapshot to know what changed.
+    previous_asset_ids = {
+        str(asset_id) for asset_id in entity_dict.get("entities_out") or []
+    }
+    new_asset_ids = {
+        str(cast["asset_id"])
+        for cast in casting
+        if "asset_id" in cast and "nb_occurences" in cast
+    }
+    added_asset_ids = sorted(new_asset_ids - previous_asset_ids)
+    removed_asset_ids = sorted(previous_asset_ids - new_asset_ids)
+
     if shots_service.is_episode(entity_dict):
         assets = _extract_removal(entity_dict, casting)
         for asset_id in assets:
@@ -298,23 +313,28 @@ def update_casting(entity_id, casting):
     nb_entities_out = len(casting)
     entity.update({"nb_entities_out": nb_entities_out})
     entity_dict = entity.serialize()
+    casting_diff = {
+        "nb_entities_out": nb_entities_out,
+        "added_asset_ids": added_asset_ids,
+        "removed_asset_ids": removed_asset_ids,
+    }
     if shots_service.is_shot(entity_dict):
         refresh_shot_casting_stats(entity_dict)
         events.emit(
             "shot:casting-update",
-            {"shot_id": entity_id, "nb_entities_out": nb_entities_out},
+            {"shot_id": entity_id, **casting_diff},
             project_id=str(entity.project_id),
         )
     elif shots_service.is_episode(entity_dict):
         events.emit(
             "episode:casting-update",
-            {"episode_id": entity_id, "nb_entities_out": nb_entities_out},
+            {"episode_id": entity_id, **casting_diff},
             project_id=str(entity.project_id),
         )
     else:
         events.emit(
             "asset:casting-update",
-            {"asset_id": entity_id},
+            {"asset_id": entity_id, **casting_diff},
             project_id=str(entity.project_id),
         )
     return casting
@@ -394,7 +414,12 @@ def _remove_asset_from_episode_shots(asset_id, episode_id):
         link.delete()
         events.emit(
             "shot:casting-update",
-            {"shot_id": str(shot.id), "nb_entities_out": shot.nb_entities_out},
+            {
+                "shot_id": str(shot.id),
+                "nb_entities_out": shot.nb_entities_out,
+                "added_asset_ids": [],
+                "removed_asset_ids": [str(asset_id)],
+            },
             project_id=str(shot.project_id),
         )
     return shots

--- a/zou/app/services/comments_service.py
+++ b/zou/app/services/comments_service.py
@@ -222,6 +222,23 @@ def _manage_status_change(task_status, task, comment):
                 },
                 project_id=task["project_id"],
             )
+            if task_status["is_feedback_request"]:
+                # Backwards-compatible: the legacy /actions/tasks/<id>/to-review
+                # endpoint emitted task:to-review whenever a task moved to a
+                # feedback-request status. Modern Kitsu posts a comment with
+                # the new task_status_id instead, so we re-emit the event from
+                # here to keep existing gazu listeners working.
+                events.emit(
+                    "task:to-review",
+                    {
+                        "task_id": task["id"],
+                        "new_task_status_id": new_data["task_status_id"],
+                        "previous_task_status_id": task["task_status_id"],
+                        "person_id": comment["person_id"],
+                        "comment_id": comment["id"],
+                    },
+                    project_id=task["project_id"],
+                )
         task.update(new_data)
     return task, status_changed
 

--- a/zou/app/services/preview_files_service.py
+++ b/zou/app/services/preview_files_service.py
@@ -64,15 +64,25 @@ def get_preview_file_dimensions(project, entity=None):
     if _is_valid_resolution(entity_resolution):
         resolution = entity_resolution
 
-    if _is_valid_resolution(resolution):
-        [width, height] = resolution.split("x")
-        width = int(width)
-        height = int(height)
+    try:
+        if _is_valid_resolution(resolution):
+            [width, height] = resolution.split("x")
+            width = int(width)
+            height = int(height)
+        elif _is_valid_partial_resolution(resolution):
+            [_, height] = resolution.split("x")
+            width = None
+            height = int(height)
+    except (ValueError, TypeError):
+        # Defensive fallback: a malformed resolution string should not
+        # crash the normalization worker, just use the default 1080.
+        from zou.app import app as current_app
 
-    if _is_valid_partial_resolution(resolution):
-        [width, height] = resolution.split("x")
+        current_app.logger.warning(
+            "Invalid resolution %r, falling back to default", resolution
+        )
         width = None
-        height = int(height)
+        height = 1080
 
     return (width, height)
 
@@ -82,7 +92,7 @@ def _is_valid_resolution(resolution):
     Return true if the dimension follows the 1920x1080 pattern.
     """
     return resolution is not None and bool(
-        re.match(r"\d{3,4}x\d{3,4}", resolution)
+        re.match(r"^\d{3,4}x\d{3,4}$", resolution)
     )
 
 
@@ -90,7 +100,30 @@ def _is_valid_partial_resolution(resolution):
     """
     Return true if the dimension follows the x1080 pattern.
     """
-    return resolution is not None and bool(re.match(r"x\d{3,4}", resolution))
+    return resolution is not None and bool(
+        re.match(r"^x\d{3,4}$", resolution)
+    )
+
+
+def validate_resolution(resolution):
+    """
+    Raise WrongParameterException if the resolution is set but doesn't
+    match the canonical "WIDTHxHEIGHT" or "xHEIGHT" format. Empty values
+    (None or "") are accepted: the runtime falls back to 1080p.
+
+    Used at the CRUD boundary so users get an immediate 400 instead of
+    a silent fallback at normalization time.
+    """
+    if resolution in (None, ""):
+        return
+    if not (
+        _is_valid_resolution(resolution)
+        or _is_valid_partial_resolution(resolution)
+    ):
+        raise WrongParameterException(
+            "Invalid resolution %r. Expected format: '1920x1080' or "
+            "'x1080'." % resolution
+        )
 
 
 def get_preview_file_fps(project, entity=None):


### PR DESCRIPTION
**Problem**
- Setting a project resolution to a non-canonical value like `"1440p"` or `"1920x1080p"` slipped past the unanchored format regex and crashed the normalization RQ worker on `int("1440p")`, leaving previews stuck in `processing`.
- The legacy `task:to-review` event is only emitted by the deprecated `/actions/tasks/<id>/to-review` endpoint. The modern comment-based status change flow only emits `task:status-changed`, so existing gazu listeners on `task:to-review` silently stopped firing (cgwire/gazu#395).
- `shot:casting-update` / `episode:casting-update` / `asset:casting-update` events only carry the parent entity id and `nb_entities_out`, forcing listeners to keep a client-side casting snapshot to know what actually changed (cgwire/gazu#393). `asset:casting-update` is also missing `nb_entities_out` entirely.

**Solution**
- Validate `resolution` in the project CRUD `check_creation_integrity` and `pre_update` hooks via a new `preview_files_service.validate_resolution()` helper, so users get an immediate 400 with the expected format. Anchor `_is_valid_resolution` / `_is_valid_partial_resolution` regexes with `^…$` and wrap parsing in `try/except` with a warning log so legacy DB rows fall back to 1080 instead of crashing.
- Re-emit `task:to-review` from `comments_service._manage_status_change` whenever a comment moves a task to a status with `is_feedback_request=True`. Payload mirrors `task:status-changed` (`task_id`, `new_task_status_id`, `previous_task_status_id`, `person_id`) plus `comment_id`.
- Snapshot the casting in `breakdown_service.update_casting` before mutating it, then add `added_asset_ids` / `removed_asset_ids` to all three `casting-update` event payloads. Add `nb_entities_out` to `asset:casting-update` for consistency. Propagate the removed asset id from `_remove_asset_from_episode_shots` so the per-shot fan-out events stay consistent.

Fixes cgwire/gazu#395, cgwire/gazu#393.
