### PR TITLE
Various improvements

### DIFF
--- a/tests/events/test_event_routes.py
+++ b/tests/events/test_event_routes.py
@@ -85,20 +85,34 @@ class LoginLogsRoutesTestCase(ApiDBTestCase):
         self.assertEqual(len(logs), 2)
 
     def test_get_last_login_logs_before(self):
-        self.create_login_logs(2)
-        before = self.get("/data/events/login-logs/last")[0]["created_at"]
-        time.sleep(0.5)
-        self.create_login_logs(1)
-        logs = self.get("/data/events/login-logs/last?before=%s" % before)
-        self.assertEqual(len(logs), 1)
+        now = datetime.now().replace(microsecond=0)
+        for i in range(3):
+            LoginLog.create(
+                person_id=self.user["id"],
+                ip_address="192.168.1.%d" % i,
+                origin="web",
+                created_at=now - timedelta(seconds=3 - i),
+            )
+        before = (now - timedelta(seconds=1)).isoformat()
+        logs = self.get(
+            "/data/events/login-logs/last?before=%s" % before
+        )
+        self.assertEqual(len(logs), 2)
 
     def test_get_last_login_logs_after(self):
-        self.create_login_logs(1)
-        after = self.get("/data/events/login-logs/last")[0]["created_at"]
-        time.sleep(0.5)
-        self.create_login_logs(2)
-        logs = self.get("/data/events/login-logs/last?after=%s" % after)
-        self.assertEqual(len(logs), 2)
+        now = datetime.now().replace(microsecond=0)
+        for i in range(3):
+            LoginLog.create(
+                person_id=self.user["id"],
+                ip_address="192.168.1.%d" % i,
+                origin="web",
+                created_at=now - timedelta(seconds=3 - i),
+            )
+        after = (now - timedelta(seconds=2)).isoformat()
+        logs = self.get(
+            "/data/events/login-logs/last?after=%s" % after
+        )
+        self.assertEqual(len(logs), 1)
 
     def test_get_last_login_logs_cursor(self):
         self.create_login_logs(3)

--- a/tests/events/test_event_routes.py
+++ b/tests/events/test_event_routes.py
@@ -1,8 +1,11 @@
 import time
+from datetime import datetime, timedelta
+
 from tests.base import ApiDBTestCase
 from zou.app.models.event import ApiEvent
+from zou.app.models.login_log import LoginLog
 
-from zou.app.services import assets_service
+from zou.app.services import assets_service, events_service
 
 
 class EventsRoutesTestCase(ApiDBTestCase):
@@ -49,3 +52,70 @@ class EventsRoutesTestCase(ApiDBTestCase):
         self.assertEqual(len(events), 6)
         events = self.get("/data/events/last?only_files=true")
         self.assertEqual(len(events), 2)
+
+
+class LoginLogsRoutesTestCase(ApiDBTestCase):
+    def setUp(self):
+        super(LoginLogsRoutesTestCase, self).setUp()
+        LoginLog.query.delete()
+
+    def create_login_logs(self, count):
+        base = datetime.now() - timedelta(seconds=count)
+        for i in range(count):
+            LoginLog.create(
+                person_id=self.user["id"],
+                ip_address="192.168.1.%d" % i,
+                origin="web",
+                created_at=base + timedelta(seconds=i),
+            )
+
+    def test_get_last_login_logs(self):
+        self.create_login_logs(3)
+        logs = self.get("/data/events/login-logs/last")
+        self.assertEqual(len(logs), 3)
+        self.assertIn("id", logs[0])
+        self.assertIn("created_at", logs[0])
+        self.assertIn("ip_address", logs[0])
+        self.assertIn("person_id", logs[0])
+        self.assertIn("origin", logs[0])
+
+    def test_get_last_login_logs_limit(self):
+        self.create_login_logs(3)
+        logs = self.get("/data/events/login-logs/last?limit=2")
+        self.assertEqual(len(logs), 2)
+
+    def test_get_last_login_logs_before(self):
+        self.create_login_logs(2)
+        before = self.get("/data/events/login-logs/last")[0]["created_at"]
+        time.sleep(0.5)
+        self.create_login_logs(1)
+        logs = self.get("/data/events/login-logs/last?before=%s" % before)
+        self.assertEqual(len(logs), 1)
+
+    def test_get_last_login_logs_after(self):
+        self.create_login_logs(1)
+        after = self.get("/data/events/login-logs/last")[0]["created_at"]
+        time.sleep(0.5)
+        self.create_login_logs(2)
+        logs = self.get("/data/events/login-logs/last?after=%s" % after)
+        self.assertEqual(len(logs), 2)
+
+    def test_get_last_login_logs_cursor(self):
+        self.create_login_logs(3)
+        logs = self.get("/data/events/login-logs/last?limit=2")
+        cursor = logs[-1]["id"]
+        logs = self.get(
+            "/data/events/login-logs/last?cursor_login_log_id=%s" % cursor
+        )
+        self.assertEqual(len(logs), 1)
+
+    def test_get_last_login_logs_invalid_cursor(self):
+        self.get(
+            "/data/events/login-logs/last?cursor_login_log_id=invalid",
+            400,
+        )
+
+    def test_get_last_login_logs_permissions(self):
+        self.generate_fixture_user_cg_artist()
+        self.log_in_cg_artist()
+        self.get("/data/events/login-logs/last", 403)

