### PR TITLE
[comments] Add for_client flag and eager-load relations

### DIFF
--- a/tests/comments/test_route_comments.py
+++ b/tests/comments/test_route_comments.py
@@ -1,5 +1,6 @@
 from tests.base import ApiDBTestCase
 
+from zou.app.models.person import Person
 from zou.app.services import comments_service, tasks_service
 
 
@@ -15,6 +16,7 @@ class CommentRoutesTestCase(ApiDBTestCase):
         self.generate_fixture_task_status()
         self.generate_fixture_person()
         self.generate_fixture_assigner()
+        self.generate_fixture_user_client()
         self.generate_fixture_task()
         self.comment = comments_service.new_comment(
             self.task.id,
@@ -97,3 +99,57 @@ class CommentRoutesTestCase(ApiDBTestCase):
         comments = tasks_service.get_comments(str(self.task.id))
         texts = [c["text"] for c in comments]
         self.assertIn("Batch comment", texts)
+
+    def test_comment_for_client_visible_to_client(self):
+        """A manager-authored comment marked for_client must be visible to
+        client users (text not blanked, listed in comments endpoint)."""
+        client_person = Person.get(self.user_client["id"])
+        self.project.team = [client_person, self.person]
+        self.project.save()
+        result = self.post(
+            f"/actions/tasks/{self.task.id}/comment",
+            {
+                "task_status_id": str(self.task_status.id),
+                "comment": "Visible to client",
+                "for_client": True,
+            },
+        )
+        self.assertTrue(result["for_client"])
+
+        self.log_in_client()
+        comments = tasks_service.get_comments(
+            str(self.task.id), is_client=True
+        )
+        texts = [c["text"] for c in comments]
+        self.assertIn("Visible to client", texts)
+
+    def test_comment_without_for_client_hidden_from_client(self):
+        """A manager-authored comment without for_client stays hidden from
+        clients (default behavior preserved)."""
+        client_person = Person.get(self.user_client["id"])
+        self.project.team = [client_person, self.person]
+        self.project.save()
+        self.post(
+            f"/actions/tasks/{self.task.id}/comment",
+            {
+                "task_status_id": str(self.task_status.id),
+                "comment": "Internal only",
+            },
+        )
+
+        self.log_in_client()
+        comments = tasks_service.get_comments(
+            str(self.task.id), is_client=True
+        )
+        texts = [c["text"] for c in comments]
+        self.assertNotIn("Internal only", texts)
+
+    def test_for_client_default_false(self):
+        result = self.post(
+            f"/actions/tasks/{self.task.id}/comment",
+            {
+                "task_status_id": str(self.task_status.id),
+                "comment": "default flag",
+            },
+        )
+        self.assertFalse(result["for_client"])

--- a/zou/app/blueprints/comments/resources.py
+++ b/zou/app/blueprints/comments/resources.py
@@ -254,6 +254,7 @@ class CommentTaskResource(Resource):
             created_at,
             checklist,
             links,
+            for_client,
         ) = self.get_arguments()
 
         user_service.check_task_action_access(task_id)
@@ -263,6 +264,7 @@ class CommentTaskResource(Resource):
         if not permissions.has_manager_permissions():
             person_id = None
             created_at = None
+            for_client = False
         comment = comments_service.create_comment(
             person_id,
             task_id,
@@ -272,6 +274,7 @@ class CommentTaskResource(Resource):
             files,
             created_at,
             links,
+            for_client=for_client,
         )
         return comment, 201
 
@@ -306,6 +309,9 @@ class CommentTaskResource(Resource):
         parser.add_argument("comment", default="", location=location)
         parser.add_argument("person_id", default="", location=location)
         parser.add_argument("created_at", default="", location=location)
+        parser.add_argument(
+            "for_client", type=bool, default=False, location=location
+        )
         args = parser.parse_args()
         return (
             args["task_status_id"],
@@ -318,6 +324,7 @@ class CommentTaskResource(Resource):
                 else json.loads(args["checklist"])
             ),
             (args["links"] if request.is_json else json.loads(args["links"])),
+            args["for_client"],
         )
 
 

--- a/zou/app/blueprints/crud/comments.py
+++ b/zou/app/blueprints/crud/comments.py
@@ -22,6 +22,15 @@ class CommentsResource(BaseModelsResource):
     def __init__(self):
         BaseModelsResource.__init__(self, Comment)
 
