### PR TITLE
[security] Restrict vendor access to sequences, episodes, scenes, and casting

### DIFF
--- a/tests/shots/test_episodes.py
+++ b/tests/shots/test_episodes.py
@@ -126,6 +126,49 @@ class EpisodeTestCase(ApiDBTestCase):
             "data/episodes?project_id=%s&name=E01" % self.project_id, 403
         )
 
+    def _setup_vendor(self):
+        self.generate_fixture_department()
+        self.generate_fixture_task_status()
+        self.generate_fixture_person()
+        self.generate_fixture_assigner()
+        self.generate_fixture_task_type()
+        self.generate_fixture_shot_task(name="VendorTask")
+        self.generate_fixture_user_vendor()
+        projects_service.add_team_member(
+            self.project_id, self.user_vendor["id"]
+        )
+        projects_service.clear_project_cache(str(self.project_id))
+        self.log_in_vendor()
+
+    def test_get_episodes_vendor_filters(self):
+        self._setup_vendor()
+        episodes = self.get(
+            "data/episodes?project_id=%s" % self.project_id
+        )
+        self.assertEqual(len(episodes), 0)
+        tasks_service.assign_task(
+            self.shot_task.id, self.user_vendor["id"]
+        )
+        episodes = self.get(
+            "data/episodes?project_id=%s" % self.project_id
+        )
+        self.assertEqual(len(episodes), 1)
+
+    def test_get_episode_vendor_no_task(self):
+        self._setup_vendor()
+        self.get("data/episodes/%s" % self.episode_02_id, 403)
+
+    def test_get_episode_tasks_vendor_blocked_no_task(self):
+        self._setup_vendor()
+        self.get("data/episodes/%s/tasks" % self.episode_id, 403)
+
+    def test_get_episodes_with_tasks_vendor_blocked(self):
+        self._setup_vendor()
+        self.get(
+            "data/episodes/with-tasks?project_id=%s" % self.project_id,
+            403,
+        )
+
     def test_force_delete_episode(self):
         self.get("data/episodes/%s" % self.episode_id)
         self.delete("data/episodes/%s?force=true" % self.episode_id)

--- a/tests/shots/test_sequences.py
+++ b/tests/shots/test_sequences.py
@@ -103,6 +103,47 @@ class SequenceTestCase(ApiDBTestCase):
             "data/sequences?project_id=%s&name=SE01" % self.project_id, 403
         )
 
+    def _setup_vendor(self):
+        self.generate_fixture_shot_task(name="VendorTask")
+        self.generate_fixture_user_vendor()
+        projects_service.add_team_member(
+            self.project_id, self.user_vendor["id"]
+        )
+        projects_service.clear_project_cache(str(self.project_id))
+        self.log_in_vendor()
+
+    def test_get_sequences_vendor_unassigned(self):
+        self._setup_vendor()
+        sequences = self.get(
+            "data/sequences?project_id=%s" % self.project_id
+        )
+        self.assertEqual(len(sequences), 0)
+
+    def test_get_sequences_vendor_assigned(self):
+        self._setup_vendor()
+        tasks_service.assign_task(
+            self.shot_task.id, self.user_vendor["id"]
+        )
+        sequences = self.get(
+            "data/sequences?project_id=%s" % self.project_id
+        )
+        self.assertEqual(len(sequences), 1)
+
+    def test_get_sequence_vendor_no_task(self):
+        self._setup_vendor()
+        self.get("data/sequences/%s" % self.sequence_02_id, 403)
+
+    def test_get_sequence_tasks_vendor_no_task(self):
+        self._setup_vendor()
+        self.get("data/sequences/%s/tasks" % self.sequence_id, 403)
+
+    def test_get_sequences_with_tasks_vendor_blocked(self):
+        self._setup_vendor()
+        self.get(
+            "data/sequences/with-tasks?project_id=%s" % self.project_id,
+            403,
+        )
+
     def test_force_delete_sequence(self):
         self.get("data/sequences/%s" % self.sequence_id)
         self.delete("data/sequences/%s?force=true" % self.sequence_id)

--- a/zou/app/blueprints/breakdown/resources.py
+++ b/zou/app/blueprints/breakdown/resources.py
@@ -281,6 +281,8 @@ class EpisodeSequenceAllCastingResource(Resource):
                               example: "Main Character"
         """
         user_service.check_project_access(project_id)
+        if permissions.has_vendor_permissions():
+            raise permissions.PermissionDenied
         return breakdown_service.get_all_sequences_casting(
             project_id, episode_id=episode_id
         )

--- a/zou/app/blueprints/breakdown/resources.py
+++ b/zou/app/blueprints/breakdown/resources.py
@@ -12,7 +12,7 @@ from zou.app.services import (
 )
 
 from zou.app.mixin import ArgsMixin
-from zou.app.utils import validation
+from zou.app.utils import permissions, validation
 from zou.app.blueprints.breakdown.schemas import (
     AddAssetInstanceSchema,
     AddSceneAssetInstanceSchema,
@@ -347,6 +347,8 @@ class SequenceAllCastingResource(Resource):
                               example: "Main Character"
         """
         user_service.check_project_access(project_id)