--- a/tests/events/test_event_routes.py
+++ b/tests/events/test_event_routes.py
@@ -1,4 +1,3 @@
-import time
 from datetime import datetime, timedelta
 
 from tests.base import ApiDBTestCase
@@ -17,23 +16,18 @@ class EventsRoutesTestCase(ApiDBTestCase):
         self.generate_fixture_asset_type()
 
     def test_get_last_events(self):
-        asset = assets_service.create_asset(
-            self.project.id, self.asset_type.id, "test 1", "", {}
-        )
-        after = asset["created_at"]
-        time.sleep(1)
-        asset = assets_service.create_asset(
-            self.project.id, self.asset_type.id, "test 2", "", {}
-        )
-        time.sleep(1)
-        asset = assets_service.create_asset(
-            self.project.id, self.asset_type.id, "test 3", "", {}
-        )
-        before = asset["created_at"]
-        time.sleep(1)
-        asset = assets_service.create_asset(
-            self.project.id, self.asset_type.id, "test 4", "", {}
-        )
+        now = datetime.now().replace(microsecond=0)
+        for name in ["test 1", "test 2", "test 3", "test 4"]:
+            assets_service.create_asset(
+                self.project.id, self.asset_type.id, name, "", {}
+            )
+
+        events_db = ApiEvent.query.order_by(ApiEvent.created_at).all()
+        for i, event in enumerate(events_db):
+            event.update({"created_at": now - timedelta(seconds=4 - i)})
+
+        after = (now - timedelta(seconds=5)).isoformat()
+        before = (now - timedelta(seconds=2)).isoformat()
 
         events = self.get("/data/events/last")
         self.assertEqual(len(events), 4)

--- a/tests/files/test_route_working_files.py
+++ b/tests/files/test_route_working_files.py
@@ -1,4 +1,4 @@
-import time
+import datetime
 
 from tests.base import ApiDBTestCase
 
@@ -148,15 +148,17 @@ class WorkingFilesTestCase(ApiDBTestCase):
 
     def test_update_modification_date(self):
         path = "/actions/working-files/%s/modified" % self.working_file.id
+        past = datetime.datetime.now().replace(
+            microsecond=0
+        ) - datetime.timedelta(seconds=2)
+        self.working_file.update({"updated_at": past})
         previous_date = self.working_file.serialize()["updated_at"]
-        time.sleep(1)
         working_file = self.put(path, {})
         current_date = working_file["updated_at"]
         self.assertTrue(previous_date < current_date)
 
-        time.sleep(1)
         now = self.now()
-        self.assertTrue(current_date < now)
+        self.assertTrue(current_date <= now)
 
     def test_get_untyped_file(self):
         working_file_id = str(self.working_file.id)

--- a/tests/services/test_events_service.py
+++ b/tests/services/test_events_service.py
@@ -1,7 +1,8 @@
-import time
+from datetime import datetime, timedelta
+
 from tests.base import ApiDBTestCase
 
-from zou.app.utils import fields
+from zou.app.models.event import ApiEvent
 from zou.app.services import events_service, assets_service
 
 