+    def get_relations_eager_load(self):
+        return [
+            Comment.previews,
+            Comment.mentions,
+            Comment.department_mentions,
+            Comment.acknowledgements,
+            Comment.attachment_files,
+        ]
+
     @jwt_required()
     def get(self):
         """
@@ -336,7 +345,9 @@ class CommentResource(BaseModelResource):
         is_client = permissions.has_client_permissions()
         if is_client:
             person = persons_service.get_person(result["person_id"])
-            if person["role"] != "client":
+            if person["role"] != "client" and not result.get(
+                "for_client", False
+            ):
                 result["text"] = ""
                 result["attachment_files"] = []
                 result["checklist"] = []
@@ -425,6 +436,13 @@ class CommentResource(BaseModelResource):
                 "checklist" in data.keys()
                 and data["checklist"] != instance["checklist"]
             )
+            change_for_client = (
+                "for_client" in data.keys()
+                and data["for_client"] != instance.get("for_client", False)
+            )
+            if change_for_client:
+                # Only managers (handled above) may toggle for_client.
+                raise permissions.PermissionDenied
             is_supervisor = permissions.has_supervisor_permissions()
             is_supervisor_in_department = (
                 current_user["departments"] == []

--- a/zou/app/blueprints/crud/entity.py
+++ b/zou/app/blueprints/crud/entity.py
@@ -55,6 +55,9 @@ class EntitiesResource(BaseModelsResource, EntityEventMixin):
     def __init__(self):
         BaseModelsResource.__init__(self, Entity)
 
+    def get_relations_eager_load(self):
+        return [Entity.entities_out, Entity.instance_casting]
+
     def check_create_permissions(self, entity):
         user_service.check_manager_project_access(entity["project_id"])
 

--- a/zou/app/blueprints/crud/metadata_descriptor.py
+++ b/zou/app/blueprints/crud/metadata_descriptor.py
@@ -19,6 +19,9 @@ class MetadataDescriptorsResource(BaseModelsResource):
     def __init__(self):
         BaseModelsResource.__init__(self, MetadataDescriptor)
 
+    def get_relations_eager_load(self):
+        return [MetadataDescriptor.departments]
+
     def check_read_permissions(self, options=None):
         return not permissions.has_vendor_permissions()
 

--- a/zou/app/blueprints/crud/person.py
+++ b/zou/app/blueprints/crud/person.py
@@ -31,6 +31,9 @@ class PersonsResource(BaseModelsResource):
     def __init__(self):
         BaseModelsResource.__init__(self, Person)
 
+    def get_relations_eager_load(self):
+        return [Person.departments]
+
     @jwt_required()
     def get(self):
         """

--- a/zou/app/blueprints/crud/playlist.py
+++ b/zou/app/blueprints/crud/playlist.py
@@ -13,6 +13,9 @@ class PlaylistsResource(BaseModelsResource):
     def __init__(self):
         BaseModelsResource.__init__(self, Playlist)
 
+    def get_relations_eager_load(self):
+        return [Playlist.build_jobs]
+
     def check_read_permissions(self, options=None):
         return True
 

--- a/zou/app/blueprints/crud/production_schedule_version.py
+++ b/zou/app/blueprints/crud/production_schedule_version.py
@@ -335,6 +335,9 @@ class ProductionScheduleVersionTaskLinksResource(BaseModelsResource):
     def __init__(self):
         BaseModelsResource.__init__(self, ProductionScheduleVersionTaskLink)
 
