### PR TITLE
[tests] Fix flaky/broken playlist sharing and working-file tests

### DIFF
--- a/tests/files/test_route_working_files.py
+++ b/tests/files/test_route_working_files.py
@@ -148,8 +148,8 @@ class WorkingFilesTestCase(ApiDBTestCase):
 
     def test_update_modification_date(self):
         path = "/actions/working-files/%s/modified" % self.working_file.id
-        past = datetime.datetime.now().replace(
-            microsecond=0
+        past = datetime.datetime.now(tz=datetime.timezone.utc).replace(
+            microsecond=0, tzinfo=None
         ) - datetime.timedelta(seconds=2)
         self.working_file.update({"updated_at": past})
         previous_date = self.working_file.serialize()["updated_at"]

--- a/tests/shared/test_playlist_sharing.py
+++ b/tests/shared/test_playlist_sharing.py
@@ -1,10 +1,5 @@
 from tests.base import ApiDBTestCase
 
-from zou.app.services import (
-    playlist_sharing_service,
-    playlists_service,
-)
-
 
 class PlaylistSharingTestCase(ApiDBTestCase):
     def setUp(self):
@@ -19,11 +14,7 @@ class PlaylistSharingTestCase(ApiDBTestCase):
         self.generate_fixture_person()
         self.generate_fixture_assigner()
         self.generate_fixture_task()
-        self.playlist = playlists_service.create_playlist(
-            self.project.id,
-            "Test Playlist",
-            self.user["id"],
-        )
+        self.playlist = self.generate_fixture_playlist("Test Playlist")
 
     # --- Authenticated share link management (manager+) ---
 
@@ -43,9 +34,7 @@ class PlaylistSharingTestCase(ApiDBTestCase):
             {},
             201,
         )
-        result = self.get(
-            f"/data/playlists/{self.playlist['id']}/share"
-        )
+        result = self.get(f"/data/playlists/{self.playlist['id']}/share")
         self.assertEqual(len(result), 1)
 
     def test_revoke_share_link(self):
@@ -55,11 +44,10 @@ class PlaylistSharingTestCase(ApiDBTestCase):
             201,
         )
         self.delete(
-            f"/data/playlists/{self.playlist['id']}/share/{link['token']}"
+            f"/data/playlists/{self.playlist['id']}/share/{link['token']}",
+            200,
         )
-        result = self.get(
-            f"/data/playlists/{self.playlist['id']}/share"
-        )
+        result = self.get(f"/data/playlists/{self.playlist['id']}/share")
         self.assertEqual(len(result), 0)
 
     # --- Public shared playlist routes ---
@@ -85,7 +73,8 @@ class PlaylistSharingTestCase(ApiDBTestCase):
             201,
         )
         self.delete(
-            f"/data/playlists/{self.playlist['id']}/share/{link['token']}"
+            f"/data/playlists/{self.playlist['id']}/share/{link['token']}",
+            200,
         )
         self.log_out()
         self.get(f"/shared/playlists/{link['token']}", 404)
@@ -97,9 +86,7 @@ class PlaylistSharingTestCase(ApiDBTestCase):
             201,
         )
         self.log_out()
-        result = self.get(
-            f"/shared/playlists/{link['token']}/context"
-        )
+        result = self.get(f"/shared/playlists/{link['token']}/context")
         self.assertIn("project", result)
         self.assertIn("task_types", result)
         self.assertIn("task_statuses", result)
@@ -136,6 +123,7 @@ class PlaylistSharingTestCase(ApiDBTestCase):
         guest2 = self.post(
             f"/shared/playlists/{link['token']}/guest",
             {"first_name": "Jane", "guest_id": guest["id"]},
+            200,
         )
         self.assertEqual(guest["id"], guest2["id"])
 


### PR DESCRIPTION
  ## Summary

  - Replace nonexistent `playlists_service.create_playlist(...)` call with the existing `generate_fixture_playlist` helper, and align expected HTTP codes with the actual
  share-link / guest resource responses
  - Fix `test_update_modification_date` so its baseline timestamp is UTC-naive, matching what the `/actions/working-files/<id>/modified` route stores

  ## Details

  `tests/shared/test_playlist_sharing.py` failed at `setUp` because it referenced a nonexistent `playlists_service.create_playlist`. The base test class already exposes
  `generate_fixture_playlist(name)` (uses `Playlist.create(...)` and returns the serialized dict), so the fixture is now built through that helper. Three tests also asserted
  incorrect HTTP codes:
  - `PlaylistShareLinkResource.delete` returns the serialized share link (200, not 204) → `test_revoke_share_link` and `test_get_shared_playlist_revoked` now pass `200` to
  `self.delete(...)`.
  - `SharedPlaylistGuestResource.post` returns the existing guest with default 200 when `guest_id` is reused → `test_reuse_guest` now passes `200` on the second
  `self.post(...)`.

  `tests/files/test_route_working_files.py::test_update_modification_date` failed on hosts whose local TZ is ahead of UTC. The route stores
  `datetime.now(tz=UTC).replace(tzinfo=None)`, but the test was seeding `previous_date` with `datetime.now()` (local naive). On CEST that made `previous_date` two hours ahead of
   `current_date`, breaking the `previous_date < current_date` assertion. The test now seeds `past` with the same UTC-naive representation as the route.