@@ -14,24 +15,22 @@ class EventsServiceTestCase(ApiDBTestCase):
         self.generate_fixture_asset_type()
 
     def test_get_last_events(self):
-        asset = assets_service.create_asset(
-            self.project.id, self.asset_type.id, "test 1", "", {}
-        )
-        date = fields.get_date_object(asset["created_at"], "%Y-%m-%dT%H:%M:%S")
-        time.sleep(1)
-        asset = assets_service.create_asset(
-            self.project.id, self.asset_type.id, "test 2", "", {}
-        )
-        time.sleep(1)
-        asset = assets_service.create_asset(
-            self.project.id, self.asset_type.id, "test 3", "", {}
-        )
+        now = datetime.now().replace(microsecond=0)
+        for name in ["test 1", "test 2", "test 3"]:
+            assets_service.create_asset(
+                self.project.id, self.asset_type.id, name, "", {}
+            )
+
+        events_db = ApiEvent.query.order_by(ApiEvent.created_at).all()
+        for i, event in enumerate(events_db):
+            event.update({"created_at": now - timedelta(seconds=3 - i)})
+
         events = events_service.get_last_events()
         self.assertEqual(len(events), 3)
         events = events_service.get_last_events(limit=2)
         self.assertEqual(len(events), 2)
-        date = fields.get_date_object(asset["created_at"], "%Y-%m-%dT%H:%M:%S")
-        events = events_service.get_last_events(before=date)
+        before = now - timedelta(seconds=1)
+        events = events_service.get_last_events(before=before)
         self.assertEqual(len(events), 2)
 
     def test_get_last_login_logs(self):

--- a/zou/app/blueprints/events/resources.py
+++ b/zou/app/blueprints/events/resources.py
@@ -2,7 +2,7 @@ from flask_restful import Resource
 from flask_jwt_extended import jwt_required
 
 from zou.app.mixin import ArgsMixin
-from zou.app.utils import fields, permissions, date_helpers
+from zou.app.utils import fields, permissions
 
 from zou.app.services import events_service
 from zou.app.services.exception import WrongParameterException
@@ -148,21 +148,35 @@ class LoginLogsResource(Resource, ArgsMixin):
         """
         Get login logs
         ---
-        description: Retrieve all login logs with filtering support. Filters can
+        description: Retrieve last login logs with filtering support. Filters can
           be specified in the query string to narrow down results by date range
-          and limit.
+          or cursor-based pagination.
         tags:
           - Events
         parameters:
           - in: query
+            name: after
+            type: string
+            format: date
+            example: "2022-07-12"
+            description: Filter logs after this date
+          - in: query
             name: before
             type: string
-            format: date-time
-            example: "2022-07-12T00:00:00"
-            description: Filter logs before this date and time
+            format: date
+            example: "2022-07-12"
+            description: Filter logs before this date
+          - in: query
+            name: cursor_login_log_id
+            required: False
+            type: string
+            format: uuid
+            example: a24a6ea4-ce75-4665-a070-57453082c25
+            description: ID of the last login log from previous page for cursor-based pagination
           - in: query
             name: limit
             type: integer
+            default: 100
             example: 100
             description: Maximum number of login logs to return
         responses:
@@ -180,34 +194,49 @@ class LoginLogsResource(Resource, ArgsMixin):
                         format: uuid
                         description: Login log unique identifier
                         example: a24a6ea4-ce75-4665-a070-57453082c25
-                      user_id:
-                        type: string
-                        format: uuid
-                        description: User identifier
-                        example: b35b7fb5-df86-5776-b181-68564193d36
-                      ip_address:
-                        type: string
-                        description: IP address of the login
-                        example: "192.168.1.100"
-                      user_agent:
-                        type: string
-                        description: User agent string
-                        example: "Mozilla/5.0 (Windows NT 10.0; Win64; x64)"
-                      success:
-                        type: boolean
-                        description: Whether the login was successful
-                        example: true
                       created_at:
                         type: string
                         format: date-time
                         description: Login timestamp
                         example: "2023-01-01T12:00:00Z"
+                      ip_address:
+                        type: string
+                        description: IP address of the login
+                        example: "192.168.1.100"
+                      person_id:
+                        type: string
+                        format: uuid
+                        description: Person identifier
+                        example: b35b7fb5-df86-5776-b181-68564193d36
+                      origin:
+                        type: string
+                        description: Login origin
+                        example: "web"
+                        enum: ["web", "script"]
         """
