### PR TITLE
Fix types for Pydantic

### DIFF
--- a/zou/app/blueprints/projects/schemas.py
+++ b/zou/app/blueprints/projects/schemas.py
@@ -26,7 +26,7 @@ class ProjectTaskTypeSchema(BaseSchema):
     """Body for adding a task type to a project."""
 
     task_type_id: str = Field(..., min_length=1)
-    priority: Optional[str] = None
+    priority: Optional[int] = None
 
 
 class ProjectTaskStatusSchema(BaseSchema):

--- a/zou/app/blueprints/tasks/schemas.py
+++ b/zou/app/blueprints/tasks/schemas.py
@@ -54,4 +54,4 @@ class AssignPersonSchema(BaseSchema):
 class TimeSpentSchema(BaseSchema):
     """Body for creating/updating time spent on a task."""
 
-    duration: int = Field(..., gt=0, description="Duration in minutes")
+    duration: float = Field(..., gt=0, description="Duration in minutes")


### PR DESCRIPTION
**Problem**
- Some endpoints reject requests.

**Solution**
- Fix type mismatches in validation schemas.


  >projects/schemas.py — priority: Optional[str] → Optional[int]

  >tasks/schemas.py — duration: int → float