+        if permissions.has_vendor_permissions():
+            raise permissions.PermissionDenied
         return breakdown_service.get_all_sequences_casting(project_id)
 
 
@@ -414,6 +416,8 @@ class SequenceCastingResource(Resource):
                               example: "Main Character"
         """
         user_service.check_project_access(project_id)
+        if permissions.has_vendor_permissions():
+            raise permissions.PermissionDenied
         shots_service.get_sequence(sequence_id)
         return breakdown_service.get_sequence_casting(sequence_id)
 

--- a/zou/app/blueprints/breakdown/resources.py
+++ b/zou/app/blueprints/breakdown/resources.py
@@ -77,6 +77,8 @@ class CastingResource(Resource):
                             example: "Main Character"
         """
         user_service.check_project_access(project_id)
+        if permissions.has_vendor_permissions():
+            raise permissions.PermissionDenied
         return breakdown_service.get_casting(entity_id)
 
     @jwt_required()
@@ -219,6 +221,8 @@ class EpisodesCastingResource(Resource):
                               example: "Main Character"
         """
         user_service.check_project_access(project_id)
+        if permissions.has_vendor_permissions():
+            raise permissions.PermissionDenied
         return breakdown_service.get_production_episodes_casting(project_id)
 
 
@@ -492,6 +496,8 @@ class AssetTypeCastingResource(Resource):
                               example: "shot"
         """
         user_service.check_project_access(project_id)
