### PR TITLE
Fix playlist deletions

### DIFF
--- a/tests/playlists/test_playlists.py
+++ b/tests/playlists/test_playlists.py
@@ -1,6 +1,7 @@
 from tests.base import ApiDBTestCase
 
-from zou.app.services import projects_service
+from zou.app.models.notification import Notification
+from zou.app.services import playlists_service, projects_service
 
 
 class PlaylistTestCase(ApiDBTestCase):
@@ -56,6 +57,39 @@ class PlaylistTestCase(ApiDBTestCase):
         self.delete("data/playlists/%s" % playlists[0]["id"])
         playlists = self.get("data/projects/%s/playlists" % self.project_id)
         self.assertEqual(len(playlists), 0)
+
+    def test_delete_playlist_with_notifications(self):
+        self.generate_fixture_playlist("Playlist 1")
+        Notification.create(
+            type="playlist-ready",
+            person_id=self.user["id"],
+            author_id=self.user["id"],
+            playlist_id=self.playlist.id,
+        )
+        playlists = self.get("data/projects/%s/playlists" % self.project_id)
+        self.delete("data/playlists/%s" % playlists[0]["id"])
+        playlists = self.get("data/projects/%s/playlists" % self.project_id)
+        self.assertEqual(len(playlists), 0)
+        notifications = Notification.query.filter_by(
+            playlist_id=self.playlist.id
+        ).all()
+        self.assertEqual(len(notifications), 0)
+
+    def test_remove_playlist_with_notifications(self):
+        self.generate_fixture_playlist("Playlist 1")
+        Notification.create(
+            type="playlist-ready",
+            person_id=self.user["id"],
+            author_id=self.user["id"],
+            playlist_id=self.playlist.id,
+        )
+        playlists_service.remove_playlist(str(self.playlist.id))
+        playlists = self.get("data/projects/%s/playlists" % self.project_id)
+        self.assertEqual(len(playlists), 0)
+        notifications = Notification.query.filter_by(
+            playlist_id=self.playlist.id
+        ).all()
+        self.assertEqual(len(notifications), 0)
 
     def test_download_playlist(self):
         self.generate_fixture_playlist("Playlist 1", for_client=False)

--- a/zou/app/blueprints/crud/playlist.py
+++ b/zou/app/blueprints/crud/playlist.py
@@ -2,6 +2,7 @@ from flask_jwt_extended import jwt_required
 
 from zou.app.models.playlist import Playlist
 from zou.app.models.build_job import BuildJob
+from zou.app.models.notification import Notification
 from zou.app.services import user_service, playlists_service, persons_service
 
 from zou.app.blueprints.crud.base import BaseModelResource, BaseModelsResource
@@ -358,6 +359,11 @@ class PlaylistResource(BaseModelResource):
         return super().delete(instance_id)
 
     def pre_delete(self, playlist):
+        notifications = Notification.query.filter_by(
+            playlist_id=playlist["id"]
+        ).all()
+        for notification in notifications:
+            notification.delete()
         query = BuildJob.query.filter_by(playlist_id=playlist["id"])
         for job in query.all():
             playlists_service.remove_build_job(playlist, job.id)

--- a/zou/app/services/playlists_service.py
+++ b/zou/app/services/playlists_service.py
@@ -20,6 +20,7 @@ from zou.app import config
 from zou.app.stores import config_store, file_store
 
 from zou.app.models.build_job import BuildJob
+from zou.app.models.notification import Notification
 from zou.app.models.playlist import Playlist
 from zou.app.models.preview_file import PreviewFile
 from zou.app.models.task import Task
@@ -404,9 +405,7 @@ def get_preview_files_for_entity(entity_id):
                     "task_id": preview_file["task_id"],
                     "original_width": preview_file.get("original_width"),
                     "original_height": preview_file.get("original_height"),
-                    "original_duration": preview_file.get(
-                        "original_duration"
-                    ),
+                    "original_duration": preview_file.get("original_duration"),
                     "original_file_size": preview_file.get(
                         "original_file_size"
                     ),
@@ -890,6 +889,9 @@ def remove_playlist(playlist_id):
     """
     playlist = get_playlist_raw(playlist_id)
     playlist_dict = playlist.serialize()
+    notifications = Notification.query.filter_by(playlist_id=playlist_id).all()
+    for notification in notifications:
+        notification.delete()
     jobs = BuildJob.query.filter_by(playlist_id=playlist_id).all()
     for job in jobs:
         _remove_build_job_impl(playlist_dict, job.serialize())


### PR DESCRIPTION
**Problem**
- You cannot delete a client playlist after notifications have been sent.

> (psycopg.errors.ForeignKeyViolation) update or delete on table "playlist" violates foreign key constraint "notification_playlist_id_fkey" on table "notification"

**Solution**
- Delete related notifications before removing a playlist.