-        args = self.get_args(["before", ("limit", 100, False, int)])
+        args = self.get_args(
+            [
+                ("after", None, False),
+                ("before", None, False),
+                ("cursor_login_log_id", None, False),
+                ("limit", 100, False, int),
+            ],
+        )
 
         permissions.check_manager_permissions()
-        before = None
-        if args["before"] is not None:
-            before = date_helpers.get_datetime_from_string(args["before"])
-        limit = args["limit"]
-        return events_service.get_last_login_logs(before, limit)
+        before = self.parse_date_parameter(args["before"])
+        after = self.parse_date_parameter(args["after"])
+        cursor_login_log_id = args["cursor_login_log_id"]
+        limit = min(args["limit"], 1000)
+        if cursor_login_log_id is not None and not fields.is_valid_id(
+            cursor_login_log_id
+        ):
+            raise WrongParameterException(
+                "The cursor_login_log_id parameter is not a valid id"
+            )
+        return events_service.get_last_login_logs(
+            after=after,
+            before=before,
+            cursor_login_log_id=cursor_login_log_id,
+            limit=limit,
+        )

--- a/zou/app/services/auth_service.py
+++ b/zou/app/services/auth_service.py
@@ -303,7 +303,7 @@ def check_totp(person, totp):
     """
     Check TOTP for a person.
     """
-    return pyotp.TOTP(person["totp_secret"]).verify(totp)
+    return pyotp.TOTP(person["totp_secret"]).verify(totp, valid_window=1)
 
 
 def check_email_otp(person, email_otp):

--- a/zou/app/services/events_service.py
+++ b/zou/app/services/events_service.py
@@ -81,26 +81,46 @@ def create_login_log(person_id, ip_address, origin):
     return login_log.serialize()
 
 
-def get_last_login_logs(before=None, limit=100):
+def get_last_login_logs(
+    after=None,
+    before=None,
+    cursor_login_log_id=None,
+    limit=100,
+):
     """
-    Return last 100 login logs published. If before parameter is set, it returns
-    last 100 login logs before this date.
+    Return paginated login logs using cursor-based pagination.
+    If cursor_login_log_id is set, it returns login logs older than this log.
     """
-    query = LoginLog.query.order_by(LoginLog.created_at.desc()).with_entities(
-        LoginLog.created_at, LoginLog.ip_address, LoginLog.person_id
-    )
+    query = LoginLog.query.order_by(LoginLog.created_at.desc())
+
+    if after is not None:
+        query = query.filter(
+            LoginLog.created_at > func.cast(after, LoginLog.created_at.type)
+        )
 
     if before is not None:
         query = query.filter(
             LoginLog.created_at < func.cast(before, LoginLog.created_at.type)
         )
 
+    if cursor_login_log_id is not None:
+        cursor_log = LoginLog.query.get(cursor_login_log_id)
+        if cursor_log is None:
+            raise WrongParameterException(
+                f"No login log found with id: {cursor_login_log_id}"
+            )
+        query = query.filter(LoginLog.created_at < cursor_log.created_at)
+
     login_logs = query.limit(limit).all()
     return [
-        {
-            "created_at": fields.serialize_value(created_at),
-            "ip_address": fields.serialize_value(ip_address),
-            "person_id": fields.serialize_value(person_id),
-        }
-        for (created_at, ip_address, person_id) in login_logs
+        fields.serialize_dict(
+            {
+                "id": log.id,
+                "created_at": log.created_at,
+                "ip_address": log.ip_address,
+                "person_id": log.person_id,
+                "origin": log.origin,
+            }
+        )
+        for log in login_logs
     ]


### PR DESCRIPTION
**Problem**
- The login logs endpoint lacks pagination.
- TOTP verification rejects valid codes at 30-second window boundaries, causing intermittent login failures.
- Several tests rely on `time.sleep(1)` for timestamp separation, making them slow (~7s wasted) and flaky.

**Solution**
- Add cursor-based pagination, date filtering, and input validation to the login logs endpoint.
- Use `valid_window=1` in TOTP verification to accept adjacent time windows, as recommended by RFC 6238.
- Replace all `time.sleep()` calls in tests with explicit timestamps on records.