+        if permissions.has_vendor_permissions():
+            raise permissions.PermissionDenied
         assets_service.get_asset_type(asset_type_id)
         return breakdown_service.get_asset_type_casting(
             project_id, asset_type_id
@@ -551,6 +557,7 @@ class ShotAssetInstancesResource(Resource, ArgsMixin):
         """
         shot = shots_service.get_shot(shot_id)
         user_service.check_project_access(shot["project_id"])
+        user_service.check_entity_access(shot_id)
         return breakdown_service.get_asset_instances_for_shot(shot_id)
 
     @jwt_required()
@@ -715,6 +722,7 @@ class SceneAssetInstancesResource(Resource, ArgsMixin):
         """
         scene = shots_service.get_scene(scene_id)
         user_service.check_project_access(scene["project_id"])
+        user_service.check_entity_access(scene_id)
         return breakdown_service.get_asset_instances_for_scene(scene_id)
 
     @jwt_required()
@@ -846,6 +854,7 @@ class SceneCameraInstancesResource(Resource):
         """
         scene = shots_service.get_scene(scene_id)
         user_service.check_project_access(scene["project_id"])
+        user_service.check_entity_access(scene_id)
         return breakdown_service.get_camera_instances_for_scene(scene_id)
 
 

--- a/zou/app/blueprints/shots/resources.py
+++ b/zou/app/blueprints/shots/resources.py
@@ -452,6 +452,8 @@ class ScenesResource(Resource):
         """
         criterions = query.get_query_criterions_from_request(request)
         user_service.check_project_access(criterions.get("project_id", None))
+        if permissions.has_vendor_permissions():
+            raise permissions.PermissionDenied
         return shots_service.get_scenes(criterions)
 
 
@@ -983,6 +985,7 @@ class SequenceTaskTypesResource(Resource):
         """
         sequence = shots_service.get_sequence(sequence_id)
         user_service.check_project_access(sequence["project_id"])
+        user_service.check_entity_access(sequence_id)
         return tasks_service.get_task_types_for_sequence(sequence_id)
 
 
@@ -2060,6 +2063,7 @@ class EpisodeTaskTypesResource(Resource):
         """
         episode = shots_service.get_episode(episode_id)
         user_service.check_project_access(episode["project_id"])
+        user_service.check_entity_access(episode_id)
         return tasks_service.get_task_types_for_episode(episode_id)
 
 
@@ -2366,7 +2370,10 @@ class ProjectScenesResource(Resource, ArgsMixin):
         """
         projects_service.get_project(project_id)
         user_service.check_project_access(project_id)
-        return shots_service.get_scenes_for_project(project_id)
+        only_assigned = permissions.has_vendor_permissions()
+        return shots_service.get_scenes_for_project(
+            project_id, only_assigned=only_assigned
+        )
 
     @jwt_required()
     def post(self, project_id):
@@ -2483,6 +2490,7 @@ class SequenceScenesResource(Resource):
         """
         sequence = shots_service.get_sequence(sequence_id)
         user_service.check_project_access(sequence["project_id"])
+        user_service.check_entity_access(sequence_id)
         return shots_service.get_scenes_for_sequence(sequence_id)
 
 

--- a/zou/app/blueprints/shots/resources.py
+++ b/zou/app/blueprints/shots/resources.py
@@ -940,6 +940,8 @@ class SequenceTasksResource(Resource, ArgsMixin):
         user_service.check_project_access(sequence["project_id"])
         user_service.check_entity_access(sequence["id"])
         relations = self.get_relations()
+        if permissions.has_vendor_permissions():
+            return user_service.get_tasks_for_entity(sequence["id"])
         return tasks_service.get_tasks_for_sequence(
             sequence_id, relations=relations
         )
@@ -2148,6 +2150,7 @@ class SequenceResource(Resource, ArgsMixin):
         """
         sequence = shots_service.get_full_sequence(sequence_id)
         user_service.check_project_access(sequence["project_id"])
+        user_service.check_entity_access(sequence["id"])
         return sequence
 
     @jwt_required()
@@ -2230,6 +2233,14 @@ class SequencesResource(Resource):
             criterions["parent_id"] = episode["id"]
             del criterions["episode_id"]
         user_service.check_project_access(criterions.get("project_id", None))
+        if permissions.has_vendor_permissions():
+            project_id = criterions.get("project_id", None)
+            if project_id is not None:
+                return shots_service.get_sequences_for_project(
+                    project_id,
+                    only_assigned=True,
+                )
+            return []
         return shots_service.get_sequences(criterions)
 
 

--- a/zou/app/blueprints/shots/resources.py
+++ b/zou/app/blueprints/shots/resources.py
@@ -1102,6 +1102,8 @@ class SceneAndTasksResource(Resource):
         """
         criterions = query.get_query_criterions_from_request(request)
         user_service.check_project_access(criterions.get("project_id", None))
+        if permissions.has_vendor_permissions():
+            raise permissions.PermissionDenied
         criterions["entity_type_id"] = shots_service.get_scene_type()["id"]
         return entities_service.get_entities_and_tasks(criterions)
 
@@ -1159,6 +1161,8 @@ class SequenceAndTasksResource(Resource):
         """
         criterions = query.get_query_criterions_from_request(request)
         user_service.check_project_access(criterions.get("project_id", None))
+        if permissions.has_vendor_permissions():
+            raise permissions.PermissionDenied
         criterions["entity_type_id"] = shots_service.get_sequence_type()["id"]
         return entities_service.get_entities_and_tasks(criterions)
 
@@ -1216,6 +1220,8 @@ class EpisodeAndTasksResource(Resource):
         """
         criterions = query.get_query_criterions_from_request(request)
         user_service.check_project_access(criterions.get("project_id", None))
+        if permissions.has_vendor_permissions():
+            raise permissions.PermissionDenied
         criterions["entity_type_id"] = shots_service.get_episode_type()["id"]
         return entities_service.get_entities_and_tasks(criterions)
 
@@ -1865,6 +1871,7 @@ class EpisodeResource(Resource, ArgsMixin):
         """
         episode = shots_service.get_full_episode(episode_id)
         user_service.check_project_access(episode["project_id"])
+        user_service.check_entity_access(episode["id"])
         return episode
 
     @jwt_required()
@@ -1944,6 +1951,14 @@ class EpisodesResource(Resource):
         """
         criterions = query.get_query_criterions_from_request(request)
         user_service.check_project_access(criterions.get("project_id", None))
+        if permissions.has_vendor_permissions():
+            project_id = criterions.get("project_id", None)
+            if project_id is not None:
+                return shots_service.get_episodes_for_project(
+                    project_id,
+                    only_assigned=True,
+                )
+            return []
         return shots_service.get_episodes(criterions)
 
 
@@ -2105,6 +2120,9 @@ class EpisodeTasksResource(Resource):
         """
         episode = shots_service.get_episode(episode_id)
         user_service.check_project_access(episode["project_id"])
+        user_service.check_entity_access(episode["id"])
+        if permissions.has_vendor_permissions():
+            return user_service.get_tasks_for_entity(episode["id"])
         return tasks_service.get_tasks_for_episode(episode_id)
 
 


### PR DESCRIPTION
**Problem**
- Vendors could see all sequences, episodes, and scenes in a project regardless of task assignment
- Vendors could see all tasks for any sequence or episode, not just their own
- Vendors could access casting data (entity, episode, sequence, asset-type) without restriction
- The /data/sequences/with-tasks, /data/episodes/with-tasks, and /data/scenes/with-tasks endpoints had no vendor filtering at all
- Task-type and asset-instance endpoints for sequences, episodes, shots, and scenes had no entity-level access check for vendors

**Solution**
- Filter sequence and episode list endpoints to only return assigned entities for vendors (via only_assigned)
- Add check_entity_access on sequence, episode, and scene detail endpoints so vendors can only view entities they have tasks on
- Return only assigned tasks for vendors on sequence/episode task endpoints, block vendors on with-tasks endpoints (get_entities_and_tasks does not support vendor filtering)
- Block vendors from all casting/breakdown endpoints (entity, episode, sequence, asset-type)
- Add check_entity_access on shot/scene asset-instance and camera-instance endpoints
- Add 9 vendor-specific tests covering sequences and episodes
