### PR TITLE
[playlists] Shared playlist guest workflow + project metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,8 @@ restore.sh
 
 # Meilisearch folder
 data.ms
+
+# Meilisearch
+.venv
+additions
+previews-test

--- a/tests/projects/test_route_metadata.py
+++ b/tests/projects/test_route_metadata.py
@@ -16,6 +16,36 @@ class ProjectMetadataRouteTestCase(ApiDBTestCase):
         self.project_id = self.project.id
         self.asset_id = self.asset.id
 
+    def test_add_project_metadata_descriptor(self):
+        descriptor = self.post(
+            "data/projects/%s/metadata-descriptors" % self.project_id,
+            {
+                "entity_type": "Project",
+                "name": "Delivery code",
+                "data_type": "string",
+            },
+        )
+        self.assertEqual(descriptor["entity_type"], "Project")
+        self.assertEqual(descriptor["field_name"], "delivery_code")
+        self.put(
+            "data/projects/%s" % self.project_id,
+            {"data": {"delivery_code": "X-12"}},
+        )
+        self.put(
+            "data/projects/%s/metadata-descriptors/%s"
+            % (self.project_id, descriptor["id"]),
+            {"name": "Ship code", "data_type": "string"},
+        )
+        project = self.get("data/projects/%s" % self.project_id)
+        self.assertEqual(project["data"].get("ship_code"), "X-12")
+        self.assertIsNone((project.get("data") or {}).get("delivery_code"))
+        self.delete(
+            "data/projects/%s/metadata-descriptors/%s"
+            % (self.project_id, descriptor["id"])
+        )
+        project = self.get("data/projects/%s" % self.project_id)
+        self.assertIsNone((project.get("data") or {}).get("ship_code"))
+
     def test_add_asset_metadata_descriptor(self):
         descriptor = self.post(
             "data/projects/%s/metadata-descriptors" % self.project_id,

--- a/tests/services/test_projects_service.py
+++ b/tests/services/test_projects_service.py
@@ -210,6 +210,59 @@ class ProjectServiceTestCase(ApiDBTestCase):
         asset = Entity.get(asset.id)
         self.assertEqual(asset.data.get("team"), "contractor 1")
 
+    def test_update_project_metadata_descriptor_renames_project_data(self):
+        descriptor = projects_service.add_metadata_descriptor(
+            self.project.id, "Project", "Studio code", "string", [], False
+        )
+        self.project.update({"data": {"studio_code": "A1"}})
+        projects_service.update_metadata_descriptor(
+            descriptor["id"], {"name": "Code", "for_client": False}
+        )
+        self.project = Project.get(self.project.id)
+        self.assertEqual(self.project.data.get("code"), "A1")
+        self.assertIsNone(self.project.data.get("studio_code"))
+
+    def test_remove_project_metadata_descriptor_clears_project_data(self):
+        descriptor = projects_service.add_metadata_descriptor(
+            self.project.id, "Project", "Studio code", "string", [], False
+        )
+        self.project.update({"data": {"studio_code": "A1"}})
+        projects_service.remove_metadata_descriptor(descriptor["id"])
+        self.project = Project.get(self.project.id)
+        self.assertIsNone((self.project.data or {}).get("studio_code"))
+        self.assertEqual(
+            len(
+                [
+                    d
+                    for d in projects_service.get_metadata_descriptors(
+                        self.project.id
+                    )
+                    if d["entity_type"] == "Project"
+                ]
+            ),
+            0,
+        )
+
+    def test_reorder_project_metadata_descriptors(self):
+        d1 = projects_service.add_metadata_descriptor(
+            self.project.id, "Project", "Alpha", "string", [], False
+        )
+        d2 = projects_service.add_metadata_descriptor(
+            self.project.id, "Project", "Beta", "string", [], False
+        )
+        d3 = projects_service.add_metadata_descriptor(
+            self.project.id, "Project", "Gamma", "string", [], False
+        )
+        reordered = projects_service.reorder_metadata_descriptors(
+            self.project.id,
+            "Project",
+            [str(d3["id"]), str(d1["id"]), str(d2["id"])],
+        )
+        self.assertEqual(reordered[0]["id"], d3["id"])
+        self.assertEqual(reordered[0]["position"], 1)
+        self.assertEqual(reordered[1]["id"], d1["id"])
+        self.assertEqual(reordered[2]["id"], d2["id"])
+
     def test_add_delete_metadata_descriptor(self):
         asset = self.generate_fixture_asset_type()
         asset = self.generate_fixture_asset()

--- a/tests/shared/test_playlist_sharing.py
+++ b/tests/shared/test_playlist_sharing.py
@@ -1,0 +1,189 @@
+from tests.base import ApiDBTestCase
+
+from zou.app.services import (
+    playlist_sharing_service,
+    playlists_service,
+)
+
+
+class PlaylistSharingTestCase(ApiDBTestCase):
+    def setUp(self):
+        super().setUp()
+        self.generate_fixture_project_status()
+        self.generate_fixture_project()
+        self.generate_fixture_asset_type()
+        self.generate_fixture_asset()
+        self.generate_fixture_department()
+        self.generate_fixture_task_type()
+        self.generate_fixture_task_status()
+        self.generate_fixture_person()
+        self.generate_fixture_assigner()
+        self.generate_fixture_task()
+        self.playlist = playlists_service.create_playlist(
+            self.project.id,
+            "Test Playlist",
+            self.user["id"],
+        )
+
+    # --- Authenticated share link management (manager+) ---
+
+    def test_create_share_link(self):
+        result = self.post(
+            f"/data/playlists/{self.playlist['id']}/share",
+            {"can_comment": True},
+            201,
+        )
+        self.assertIsNotNone(result["token"])
+        self.assertTrue(result["is_active"])
+        self.assertTrue(result["can_comment"])
+
+    def test_list_share_links(self):
+        self.post(
+            f"/data/playlists/{self.playlist['id']}/share",
+            {},
+            201,
+        )
+        result = self.get(
+            f"/data/playlists/{self.playlist['id']}/share"
+        )
+        self.assertEqual(len(result), 1)
+
+    def test_revoke_share_link(self):
+        link = self.post(
+            f"/data/playlists/{self.playlist['id']}/share",
+            {},
+            201,
+        )
+        self.delete(
+            f"/data/playlists/{self.playlist['id']}/share/{link['token']}"
+        )
+        result = self.get(
+            f"/data/playlists/{self.playlist['id']}/share"
+        )
+        self.assertEqual(len(result), 0)
+
+    # --- Public shared playlist routes ---
+
+    def test_get_shared_playlist(self):
+        link = self.post(
+            f"/data/playlists/{self.playlist['id']}/share",
+            {},
+            201,
+        )
+        self.log_out()
+        result = self.get(f"/shared/playlists/{link['token']}")
+        self.assertEqual(result["id"], self.playlist["id"])
+
+    def test_get_shared_playlist_invalid_token(self):
+        self.log_out()
+        self.get("/shared/playlists/invalid-token", 404)
+
+    def test_get_shared_playlist_revoked(self):
+        link = self.post(
+            f"/data/playlists/{self.playlist['id']}/share",
+            {},
+            201,
+        )
+        self.delete(
+            f"/data/playlists/{self.playlist['id']}/share/{link['token']}"
+        )
+        self.log_out()
+        self.get(f"/shared/playlists/{link['token']}", 404)
+
+    def test_get_shared_playlist_context(self):
+        link = self.post(
+            f"/data/playlists/{self.playlist['id']}/share",
+            {},
+            201,
+        )
+        self.log_out()
+        result = self.get(
+            f"/shared/playlists/{link['token']}/context"
+        )
+        self.assertIn("project", result)
+        self.assertIn("task_types", result)
+        self.assertIn("task_statuses", result)
+
+    # --- Guest management ---
+
+    def test_create_guest(self):
+        link = self.post(
+            f"/data/playlists/{self.playlist['id']}/share",
+            {},
+            201,
+        )
+        self.log_out()
+        guest = self.post(
+            f"/shared/playlists/{link['token']}/guest",
+            {"first_name": "John", "last_name": "Doe"},
+            201,
+        )
+        self.assertEqual(guest["first_name"], "John")
+        self.assertTrue(guest["is_guest"])
+
+    def test_reuse_guest(self):
+        link = self.post(
+            f"/data/playlists/{self.playlist['id']}/share",
+            {},
+            201,
+        )
+        self.log_out()
+        guest = self.post(
+            f"/shared/playlists/{link['token']}/guest",
+            {"first_name": "John"},
+            201,
+        )
+        guest2 = self.post(
+            f"/shared/playlists/{link['token']}/guest",
+            {"first_name": "Jane", "guest_id": guest["id"]},
+        )
+        self.assertEqual(guest["id"], guest2["id"])
+
+    # --- Guest comments ---
+
+    def test_guest_comment(self):
+        link = self.post(
+            f"/data/playlists/{self.playlist['id']}/share",
+            {"can_comment": True},
+            201,
+        )
+        self.log_out()
+        guest = self.post(
+            f"/shared/playlists/{link['token']}/guest",
+            {"first_name": "Reviewer"},
+            201,
+        )
+        comment = self.post(
+            f"/shared/playlists/{link['token']}/comments",
+            {
+                "guest_id": guest["id"],
+                "task_id": str(self.task.id),
+                "task_status_id": str(self.task_status.id),
+                "text": "Great work!",
+            },
+            201,
+        )
+        self.assertEqual(comment["text"], "Great work!")
+
+    def test_guest_comment_disabled(self):
+        link = self.post(
+            f"/data/playlists/{self.playlist['id']}/share",
+            {"can_comment": False},
+            201,
+        )
+        self.log_out()
+        guest = self.post(
+            f"/shared/playlists/{link['token']}/guest",
+            {"first_name": "Reviewer"},
+            201,
+        )
+        self.post(
+            f"/shared/playlists/{link['token']}/comments",
+            {
+                "guest_id": guest["id"],
+                "task_id": str(self.task.id),
+                "task_status_id": str(self.task_status.id),
+                "text": "Should fail",
+            },
+            403,
+        )

--- a/zou/app/api.py
+++ b/zou/app/api.py
@@ -16,6 +16,7 @@ from zou.app.blueprints.search import blueprint as search_blueprint
 from zou.app.blueprints.news import blueprint as news_blueprint
 from zou.app.blueprints.persons import blueprint as persons_blueprint
 from zou.app.blueprints.playlists import blueprint as playlists_blueprint
+from zou.app.blueprints.shared import blueprint as shared_blueprint
 from zou.app.blueprints.projects import blueprint as projects_blueprint
 from zou.app.blueprints.project_templates import (
     blueprint as project_templates_blueprint,
@@ -66,6 +67,7 @@ def configure_api_routes(app):
     app.register_blueprint(news_blueprint)
     app.register_blueprint(persons_blueprint)
     app.register_blueprint(playlists_blueprint)
+    app.register_blueprint(shared_blueprint)
     app.register_blueprint(projects_blueprint)
     app.register_blueprint(project_templates_blueprint)
     app.register_blueprint(shots_blueprint)

--- a/zou/app/blueprints/crud/person.py
+++ b/zou/app/blueprints/crud/person.py
@@ -1,5 +1,6 @@
 import datetime
 
+import sqlalchemy.orm as orm
 from flask_jwt_extended import jwt_required
 
 from zou.app.models.person import (
@@ -221,6 +222,10 @@ class PersonsResource(BaseModelsResource):
     def all_entries(self, query=None, relations=False):
         if query is None:
             query = self.model.query
+
+        if relations:
+            for relationship in self.get_relations_eager_load():
+                query = query.options(orm.selectinload(relationship))
 
         if permissions.has_admin_permissions():
             if self.get_bool_parameter("with_pass_hash"):

--- a/zou/app/blueprints/playlists/__init__.py
+++ b/zou/app/blueprints/playlists/__init__.py
@@ -9,6 +9,8 @@ from zou.app.blueprints.playlists.resources import (
     EpisodePlaylistsResource,
     PlaylistAddEntityResource,
     NotifyClientsResource,
+    PlaylistShareLinksResource,
+    PlaylistShareLinkResource,
     ProjectPlaylistsResource,
     ProjectAllPlaylistsResource,
     ProjectBuildJobsResource,
@@ -51,6 +53,14 @@ routes = [
         PlaylistAddEntityResource,
     ),
     ("/data/playlists/<playlist_id>/notify-clients", NotifyClientsResource),
+    (
+        "/data/playlists/<playlist_id>/share",
+        PlaylistShareLinksResource,
+    ),
+    (
+        "/data/playlists/<playlist_id>/share/<token>",
+        PlaylistShareLinkResource,
+    ),
 ]
 
 blueprint = Blueprint("playlists", "playlists")

--- a/zou/app/blueprints/playlists/resources.py
+++ b/zou/app/blueprints/playlists/resources.py
@@ -941,7 +941,7 @@ class NotifyClientsResource(Resource, ArgsMixin):
 
 class PlaylistShareLinksResource(Resource):
     """
-    Manage share links for a playlist (supervisor+).
+    Manage share links for a playlist (manager+).
     """
 
     @jwt_required()
@@ -968,7 +968,7 @@ class PlaylistShareLinksResource(Resource):
 
 class PlaylistShareLinkResource(Resource):
     """
-    Revoke a specific share link (supervisor+).
+    Revoke a specific share link (manager+).
     """
 
     @jwt_required()

--- a/zou/app/blueprints/playlists/resources.py
+++ b/zou/app/blueprints/playlists/resources.py
@@ -22,6 +22,7 @@ from zou.app.blueprints.playlists.schemas import (
 from zou.app.services import (
     entities_service,
     notifications_service,
+    playlist_sharing_service,
     playlists_service,
     persons_service,
     preview_files_service,
@@ -936,3 +937,41 @@ class NotifyClientsResource(Resource, ArgsMixin):
             playlist, studio_id, department_id
         )
         return {"status": "success"}
+
+
+class PlaylistShareLinksResource(Resource):
+    """
+    Manage share links for a playlist (supervisor+).
+    """
+
+    @jwt_required()
+    def get(self, playlist_id):
+        permissions.check_manager_permissions()
+        return playlist_sharing_service.get_share_links_for_playlist(
+            playlist_id
+        )
+
+    @jwt_required()
+    def post(self, playlist_id):
+        permissions.check_manager_permissions()
+        person = persons_service.get_current_user()
+        data = request.get_json(silent=True) or {}
+        share_link = playlist_sharing_service.create_share_link(
+            playlist_id,
+            person["id"],
+            expiration_date=data.get("expiration_date"),
+            can_comment=data.get("can_comment", True),
+            password=data.get("password"),
+        )
+        return share_link, 201
+
+
+class PlaylistShareLinkResource(Resource):
+    """
+    Revoke a specific share link (supervisor+).
+    """
+
+    @jwt_required()
+    def delete(self, playlist_id, token):
+        permissions.check_manager_permissions()
+        return playlist_sharing_service.revoke_share_link(token)

--- a/zou/app/blueprints/projects/resources.py
+++ b/zou/app/blueprints/projects/resources.py
@@ -1032,7 +1032,13 @@ class ProductionMetadataDescriptorsResource(Resource, ArgsMixin):
                   entity_type:
                     type: string
                     description: Entity type for the metadata descriptor
-                    enum: ["Asset", "Shot", "Edit", "Episode", "Sequence"]
+                    enum:
+                      - Asset
+                      - Shot
+                      - Edit
+                      - Episode
+                      - Sequence
+                      - Project
                     default: "Asset"
                     example: "Asset"
                   name:
@@ -1094,9 +1100,11 @@ class ProductionMetadataDescriptorsResource(Resource, ArgsMixin):
             "Edit",
             "Episode",
             "Sequence",
+            "Project",
         ]:
             raise WrongParameterException(
-                "Wrong entity type. Please select Asset, Shot, Sequence, Episode or Edit."
+                "Wrong entity type. Please select Asset, Shot, Sequence, "
+                "Episode, Edit, or Project."
             )
 
         types = [type_name for type_name, _ in METADATA_DESCRIPTOR_TYPES]
@@ -1316,7 +1324,13 @@ class ProductionMetadataDescriptorsReorderResource(Resource, ArgsMixin):
                   entity_type:
                     type: string
                     description: Entity type for the metadata descriptors
-                    enum: ["Asset", "Shot", "Edit", "Episode", "Sequence"]
+                    enum:
+                      - Asset
+                      - Shot
+                      - Edit
+                      - Episode
+                      - Sequence
+                      - Project
                     example: "Asset"
                   descriptor_ids:
                     type: array
@@ -1366,9 +1380,11 @@ class ProductionMetadataDescriptorsReorderResource(Resource, ArgsMixin):
             "Edit",
             "Episode",
             "Sequence",
+            "Project",
         ]:
             raise WrongParameterException(
-                "Wrong entity type. Please select Asset, Shot, Sequence, Episode or Edit."
+                "Wrong entity type. Please select Asset, Shot, Sequence, "
+                "Episode, Edit, or Project."
             )
 
         return projects_service.reorder_metadata_descriptors(

--- a/zou/app/blueprints/shared/__init__.py
+++ b/zou/app/blueprints/shared/__init__.py
@@ -11,6 +11,7 @@ from zou.app.blueprints.shared.resources import (
     SharedPlaylistPreviewFileMovieResource,
     SharedPlaylistPreviewFileThumbnailResource,
     SharedPlaylistPreviewFileOriginalResource,
+    SharedPlaylistPreviewFileTileResource,
     SharedPlaylistContextResource,
 )
 
@@ -49,6 +50,11 @@ routes = [
         "/shared/playlists/<token>/pictures/originals/"
         "preview-files/<preview_file_id>.png",
         SharedPlaylistPreviewFileOriginalResource,
+    ),
+    (
+        "/shared/playlists/<token>/movies/tiles/"
+        "preview-files/<preview_file_id>.png",
+        SharedPlaylistPreviewFileTileResource,
     ),
     (
         "/shared/playlists/<token>/context",

--- a/zou/app/blueprints/shared/__init__.py
+++ b/zou/app/blueprints/shared/__init__.py
@@ -1,0 +1,60 @@
+from flask import Blueprint
+
+from zou.app.utils.api import configure_api_from_blueprint
+
+from zou.app.blueprints.shared.resources import (
+    SharedPlaylistResource,
+    SharedPlaylistGuestResource,
+    SharedPlaylistCommentsResource,
+    SharedPlaylistAnnotationsResource,
+    SharedPlaylistPreviewFileResource,
+    SharedPlaylistPreviewFileMovieResource,
+    SharedPlaylistPreviewFileThumbnailResource,
+    SharedPlaylistPreviewFileOriginalResource,
+    SharedPlaylistContextResource,
+)
+
+routes = [
+    (
+        "/shared/playlists/<token>",
+        SharedPlaylistResource,
+    ),
+    (
+        "/shared/playlists/<token>/guest",
+        SharedPlaylistGuestResource,
+    ),
+    (
+        "/shared/playlists/<token>/comments",
+        SharedPlaylistCommentsResource,
+    ),
+    (
+        "/shared/playlists/<token>/annotations",
+        SharedPlaylistAnnotationsResource,
+    ),
+    (
+        "/shared/playlists/<token>/preview-files/<preview_file_id>",
+        SharedPlaylistPreviewFileResource,
+    ),
+    (
+        "/shared/playlists/<token>/movies/originals/"
+        "preview-files/<preview_file_id>.mp4",
+        SharedPlaylistPreviewFileMovieResource,
+    ),
+    (
+        "/shared/playlists/<token>/pictures/thumbnails/"
+        "preview-files/<preview_file_id>.png",
+        SharedPlaylistPreviewFileThumbnailResource,
+    ),
+    (
+        "/shared/playlists/<token>/pictures/originals/"
+        "preview-files/<preview_file_id>.png",
+        SharedPlaylistPreviewFileOriginalResource,
+    ),
+    (
+        "/shared/playlists/<token>/context",
+        SharedPlaylistContextResource,
+    ),
+]
+
+blueprint = Blueprint("shared", "shared")
+api = configure_api_from_blueprint(blueprint, routes)

--- a/zou/app/blueprints/shared/__init__.py
+++ b/zou/app/blueprints/shared/__init__.py
@@ -6,6 +6,10 @@ from zou.app.blueprints.shared.resources import (
     SharedPlaylistResource,
     SharedPlaylistGuestResource,
     SharedPlaylistCommentsResource,
+    SharedPlaylistCommentResource,
+    SharedPlaylistCommentAttachmentsResource,
+    SharedPlaylistCommentAttachmentResource,
+    SharedPlaylistAttachmentFileResource,
     SharedPlaylistAnnotationsResource,
     SharedPlaylistPreviewFileResource,
     SharedPlaylistPreviewFileMovieResource,
@@ -27,6 +31,24 @@ routes = [
     (
         "/shared/playlists/<token>/comments",
         SharedPlaylistCommentsResource,
+    ),
+    (
+        "/shared/playlists/<token>/comments/<comment_id>",
+        SharedPlaylistCommentResource,
+    ),
+    (
+        "/shared/playlists/<token>/comments/<comment_id>/attachments",
+        SharedPlaylistCommentAttachmentsResource,
+    ),
+    (
+        "/shared/playlists/<token>/comments/<comment_id>/"
+        "attachments/<attachment_id>",
+        SharedPlaylistCommentAttachmentResource,
+    ),
+    (
+        "/shared/playlists/<token>/attachment-files/"
+        "<attachment_id>/file/<file_name>",
+        SharedPlaylistAttachmentFileResource,
     ),
     (
         "/shared/playlists/<token>/annotations",

--- a/zou/app/blueprints/shared/decorators.py
+++ b/zou/app/blueprints/shared/decorators.py
@@ -1,0 +1,36 @@
+from functools import wraps
+
+from flask import g, request
+
+from zou.app.services import playlist_sharing_service
+
+
+def require_valid_playlist_share_link(with_password=False):
+    """
+    Validate the path token and store the serialized share link on
+    ``g.playlist_share_link`` for the request.
+
+    :param with_password: When True, pass the optional ``password`` query
+        parameter to ``playlist_sharing_service.validate_share_token`` (for
+        protected links).
+    """
+
+    def decorator(view_fn):
+        @wraps(view_fn)
+        def wrapped(self, token, *args, **kwargs):
+            if with_password:
+                password = request.args.get("password")
+                g.playlist_share_link = (
+                    playlist_sharing_service.validate_share_token(
+                        token, password=password
+                    )
+                )
+            else:
+                g.playlist_share_link = (
+                    playlist_sharing_service.validate_share_token(token)
+                )
+            return view_fn(self, token, *args, **kwargs)
+
+        return wrapped
+
+    return decorator

--- a/zou/app/blueprints/shared/resources.py
+++ b/zou/app/blueprints/shared/resources.py
@@ -1,4 +1,4 @@
-from flask import request
+from flask import g, request
 from flask_fs.errors import FileNotFound
 from flask_restful import Resource
 
@@ -6,47 +6,104 @@ from zou.app.blueprints.previews.resources import (
     send_movie_file,
     send_picture_file,
 )
+from zou.app.blueprints.shared.decorators import (
+    require_valid_playlist_share_link,
+)
 from zou.app.services import (
     comments_service,
     files_service,
     playlist_sharing_service,
     playlists_service,
     preview_files_service,
-    tasks_service,
 )
 
 
 class SharedPlaylistResource(Resource):
-    """
-    GET /api/shared/playlists/<token>
-    Return playlist data with preview file revisions, accessible via
-    a share token. No authentication required — token is the credential.
-    """
-
+    @require_valid_playlist_share_link(with_password=True)
     def get(self, token):
-        password = request.args.get("password")
-        share_link = playlist_sharing_service.validate_share_token(
-            token, password=password
+        """
+        Get shared playlist
+        ---
+        description: Retrieve a playlist with preview file revisions for a
+          secret share link. No JWT; the path token (and optional query
+          password) is the credential.
+        tags:
+          - Playlists
+        parameters:
+          - in: path
+            name: token
+            required: true
+            schema:
+              type: string
+            description: Share link token
+          - in: query
+            name: password
+            required: false
+            schema:
+              type: string
+            description: Password when the link is protected
+        responses:
+          200:
+            description: Playlist with preview file revisions and enriched shots
+            content:
+              application/json:
+                schema:
+                  type: object
+        """
+        share_link = g.playlist_share_link
+        playlist = playlists_service.get_playlist_with_preview_file_revisions(
+            share_link["playlist_id"]
         )
-        playlist = (
-            playlists_service.get_playlist_with_preview_file_revisions(
-                share_link["playlist_id"]
-            )
-        )
-        return playlist_sharing_service.enrich_shots_with_entity_info(
-            playlist
-        )
+        return playlist_sharing_service.enrich_shots_with_entity_info(playlist)
 
 
 class SharedPlaylistGuestResource(Resource):
-    """
-    POST /api/shared/playlists/<token>/guest
-    Create or retrieve a guest identity for the shared playlist.
-    Body: { "first_name": "John", "last_name": "Doe" (optional) }
-    """
-
+    @require_valid_playlist_share_link()
     def post(self, token):
-        playlist_sharing_service.validate_share_token(token)
+        """
+        Create or retrieve guest for shared playlist
+        ---
+        description: Create a guest identity for the shared playlist, or return
+          an existing guest when `guest_id` is provided and still valid.
+        tags:
+          - Playlists
+        parameters:
+          - in: path
+            name: token
+            required: true
+            schema:
+              type: string
+            description: Share link token
+        requestBody:
+          required: false
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  first_name:
+                    type: string
+                    default: Guest
+                  last_name:
+                    type: string
+                  guest_id:
+                    type: string
+                    format: uuid
+                    description: If set, return this guest if it still exists
+        responses:
+          200:
+            description: Existing guest returned
+            content:
+              application/json:
+                schema:
+                  type: object
+          201:
+            description: New guest created
+            content:
+              application/json:
+                schema:
+                  type: object
+        """
         data = request.get_json(silent=True) or {}
         first_name = data.get("first_name", "Guest")
         last_name = data.get("last_name", "")
@@ -67,40 +124,135 @@ class SharedPlaylistGuestResource(Resource):
 
 
 class SharedPlaylistCommentsResource(Resource):
-    """
-    GET /api/shared/playlists/<token>/comments
-    List comments for the playlist's tasks.
-
-    POST /api/shared/playlists/<token>/comments
-    Post a comment as a guest.
-    Body: { "guest_id": "...", "task_id": "...",
-            "task_status_id": "...", "text": "..." }
-    """
-
+    @require_valid_playlist_share_link(with_password=True)
     def get(self, token):
-        share_link = playlist_sharing_service.validate_share_token(
-            token
+        """
+        List shared playlist comments
+        ---
+        description: List comments for tasks that appear in the shared playlist
+          (aggregated from each shot's preview task). Same optional `password`
+          query param as the main shared playlist when the link is protected.
+        tags:
+          - Playlists
+        parameters:
+          - in: path
+            name: token
+            required: true
+            schema:
+              type: string
+            description: Share link token
+          - in: query
+            name: password
+            required: false
+            schema:
+              type: string
+            description: Password when the link is protected
+        responses:
+          200:
+            description: Comment entries for the playlist
+            content:
+              application/json:
+                schema:
+                  type: array
+                  items:
+                    type: object
+        """
+        share_link = g.playlist_share_link
+        playlist = playlists_service.get_playlist_with_preview_file_revisions(
+            share_link["playlist_id"]
         )
-        playlist = playlist_sharing_service.get_shared_playlist(token)
+        task_ids = {
+            shot.get("preview_file_task_id")
+            for shot in playlist.get("shots", [])
+            if shot.get("preview_file_task_id")
+        }
         comments = []
-        for shot_entry in playlist.get("shots", []):
-            entity_id = shot_entry.get("entity_id")
-            if entity_id:
-                task_id = shot_entry.get("preview_file_task_id")
-                if task_id:
-                    try:
-                        task_comments = tasks_service.get_comments(
-                            task_id, is_client=True
-                        )
-                        comments.extend(task_comments)
-                    except Exception:
-                        pass
+        for task_id in task_ids:
+            try:
+                comments.extend(
+                    playlist_sharing_service.get_shared_task_comments(task_id)
+                )
+            except Exception:
+                pass
         return comments
 
+    @require_valid_playlist_share_link(with_password=True)
     def post(self, token):
-        share_link = playlist_sharing_service.validate_share_token(
-            token
-        )
+        """
+        Post comment on shared playlist
+        ---
+        description: Add a review comment as a guest. Requires `guest_id`,
+          `task_id`, `task_status_id` and `text` when the link allows
+          commenting. Optional `password` query param if the link is
+          protected.
+        tags:
+          - Playlists
+        parameters:
+          - in: path
+            name: token
+            required: true
+            schema:
+              type: string
+            description: Share link token
+          - in: query
+            name: password
+            required: false
+            schema:
+              type: string
+            description: Password when the link is protected
+        requestBody:
+          required: true
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - guest_id
+                  - task_id
+                  - task_status_id
+                properties:
+                  guest_id:
+                    type: string
+                    format: uuid
+                  task_id:
+                    type: string
+                    format: uuid
+                  task_status_id:
+                    type: string
+                    format: uuid
+                  text:
+                    type: string
+                  checklist:
+                    type: array
+                    items:
+                      type: object
+        responses:
+          201:
+            description: Comment created
+            content:
+              application/json:
+                schema:
+                  type: object
+          400:
+            description: Missing required body fields
+            content:
+              application/json:
+                schema:
+                  type: object
+                  properties:
+                    error:
+                      type: string
+          403:
+            description: Comments disabled for this share link
+            content:
+              application/json:
+                schema:
+                  type: object
+                  properties:
+                    error:
+                      type: string
+        """
+        share_link = g.playlist_share_link
         if not share_link.get("can_comment", True):
             return {"error": "Comments are disabled for this link"}, 403
 
@@ -109,6 +261,7 @@ class SharedPlaylistCommentsResource(Resource):
         task_id = data.get("task_id")
         task_status_id = data.get("task_status_id")
         text = data.get("text", "")
+        checklist = data.get("checklist") or []
 
         if not guest_id or not task_id or not task_status_id:
             return {"error": "Missing required fields"}, 400
@@ -120,23 +273,80 @@ class SharedPlaylistCommentsResource(Resource):
             task_id=task_id,
             task_status_id=task_status_id,
             text=text,
+            checklist=checklist,
             for_client=True,
         )
         return comment, 201
 
 
 class SharedPlaylistAnnotationsResource(Resource):
-    """
-    POST /api/shared/playlists/<token>/annotations
-    Save an annotation as a guest.
-    Body: { "guest_id": "...", "preview_file_id": "...",
-            "annotations": [...] }
-    """
-
+    @require_valid_playlist_share_link()
     def post(self, token):
-        share_link = playlist_sharing_service.validate_share_token(
-            token
-        )
+        """
+        Save guest annotations for preview
+        ---
+        description: Update preview file annotations in the context of a shared
+          playlist. Only allowed when the link permits commenting/annotations.
+        tags:
+          - Playlists
+        parameters:
+          - in: path
+            name: token
+            required: true
+            schema:
+              type: string
+            description: Share link token
+        requestBody:
+          required: true
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - guest_id
+                  - preview_file_id
+                properties:
+                  guest_id:
+                    type: string
+                    format: uuid
+                  preview_file_id:
+                    type: string
+                    format: uuid
+                  annotations:
+                    type: array
+                    items:
+                      type: object
+        responses:
+          200:
+            description: Annotations stored
+            content:
+              application/json:
+                schema:
+                  type: object
+                  properties:
+                    status:
+                      type: string
+                      example: success
+          400:
+            description: Missing required body fields
+            content:
+              application/json:
+                schema:
+                  type: object
+                  properties:
+                    error:
+                      type: string
+          403:
+            description: Annotations disabled for this share link
+            content:
+              application/json:
+                schema:
+                  type: object
+                  properties:
+                    error:
+                      type: string
+        """
+        share_link = g.playlist_share_link
         if not share_link.get("can_comment", True):
             return {"error": "Annotations are disabled"}, 403
 
@@ -158,25 +368,83 @@ class SharedPlaylistAnnotationsResource(Resource):
 
 
 class SharedPlaylistPreviewFileResource(Resource):
-    """
-    GET /api/shared/playlists/<token>/preview-files/<preview_file_id>
-    Return preview file metadata accessible via the share token.
-    """
-
+    @require_valid_playlist_share_link()
     def get(self, token, preview_file_id):
-        playlist_sharing_service.validate_share_token(token)
+        """
+        Get shared preview file metadata
+        ---
+        description: Return preview file record when the request includes a
+          valid share token. No JWT.
+        tags:
+          - Playlists
+        parameters:
+          - in: path
+            name: token
+            required: true
+            schema:
+              type: string
+            description: Share link token
+          - in: path
+            name: preview_file_id
+            required: true
+            schema:
+              type: string
+              format: uuid
+            description: Preview file unique identifier
+        responses:
+          200:
+            description: Preview file metadata
+            content:
+              application/json:
+                schema:
+                  type: object
+        """
         return files_service.get_preview_file(preview_file_id)
 
 
 class SharedPlaylistPreviewFileMovieResource(Resource):
-    """
-    GET /api/shared/playlists/<token>/movies/originals/
-        preview-files/<preview_file_id>.mp4
-    Stream an original movie preview file.
-    """
-
+    @require_valid_playlist_share_link()
     def get(self, token, preview_file_id):
-        playlist_sharing_service.validate_share_token(token)
+        """
+        Get shared original movie preview
+        ---
+        description: Stream the original movie file for a preview, authorized by
+          the share token. Same role as the authenticated original movie
+          preview route, without JWT.
+        tags:
+          - Playlists
+        parameters:
+          - in: path
+            name: token
+            required: true
+            schema:
+              type: string
+            description: Share link token
+          - in: path
+            name: preview_file_id
+            required: true
+            schema:
+              type: string
+              format: uuid
+            description: Preview file unique identifier
+        responses:
+          200:
+            description: Movie preview file stream
+            content:
+              video/mp4:
+                schema:
+                  type: string
+                  format: binary
+          404:
+            description: Preview file not on disk
+            content:
+              application/json:
+                schema:
+                  type: object
+                  properties:
+                    error:
+                      type: string
+        """
         try:
             return send_movie_file(preview_file_id)
         except FileNotFound:
@@ -184,14 +452,47 @@ class SharedPlaylistPreviewFileMovieResource(Resource):
 
 
 class SharedPlaylistPreviewFileThumbnailResource(Resource):
-    """
-    GET /api/shared/playlists/<token>/pictures/thumbnails/
-        preview-files/<preview_file_id>.png
-    Serve a preview file thumbnail.
-    """
-
+    @require_valid_playlist_share_link()
     def get(self, token, preview_file_id):
-        playlist_sharing_service.validate_share_token(token)
+        """
+        Get shared preview thumbnail
+        ---
+        description: Serve the PNG thumbnail for a preview file when the share
+          token is valid.
+        tags:
+          - Playlists
+        parameters:
+          - in: path
+            name: token
+            required: true
+            schema:
+              type: string
+            description: Share link token
+          - in: path
+            name: preview_file_id
+            required: true
+            schema:
+              type: string
+              format: uuid
+            description: Preview file unique identifier
+        responses:
+          200:
+            description: Thumbnail image
+            content:
+              image/png:
+                schema:
+                  type: string
+                  format: binary
+          404:
+            description: Thumbnail file missing
+            content:
+              application/json:
+                schema:
+                  type: object
+                  properties:
+                    error:
+                      type: string
+        """
         try:
             return send_picture_file("thumbnails", preview_file_id)
         except FileNotFound:
@@ -199,14 +500,47 @@ class SharedPlaylistPreviewFileThumbnailResource(Resource):
 
 
 class SharedPlaylistPreviewFileOriginalResource(Resource):
-    """
-    GET /api/shared/playlists/<token>/pictures/originals/
-        preview-files/<preview_file_id>.png
-    Serve an original preview picture.
-    """
-
+    @require_valid_playlist_share_link()
     def get(self, token, preview_file_id):
-        playlist_sharing_service.validate_share_token(token)
+        """
+        Get shared original picture preview
+        ---
+        description: Serve the full-size PNG for a still preview, authorized by
+          the share token.
+        tags:
+          - Playlists
+        parameters:
+          - in: path
+            name: token
+            required: true
+            schema:
+              type: string
+            description: Share link token
+          - in: path
+            name: preview_file_id
+            required: true
+            schema:
+              type: string
+              format: uuid
+            description: Preview file unique identifier
+        responses:
+          200:
+            description: Original picture file
+            content:
+              image/png:
+                schema:
+                  type: string
+                  format: binary
+          404:
+            description: Original file missing
+            content:
+              application/json:
+                schema:
+                  type: object
+                  properties:
+                    error:
+                      type: string
+        """
         try:
             return send_picture_file("original", preview_file_id)
         except FileNotFound:
@@ -214,15 +548,47 @@ class SharedPlaylistPreviewFileOriginalResource(Resource):
 
 
 class SharedPlaylistPreviewFileTileResource(Resource):
-    """
-    GET /api/shared/playlists/<token>/movies/tiles/
-        preview-files/<preview_file_id>.png
-    Serve a movie preview tile sprite (used by the playlist timeline to show
-    thumbnails on hover).
-    """
-
+    @require_valid_playlist_share_link()
     def get(self, token, preview_file_id):
-        playlist_sharing_service.validate_share_token(token)
+        """
+        Get shared movie tile strip
+        ---
+        description: Serve the filmstrip/tile image used for timeline hover
+          previews, when the share token is valid.
+        tags:
+          - Playlists
+        parameters:
+          - in: path
+            name: token
+            required: true
+            schema:
+              type: string
+            description: Share link token
+          - in: path
+            name: preview_file_id
+            required: true
+            schema:
+              type: string
+              format: uuid
+            description: Preview file unique identifier
+        responses:
+          200:
+            description: Tile sprite image
+            content:
+              image/png:
+                schema:
+                  type: string
+                  format: binary
+          404:
+            description: Tile file missing
+            content:
+              application/json:
+                schema:
+                  type: object
+                  properties:
+                    error:
+                      type: string
+        """
         try:
             return send_picture_file("tiles", preview_file_id)
         except FileNotFound:
@@ -230,16 +596,35 @@ class SharedPlaylistPreviewFileTileResource(Resource):
 
 
 class SharedPlaylistContextResource(Resource):
-    """
-    GET /api/shared/playlists/<token>/context
-    Return minimal project context for displaying the shared playlist.
-    """
-
+    @require_valid_playlist_share_link(with_password=True)
     def get(self, token):
-        password = request.args.get("password")
-        playlist_sharing_service.validate_share_token(
-            token, password=password
-        )
-        return playlist_sharing_service.get_shared_playlist_context(
-            token
-        )
+        """
+        Get shared playlist context
+        ---
+        description: Return minimal project and playlist context needed to
+          render the shared playlist UI. Optional `password` query param when
+          the link is protected.
+        tags:
+          - Playlists
+        parameters:
+          - in: path
+            name: token
+            required: true
+            schema:
+              type: string
+            description: Share link token
+          - in: query
+            name: password
+            required: false
+            schema:
+              type: string
+            description: Password when the link is protected
+        responses:
+          200:
+            description: Context payload for the share page
+            content:
+              application/json:
+                schema:
+                  type: object
+        """
+        return playlist_sharing_service.get_shared_playlist_context(token)

--- a/zou/app/blueprints/shared/resources.py
+++ b/zou/app/blueprints/shared/resources.py
@@ -1,4 +1,5 @@
 from flask import request
+from flask_fs.errors import FileNotFound
 from flask_restful import Resource
 
 from zou.app.blueprints.previews.resources import (
@@ -176,7 +177,10 @@ class SharedPlaylistPreviewFileMovieResource(Resource):
 
     def get(self, token, preview_file_id):
         playlist_sharing_service.validate_share_token(token)
-        return send_movie_file(preview_file_id)
+        try:
+            return send_movie_file(preview_file_id)
+        except FileNotFound:
+            return {"error": "Preview file not found"}, 404
 
 
 class SharedPlaylistPreviewFileThumbnailResource(Resource):
@@ -188,7 +192,10 @@ class SharedPlaylistPreviewFileThumbnailResource(Resource):
 
     def get(self, token, preview_file_id):
         playlist_sharing_service.validate_share_token(token)
-        return send_picture_file("thumbnails", preview_file_id)
+        try:
+            return send_picture_file("thumbnails", preview_file_id)
+        except FileNotFound:
+            return {"error": "Thumbnail not found"}, 404
 
 
 class SharedPlaylistPreviewFileOriginalResource(Resource):
@@ -200,7 +207,26 @@ class SharedPlaylistPreviewFileOriginalResource(Resource):
 
     def get(self, token, preview_file_id):
         playlist_sharing_service.validate_share_token(token)
-        return send_picture_file("original", preview_file_id)
+        try:
+            return send_picture_file("original", preview_file_id)
+        except FileNotFound:
+            return {"error": "Original not found"}, 404
+
+
+class SharedPlaylistPreviewFileTileResource(Resource):
+    """
+    GET /api/shared/playlists/<token>/movies/tiles/
+        preview-files/<preview_file_id>.png
+    Serve a movie preview tile sprite (used by the playlist timeline to show
+    thumbnails on hover).
+    """
+
+    def get(self, token, preview_file_id):
+        playlist_sharing_service.validate_share_token(token)
+        try:
+            return send_picture_file("tiles", preview_file_id)
+        except FileNotFound:
+            return {"error": "Tile not found"}, 404
 
 
 class SharedPlaylistContextResource(Resource):

--- a/zou/app/blueprints/shared/resources.py
+++ b/zou/app/blueprints/shared/resources.py
@@ -15,6 +15,7 @@ from zou.app.services import (
     playlist_sharing_service,
     playlists_service,
     preview_files_service,
+    tasks_service,
 )
 
 
@@ -279,14 +280,152 @@ class SharedPlaylistCommentsResource(Resource):
         return comment, 201
 
 
+class SharedPlaylistCommentResource(Resource):
+    """Edit or delete a single comment authored by a guest."""
+
+    @require_valid_playlist_share_link()
+    def put(self, token, comment_id):
+        """
+        Edit guest-owned comment
+        ---
+        description: Update the text / checklist / task status of a comment
+          previously posted by the same guest.
+        tags:
+          - Playlists
+        """
+        share_link = g.playlist_share_link
+        if not share_link.get("can_comment", True):
+            return {"error": "Comments are disabled for this link"}, 403
+
+        data = request.get_json(silent=True) or {}
+        try:
+            return playlist_sharing_service.update_guest_comment(
+                comment_id, data.get("guest_id"), data
+            )
+        except playlist_sharing_service.GuestCommentForbidden:
+            return {"error": "Forbidden"}, 403
+        except playlist_sharing_service.GuestCommentNotFound:
+            return {"error": "Comment not found"}, 404
+
+    @require_valid_playlist_share_link()
+    def delete(self, token, comment_id):
+        """
+        Delete guest-owned comment
+        ---
+        description: Delete a comment previously posted by the same guest.
+        tags:
+          - Playlists
+        """
+        share_link = g.playlist_share_link
+        if not share_link.get("can_comment", True):
+            return {"error": "Comments are disabled for this link"}, 403
+
+        guest_id = request.args.get("guest_id") or (
+            request.get_json(silent=True) or {}
+        ).get("guest_id")
+        try:
+            playlist_sharing_service.delete_guest_comment(
+                comment_id, guest_id
+            )
+            return "", 204
+        except playlist_sharing_service.GuestCommentForbidden:
+            return {"error": "Forbidden"}, 403
+        except playlist_sharing_service.GuestCommentNotFound:
+            return {"error": "Comment not found"}, 404
+
+
+class SharedPlaylistCommentAttachmentsResource(Resource):
+    """Add an attachment file to a guest-owned comment."""
+
+    @require_valid_playlist_share_link()
+    def post(self, token, comment_id):
+        """
+        Attach files to a guest-owned comment
+        ---
+        description: Upload one or more files as attachments to a comment the
+          same guest previously posted.
+        tags:
+          - Playlists
+        """
+        share_link = g.playlist_share_link
+        if not share_link.get("can_comment", True):
+            return {"error": "Comments are disabled for this link"}, 403
+
+        guest_id = request.form.get("guest_id") or (
+            request.args.get("guest_id")
+        )
+        try:
+            comment = playlist_sharing_service.add_guest_comment_attachments(
+                comment_id, guest_id, request.files
+            )
+            return comment, 201
+        except playlist_sharing_service.GuestCommentForbidden:
+            return {"error": "Forbidden"}, 403
+        except playlist_sharing_service.GuestCommentNotFound:
+            return {"error": "Comment not found"}, 404
+
+
+class SharedPlaylistCommentAttachmentResource(Resource):
+    """Delete one attachment from a guest-owned comment."""
+
+    @require_valid_playlist_share_link()
+    def delete(self, token, comment_id, attachment_id):
+        """
+        Delete an attachment from a guest-owned comment
+        ---
+        tags:
+          - Playlists
+        """
+        share_link = g.playlist_share_link
+        if not share_link.get("can_comment", True):
+            return {"error": "Comments are disabled for this link"}, 403
+
+        guest_id = request.args.get("guest_id") or (
+            request.get_json(silent=True) or {}
+        ).get("guest_id")
+        try:
+            playlist_sharing_service.remove_guest_comment_attachment(
+                comment_id, guest_id, attachment_id
+            )
+            return "", 204
+        except playlist_sharing_service.GuestCommentForbidden:
+            return {"error": "Forbidden"}, 403
+        except playlist_sharing_service.GuestCommentNotFound:
+            return {"error": "Comment not found"}, 404
+
+
+class SharedPlaylistAttachmentFileResource(Resource):
+    """Download an attachment that belongs to a visible shared comment."""
+
+    @require_valid_playlist_share_link()
+    def get(self, token, attachment_id, file_name):
+        """
+        Download attachment file
+        ---
+        description: Serve an attachment file linked to a comment visible in
+          this shared playlist (either `for_client=True` or authored by a
+          guest).
+        tags:
+          - Playlists
+        """
+        try:
+            return playlist_sharing_service.download_shared_attachment(
+                token, attachment_id, file_name
+            )
+        except playlist_sharing_service.GuestCommentNotFound:
+            return {"error": "Attachment not found"}, 404
+
+
 class SharedPlaylistAnnotationsResource(Resource):
     @require_valid_playlist_share_link()
-    def post(self, token):
+    def put(self, token):
         """
-        Save guest annotations for preview
+        Update guest annotations for a preview file
         ---
         description: Update preview file annotations in the context of a shared
-          playlist. Only allowed when the link permits commenting/annotations.
+          playlist. Reuses the same additions/updates/deletions diff format as
+          the manager-facing /actions/preview-files/<id>/update-annotations
+          route, so concurrent edits stay safe via the Redis lock.
         tags:
           - Playlists
         parameters:
@@ -312,39 +451,31 @@ class SharedPlaylistAnnotationsResource(Resource):
                   preview_file_id:
                     type: string
                     format: uuid
-                  annotations:
+                  additions:
                     type: array
                     items:
                       type: object
+                  updates:
+                    type: array
+                    items:
+                      type: object
+                  deletions:
+                    type: array
+                    items:
+                      type: string
+                      format: uuid
         responses:
           200:
-            description: Annotations stored
+            description: Updated preview file with the new annotations
             content:
               application/json:
                 schema:
                   type: object
-                  properties:
-                    status:
-                      type: string
-                      example: success
           400:
             description: Missing required body fields
-            content:
-              application/json:
-                schema:
-                  type: object
-                  properties:
-                    error:
-                      type: string
           403:
-            description: Annotations disabled for this share link
-            content:
-              application/json:
-                schema:
-                  type: object
-                  properties:
-                    error:
-                      type: string
+            description: Annotations disabled for this share link, or the
+              preview file is not part of the shared playlist
         """
         share_link = g.playlist_share_link
         if not share_link.get("can_comment", True):
@@ -353,18 +484,46 @@ class SharedPlaylistAnnotationsResource(Resource):
         data = request.get_json(silent=True) or {}
         guest_id = data.get("guest_id")
         preview_file_id = data.get("preview_file_id")
-        annotations = data.get("annotations", [])
+        additions = data.get("additions", [])
+        updates = data.get("updates", [])
+        deletions = data.get("deletions", [])
 
         if not guest_id or not preview_file_id:
             return {"error": "Missing required fields"}, 400
 
         playlist_sharing_service.get_guest(guest_id)
 
-        files_service.get_preview_file(preview_file_id)
-        preview_files_service.update_preview_file(
-            preview_file_id, {"annotations": annotations}
+        if not _is_preview_file_in_shared_playlist(token, preview_file_id):
+            return {
+                "error": "Preview file not part of this shared playlist"
+            }, 403
+
+        preview_file = files_service.get_preview_file(preview_file_id)
+        task = tasks_service.get_task(preview_file["task_id"])
+        return preview_files_service.update_preview_file_annotations(
+            guest_id,
+            task["project_id"],
+            preview_file_id,
+            additions=additions,
+            updates=updates,
+            deletions=deletions,
         )
-        return {"status": "success"}
+
+
+def _is_preview_file_in_shared_playlist(token, preview_file_id):
+    """
+    Ensure the given preview file id belongs to a shot (or one of its
+    revisions) of the playlist exposed by the share token.
+    """
+    playlist = playlist_sharing_service.get_shared_playlist(token)
+    pid = str(preview_file_id)
+    for shot in playlist.get("shots", []) or []:
+        if str(shot.get("preview_file_id") or "") == pid:
+            return True
+        for sub in shot.get("preview_file_previews", []) or []:
+            if str(sub.get("id") or "") == pid:
+                return True
+    return False
 
 
 class SharedPlaylistPreviewFileResource(Resource):

--- a/zou/app/blueprints/shared/resources.py
+++ b/zou/app/blueprints/shared/resources.py
@@ -1,0 +1,246 @@
+from flask import request, send_file as flask_send_file
+from flask_restful import Resource
+
+from zou.app.services import (
+    comments_service,
+    playlist_sharing_service,
+    playlists_service,
+    preview_files_service,
+    tasks_service,
+)
+from zou.app.stores import file_store
+
+
+class SharedPlaylistResource(Resource):
+    """
+    GET /api/shared/playlists/<token>
+    Return playlist data with preview file revisions, accessible via
+    a share token. No authentication required — token is the credential.
+    """
+
+    def get(self, token):
+        password = request.args.get("password")
+        share_link = playlist_sharing_service.validate_share_token(
+            token, password=password
+        )
+        return playlists_service.get_playlist_with_preview_file_revisions(
+            share_link["playlist_id"]
+        )
+
+
+class SharedPlaylistGuestResource(Resource):
+    """
+    POST /api/shared/playlists/<token>/guest
+    Create or retrieve a guest identity for the shared playlist.
+    Body: { "first_name": "John", "last_name": "Doe" (optional) }
+    """
+
+    def post(self, token):
+        playlist_sharing_service.validate_share_token(token)
+        data = request.get_json(silent=True) or {}
+        first_name = data.get("first_name", "Guest")
+        last_name = data.get("last_name", "")
+
+        # If a guest_id is provided, try to reuse it
+        guest_id = data.get("guest_id")
+        if guest_id:
+            try:
+                guest = playlist_sharing_service.get_guest(guest_id)
+                return guest
+            except Exception:
+                pass
+
+        guest = playlist_sharing_service.create_guest(
+            token, first_name, last_name
+        )
+        return guest, 201
+
+
+class SharedPlaylistCommentsResource(Resource):
+    """
+    GET /api/shared/playlists/<token>/comments
+    List comments for the playlist's tasks.
+
+    POST /api/shared/playlists/<token>/comments
+    Post a comment as a guest.
+    Body: { "guest_id": "...", "task_id": "...",
+            "task_status_id": "...", "text": "..." }
+    """
+
+    def get(self, token):
+        share_link = playlist_sharing_service.validate_share_token(
+            token
+        )
+        playlist = playlist_sharing_service.get_shared_playlist(token)
+        comments = []
+        for shot_entry in playlist.get("shots", []):
+            entity_id = shot_entry.get("entity_id")
+            if entity_id:
+                task_id = shot_entry.get("preview_file_task_id")
+                if task_id:
+                    try:
+                        task_comments = tasks_service.get_comments(
+                            task_id, is_client=True
+                        )
+                        comments.extend(task_comments)
+                    except Exception:
+                        pass
+        return comments
+
+    def post(self, token):
+        share_link = playlist_sharing_service.validate_share_token(
+            token
+        )
+        if not share_link.get("can_comment", True):
+            return {"error": "Comments are disabled for this link"}, 403
+
+        data = request.get_json(silent=True) or {}
+        guest_id = data.get("guest_id")
+        task_id = data.get("task_id")
+        task_status_id = data.get("task_status_id")
+        text = data.get("text", "")
+
+        if not guest_id or not task_id or not task_status_id:
+            return {"error": "Missing required fields"}, 400
+
+        playlist_sharing_service.get_guest(guest_id)
+
+        comment = comments_service.create_comment(
+            person_id=guest_id,
+            task_id=task_id,
+            task_status_id=task_status_id,
+            text=text,
+            for_client=True,
+        )
+        return comment, 201
+
+
+class SharedPlaylistAnnotationsResource(Resource):
+    """
+    POST /api/shared/playlists/<token>/annotations
+    Save an annotation as a guest.
+    Body: { "guest_id": "...", "preview_file_id": "...",
+            "annotations": [...] }
+    """
+
+    def post(self, token):
+        share_link = playlist_sharing_service.validate_share_token(
+            token
+        )
+        if not share_link.get("can_comment", True):
+            return {"error": "Annotations are disabled"}, 403
+
+        data = request.get_json(silent=True) or {}
+        guest_id = data.get("guest_id")
+        preview_file_id = data.get("preview_file_id")
+        annotations = data.get("annotations", [])
+
+        if not guest_id or not preview_file_id:
+            return {"error": "Missing required fields"}, 400
+
+        playlist_sharing_service.get_guest(guest_id)
+
+        preview_file = preview_files_service.get_preview_file(
+            preview_file_id
+        )
+        preview_files_service.update_preview_file(
+            preview_file_id, {"annotations": annotations}
+        )
+        return {"status": "success"}
+
+
+class SharedPlaylistPreviewFileResource(Resource):
+    """
+    GET /api/shared/playlists/<token>/preview-files/<preview_file_id>
+    Return preview file metadata accessible via the share token.
+    """
+
+    def get(self, token, preview_file_id):
+        playlist_sharing_service.validate_share_token(token)
+        return preview_files_service.get_preview_file(preview_file_id)
+
+
+class SharedPlaylistPreviewFileMovieResource(Resource):
+    """
+    GET /api/shared/playlists/<token>/movies/originals/
+        preview-files/<preview_file_id>.mp4
+    Stream an original movie preview file.
+    """
+
+    def get(self, token, preview_file_id):
+        playlist_sharing_service.validate_share_token(token)
+        preview_file = preview_files_service.get_preview_file(
+            preview_file_id
+        )
+        extension = preview_file.get("extension", "mp4")
+        file_path = file_store.get_local_movie_path(
+            "previews", preview_file_id
+        )
+        try:
+            return flask_send_file(
+                file_path,
+                conditional=True,
+                mimetype=f"video/{extension}",
+            )
+        except FileNotFoundError:
+            return {"error": "Preview file not found"}, 404
+
+
+class SharedPlaylistPreviewFileThumbnailResource(Resource):
+    """
+    GET /api/shared/playlists/<token>/pictures/thumbnails/
+        preview-files/<preview_file_id>.png
+    Serve a preview file thumbnail.
+    """
+
+    def get(self, token, preview_file_id):
+        playlist_sharing_service.validate_share_token(token)
+        file_path = file_store.get_local_picture_path(
+            "thumbnails", preview_file_id
+        )
+        try:
+            return flask_send_file(
+                file_path,
+                conditional=True,
+                mimetype="image/png",
+            )
+        except FileNotFoundError:
+            return {"error": "Thumbnail not found"}, 404
+
+
+class SharedPlaylistPreviewFileOriginalResource(Resource):
+    """
+    GET /api/shared/playlists/<token>/pictures/originals/
+        preview-files/<preview_file_id>.png
+    Serve an original preview picture.
+    """
+
+    def get(self, token, preview_file_id):
+        playlist_sharing_service.validate_share_token(token)
+        file_path = file_store.get_local_picture_path(
+            "originals", preview_file_id
+        )
+        try:
+            return flask_send_file(
+                file_path,
+                conditional=True,
+                mimetype="image/png",
+            )
+        except FileNotFoundError:
+            return {"error": "Original not found"}, 404
+
+
+class SharedPlaylistContextResource(Resource):
+    """
+    GET /api/shared/playlists/<token>/context
+    Return minimal project context for displaying the shared playlist.
+    """
+
+    def get(self, token):
+        password = request.args.get("password")
+        playlist_sharing_service.validate_share_token(
+            token, password=password
+        )
+        return playlist_sharing_service.get_shared_playlist_context(
+            token
+        )

--- a/zou/app/blueprints/shared/resources.py
+++ b/zou/app/blueprints/shared/resources.py
@@ -1,14 +1,18 @@
-from flask import request, send_file as flask_send_file
+from flask import request
 from flask_restful import Resource
 
+from zou.app.blueprints.previews.resources import (
+    send_movie_file,
+    send_picture_file,
+)
 from zou.app.services import (
     comments_service,
+    files_service,
     playlist_sharing_service,
     playlists_service,
     preview_files_service,
     tasks_service,
 )
-from zou.app.stores import file_store
 
 
 class SharedPlaylistResource(Resource):
@@ -23,8 +27,13 @@ class SharedPlaylistResource(Resource):
         share_link = playlist_sharing_service.validate_share_token(
             token, password=password
         )
-        return playlists_service.get_playlist_with_preview_file_revisions(
-            share_link["playlist_id"]
+        playlist = (
+            playlists_service.get_playlist_with_preview_file_revisions(
+                share_link["playlist_id"]
+            )
+        )
+        return playlist_sharing_service.enrich_shots_with_entity_info(
+            playlist
         )
 
 
@@ -140,9 +149,7 @@ class SharedPlaylistAnnotationsResource(Resource):
 
         playlist_sharing_service.get_guest(guest_id)
 
-        preview_file = preview_files_service.get_preview_file(
-            preview_file_id
-        )
+        files_service.get_preview_file(preview_file_id)
         preview_files_service.update_preview_file(
             preview_file_id, {"annotations": annotations}
         )
@@ -157,7 +164,7 @@ class SharedPlaylistPreviewFileResource(Resource):
 
     def get(self, token, preview_file_id):
         playlist_sharing_service.validate_share_token(token)
-        return preview_files_service.get_preview_file(preview_file_id)
+        return files_service.get_preview_file(preview_file_id)
 
 
 class SharedPlaylistPreviewFileMovieResource(Resource):
@@ -169,21 +176,7 @@ class SharedPlaylistPreviewFileMovieResource(Resource):
 
     def get(self, token, preview_file_id):
         playlist_sharing_service.validate_share_token(token)
-        preview_file = preview_files_service.get_preview_file(
-            preview_file_id
-        )
-        extension = preview_file.get("extension", "mp4")
-        file_path = file_store.get_local_movie_path(
-            "previews", preview_file_id
-        )
-        try:
-            return flask_send_file(
-                file_path,
-                conditional=True,
-                mimetype=f"video/{extension}",
-            )
-        except FileNotFoundError:
-            return {"error": "Preview file not found"}, 404
+        return send_movie_file(preview_file_id)
 
 
 class SharedPlaylistPreviewFileThumbnailResource(Resource):
@@ -195,17 +188,7 @@ class SharedPlaylistPreviewFileThumbnailResource(Resource):
 
     def get(self, token, preview_file_id):
         playlist_sharing_service.validate_share_token(token)
-        file_path = file_store.get_local_picture_path(
-            "thumbnails", preview_file_id
-        )
-        try:
-            return flask_send_file(
-                file_path,
-                conditional=True,
-                mimetype="image/png",
-            )
-        except FileNotFoundError:
-            return {"error": "Thumbnail not found"}, 404
+        return send_picture_file("thumbnails", preview_file_id)
 
 
 class SharedPlaylistPreviewFileOriginalResource(Resource):
@@ -217,17 +200,7 @@ class SharedPlaylistPreviewFileOriginalResource(Resource):
 
     def get(self, token, preview_file_id):
         playlist_sharing_service.validate_share_token(token)
-        file_path = file_store.get_local_picture_path(
-            "originals", preview_file_id
-        )
-        try:
-            return flask_send_file(
-                file_path,
-                conditional=True,
-                mimetype="image/png",
-            )
-        except FileNotFoundError:
-            return {"error": "Original not found"}, 404
+        return send_picture_file("original", preview_file_id)
 
 
 class SharedPlaylistContextResource(Resource):

--- a/zou/app/models/person.py
+++ b/zou/app/models/person.py
@@ -137,6 +137,7 @@ class Person(db.Model, BaseMixin, SerializerMixin):
     notifications_discord_userid = db.Column(db.String(60), default="")
 
     is_bot = db.Column(db.Boolean(), default=False, nullable=False)
+    is_guest = db.Column(db.Boolean(), default=False, nullable=False)
     jti = db.Column(db.String(60), nullable=True, unique=True)
     expiration_date = db.Column(db.Date(), nullable=True)
 

--- a/zou/app/models/playlist_share_link.py
+++ b/zou/app/models/playlist_share_link.py
@@ -1,0 +1,39 @@
+from sqlalchemy_utils import UUIDType
+
+from zou.app import db
+from zou.app.models.serializer import SerializerMixin
+from zou.app.models.base import BaseMixin
+
+
+class PlaylistShareLink(db.Model, BaseMixin, SerializerMixin):
+    """
+    Map a random token to a playlist, allowing external users to access
+    and comment on it without a Kitsu account.
+    """
+
+    token = db.Column(
+        db.String(64), unique=True, nullable=False, index=True
+    )
+    playlist_id = db.Column(
+        UUIDType(binary=False),
+        db.ForeignKey("playlist.id"),
+        nullable=False,
+        index=True,
+    )
+    created_by = db.Column(
+        UUIDType(binary=False),
+        db.ForeignKey("person.id"),
+        nullable=False,
+    )
+    expiration_date = db.Column(db.DateTime, nullable=True)
+    is_active = db.Column(db.Boolean(), default=True, nullable=False)
+    can_comment = db.Column(db.Boolean(), default=True, nullable=False)
+    password = db.Column(db.String(255), nullable=True)
+
+    __table_args__ = (
+        db.Index(
+            "ix_playlist_share_link_playlist_active",
+            "playlist_id",
+            "is_active",
+        ),
+    )

--- a/zou/app/services/exception.py
+++ b/zou/app/services/exception.py
@@ -145,6 +145,10 @@ class PlaylistNotFoundException(NotFound):
     pass
 
 
+class PlaylistShareLinkNotFoundException(NotFound):
+    pass
+
+
 class SearchFilterNotFoundException(NotFound):
     pass
 

--- a/zou/app/services/playlist_sharing_service.py
+++ b/zou/app/services/playlist_sharing_service.py
@@ -29,7 +29,7 @@ def create_share_link(
     password=None,
 ):
     """
-    Generate a share link for a playlist. Only supervisors and above
+    Generate a share link for a playlist. Only managers and above
     should call this (enforced at the resource level).
     """
     playlists_service.get_playlist(playlist_id)
@@ -113,6 +113,222 @@ def get_shared_playlist(token):
     share_link = validate_share_token(token)
     playlist = playlists_service.get_playlist(share_link["playlist_id"])
     return playlist
+
+
+class GuestCommentForbidden(Exception):
+    pass
+
+
+class GuestCommentNotFound(Exception):
+    pass
+
+
+def _load_guest_comment(comment_id, guest_id):
+    """
+    Fetch a comment by id and ensure it was authored by the given guest.
+    Raises :class:`GuestCommentForbidden` or :class:`GuestCommentNotFound`.
+    """
+    if not guest_id:
+        raise GuestCommentForbidden
+    # Ensure the guest actually exists.
+    get_guest(guest_id)
+    try:
+        comment = tasks_service.get_comment(comment_id)
+    except Exception:
+        raise GuestCommentNotFound
+    if str(comment.get("person_id")) != str(guest_id):
+        raise GuestCommentForbidden
+    return comment
+
+
+def update_guest_comment(comment_id, guest_id, data):
+    """
+    Update a comment authored by a guest. Accepts ``text``, ``checklist`` and
+    ``task_status_id`` in ``data``. Triggers the same post-update side effects
+    as the regular CRUD path (reset mentions, cache, events, task status
+    reset when needed).
+    """
+    from zou.app.models.comment import Comment
+    from zou.app.services import comments_service, notifications_service
+    from zou.app.utils import events
+
+    instance = _load_guest_comment(comment_id, guest_id)
+
+    new_status_id = data.get("task_status_id")
+    status_changed = bool(
+        new_status_id and instance.get("task_status_id") != new_status_id
+    )
+    previous_status_id = instance.get("task_status_id")
+
+    comment_row = Comment.get(comment_id)
+    if "text" in data:
+        comment_row.text = data["text"] or ""
+    if "checklist" in data:
+        comment_row.checklist = data["checklist"] or []
+    if new_status_id:
+        comment_row.task_status_id = new_status_id
+    comment_row.editor_id = guest_id
+    comment_row.save()
+
+    # reset_mentions walks the mentions table; feed it the relations-loaded
+    # dict so it has the `mentions` / `department_mentions` keys it expects.
+    tasks_service.clear_comment_cache(comment_id)
+    updated = tasks_service.get_comment(comment_id, relations=True)
+    comments_service.reset_mentions(updated)
+
+    task_id = updated["object_id"]
+    task = tasks_service.get_task(task_id)
+    if status_changed:
+        tasks_service.reset_task_data(task_id)
+        events.emit(
+            "task:status-changed",
+            {
+                "task_id": task_id,
+                "new_task_status_id": new_status_id,
+                "previous_task_status_id": previous_status_id,
+                "person_id": guest_id,
+            },
+            project_id=task["project_id"],
+        )
+    tasks_service.clear_comment_cache(comment_id)
+    try:
+        notifications_service.reset_notifications_for_mentions(updated)
+    except KeyError:
+        # Some serialized dicts lack the `mentions` key; guest comments
+        # never carry mentions anyway, so ignore.
+        pass
+    events.emit(
+        "comment:update",
+        {"comment_id": updated["id"], "task_id": task_id},
+        project_id=task["project_id"],
+    )
+    return _serialize_enriched_comment(comment_id)
+
+
+def delete_guest_comment(comment_id, guest_id):
+    """
+    Delete a comment authored by a guest. Triggers the same side effects as
+    the regular CRUD delete: removal via ``deletion_service``, task data
+    reset and task status event if the status changed.
+    """
+    from zou.app.services import deletion_service
+    from zou.app.utils import events
+
+    instance = _load_guest_comment(comment_id, guest_id)
+
+    task_id = instance["object_id"]
+    task_before = tasks_service.get_task(task_id)
+    previous_status_id = task_before["task_status_id"]
+
+    deletion_service.remove_comment(comment_id)
+    tasks_service.reset_task_data(task_id)
+    tasks_service.clear_comment_cache(comment_id)
+
+    task_after = tasks_service.get_task(task_id)
+    new_status_id = task_after["task_status_id"]
+    if previous_status_id != new_status_id:
+        events.emit(
+            "task:status-changed",
+            {
+                "task_id": task_id,
+                "new_task_status_id": new_status_id,
+                "previous_task_status_id": previous_status_id,
+                "person_id": guest_id,
+            },
+            project_id=task_after["project_id"],
+        )
+
+
+def _serialize_enriched_comment(comment_id):
+    """
+    Return a comment dict with `attachment_files` expanded to full objects
+    (same shape as `_run_task_comments_query`'s output), so the shared client
+    can render filenames/sizes without extra lookups.
+    """
+    from zou.app.models.attachment_file import AttachmentFile
+
+    comment = tasks_service.get_comment(comment_id, relations=True)
+    ids = comment.get("attachment_files") or []
+    if ids and all(isinstance(item, str) for item in ids):
+        attachments = AttachmentFile.query.filter(
+            AttachmentFile.id.in_(ids)
+        ).all()
+        comment["attachment_files"] = [af.present() for af in attachments]
+    return comment
+
+
+def add_guest_comment_attachments(comment_id, guest_id, files):
+    """
+    Attach uploaded files to a comment authored by the given guest.
+    Returns the updated comment dict (with relations).
+    """
+    from zou.app.services import comments_service
+
+    comment = _load_guest_comment(comment_id, guest_id)
+    comments_service.add_attachments_to_comment(comment, files)
+    return _serialize_enriched_comment(comment_id)
+
+
+def download_shared_attachment(token, attachment_id, file_name):
+    """
+    Serve an attachment file linked to a comment that is visible to this
+    share link (guest-posted or for_client=True on a task that's part of the
+    playlist). Raises ``GuestCommentNotFound`` if the attachment is not
+    served by this link.
+    """
+    from flask import send_file as flask_send_file
+    from zou.app.services import comments_service
+
+    attachment = comments_service.get_attachment_file(attachment_id)
+    comment_id = attachment.get("comment_id")
+    if not comment_id:
+        raise GuestCommentNotFound
+
+    comment = tasks_service.get_comment(comment_id)
+    task_id = comment.get("object_id")
+    if not task_id:
+        raise GuestCommentNotFound
+
+    # The comment must belong to a task in the playlist that this token
+    # shares, and must be visible (guest or for_client).
+    playlist = get_shared_playlist(token)
+    task_ids = {
+        str(shot.get("preview_file_task_id"))
+        for shot in playlist.get("shots", [])
+        if shot.get("preview_file_task_id")
+    }
+    if str(task_id) not in task_ids:
+        raise GuestCommentNotFound
+
+    author_is_guest = False
+    if comment.get("person_id"):
+        person = persons_service.get_person(comment["person_id"])
+        author_is_guest = bool(person.get("is_guest"))
+    if not (comment.get("for_client") or author_is_guest):
+        raise GuestCommentNotFound
+
+    file_path = comments_service.get_attachment_file_path(attachment)
+    return flask_send_file(
+        file_path,
+        conditional=True,
+        mimetype=attachment["mimetype"],
+        as_attachment=False,
+        download_name=attachment["name"],
+    )
+
+
+def remove_guest_comment_attachment(comment_id, guest_id, attachment_id):
+    """
+    Remove a single attachment from a comment authored by the given guest.
+    """
+    from zou.app.models.attachment_file import AttachmentFile
+    from zou.app.services import deletion_service
+
+    _load_guest_comment(comment_id, guest_id)
+    attachment = AttachmentFile.get(attachment_id)
+    if attachment is None or str(attachment.comment_id) != str(comment_id):
+        raise GuestCommentNotFound
+    deletion_service.remove_attachment_file(attachment)
 
 
 def get_shared_task_comments(task_id):
@@ -293,10 +509,26 @@ def enrich_shots_with_entity_info(playlist_dict):
 
 def create_guest(token, first_name, last_name=""):
     """
-    Create a guest Person tied to a shared playlist session.
-    The guest has is_guest=True, role=client, and no password.
+    Return or create a guest Person tied to a shared playlist session.
+
+    If a guest already exists with the same first/last name, we reuse it so
+    that a returning reviewer recovers ownership of their previous comments
+    (the UUID is otherwise volatile since the link itself is the credential
+    and no persistent account backs a guest). The guest always has
+    `is_guest=True` and `role=client`.
     """
     validate_share_token(token)
+    first_name = (first_name or "Guest").strip()
+    last_name = (last_name or "").strip()
+
+    existing = Person.query.filter_by(
+        is_guest=True,
+        first_name=first_name,
+        last_name=last_name,
+    ).first()
+    if existing is not None:
+        return existing.serialize()
+
     guest = Person.create(
         first_name=first_name,
         last_name=last_name,
@@ -356,13 +588,16 @@ def get_shared_playlist_context(token):
             "ratio": project.get("ratio"),
             "resolution": project.get("resolution"),
         },
+        # Task types are sent without `department_id` on purpose: the shared
+        # client never populates the department map, and several widgets
+        # (EditCommentModal, comment mentions) crash when they try to look
+        # up an unknown department.
         "task_types": [
             {
                 "id": tt["id"],
                 "name": tt["name"],
                 "color": tt["color"],
                 "for_entity": tt.get("for_entity"),
-                "department_id": tt.get("department_id"),
             }
             for tt in task_types
         ],

--- a/zou/app/services/playlist_sharing_service.py
+++ b/zou/app/services/playlist_sharing_service.py
@@ -1,8 +1,12 @@
 import datetime
 import uuid
 
+from zou.app.models.entity import Entity
+from zou.app.models.entity_type import EntityType
 from zou.app.models.person import Person
 from zou.app.models.playlist_share_link import PlaylistShareLink
+from zou.app.models.task import Task
+from zou.app.models.task_type import TaskType
 from zou.app.services import (
     persons_service,
     playlists_service,
@@ -112,6 +116,85 @@ def get_shared_playlist(token):
         share_link["playlist_id"]
     )
     return playlist
+
+
+def enrich_shots_with_entity_info(playlist_dict):
+    """
+    Augment each shot entry in the playlist with `name` and `parent_name`
+    (sequence/episode/asset_type name). The stored `playlist.shots` only
+    keeps preview/entity references — in the shared context, consumers
+    have no auth'd access to entity/asset/shot stores, so names must be
+    inlined here.
+    """
+    shots = playlist_dict.get("shots") or []
+    entity_ids = [
+        shot["id"] for shot in shots if shot.get("id")
+    ]
+    if not entity_ids:
+        return playlist_dict
+
+    entities = Entity.query.filter(Entity.id.in_(entity_ids)).all()
+    entity_map = {str(e.id): e for e in entities}
+
+    parent_ids = {
+        str(e.parent_id) for e in entities if e.parent_id is not None
+    }
+    type_ids = {
+        str(e.entity_type_id) for e in entities if e.entity_type_id
+    }
+
+    parent_map = {}
+    if parent_ids:
+        parents = Entity.query.filter(Entity.id.in_(parent_ids)).all()
+        parent_map = {str(p.id): p.name for p in parents}
+
+    type_map = {}
+    if type_ids:
+        types = EntityType.query.filter(
+            EntityType.id.in_(type_ids)
+        ).all()
+        type_map = {str(t.id): t.name for t in types}
+
+    shot_type_names = {"Shot", "Sequence", "Episode", "Edit", "Concept"}
+
+    task_ids = {
+        shot["preview_file_task_id"]
+        for shot in shots
+        if shot.get("preview_file_task_id")
+    }
+    task_type_name_by_task_id = {}
+    if task_ids:
+        rows = (
+            Task.query.join(TaskType, TaskType.id == Task.task_type_id)
+            .filter(Task.id.in_(task_ids))
+            .add_columns(Task.id, TaskType.name)
+            .all()
+        )
+        task_type_name_by_task_id = {
+            str(task_id): task_type_name
+            for (_, task_id, task_type_name) in rows
+        }
+
+    for shot in shots:
+        entity = entity_map.get(str(shot.get("id")))
+        if entity is None:
+            continue
+        shot["name"] = entity.name
+        entity_type_name = type_map.get(str(entity.entity_type_id), "")
+        if entity_type_name in shot_type_names:
+            # Shots/sequences/episodes: parent is another entity.
+            shot["parent_name"] = parent_map.get(
+                str(entity.parent_id), ""
+            )
+        else:
+            # Assets: "parent" is the asset type name.
+            shot["parent_name"] = entity_type_name
+        task_id = shot.get("preview_file_task_id")
+        if task_id:
+            shot["preview_file_task_type_name"] = (
+                task_type_name_by_task_id.get(str(task_id), "")
+            )
+    return playlist_dict
 
 
 def create_guest(token, first_name, last_name=""):

--- a/zou/app/services/playlist_sharing_service.py
+++ b/zou/app/services/playlist_sharing_service.py
@@ -1,0 +1,202 @@
+import datetime
+import uuid
+
+from zou.app.models.person import Person
+from zou.app.models.playlist_share_link import PlaylistShareLink
+from zou.app.services import (
+    persons_service,
+    playlists_service,
+    tasks_service,
+    projects_service,
+)
+from zou.app.services.exception import (
+    PlaylistShareLinkNotFoundException,
+    PlaylistNotFoundException,
+)
+from zou.app.utils import fields
+
+
+def create_share_link(
+    playlist_id,
+    person_id,
+    expiration_date=None,
+    can_comment=True,
+    password=None,
+):
+    """
+    Generate a share link for a playlist. Only supervisors and above
+    should call this (enforced at the resource level).
+    """
+    playlists_service.get_playlist(playlist_id)
+    token = str(uuid.uuid4())
+    share_link = PlaylistShareLink.create(
+        token=token,
+        playlist_id=playlist_id,
+        created_by=person_id,
+        expiration_date=(
+            fields.get_date_object(expiration_date)
+            if expiration_date
+            else None
+        ),
+        can_comment=can_comment,
+        password=password,
+    )
+    return share_link.serialize()
+
+
+def get_share_links_for_playlist(playlist_id):
+    """
+    Return all active share links for a playlist.
+    """
+    playlists_service.get_playlist(playlist_id)
+    links = PlaylistShareLink.get_all_by(
+        playlist_id=playlist_id, is_active=True
+    )
+    return [link.serialize() for link in links]
+
+
+def revoke_share_link(token):
+    """
+    Deactivate a share link without deleting it.
+    """
+    share_link = get_share_link_by_token_raw(token)
+    share_link.update({"is_active": False})
+    return share_link.serialize()
+
+
+def get_share_link_by_token_raw(token):
+    """
+    Return the raw ORM share link for a token.
+    Raises PlaylistShareLinkNotFoundException if not found.
+    """
+    share_link = PlaylistShareLink.get_by(token=token)
+    if share_link is None:
+        raise PlaylistShareLinkNotFoundException
+    return share_link
+
+
+def validate_share_token(token, password=None):
+    """
+    Validate that a share token is active and not expired.
+    Returns the serialized share link on success.
+    Raises appropriate exceptions on failure.
+    """
+    share_link = get_share_link_by_token_raw(token)
+    if not share_link.is_active:
+        raise PlaylistShareLinkNotFoundException
+
+    if share_link.expiration_date is not None:
+        now = datetime.datetime.now(datetime.timezone.utc)
+        expiration = share_link.expiration_date
+        if expiration.tzinfo is None:
+            expiration = expiration.replace(
+                tzinfo=datetime.timezone.utc
+            )
+        if now > expiration:
+            raise PlaylistShareLinkNotFoundException
+
+    if share_link.password is not None and share_link.password != "":
+        if password != share_link.password:
+            raise PlaylistShareLinkNotFoundException
+
+    return share_link.serialize()
+
+
+def get_shared_playlist(token):
+    """
+    Return the playlist data accessible via a share token.
+    Validates the token first.
+    """
+    share_link = validate_share_token(token)
+    playlist = playlists_service.get_playlist(
+        share_link["playlist_id"]
+    )
+    return playlist
+
+
+def create_guest(token, first_name, last_name=""):
+    """
+    Create a guest Person tied to a shared playlist session.
+    The guest has is_guest=True, role=client, and no password.
+    """
+    validate_share_token(token)
+    guest = Person.create(
+        first_name=first_name,
+        last_name=last_name,
+        email=f"guest-{uuid.uuid4().hex[:8]}@guest.kitsu",
+        role="client",
+        is_guest=True,
+    )
+    return guest.serialize()
+
+
+def get_guest(guest_id):
+    """
+    Retrieve a guest person. Raises if not found or not a guest.
+    """
+    person = persons_service.get_person(guest_id)
+    if not person.get("is_guest", False):
+        raise PlaylistShareLinkNotFoundException
+    return person
+
+
+def get_shared_playlist_context(token):
+    """
+    Return the minimal project context needed to display a shared
+    playlist: task types, task statuses, and entity names referenced
+    by the playlist.
+    """
+    share_link = validate_share_token(token)
+    playlist = playlists_service.get_playlist(
+        share_link["playlist_id"]
+    )
+    project_id = playlist["project_id"]
+    project = projects_service.get_project(project_id)
+
+    task_types = projects_service.get_project_task_types(project_id)
+    task_statuses = projects_service.get_project_task_statuses(
+        project_id
+    )
+
+    # Collect entity names from playlist shots
+    entity_names = {}
+    for shot_entry in playlist.get("shots", []):
+        entity_id = shot_entry.get("entity_id")
+        if entity_id and entity_id not in entity_names:
+            try:
+                from zou.app.services import entities_service
+
+                entity = entities_service.get_entity(entity_id)
+                entity_names[entity_id] = {
+                    "id": entity_id,
+                    "name": entity.get("name", ""),
+                    "preview_file_id": entity.get(
+                        "preview_file_id"
+                    ),
+                }
+            except Exception:
+                pass
+
+    return {
+        "project": {
+            "id": project["id"],
+            "name": project["name"],
+            "fps": project.get("fps"),
+            "ratio": project.get("ratio"),
+            "resolution": project.get("resolution"),
+        },
+        "task_types": [
+            {"id": tt["id"], "name": tt["name"], "color": tt["color"]}
+            for tt in task_types
+        ],
+        "task_statuses": [
+            {
+                "id": ts["id"],
+                "name": ts["name"],
+                "short_name": ts["short_name"],
+                "color": ts["color"],
+            }
+            for ts in task_statuses
+        ],
+        "entities": list(entity_names.values()),
+    }

--- a/zou/app/services/playlist_sharing_service.py
+++ b/zou/app/services/playlist_sharing_service.py
@@ -94,9 +94,7 @@ def validate_share_token(token, password=None):
         now = datetime.datetime.now(datetime.timezone.utc)
         expiration = share_link.expiration_date
         if expiration.tzinfo is None:
-            expiration = expiration.replace(
-                tzinfo=datetime.timezone.utc
-            )
+            expiration = expiration.replace(tzinfo=datetime.timezone.utc)
         if now > expiration:
             raise PlaylistShareLinkNotFoundException
 
@@ -113,10 +111,120 @@ def get_shared_playlist(token):
     Validates the token first.
     """
     share_link = validate_share_token(token)
-    playlist = playlists_service.get_playlist(
-        share_link["playlist_id"]
-    )
+    playlist = playlists_service.get_playlist(share_link["playlist_id"])
     return playlist
+
+
+def get_shared_task_comments(task_id):
+    """
+    Return comments visible in the shared context for a task: those flagged
+    `for_client=True` plus those posted by a guest. Bypasses
+    tasks_service.get_comments which requires a JWT-authenticated current
+    user.
+    """
+    from zou.app.services.tasks_service import (
+        _prepare_query,
+        _run_task_comments_query,
+    )
+
+    query = _prepare_query(task_id, is_client=True, is_manager=False)
+    comments, _ = _run_task_comments_query(query)
+
+    guest_ids = {
+        str(person_id)
+        for (person_id,) in Person.query.filter_by(is_guest=True)
+        .with_entities(Person.id)
+        .all()
+    }
+    visible = []
+    for comment in comments:
+        author_id = str(comment.get("person_id", ""))
+        is_guest_author = author_id in guest_ids
+        if not (comment.get("for_client") or is_guest_author):
+            continue
+        if comment.get("person"):
+            comment["person"]["is_guest"] = is_guest_author
+        visible.append(comment)
+    return visible
+
+
+# Entity types for which "parent" is a parent record (shot/seq/episode/…).
+# For other types, we show the entity type name as the logical parent
+# (e.g. assets).
+_SHOT_LIKE_ENTITY_TYPE_NAMES = frozenset(
+    ("Shot", "Sequence", "Episode", "Edit", "Concept")
+)
+
+
+def _enrich_shared_playlist_project_line(playlist_dict):
+    project_id = playlist_dict.get("project_id")
+    if not project_id:
+        return
+    project = projects_service.get_project(str(project_id))
+    playlist_dict["project_fps"] = project.get("fps")
+    playlist_dict["project_name"] = project.get("name")
+
+
+def _load_task_styling_by_task_id(task_ids):
+    """Return (task_type_by_task_id, task_status_color_by_task_id) dicts."""
+    if not task_ids:
+        return {}, {}
+
+    rows = (
+        Task.query.join(TaskType, TaskType.id == Task.task_type_id)
+        .join(TaskStatus, TaskStatus.id == Task.task_status_id)
+        .filter(Task.id.in_(task_ids))
+        .add_columns(
+            Task.id,
+            TaskType.id,
+            TaskType.name,
+            TaskType.color,
+            TaskType.for_entity,
+            TaskStatus.color,
+        )
+        .all()
+    )
+    task_type_by_task_id = {}
+    task_status_color_by_task_id = {}
+    for (
+        _,
+        task_id,
+        task_type_id,
+        task_type_name,
+        task_type_color,
+        task_type_for_entity,
+        task_status_color,
+    ) in rows:
+        tid = str(task_id)
+        task_type_by_task_id[tid] = {
+            "id": str(task_type_id),
+            "name": task_type_name,
+            "color": task_type_color,
+            "for_entity": task_type_for_entity,
+        }
+        task_status_color_by_task_id[tid] = task_status_color
+    return task_type_by_task_id, task_status_color_by_task_id
+
+
+def _parent_name_for_shot_entry(entity, entity_type_name, parent_map):
+    if entity_type_name in _SHOT_LIKE_ENTITY_TYPE_NAMES:
+        if entity.parent_id is None:
+            return ""
+        return parent_map.get(str(entity.parent_id), "")
+    return entity_type_name
+
+
+def _apply_task_styling_to_shot(
+    shot, task_id, task_type_by_task_id, task_status_color_by_task_id
+):
+    tid = str(task_id)
+    task_type = task_type_by_task_id.get(tid)
+    if task_type:
+        shot["preview_file_task_type"] = task_type
+        shot["preview_file_task_type_name"] = task_type["name"]
+    color = task_status_color_by_task_id.get(tid)
+    if color:
+        shot["task_status_color"] = color
 
 
 def enrich_shots_with_entity_info(playlist_dict):
@@ -127,81 +235,40 @@ def enrich_shots_with_entity_info(playlist_dict):
     have no auth'd access to entity/asset/shot stores, so names must be
     inlined here.
     """
-    project_id = playlist_dict.get("project_id")
-    if project_id:
-        project = projects_service.get_project(str(project_id))
-        playlist_dict["project_fps"] = project.get("fps")
-        playlist_dict["project_name"] = project.get("name")
+    _enrich_shared_playlist_project_line(playlist_dict)
 
     shots = playlist_dict.get("shots") or []
-    entity_ids = [
-        shot["id"] for shot in shots if shot.get("id")
-    ]
+    entity_ids = [shot["id"] for shot in shots if shot.get("id")]
     if not entity_ids:
         return playlist_dict
 
     entities = Entity.query.filter(Entity.id.in_(entity_ids)).all()
     entity_map = {str(e.id): e for e in entities}
 
-    parent_ids = {
-        str(e.parent_id) for e in entities if e.parent_id is not None
-    }
-    type_ids = {
-        str(e.entity_type_id) for e in entities if e.entity_type_id
-    }
-
+    parent_ids = {str(e.parent_id) for e in entities if e.parent_id}
     parent_map = {}
     if parent_ids:
-        parents = Entity.query.filter(Entity.id.in_(parent_ids)).all()
-        parent_map = {str(p.id): p.name for p in parents}
+        parent_map = {
+            str(p.id): p.name
+            for p in Entity.query.filter(Entity.id.in_(parent_ids)).all()
+        }
 
+    type_ids = {str(e.entity_type_id) for e in entities if e.entity_type_id}
     type_map = {}
     if type_ids:
-        types = EntityType.query.filter(
-            EntityType.id.in_(type_ids)
-        ).all()
-        type_map = {str(t.id): t.name for t in types}
-
-    shot_type_names = {"Shot", "Sequence", "Episode", "Edit", "Concept"}
+        type_map = {
+            str(t.id): t.name
+            for t in EntityType.query.filter(EntityType.id.in_(type_ids)).all()
+        }
 
     task_ids = {
-        shot["preview_file_task_id"]
-        for shot in shots
-        if shot.get("preview_file_task_id")
+        s["preview_file_task_id"]
+        for s in shots
+        if s.get("preview_file_task_id")
     }
-    task_type_by_task_id = {}
-    task_status_color_by_task_id = {}
-    if task_ids:
-        rows = (
-            Task.query.join(TaskType, TaskType.id == Task.task_type_id)
-            .join(TaskStatus, TaskStatus.id == Task.task_status_id)
-            .filter(Task.id.in_(task_ids))
-            .add_columns(
-                Task.id,
-                TaskType.id,
-                TaskType.name,
-                TaskType.color,
-                TaskType.for_entity,
-                TaskStatus.color,
-            )
-            .all()
-        )
-        for (
-            _,
-            task_id,
-            task_type_id,
-            task_type_name,
-            task_type_color,
-            task_type_for_entity,
-            task_status_color,
-        ) in rows:
-            task_type_by_task_id[str(task_id)] = {
-                "id": str(task_type_id),
-                "name": task_type_name,
-                "color": task_type_color,
-                "for_entity": task_type_for_entity,
-            }
-            task_status_color_by_task_id[str(task_id)] = task_status_color
+    task_type_by_task_id, task_status_color_by_task_id = (
+        _load_task_styling_by_task_id(task_ids)
+    )
 
     for shot in shots:
         entity = entity_map.get(str(shot.get("id")))
@@ -209,25 +276,18 @@ def enrich_shots_with_entity_info(playlist_dict):
             continue
         shot["name"] = entity.name
         entity_type_name = type_map.get(str(entity.entity_type_id), "")
-        if entity_type_name in shot_type_names:
-            # Shots/sequences/episodes: parent is another entity.
-            shot["parent_name"] = parent_map.get(
-                str(entity.parent_id), ""
-            )
-        else:
-            # Assets: "parent" is the asset type name.
-            shot["parent_name"] = entity_type_name
+        shot["parent_name"] = _parent_name_for_shot_entry(
+            entity, entity_type_name, parent_map
+        )
         task_id = shot.get("preview_file_task_id")
-        if task_id:
-            task_type = task_type_by_task_id.get(str(task_id))
-            if task_type:
-                shot["preview_file_task_type"] = task_type
-                shot["preview_file_task_type_name"] = task_type["name"]
-            task_status_color = task_status_color_by_task_id.get(
-                str(task_id)
-            )
-            if task_status_color:
-                shot["task_status_color"] = task_status_color
+        if not task_id:
+            continue
+        _apply_task_styling_to_shot(
+            shot,
+            task_id,
+            task_type_by_task_id,
+            task_status_color_by_task_id,
+        )
     return playlist_dict
 
 
@@ -264,16 +324,12 @@ def get_shared_playlist_context(token):
     by the playlist.
     """
     share_link = validate_share_token(token)
-    playlist = playlists_service.get_playlist(
-        share_link["playlist_id"]
-    )
+    playlist = playlists_service.get_playlist(share_link["playlist_id"])
     project_id = playlist["project_id"]
     project = projects_service.get_project(project_id)
 
     task_types = projects_service.get_project_task_types(project_id)
-    task_statuses = projects_service.get_project_task_statuses(
-        project_id
-    )
+    task_statuses = projects_service.get_project_task_statuses(project_id)
 
     # Collect entity names from playlist shots
     entity_names = {}
@@ -287,9 +343,7 @@ def get_shared_playlist_context(token):
                 entity_names[entity_id] = {
                     "id": entity_id,
                     "name": entity.get("name", ""),
-                    "preview_file_id": entity.get(
-                        "preview_file_id"
-                    ),
+                    "preview_file_id": entity.get("preview_file_id"),
                 }
             except Exception:
                 pass
@@ -303,7 +357,13 @@ def get_shared_playlist_context(token):
             "resolution": project.get("resolution"),
         },
         "task_types": [
-            {"id": tt["id"], "name": tt["name"], "color": tt["color"]}
+            {
+                "id": tt["id"],
+                "name": tt["name"],
+                "color": tt["color"],
+                "for_entity": tt.get("for_entity"),
+                "department_id": tt.get("department_id"),
+            }
             for tt in task_types
         ],
         "task_statuses": [
@@ -312,6 +372,9 @@ def get_shared_playlist_context(token):
                 "name": ts["name"],
                 "short_name": ts["short_name"],
                 "color": ts["color"],
+                "is_client_allowed": ts.get("is_client_allowed", False),
+                "is_default": ts.get("is_default", False),
+                "for_concept": ts.get("for_concept", False),
             }
             for ts in task_statuses
         ],

--- a/zou/app/services/playlist_sharing_service.py
+++ b/zou/app/services/playlist_sharing_service.py
@@ -6,6 +6,7 @@ from zou.app.models.entity_type import EntityType
 from zou.app.models.person import Person
 from zou.app.models.playlist_share_link import PlaylistShareLink
 from zou.app.models.task import Task
+from zou.app.models.task_status import TaskStatus
 from zou.app.models.task_type import TaskType
 from zou.app.services import (
     persons_service,
@@ -126,6 +127,12 @@ def enrich_shots_with_entity_info(playlist_dict):
     have no auth'd access to entity/asset/shot stores, so names must be
     inlined here.
     """
+    project_id = playlist_dict.get("project_id")
+    if project_id:
+        project = projects_service.get_project(str(project_id))
+        playlist_dict["project_fps"] = project.get("fps")
+        playlist_dict["project_name"] = project.get("name")
+
     shots = playlist_dict.get("shots") or []
     entity_ids = [
         shot["id"] for shot in shots if shot.get("id")
@@ -162,18 +169,39 @@ def enrich_shots_with_entity_info(playlist_dict):
         for shot in shots
         if shot.get("preview_file_task_id")
     }
-    task_type_name_by_task_id = {}
+    task_type_by_task_id = {}
+    task_status_color_by_task_id = {}
     if task_ids:
         rows = (
             Task.query.join(TaskType, TaskType.id == Task.task_type_id)
+            .join(TaskStatus, TaskStatus.id == Task.task_status_id)
             .filter(Task.id.in_(task_ids))
-            .add_columns(Task.id, TaskType.name)
+            .add_columns(
+                Task.id,
+                TaskType.id,
+                TaskType.name,
+                TaskType.color,
+                TaskType.for_entity,
+                TaskStatus.color,
+            )
             .all()
         )
-        task_type_name_by_task_id = {
-            str(task_id): task_type_name
-            for (_, task_id, task_type_name) in rows
-        }
+        for (
+            _,
+            task_id,
+            task_type_id,
+            task_type_name,
+            task_type_color,
+            task_type_for_entity,
+            task_status_color,
+        ) in rows:
+            task_type_by_task_id[str(task_id)] = {
+                "id": str(task_type_id),
+                "name": task_type_name,
+                "color": task_type_color,
+                "for_entity": task_type_for_entity,
+            }
+            task_status_color_by_task_id[str(task_id)] = task_status_color
 
     for shot in shots:
         entity = entity_map.get(str(shot.get("id")))
@@ -191,9 +219,15 @@ def enrich_shots_with_entity_info(playlist_dict):
             shot["parent_name"] = entity_type_name
         task_id = shot.get("preview_file_task_id")
         if task_id:
-            shot["preview_file_task_type_name"] = (
-                task_type_name_by_task_id.get(str(task_id), "")
+            task_type = task_type_by_task_id.get(str(task_id))
+            if task_type:
+                shot["preview_file_task_type"] = task_type
+                shot["preview_file_task_type_name"] = task_type["name"]
+            task_status_color = task_status_color_by_task_id.get(
+                str(task_id)
             )
+            if task_status_color:
+                shot["task_status_color"] = task_status_color
     return playlist_dict
 
 

--- a/zou/app/services/projects_service.py
+++ b/zou/app/services/projects_service.py
@@ -260,7 +260,8 @@ def _build_project_dict_with_extra_data(
 
 def get_projects():
     """
-    Return all projects. Allow to filter projects by name.
+    Return all projects, with their Project-scoped metadata descriptors so the
+    admin productions view can render Project metadata columns.
     """
     query = (
         Project.query.join(
@@ -270,14 +271,36 @@ def get_projects():
         .order_by(Project.name)
     )
 
+    entries = query.all()
+    if not entries:
+        return []
+
+    descriptors_by_project = _fetch_all_project_descriptors_by_project()
+
     result = []
-    for entry in query.all():
-        project, project_status_name = entry
+    for project, project_status_name in entries:
         data = project.serialize()
         data["project_status_name"] = project_status_name
+        data["descriptors"] = [
+            _serialize_descriptor(descriptor)
+            for descriptor in descriptors_by_project.get(project.id, [])
+        ]
         result.append(data)
-
     return result
+
+
+def _fetch_all_project_descriptors_by_project():
+    descriptors = (
+        MetadataDescriptor.query.filter(
+            MetadataDescriptor.entity_type == "Project"
+        )
+        .options(joinedload(MetadataDescriptor.departments))
+        .all()
+    )
+    by_project = defaultdict(list)
+    for descriptor in descriptors:
+        by_project[descriptor.project_id].append(descriptor)
+    return by_project
 
 
 @cache.memoize_function(480)

--- a/zou/app/services/projects_service.py
+++ b/zou/app/services/projects_service.py
@@ -559,6 +559,86 @@ def _save_project(project):
     return project.serialize()
 
 
+def _migrate_metadata_field_name(model, old_key, new_key, *, use_no_commit):
+    """
+    Move a value from old_key to new_key in model.data. No-op if old_key
+    is absent. Returns whether an update was applied.
+    """
+    metadata = fields.serialize_value(model.data) or {}
+    value = metadata.pop(old_key, None)
+    if value is None:
+        return False
+    metadata[new_key] = value
+    if use_no_commit:
+        model.update_no_commit({"data": metadata})
+    else:
+        model.update({"data": metadata})
+    return True
+
+
+def _entity_query_for_descriptor_entity_type(descriptor):
+    """
+    Entities whose `data` may hold values for this descriptor (non-Project).
+    """
+    query = Entity.query.filter(Entity.project_id == descriptor.project_id)
+    if descriptor.entity_type == "Shot":
+        shot_type = shots_service.get_shot_type()
+        return query.filter(Entity.entity_type_id == shot_type["id"])
+    if descriptor.entity_type == "Asset":
+        return query.filter(assets_service.build_asset_type_filter())
+    if descriptor.entity_type == "Edit":
+        edit_type = edits_service.get_edit_type()
+        return query.filter(Entity.entity_type_id == edit_type["id"])
+    return query
+
+
+def _strip_metadata_field_from_model_data(model, field_name):
+    """
+    Remove field_name from model.data when `data` is not null.
+    """
+    metadata = fields.serialize_value(model.data)
+    if metadata is not None:
+        metadata.pop(field_name, None)
+        model.update({"data": metadata})
+
+
+def _migrate_descriptor_field_rename(descriptor, new_field_name):
+    """
+    Apply a metadata field rename to Project.data or matching Entity rows.
+    """
+    if descriptor.entity_type == "Project":
+        project = get_project_raw(descriptor.project_id)
+        _migrate_metadata_field_name(
+            project,
+            descriptor.field_name,
+            new_field_name,
+            use_no_commit=False,
+        )
+        return
+    entities = _entity_query_for_descriptor_entity_type(descriptor).all()
+    for entity in entities:
+        _migrate_metadata_field_name(
+            entity,
+            descriptor.field_name,
+            new_field_name,
+            use_no_commit=True,
+        )
+    Entity.commit()
+
+
+def _remove_stored_values_for_metadata_descriptor(descriptor):
+    """
+    Remove descriptor field values from Project.data (Project type) or from
+    all Entity.data rows in the project (other types).
+    """
+    if descriptor.entity_type == "Project":
+        project = get_project_raw(descriptor.project_id)
+        _strip_metadata_field_from_model_data(project, descriptor.field_name)
+        return
+    for entity in Entity.get_all_by(project_id=descriptor.project_id):
+        _strip_metadata_field_from_model_data(entity, descriptor.field_name)
+
+
 def add_metadata_descriptor(
     project_id,
     entity_type,
@@ -568,6 +648,11 @@ def add_metadata_descriptor(
     for_client,
     departments=None,
 ):
+    """
+    Register a custom field for the given `entity_type` in this project.
+    Values are stored in `Entity.data` (Asset, Shot, …) or in `Project.data`
+    when `entity_type` is ``Project``.
+    """
     if not departments:
         departments = []
 
@@ -647,26 +732,7 @@ def update_metadata_descriptor(metadata_descriptor_id, changes):
     if "name" in changes and len(changes["name"]) > 0:
         changes["field_name"] = slugify.slugify(changes["name"], separator="_")
         if descriptor.field_name != changes["field_name"]:
-            query = Entity.query.filter(
-                Entity.project_id == descriptor.project_id
-            )
-            if descriptor.entity_type == "Shot":
-                shot_type = shots_service.get_shot_type()
-                query = query.filter(Entity.entity_type_id == shot_type["id"])
-            elif descriptor.entity_type == "Asset":
-                query = query.filter(assets_service.build_asset_type_filter())
-            elif descriptor.entity_type == "Edit":
-                edit_type = edits_service.get_edit_type()
-                query = query.filter(Entity.entity_type_id == edit_type["id"])
-
-            entities = query.all()
-            for entity in entities:
-                metadata = fields.serialize_value(entity.data) or {}
-                value = metadata.pop(descriptor.field_name, None)
-                if value is not None:
-                    metadata[changes["field_name"]] = value
-                    entity.update_no_commit({"data": metadata})
-            Entity.commit()
+            _migrate_descriptor_field_rename(descriptor, changes["field_name"])
 
     if "departments" in changes:
         if not changes["departments"]:
@@ -740,12 +806,7 @@ def remove_metadata_descriptor(metadata_descriptor_id):
     Delete metadata descriptor and related informations.
     """
     descriptor = get_metadata_descriptor_raw(metadata_descriptor_id)
-    entities = Entity.get_all_by(project_id=descriptor.project_id)
-    for entity in entities:
-        metadata = fields.serialize_value(entity.data)
-        if metadata is not None:
-            metadata.pop(descriptor.field_name, None)
-            entity.update({"data": metadata})
+    _remove_stored_values_for_metadata_descriptor(descriptor)
     try:
         descriptor.delete()
     except ObjectDeletedError:

--- a/zou/app/services/tasks_service.py
+++ b/zou/app/services/tasks_service.py
@@ -1853,7 +1853,9 @@ def reset_task_data(task_id):
         }
     )
     project_id = str(task.project_id)
-    events.emit("task:update", {"task_id": task.id}, project_id)
+    events.emit(
+        "task:update", {"task_id": str(task.id)}, project_id=project_id
+    )
     return task.serialize(relations=True)
 
 

--- a/zou/migrations/versions/a1bc96e68661_add_playlist_sharing_support.py
+++ b/zou/migrations/versions/a1bc96e68661_add_playlist_sharing_support.py
@@ -1,0 +1,54 @@
+"""add playlist sharing support
+
+Revision ID: a1bc96e68661
+Revises: c4e7f9a3b8d2
+Create Date: 2026-04-21 11:28:32.322788
+
+"""
+from alembic import op
+import sqlalchemy as sa
+import sqlalchemy_utils
+import uuid
+
+# revision identifiers, used by Alembic.
+revision = 'a1bc96e68661'
+down_revision = 'c4e7f9a3b8d2'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table('playlist_share_link',
+    sa.Column('token', sa.String(length=64), nullable=False),
+    sa.Column('playlist_id', sqlalchemy_utils.types.uuid.UUIDType(binary=False), default=uuid.uuid4, nullable=False),
+    sa.Column('created_by', sqlalchemy_utils.types.uuid.UUIDType(binary=False), default=uuid.uuid4, nullable=False),
+    sa.Column('expiration_date', sa.DateTime(), nullable=True),
+    sa.Column('is_active', sa.Boolean(), nullable=False),
+    sa.Column('can_comment', sa.Boolean(), nullable=False),
+    sa.Column('password', sa.String(length=255), nullable=True),
+    sa.Column('id', sqlalchemy_utils.types.uuid.UUIDType(binary=False), default=uuid.uuid4, nullable=False),
+    sa.Column('created_at', sa.DateTime(), nullable=True),
+    sa.Column('updated_at', sa.DateTime(), nullable=True),
+    sa.ForeignKeyConstraint(['created_by'], ['person.id'], ),
+    sa.ForeignKeyConstraint(['playlist_id'], ['playlist.id'], ),
+    sa.PrimaryKeyConstraint('id')
+    )
+    with op.batch_alter_table('playlist_share_link', schema=None) as batch_op:
+        batch_op.create_index('ix_playlist_share_link_playlist_active', ['playlist_id', 'is_active'], unique=False)
+        batch_op.create_index(batch_op.f('ix_playlist_share_link_playlist_id'), ['playlist_id'], unique=False)
+        batch_op.create_index(batch_op.f('ix_playlist_share_link_token'), ['token'], unique=True)
+
+    with op.batch_alter_table('person', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('is_guest', sa.Boolean(), nullable=False, server_default=sa.false()))
+
+
+def downgrade():
+    with op.batch_alter_table('person', schema=None) as batch_op:
+        batch_op.drop_column('is_guest')
+
+    with op.batch_alter_table('playlist_share_link', schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f('ix_playlist_share_link_token'))
+        batch_op.drop_index(batch_op.f('ix_playlist_share_link_playlist_id'))
+        batch_op.drop_index('ix_playlist_share_link_playlist_active')
+
+    op.drop_table('playlist_share_link')


### PR DESCRIPTION
**Problem**

- Studios cannot share a playlist with a client via a secret URL: no share-link model, no token-aware routes, no guest identity, no guest commenting / annotation
- Project metadata descriptors attached to a production are not exposed on the all-projects endpoint, so the front-end cannot surface them in the productions list
- `reset_task_data` shipped wrong args in the `task:update` event, breaking downstream listeners
- `PersonsResource` could not eagerly load relationships, forcing callers to issue extra round-trips
- Project storage helpers were duplicated across services

**Solution**

- Add a `playlist_share_link` model + Alembic migration, the matching sharing service, and a `/shared/playlists/<token>/...` family of routes (token-validated decorator, no JWT) covering playlist read, context, comments (POST / PUT / DELETE), comment attachments, preview movie / picture / thumbnail / tile serving and the preview-file annotation diff endpoint reusing `update_preview_file_annotations` so guest writes go through the same Redis lock + event emission as the manager-facing route
- Lower share-link management permissions from supervisor+ to manager+
- Expose project metadata descriptors on `/data/projects/all` and factor the project storage helpers into `projects_service`
- Fix the `task:update` event args in `reset_task_data`
- Enhance `PersonsResource` with optional eager loading of relationships
- Tests for the shared playlist routes, the project metadata payload and the projects service helpers