+    def get_relations_eager_load(self):
+        return [ProductionScheduleVersionTaskLink.assignees]
+
     def check_read_permissions(self, options=None):
         if (
             permissions.has_vendor_permissions()

--- a/zou/app/blueprints/crud/project.py
+++ b/zou/app/blueprints/crud/project.py
@@ -32,6 +32,15 @@ class ProjectsResource(BaseModelsResource):
         self._template_id_to_apply = None
         self._template_overrides = {}
 
+    def get_relations_eager_load(self):
+        return [
+            Project.asset_types,
+            Project.task_statuses,
+            Project.task_types,
+            Project.status_automations,
+            Project.preview_background_files,
+        ]
+
     @jwt_required()
     def get(self):
         """

--- a/zou/app/blueprints/crud/project_template.py
+++ b/zou/app/blueprints/crud/project_template.py
@@ -18,6 +18,15 @@ class ProjectTemplatesResource(BaseModelsResource):
     def __init__(self):
         BaseModelsResource.__init__(self, ProjectTemplate)
 
+    def get_relations_eager_load(self):
+        return [
+            ProjectTemplate.asset_types,
+            ProjectTemplate.task_statuses,
+            ProjectTemplate.task_types,
+            ProjectTemplate.status_automations,
+            ProjectTemplate.preview_background_files,
+        ]
+
     def check_read_permissions(self, options=None):
         return permissions.check_manager_permissions()
 

--- a/zou/app/blueprints/crud/working_file.py
+++ b/zou/app/blueprints/crud/working_file.py
@@ -18,6 +18,9 @@ class WorkingFilesResource(BaseModelsResource):
     def __init__(self):
         BaseModelsResource.__init__(self, WorkingFile)
 
+    def get_relations_eager_load(self):
+        return [WorkingFile.outputs]
+
     def check_read_permissions(self, options=None):
         """
         Overriding so that people without admin credentials can still access

--- a/zou/app/models/comment.py
+++ b/zou/app/models/comment.py
@@ -90,6 +90,7 @@ class Comment(db.Model, BaseMixin, SerializerMixin):
     replies = db.Column(JSONB, default=[])
     checklist = db.Column(JSONB)
     pinned = db.Column(db.Boolean)
+    for_client = db.Column(db.Boolean(), default=False)
     links = db.Column(db.ARRAY(db.String()))
 
     task_status_id = db.Column(

--- a/zou/app/services/comments_service.py
+++ b/zou/app/services/comments_service.py
@@ -82,6 +82,7 @@ def create_comment(
     created_at="",
     links=None,
     with_hashtags=True,
+    for_client=False,
 ):
     """
     Create a new comment and related: news, notifications and events.
@@ -108,6 +109,7 @@ def create_comment(
         checklist=checklist,
         created_at=created_at,
         links=links,
+        for_client=for_client,
     )
 
     if with_hashtags:
@@ -355,6 +357,7 @@ def new_comment(
     checklist=None,
     created_at="",
     links=None,
+    for_client=False,
 ):
     """
     Create a new comment for given object (by default, it considers this object
@@ -392,6 +395,7 @@ def new_comment(
         text=text,
         created_at=created_at_date,
         links=links,
+        for_client=for_client,
     )
 
     comment = comment.serialize(relations=True)

--- a/zou/app/services/tasks_service.py
+++ b/zou/app/services/tasks_service.py
@@ -665,10 +665,17 @@ def get_comments(task_id, is_client=False, is_manager=False):
             person = persons_map.get(comment["person_id"], {})
             is_author = comment["person_id"] == current_user["id"]
             is_author_client = person.get("role") == "client"
-            is_allowed = (is_clients_isolated and is_author) or (
-                not is_clients_isolated and is_author_client
+            is_for_client = comment.get("for_client", False)
+            is_allowed = (
+                is_for_client
+                or (is_clients_isolated and is_author)
+                or (not is_clients_isolated and is_author_client)
             )
-            if len(comment["previews"]) > 0 and not is_author_client:
+            if (
+                len(comment["previews"]) > 0
+                and not is_author_client
+                and not is_for_client
+            ):
                 comment["text"] = ""
                 comment["attachment_files"] = []
                 comment["checklist"] = []

--- a/zou/migrations/versions/c4e7f9a3b8d2_add_for_client_to_comments.py
+++ b/zou/migrations/versions/c4e7f9a3b8d2_add_for_client_to_comments.py
@@ -1,0 +1,34 @@
+"""add for_client flag to comments
+
+Revision ID: c4e7f9a3b8d2
+Revises: 8d42b9e1f7a3
+Create Date: 2026-04-16 10:00:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "c4e7f9a3b8d2"
+down_revision = "8d42b9e1f7a3"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("comment", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "for_client",
+                sa.Boolean(),
+                nullable=True,
+                server_default=sa.false(),
+            )
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("comment", schema=None) as batch_op:
+        batch_op.drop_column("for_client")


### PR DESCRIPTION
**Problem**
- Managers and supervisors have no way to post a comment that is visible to clients — visibility is derived solely from the author's role, forcing parallel email threads.
- Listing CRUD resources with ?relations=true falls into N+1 queries because their collection relationships are not declared for eager loading.

**Solution**
- Add a \`for_client\` boolean column on the Comment model with a matching migration; expose it on POST and PUT endpoints (manager-only) and adjust \`tasks_service.get_comments()\` / \`crud/comments.py:clean_get_result()\` so client users see the text/attachments/checklist of comments flagged for_client.
- Declare \`get_relations_eager_load()\` on the CommentsResource, ProjectsResource, ProjectTemplatesResource, EntitiesResource, PersonsResource, MetadataDescriptorsResource, PlaylistsResource, WorkingFilesResource and ProductionScheduleVersionTaskLinksResource to batch-load their collection relationships.