### PR TITLE
Fix EDL file import when TC offset

### DIFF
--- a/tests/fixtures/edl/no_offset.edl
+++ b/tests/fixtures/edl/no_offset.edl
@@ -1,0 +1,11 @@
+TITLE: TestProject_EDL
+FCM: NON-DROP FRAME
+
+001  AX       V     C        00:00:00:00 00:00:05:05 00:00:00:00 00:00:05:05
+* FROM CLIP NAME: TestProject_SQ010-sc010.mp4
+
+002  AX       V     C        00:00:00:00 00:00:02:23 00:00:05:05 00:00:08:03
+* FROM CLIP NAME: TestProject_SQ010-sc020.mp4
+
+003  AX       V     C        00:00:00:00 00:00:06:24 00:00:08:03 00:00:15:02
+* FROM CLIP NAME: TestProject_SQ020-sc010.mp4

--- a/tests/fixtures/edl/tc_offset.edl
+++ b/tests/fixtures/edl/tc_offset.edl
@@ -1,0 +1,11 @@
+TITLE: TestProject_EDL
+FCM: NON-DROP FRAME
+
+001  AX       V     C        00:00:00:00 00:00:05:05 10:00:00:00 10:00:05:05
+* FROM CLIP NAME: TestProject_SQ010-sc010.mp4
+
+002  AX       V     C        00:00:00:00 00:00:02:23 10:00:05:05 10:00:08:03
+* FROM CLIP NAME: TestProject_SQ010-sc020.mp4
+
+003  AX       V     C        00:00:00:00 00:00:06:24 10:00:08:03 10:00:15:02
+* FROM CLIP NAME: TestProject_SQ020-sc010.mp4

--- a/tests/source/test_import_otio.py
+++ b/tests/source/test_import_otio.py
@@ -1,0 +1,78 @@
+import os
+
+from tests.base import ApiDBTestCase
+
+from zou.app.services import shots_service
+
+
+class ImportOTIOEdlTestCase(ApiDBTestCase):
+    def setUp(self):
+        super().setUp()
+        self.generate_fixture_project_status()
+        self.generate_fixture_project(name="TestProject")
+        self.project.update({"fps": "25"})
+
+    def import_edl(self, edl_filename):
+        path = "/import/otio/projects/%s" % self.project.id
+        file_path = self.get_fixture_file_path(
+            os.path.join("edl", edl_filename)
+        )
+        self.upload_file(path, file_path)
+
+    def test_import_edl_no_offset(self):
+        self.import_edl("no_offset.edl")
+
+        sequences = shots_service.get_sequences()
+        self.assertEqual(len(sequences), 2)
+
+        shots = shots_service.get_shots()
+        self.assertEqual(len(shots), 3)
+
+        shots_by_name = {s["name"]: s for s in shots}
+
+        shot1 = shots_by_name["sc010"]
+        self.assertEqual(shot1["nb_frames"], 130)
+        self.assertEqual(shot1["data"]["frame_in"], 0)
+        self.assertEqual(shot1["data"]["frame_out"], 129)
+
+        shot2 = shots_by_name["sc020"]
+        self.assertEqual(shot2["nb_frames"], 73)
+        self.assertEqual(shot2["data"]["frame_in"], 130)
+        self.assertEqual(shot2["data"]["frame_out"], 202)
+
+    def test_import_edl_with_tc_offset(self):
+        self.import_edl("tc_offset.edl")
+
+        sequences = shots_service.get_sequences()
+        self.assertEqual(len(sequences), 2)
+
+        shots = shots_service.get_shots()
+        self.assertEqual(len(shots), 3)
+
+        shots_by_name = {s["name"]: s for s in shots}
+
+        shot1 = shots_by_name["sc010"]
+        self.assertEqual(shot1["nb_frames"], 130)
+        self.assertEqual(shot1["data"]["frame_in"], 0)
+        self.assertEqual(shot1["data"]["frame_out"], 129)
+
+        shot2 = shots_by_name["sc020"]
+        self.assertEqual(shot2["nb_frames"], 73)
+        self.assertEqual(shot2["data"]["frame_in"], 130)
+        self.assertEqual(shot2["data"]["frame_out"], 202)
+
+    def test_import_edl_creates_sequences(self):
+        self.import_edl("tc_offset.edl")
+
+        sequences = shots_service.get_sequences()
+        sequence_names = {s["name"] for s in sequences}
+        self.assertEqual(sequence_names, {"SQ010", "SQ020"})
+
+    def test_import_edl_updates_existing_shots(self):
+        self.import_edl("no_offset.edl")
+        shots = shots_service.get_shots()
+        self.assertEqual(len(shots), 3)
+
+        self.import_edl("no_offset.edl")
+        shots = shots_service.get_shots()
+        self.assertEqual(len(shots), 3)

--- a/zou/app/blueprints/source/otio.py
+++ b/zou/app/blueprints/source/otio.py
@@ -242,7 +242,7 @@ class OTIOBaseResource(Resource, ArgsMixin):
                     try:
                         try:
                             data["frame_in"] = (
-                                track.trimmed_range_in_parent().start_time.to_frames()
+                                track.range_in_parent().start_time.to_frames()
                             )
                         except Exception:
                             data["frame_in"] = (
@@ -255,7 +255,7 @@ class OTIOBaseResource(Resource, ArgsMixin):
                     try:
                         try:
                             data["frame_out"] = (
-                                track.trimmed_range_in_parent()
+                                track.range_in_parent()
                                 .end_time_inclusive()
                                 .to_frames()
                             )


### PR DESCRIPTION
**Problem**
Importing an EDL with a record timecode offset (e.g. 10:00:00:00) results in all shots having frame_in at 0 and frame_out at nb_frames - 1 instead of their actual position in the timeline.

**Solution**
Fix frame_in/frame_out when the EDL has a TC offset record.
 
`trimmed_range_in_parent()` fails with OTIO 0.18 when the EDL record timecode starts at a non-zero value (e.g. 01:00:00:00 or 10:00:00:00), causing frame_in to always be 0 and frame_out to equal nb_frames - 1. `range_in_parent()` returns the same values when there is no track trim and handles the TC offset case correctly.
