### PR TITLE
fix pre-1.0.0 squash and add reconciliation migrations

### DIFF
--- a/scripts/check_squash_schema.py
+++ b/scripts/check_squash_schema.py
@@ -1,0 +1,388 @@
+"""Detect and optionally repair schemas affected by the buggy pre-1.0.0 squash.
+
+The pre-1.0.0 squash migration (revision a1b2c3d4e5f6) was generated from a
+live model snapshot and lost several DDL details (TEXT vs VARCHAR, server
+defaults, CHECK constraints, ENUM types, indexes, constraint names). Databases
+created from a buggy build of that squash have a schema that diverges from
+the one legacy databases hold.
+
+This script probes a target database for each known divergence and reports
+or repairs them. The repair logic mirrors the reconciliation Alembic
+migration (2b8f88aa610f) and is idempotent — safe to re-run.
+
+Usage:
+    python scripts/check_squash_schema.py            # detect only
+    python scripts/check_squash_schema.py --fix      # detect and repair
+
+Connection settings are read from the same env vars as zou itself
+(DB_HOST, DB_PORT, DB_USERNAME, DB_PASSWORD, DB_DATABASE).
+"""
+
+import argparse
+import os
+import sys
+from dataclasses import dataclass
+from typing import Callable
+
+import psycopg
+
+
+@dataclass
+class Probe:
+    name: str
+    description: str
+    is_drifted: Callable[[psycopg.Connection], bool]
+    repair_sql: str
+
+
+def text_column_drifted(table: str, column: str) -> Callable:
+    def check(conn):
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT data_type FROM information_schema.columns
+                WHERE table_schema = 'public'
+                  AND table_name = %s AND column_name = %s
+                """,
+                (table, column),
+            )
+            row = cur.fetchone()
+            return row is not None and row[0] != "text"
+
+    return check
+
+
+def server_default_missing(table: str, column: str, expected: str) -> Callable:
+    def check(conn):
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT column_default FROM information_schema.columns
+                WHERE table_schema = 'public'
+                  AND table_name = %s AND column_name = %s
+                """,
+                (table, column),
+            )
+            row = cur.fetchone()
+            return row is not None and (
+                row[0] is None or expected not in (row[0] or "")
+            )
+
+    return check
+
+
+def server_default_unexpected(table: str, column: str) -> Callable:
+    def check(conn):
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT column_default FROM information_schema.columns
+                WHERE table_schema = 'public'
+                  AND table_name = %s AND column_name = %s
+                """,
+                (table, column),
+            )
+            row = cur.fetchone()
+            return row is not None and row[0] is not None
+
+    return check
+
+
+def constraint_missing(name: str) -> Callable:
+    def check(conn):
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT 1 FROM pg_constraint WHERE conname = %s", (name,)
+            )
+            return cur.fetchone() is None
+
+    return check
+
+
+def index_missing(name: str) -> Callable:
+    def check(conn):
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT 1 FROM pg_indexes
+                WHERE schemaname = 'public' AND indexname = %s
+                """,
+                (name,),
+            )
+            return cur.fetchone() is None
+
+    return check
+
+
+def email_index_not_partial(conn) -> bool:
+    with conn.cursor() as cur:
+        cur.execute("""
+            SELECT indexdef FROM pg_indexes
+            WHERE schemaname = 'public'
+              AND indexname = 'only_one_email_by_person'
+            """)
+        row = cur.fetchone()
+        return row is not None and "WHERE" not in row[0]
+
+
+def enum_missing(conn) -> bool:
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT 1 FROM pg_type WHERE typname = 'import_source_enum'"
+        )
+        return cur.fetchone() is None
+
+
+def constraint_renamed_in_fresh(old: str, new: str) -> Callable:
+    def check(conn):
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT 1 FROM pg_constraint WHERE conname = %s", (old,)
+            )
+            has_old = cur.fetchone() is not None
+            cur.execute(
+                "SELECT 1 FROM pg_constraint WHERE conname = %s", (new,)
+            )
+            has_new = cur.fetchone() is not None
+            return has_old and not has_new
+
+    return check
+
+
+def pk_uc_collapsed(table: str) -> Callable:
+    def check(conn):
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT contype FROM pg_constraint WHERE conname = %s
+                """,
+                (f"{table}_uc",),
+            )
+            row = cur.fetchone()
+            return row is not None and row[0] == "p"
+
+    return check
+
+
+def asset_types_present(conn) -> bool:
+    with conn.cursor() as cur:
+        cur.execute("""
+            SELECT 1 FROM information_schema.tables
+            WHERE table_schema = 'public' AND table_name = 'asset_types'
+            """)
+        return cur.fetchone() is not None
+
+
+PROBES: list[Probe] = [
+    Probe(
+        "asset_types orphan table",
+        "Legacy table with no PK or modern usage; should be dropped.",
+        asset_types_present,
+        "DROP TABLE IF EXISTS asset_types CASCADE",
+    ),
+    Probe(
+        "import_source_enum type missing",
+        "ENUM ('csv', 'shotgun') used by data_import_error.source.",
+        enum_missing,
+        """
+        CREATE TYPE public.import_source_enum AS ENUM ('csv', 'shotgun');
+        ALTER TABLE data_import_error
+            ALTER COLUMN source TYPE public.import_source_enum
+            USING source::public.import_source_enum;
+        """,
+    ),
+    Probe(
+        "only_one_email_by_person not a partial index",
+        "Should be UNIQUE (email, is_bot) WHERE (is_bot IS NOT TRUE).",
+        email_index_not_partial,
+        """
+        DROP INDEX only_one_email_by_person;
+        CREATE UNIQUE INDEX only_one_email_by_person
+            ON person (email, is_bot)
+            WHERE (is_bot IS NOT TRUE);
+        """,
+    ),
+]
+
+TEXT_COLUMNS = [
+    ("chat_message", "text"),
+    ("comment", "text"),
+    ("day_off", "description"),
+    ("entity", "description"),
+    ("entity_type", "description"),
+    ("output_file", "comment"),
+    ("output_file", "description"),
+    ("plugin", "description"),
+    ("preview_file", "description"),
+    ("project", "description"),
+    ("task", "description"),
+    ("task_status", "description"),
+    ("task_type", "description"),
+    ("working_file", "comment"),
+    ("working_file", "description"),
+]
+for table, column in TEXT_COLUMNS:
+    PROBES.append(
+        Probe(
+            f"{table}.{column} should be TEXT",
+            f"Squash created it as character varying.",
+            text_column_drifted(table, column),
+            f"ALTER TABLE {table} ALTER COLUMN {column} TYPE text",
+        )
+    )
+
+SERVER_DEFAULTS = [
+    ("entity", "is_shared", "false"),
+    ("person", "contract_type", "'open-ended'"),
+    ("person", "is_bot", "false"),
+    ("status_automation", "import_last_revision", "false"),
+    ("task", "difficulty", "3"),
+]
+for table, column, default in SERVER_DEFAULTS:
+    PROBES.append(
+        Probe(
+            f"{table}.{column} default missing",
+            f"Should default to {default}.",
+            server_default_missing(table, column, default),
+            f"ALTER TABLE {table} ALTER COLUMN {column} SET DEFAULT {default}",
+        )
+    )
+
+PROBES.append(
+    Probe(
+        "task_status.is_wip default unexpected",
+        "Squash added DEFAULT false; prod has no default.",
+        server_default_unexpected("task_status", "is_wip"),
+        "ALTER TABLE task_status ALTER COLUMN is_wip DROP DEFAULT",
+    )
+)
+
+CHECK_CONSTRAINTS = [
+    ("check_difficulty", "task", "((difficulty > 0) AND (difficulty < 6))"),
+    ("day_off_date_check", "day_off", "(date <= end_date)"),
+    (
+        "check_duration_positive",
+        "time_spent",
+        "(duration > (0)::double precision)",
+    ),
+]
+for cname, table, expr in CHECK_CONSTRAINTS:
+    PROBES.append(
+        Probe(
+            f"CHECK {cname} missing",
+            f"Lost in squash on table {table}.",
+            constraint_missing(cname),
+            f"ALTER TABLE {table} ADD CONSTRAINT {cname} CHECK {expr}",
+        )
+    )
+
+MISSING_INDEXES = [
+    ("ix_entity_entity_type_parent", "entity", "(entity_type_id, parent_id)"),
+    (
+        "ix_entity_entity_type_project",
+        "entity",
+        "(entity_type_id, project_id)",
+    ),
+    ("ix_task_entity_project", "task", "(entity_id, project_id)"),
+]
+for idx, table, cols in MISSING_INDEXES:
+    PROBES.append(
+        Probe(
+            f"index {idx} missing",
+            f"Lost legacy performance index on {table}.",
+            index_missing(idx),
+            f"CREATE INDEX {idx} ON {table} {cols}",
+        )
+    )
+
+CONSTRAINT_RENAMES = [
+    ("entity_preview_file_id_fkey", "fk_main_preview", "entity"),
+    ("entity_ready_for_fkey", "fk_ready_for", "entity"),
+    ("task_person_link_pkey", "assignations_pkey", "task_person_link"),
+]
+for old, new, table in CONSTRAINT_RENAMES:
+    PROBES.append(
+        Probe(
+            f"constraint renamed: {old} should be {new}",
+            f"Squash auto-named what legacy had as {new}.",
+            constraint_renamed_in_fresh(old, new),
+            f"ALTER TABLE {table} RENAME CONSTRAINT {old} TO {new}",
+        )
+    )
+
+PK_UC_TABLES = [
+    ("department_link", "person_id, department_id"),
+    (
+        "department_metadata_descriptor_link",
+        "metadata_descriptor_id, department_id",
+    ),
+    ("task_type_asset_type_link", "asset_type_id, task_type_id"),
+]
+for table, cols in PK_UC_TABLES:
+    PROBES.append(
+        Probe(
+            f"{table}: PK and UC collapsed into {table}_uc",
+            f"Should have separate {table}_pkey and {table}_uc.",
+            pk_uc_collapsed(table),
+            f"""
+            ALTER TABLE {table} RENAME CONSTRAINT {table}_uc TO {table}_pkey;
+            ALTER TABLE {table} ADD CONSTRAINT {table}_uc UNIQUE ({cols});
+            """,
+        )
+    )
+
+
+def connect() -> psycopg.Connection:
+    dsn = (
+        f"host={os.environ.get('DB_HOST', 'localhost')} "
+        f"port={os.environ.get('DB_PORT', '5432')} "
+        f"user={os.environ['DB_USERNAME']} "
+        f"password={os.environ['DB_PASSWORD']} "
+        f"dbname={os.environ['DB_DATABASE']}"
+    )
+    return psycopg.connect(dsn)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--fix",
+        action="store_true",
+        help="Apply repair SQL for every detected drift.",
+    )
+    args = parser.parse_args()
+
+    drifted = []
+    with connect() as conn:
+        for probe in PROBES:
+            try:
+                if probe.is_drifted(conn):
+                    drifted.append(probe)
+            except psycopg.Error as exc:
+                print(f"  warning: probe '{probe.name}' raised {exc!r}")
+                conn.rollback()
+
+        if not drifted:
+            print("Schema is in sync with the reconciled state.")
+            return 0
+
+        print(f"Detected {len(drifted)} drift(s):")
+        for p in drifted:
+            print(f"  - {p.name}: {p.description}")
+
+        if not args.fix:
+            print("\nRun with --fix to repair, or apply via `zou upgrade-db`.")
+            return 1
+
+        print("\nApplying repairs...")
+        for p in drifted:
+            print(f"  → {p.name}")
+            with conn.cursor() as cur:
+                cur.execute(p.repair_sql)
+            conn.commit()
+        print("Done.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/zou/migrations/versions/0001_squash_pre_1_0_0.py
+++ b/zou/migrations/versions/0001_squash_pre_1_0_0.py
@@ -61,11 +61,6 @@ def upgrade():
         ),
         sa.Column("created_at", sa.DateTime(timezone=False)),
         sa.Column("updated_at", sa.DateTime(timezone=False)),
-        sa.ForeignKeyConstraint(["scene_id"], ["entity.id"]),
-        sa.ForeignKeyConstraint(["entity_type_id"], ["entity_type.id"]),
-        sa.ForeignKeyConstraint(["asset_id"], ["entity.id"]),
-        sa.ForeignKeyConstraint(["entity_id"], ["entity.id"]),
-        sa.ForeignKeyConstraint(["target_asset_id"], ["entity.id"]),
         sa.PrimaryKeyConstraint("id"),
         sa.UniqueConstraint(
             "asset_id",
@@ -162,7 +157,7 @@ def upgrade():
         sa.Column("nb_entities_out", sa.Integer()),
         sa.Column("is_casting_standby", sa.Boolean()),
         sa.Column("is_shared", sa.Boolean(), nullable=False),
-        sa.Column("status", ChoiceType(length=255), nullable=False),
+        sa.Column("status", sa.String(length=255), nullable=False),
         sa.Column(
             "project_id",
             sqlalchemy_utils.types.uuid.UUIDType(binary=False),
@@ -203,13 +198,6 @@ def upgrade():
         ),
         sa.Column("created_at", sa.DateTime(timezone=False)),
         sa.Column("updated_at", sa.DateTime(timezone=False)),
-        sa.ForeignKeyConstraint(["parent_id"], ["entity.id"]),
-        sa.ForeignKeyConstraint(["created_by"], ["person.id"]),
-        sa.ForeignKeyConstraint(["preview_file_id"], ["preview_file.id"]),
-        sa.ForeignKeyConstraint(["entity_type_id"], ["entity_type.id"]),
-        sa.ForeignKeyConstraint(["ready_for"], ["task_type.id"]),
-        sa.ForeignKeyConstraint(["source_id"], ["entity.id"]),
-        sa.ForeignKeyConstraint(["project_id"], ["project.id"]),
         sa.PrimaryKeyConstraint("id"),
         sa.UniqueConstraint(
             "name",
@@ -357,14 +345,6 @@ def upgrade():
         ),
         sa.Column("created_at", sa.DateTime(timezone=False)),
         sa.Column("updated_at", sa.DateTime(timezone=False)),
-        sa.ForeignKeyConstraint(["task_type_id"], ["task_type.id"]),
-        sa.ForeignKeyConstraint(["entity_id"], ["entity.id"]),
-        sa.ForeignKeyConstraint(["source_file_id"], ["working_file.id"]),
-        sa.ForeignKeyConstraint(["file_status_id"], ["file_status.id"]),
-        sa.ForeignKeyConstraint(["output_type_id"], ["output_type.id"]),
-        sa.ForeignKeyConstraint(["person_id"], ["person.id"]),
-        sa.ForeignKeyConstraint(["asset_instance_id"], ["asset_instance.id"]),
-        sa.ForeignKeyConstraint(["temporal_entity_id"], ["entity.id"]),
         sa.PrimaryKeyConstraint("id"),
         sa.UniqueConstraint(
             "name",
@@ -399,8 +379,8 @@ def upgrade():
         sa.Column("description", sa.String(length=None)),
         sa.Column("version", sa.String(length=50), nullable=False),
         sa.Column("maintainer_name", sa.String(length=200), nullable=False),
-        sa.Column("maintainer_email", EmailType(length=255)),
-        sa.Column("website", URLType()),
+        sa.Column("maintainer_email", sa.String(length=255)),
+        sa.Column("website", sa.Text()),
         sa.Column("license", sa.String(length=80), nullable=False),
         sa.Column("revision", sa.String(length=12)),
         sa.Column(
@@ -442,8 +422,8 @@ def upgrade():
         sa.Column("path", sa.String(length=400)),
         sa.Column("source", sa.String(length=40)),
         sa.Column("file_size", sa.BigInteger()),
-        sa.Column("status", ChoiceType(length=255), nullable=False),
-        sa.Column("validation_status", ChoiceType(length=255), nullable=False),
+        sa.Column("status", sa.String(length=255), nullable=False),
+        sa.Column("validation_status", sa.String(length=255), nullable=False),
         sa.Column("annotations", postgresql.JSONB(astext_type=sa.Text())),
         sa.Column("width", sa.Integer()),
         sa.Column("height", sa.Integer()),
@@ -476,9 +456,6 @@ def upgrade():
         ),
         sa.Column("created_at", sa.DateTime(timezone=False)),
         sa.Column("updated_at", sa.DateTime(timezone=False)),
-        sa.ForeignKeyConstraint(["task_id"], ["task.id"]),
-        sa.ForeignKeyConstraint(["person_id"], ["person.id"]),
-        sa.ForeignKeyConstraint(["source_file_id"], ["output_file.id"]),
         sa.PrimaryKeyConstraint("id"),
         sa.UniqueConstraint("name", "task_id", "revision", name="preview_uc"),
         sa.UniqueConstraint("shotgun_id"),
@@ -595,11 +572,6 @@ def upgrade():
         ),
         sa.Column("created_at", sa.DateTime(timezone=False)),
         sa.Column("updated_at", sa.DateTime(timezone=False)),
-        sa.ForeignKeyConstraint(["task_status_id"], ["task_status.id"]),
-        sa.ForeignKeyConstraint(["assigner_id"], ["person.id"]),
-        sa.ForeignKeyConstraint(["project_id"], ["project.id"]),
-        sa.ForeignKeyConstraint(["task_type_id"], ["task_type.id"]),
-        sa.ForeignKeyConstraint(["entity_id"], ["entity.id"]),
         sa.PrimaryKeyConstraint("id"),
         sa.UniqueConstraint(
             "name", "project_id", "task_type_id", "entity_id", name="task_uc"
@@ -673,10 +645,6 @@ def upgrade():
         ),
         sa.Column("created_at", sa.DateTime(timezone=False)),
         sa.Column("updated_at", sa.DateTime(timezone=False)),
-        sa.ForeignKeyConstraint(["person_id"], ["person.id"]),
-        sa.ForeignKeyConstraint(["task_id"], ["task.id"]),
-        sa.ForeignKeyConstraint(["entity_id"], ["entity.id"]),
-        sa.ForeignKeyConstraint(["software_id"], ["software.id"]),
         sa.PrimaryKeyConstraint("id"),
         sa.UniqueConstraint(
             "name", "task_id", "entity_id", "revision", name="working_file_uc"
@@ -696,8 +664,6 @@ def upgrade():
             default=uuid.uuid4,
             nullable=False,
         ),
-        sa.ForeignKeyConstraint(["asset_instance_id"], ["asset_instance.id"]),
-        sa.ForeignKeyConstraint(["entity_id"], ["entity.id"]),
         sa.PrimaryKeyConstraint("entity_id", "asset_instance_id"),
     )
     op.create_table(
@@ -722,8 +688,6 @@ def upgrade():
         ),
         sa.Column("created_at", sa.DateTime(timezone=False)),
         sa.Column("updated_at", sa.DateTime(timezone=False)),
-        sa.ForeignKeyConstraint(["entity_out_id"], ["entity.id"]),
-        sa.ForeignKeyConstraint(["entity_in_id"], ["entity.id"]),
         sa.PrimaryKeyConstraint("entity_in_id", "entity_out_id", "id"),
     )
     op.create_table(
@@ -751,8 +715,6 @@ def upgrade():
         ),
         sa.Column("created_at", sa.DateTime(timezone=False)),
         sa.Column("updated_at", sa.DateTime(timezone=False)),
-        sa.ForeignKeyConstraint(["entity_out_id"], ["entity.id"]),
-        sa.ForeignKeyConstraint(["entity_in_id"], ["entity.id"]),
         sa.PrimaryKeyConstraint("entity_in_id", "entity_out_id", "id"),
         sa.UniqueConstraint(
             "entity_in_id", "entity_out_id", name="entity_link_uc"
@@ -780,8 +742,6 @@ def upgrade():
         ),
         sa.Column("created_at", sa.DateTime(timezone=False)),
         sa.Column("updated_at", sa.DateTime(timezone=False)),
-        sa.ForeignKeyConstraint(["hardware_item_id"], ["hardware_item.id"]),
-        sa.ForeignKeyConstraint(["department_id"], ["department.id"]),
         sa.PrimaryKeyConstraint("department_id", "hardware_item_id", "id"),
         sa.UniqueConstraint(
             "hardware_item_id",
@@ -793,9 +753,9 @@ def upgrade():
         "person",
         sa.Column("first_name", sa.String(length=80), nullable=False),
         sa.Column("last_name", sa.String(length=80), nullable=False),
-        sa.Column("email", EmailType(length=255)),
+        sa.Column("email", sa.String(length=255)),
         sa.Column("phone", sa.String(length=30)),
-        sa.Column("contract_type", ChoiceType(length=255), nullable=False),
+        sa.Column("contract_type", sa.String(length=255), nullable=False),
         sa.Column("active", sa.Boolean()),
         sa.Column("archived", sa.Boolean()),
         sa.Column("last_presence", sa.Date()),
@@ -808,18 +768,23 @@ def upgrade():
         sa.Column("email_otp_enabled", sa.Boolean()),
         sa.Column("email_otp_secret", sa.String(length=32)),
         sa.Column("fido_enabled", sa.Boolean()),
-        sa.Column("fido_credentials", ARRAY(JSONB(astext_type=Text()))),
-        sa.Column("otp_recovery_codes", ARRAY(LargeBinary(length=60))),
         sa.Column(
-            "preferred_two_factor_authentication", ChoiceType(length=255)
+            "fido_credentials",
+            postgresql.ARRAY(postgresql.JSONB(astext_type=sa.Text())),
+        ),
+        sa.Column(
+            "otp_recovery_codes", postgresql.ARRAY(sa.LargeBinary(length=60))
+        ),
+        sa.Column(
+            "preferred_two_factor_authentication", sa.String(length=255)
         ),
         sa.Column("shotgun_id", sa.Integer()),
-        sa.Column("timezone", TimezoneType(length=50)),
-        sa.Column("locale", LocaleType(length=10)),
+        sa.Column("timezone", sa.String(length=50)),
+        sa.Column("locale", sa.String(length=10)),
         sa.Column("data", postgresql.JSONB(astext_type=sa.Text())),
-        sa.Column("role", ChoiceType(length=255), nullable=False),
-        sa.Column("position", ChoiceType(length=255)),
-        sa.Column("seniority", ChoiceType(length=255)),
+        sa.Column("role", sa.String(length=255), nullable=False),
+        sa.Column("position", sa.String(length=255)),
+        sa.Column("seniority", sa.String(length=255)),
         sa.Column("daily_salary", sa.Integer()),
         sa.Column("has_avatar", sa.Boolean()),
         sa.Column("notifications_enabled", sa.Boolean()),
@@ -847,7 +812,6 @@ def upgrade():
         ),
         sa.Column("created_at", sa.DateTime(timezone=False)),
         sa.Column("updated_at", sa.DateTime(timezone=False)),
-        sa.ForeignKeyConstraint(["studio_id"], ["studio.id"]),
         sa.PrimaryKeyConstraint("id"),
         sa.UniqueConstraint("jti"),
         sa.UniqueConstraint("shotgun_id"),
@@ -866,7 +830,7 @@ def upgrade():
         sa.Column("ratio", sa.String(length=10)),
         sa.Column("resolution", sa.String(length=12)),
         sa.Column("production_type", sa.String(length=20)),
-        sa.Column("production_style", ChoiceType(length=255), nullable=False),
+        sa.Column("production_style", sa.String(length=255), nullable=False),
         sa.Column("start_date", sa.Date()),
         sa.Column("end_date", sa.Date()),
         sa.Column("man_days", sa.Integer()),
@@ -903,14 +867,6 @@ def upgrade():
         ),
         sa.Column("created_at", sa.DateTime(timezone=False)),
         sa.Column("updated_at", sa.DateTime(timezone=False)),
-        sa.ForeignKeyConstraint(["project_status_id"], ["project_status.id"]),
-        sa.ForeignKeyConstraint(
-            ["from_schedule_version_id"], ["production_schedule_version.id"]
-        ),
-        sa.ForeignKeyConstraint(
-            ["default_preview_background_file_id"],
-            ["preview_background_file.id"],
-        ),
         sa.PrimaryKeyConstraint("id"),
     )
     op.create_table(
@@ -921,8 +877,8 @@ def upgrade():
             default=uuid.uuid4,
             nullable=False,
         ),
-        sa.Column("position", ChoiceType(length=255)),
-        sa.Column("seniority", ChoiceType(length=255)),
+        sa.Column("position", sa.String(length=255)),
+        sa.Column("seniority", sa.String(length=255)),
         sa.Column("salary", sa.Integer(), nullable=False),
         sa.Column(
             "id",
@@ -932,7 +888,6 @@ def upgrade():
         ),
         sa.Column("created_at", sa.DateTime(timezone=False)),
         sa.Column("updated_at", sa.DateTime(timezone=False)),
-        sa.ForeignKeyConstraint(["department_id"], ["department.id"]),
         sa.PrimaryKeyConstraint("id"),
     )
     op.create_table(
@@ -957,8 +912,6 @@ def upgrade():
         ),
         sa.Column("created_at", sa.DateTime(timezone=False)),
         sa.Column("updated_at", sa.DateTime(timezone=False)),
-        sa.ForeignKeyConstraint(["department_id"], ["department.id"]),
-        sa.ForeignKeyConstraint(["software_id"], ["software.id"]),
         sa.PrimaryKeyConstraint("department_id", "software_id", "id"),
         sa.UniqueConstraint(
             "department_id", "software_id", name="software_department_link_uc"
@@ -988,7 +941,6 @@ def upgrade():
         ),
         sa.Column("created_at", sa.DateTime(timezone=False)),
         sa.Column("updated_at", sa.DateTime(timezone=False)),
-        sa.ForeignKeyConstraint(["department_id"], ["department.id"]),
         sa.PrimaryKeyConstraint("id"),
         sa.UniqueConstraint(
             "name", "for_entity", "department_id", name="task_type_uc"
@@ -1016,8 +968,6 @@ def upgrade():
         ),
         sa.Column("created_at", sa.DateTime(timezone=False)),
         sa.Column("updated_at", sa.DateTime(timezone=False)),
-        sa.ForeignKeyConstraint(["project_id"], ["project.id"]),
-        sa.ForeignKeyConstraint(["user_id"], ["person.id"]),
         sa.PrimaryKeyConstraint("id"),
     )
     op.create_table(
@@ -1038,7 +988,6 @@ def upgrade():
         ),
         sa.Column("created_at", sa.DateTime(timezone=False)),
         sa.Column("updated_at", sa.DateTime(timezone=False)),
-        sa.ForeignKeyConstraint(["project_id"], ["project.id"]),
         sa.PrimaryKeyConstraint("id"),
     )
     op.create_table(
@@ -1064,8 +1013,6 @@ def upgrade():
         ),
         sa.Column("created_at", sa.DateTime(timezone=False)),
         sa.Column("updated_at", sa.DateTime(timezone=False)),
-        sa.ForeignKeyConstraint(["person_id"], ["person.id"]),
-        sa.ForeignKeyConstraint(["chat_id"], ["chat.id"]),
         sa.PrimaryKeyConstraint("id"),
     )
     op.create_table(
@@ -1082,8 +1029,6 @@ def upgrade():
             default=uuid.uuid4,
             nullable=False,
         ),
-        sa.ForeignKeyConstraint(["chat_id"], ["chat.id"]),
-        sa.ForeignKeyConstraint(["person_id"], ["person.id"]),
         sa.PrimaryKeyConstraint("chat_id", "person_id"),
     )
     op.create_table(
@@ -1101,7 +1046,7 @@ def upgrade():
         sa.Column("replies", postgresql.JSONB(astext_type=sa.Text())),
         sa.Column("checklist", postgresql.JSONB(astext_type=sa.Text())),
         sa.Column("pinned", sa.Boolean()),
-        sa.Column("links", ARRAY(String())),
+        sa.Column("links", postgresql.ARRAY(sa.String())),
         sa.Column(
             "task_status_id",
             sqlalchemy_utils.types.uuid.UUIDType(binary=False),
@@ -1131,10 +1076,6 @@ def upgrade():
         ),
         sa.Column("created_at", sa.DateTime(timezone=False)),
         sa.Column("updated_at", sa.DateTime(timezone=False)),
-        sa.ForeignKeyConstraint(["task_status_id"], ["task_status.id"]),
-        sa.ForeignKeyConstraint(["editor_id"], ["person.id"]),
-        sa.ForeignKeyConstraint(["person_id"], ["person.id"]),
-        sa.ForeignKeyConstraint(["preview_file_id"], ["preview_file.id"]),
         sa.PrimaryKeyConstraint("id"),
     )
     op.create_table(
@@ -1155,7 +1096,6 @@ def upgrade():
         ),
         sa.Column("created_at", sa.DateTime(timezone=False)),
         sa.Column("updated_at", sa.DateTime(timezone=False)),
-        sa.ForeignKeyConstraint(["person_id"], ["person.id"]),
         sa.PrimaryKeyConstraint("id"),
         sa.UniqueConstraint("person_id", "date", name="day_off_uc"),
     )
@@ -1173,8 +1113,6 @@ def upgrade():
             default=uuid.uuid4,
             nullable=False,
         ),
-        sa.ForeignKeyConstraint(["person_id"], ["person.id"]),
-        sa.ForeignKeyConstraint(["department_id"], ["department.id"]),
         sa.PrimaryKeyConstraint("person_id", "department_id"),
         sa.UniqueConstraint(
             "person_id", "department_id", name="department_link_uc"
@@ -1197,7 +1135,6 @@ def upgrade():
         ),
         sa.Column("created_at", sa.DateTime(timezone=False)),
         sa.Column("updated_at", sa.DateTime(timezone=False)),
-        sa.ForeignKeyConstraint(["person_id"], ["person.id"]),
         sa.PrimaryKeyConstraint("id"),
     )
     op.create_table(
@@ -1222,8 +1159,6 @@ def upgrade():
         ),
         sa.Column("created_at", sa.DateTime(timezone=False)),
         sa.Column("updated_at", sa.DateTime(timezone=False)),
-        sa.ForeignKeyConstraint(["person_id"], ["person.id"]),
-        sa.ForeignKeyConstraint(["entity_id"], ["entity.id"]),
         sa.PrimaryKeyConstraint("id"),
     )
     op.create_table(
@@ -1234,8 +1169,8 @@ def upgrade():
             default=uuid.uuid4,
             nullable=False,
         ),
-        sa.Column("ip_address", IPAddressType(length=50)),
-        sa.Column("origin", ChoiceType(length=255)),
+        sa.Column("ip_address", sa.String(length=50)),
+        sa.Column("origin", sa.String(length=255)),
         sa.Column(
             "id",
             sqlalchemy_utils.types.uuid.UUIDType(binary=False),
@@ -1244,7 +1179,6 @@ def upgrade():
         ),
         sa.Column("created_at", sa.DateTime(timezone=False)),
         sa.Column("updated_at", sa.DateTime(timezone=False)),
-        sa.ForeignKeyConstraint(["person_id"], ["person.id"]),
         sa.PrimaryKeyConstraint("id"),
     )
     op.create_table(
@@ -1257,7 +1191,7 @@ def upgrade():
         ),
         sa.Column("entity_type", sa.String(length=60), nullable=False),
         sa.Column("name", sa.String(length=120), nullable=False),
-        sa.Column("data_type", ChoiceType(length=255)),
+        sa.Column("data_type", sa.String(length=255)),
         sa.Column("field_name", sa.String(length=120), nullable=False),
         sa.Column("choices", postgresql.JSONB(astext_type=sa.Text())),
         sa.Column("for_client", sa.Boolean()),
@@ -1270,7 +1204,6 @@ def upgrade():
         ),
         sa.Column("created_at", sa.DateTime(timezone=False)),
         sa.Column("updated_at", sa.DateTime(timezone=False)),
-        sa.ForeignKeyConstraint(["project_id"], ["project.id"]),
         sa.PrimaryKeyConstraint("id"),
         sa.UniqueConstraint(
             "project_id",
@@ -1304,8 +1237,6 @@ def upgrade():
         ),
         sa.Column("created_at", sa.DateTime(timezone=False)),
         sa.Column("updated_at", sa.DateTime(timezone=False)),
-        sa.ForeignKeyConstraint(["task_type_id"], ["task_type.id"]),
-        sa.ForeignKeyConstraint(["project_id"], ["project.id"]),
         sa.PrimaryKeyConstraint("id"),
     )
     op.create_table(
@@ -1338,10 +1269,6 @@ def upgrade():
         ),
         sa.Column("created_at", sa.DateTime(timezone=False)),
         sa.Column("updated_at", sa.DateTime(timezone=False)),
-        sa.ForeignKeyConstraint(["episode_id"], ["entity.id"]),
-        sa.ForeignKeyConstraint(["task_type_id"], ["task_type.id"]),
-        sa.ForeignKeyConstraint(["created_by"], ["person.id"]),
-        sa.ForeignKeyConstraint(["project_id"], ["project.id"]),
         sa.PrimaryKeyConstraint("id"),
         sa.UniqueConstraint(
             "name", "project_id", "episode_id", name="playlist_uc"
@@ -1371,10 +1298,6 @@ def upgrade():
         ),
         sa.Column("created_at", sa.DateTime(timezone=False)),
         sa.Column("updated_at", sa.DateTime(timezone=False)),
-        sa.ForeignKeyConstraint(["project_id"], ["project.id"]),
-        sa.ForeignKeyConstraint(
-            ["production_schedule_from"], ["production_schedule_version.id"]
-        ),
         sa.PrimaryKeyConstraint("id"),
         sa.UniqueConstraint(
             "name", "project_id", name="production_schedule_version_uc"
@@ -1394,8 +1317,6 @@ def upgrade():
             default=uuid.uuid4,
             nullable=False,
         ),
-        sa.ForeignKeyConstraint(["asset_type_id"], ["entity_type.id"]),
-        sa.ForeignKeyConstraint(["project_id"], ["project.id"]),
         sa.PrimaryKeyConstraint("project_id", "asset_type_id"),
     )
     op.create_table(
@@ -1413,8 +1334,6 @@ def upgrade():
             nullable=False,
         ),
         sa.Column("shotgun_id", sa.Integer()),
-        sa.ForeignKeyConstraint(["project_id"], ["project.id"]),
-        sa.ForeignKeyConstraint(["person_id"], ["person.id"]),
         sa.PrimaryKeyConstraint("project_id", "person_id"),
     )
     op.create_table(
@@ -1430,10 +1349,6 @@ def upgrade():
             sqlalchemy_utils.types.uuid.UUIDType(binary=False),
             default=uuid.uuid4,
             nullable=False,
-        ),
-        sa.ForeignKeyConstraint(["project_id"], ["project.id"]),
-        sa.ForeignKeyConstraint(
-            ["preview_background_file_id"], ["preview_background_file.id"]
         ),
         sa.PrimaryKeyConstraint("project_id", "preview_background_file_id"),
     )
@@ -1452,7 +1367,7 @@ def upgrade():
             nullable=False,
         ),
         sa.Column("priority", sa.Integer()),
-        sa.Column("roles_for_board", ARRAY(ChoiceType(length=255))),
+        sa.Column("roles_for_board", postgresql.ARRAY(sa.String(length=255))),
         sa.Column(
             "id",
             sqlalchemy_utils.types.uuid.UUIDType(binary=False),
@@ -1461,8 +1376,6 @@ def upgrade():
         ),
         sa.Column("created_at", sa.DateTime(timezone=False)),
         sa.Column("updated_at", sa.DateTime(timezone=False)),
-        sa.ForeignKeyConstraint(["task_status_id"], ["task_status.id"]),
-        sa.ForeignKeyConstraint(["project_id"], ["project.id"]),
         sa.PrimaryKeyConstraint("project_id", "task_status_id", "id"),
         sa.UniqueConstraint(
             "project_id", "task_status_id", name="project_taskstatus_uc"
@@ -1491,8 +1404,6 @@ def upgrade():
         ),
         sa.Column("created_at", sa.DateTime(timezone=False)),
         sa.Column("updated_at", sa.DateTime(timezone=False)),
-        sa.ForeignKeyConstraint(["project_id"], ["project.id"]),
-        sa.ForeignKeyConstraint(["task_type_id"], ["task_type.id"]),
         sa.PrimaryKeyConstraint("project_id", "task_type_id", "id"),
         sa.UniqueConstraint(
             "project_id", "task_type_id", name="project_tasktype_uc"
@@ -1526,8 +1437,6 @@ def upgrade():
         ),
         sa.Column("created_at", sa.DateTime(timezone=False)),
         sa.Column("updated_at", sa.DateTime(timezone=False)),
-        sa.ForeignKeyConstraint(["project_id"], ["project.id"]),
-        sa.ForeignKeyConstraint(["task_type_id"], ["task_type.id"]),
         sa.PrimaryKeyConstraint("id"),
         sa.UniqueConstraint(
             "project_id", "task_type_id", "object_id", name="schedule_item_uc"
@@ -1568,9 +1477,6 @@ def upgrade():
         ),
         sa.Column("created_at", sa.DateTime(timezone=False)),
         sa.Column("updated_at", sa.DateTime(timezone=False)),
-        sa.ForeignKeyConstraint(["department_id"], ["department.id"]),
-        sa.ForeignKeyConstraint(["person_id"], ["person.id"]),
-        sa.ForeignKeyConstraint(["project_id"], ["project.id"]),
         sa.PrimaryKeyConstraint("id"),
     )
     op.create_table(
@@ -1586,7 +1492,7 @@ def upgrade():
             sqlalchemy_utils.types.uuid.UUIDType(binary=False),
             default=uuid.uuid4,
         ),
-        sa.Column("out_field_type", ChoiceType(length=255), nullable=False),
+        sa.Column("out_field_type", sa.String(length=255), nullable=False),
         sa.Column(
             "out_task_type_id",
             sqlalchemy_utils.types.uuid.UUIDType(binary=False),
@@ -1607,10 +1513,6 @@ def upgrade():
         ),
         sa.Column("created_at", sa.DateTime(timezone=False)),
         sa.Column("updated_at", sa.DateTime(timezone=False)),
-        sa.ForeignKeyConstraint(["in_task_status_id"], ["task_status.id"]),
-        sa.ForeignKeyConstraint(["out_task_type_id"], ["task_type.id"]),
-        sa.ForeignKeyConstraint(["out_task_status_id"], ["task_status.id"]),
-        sa.ForeignKeyConstraint(["in_task_type_id"], ["task_type.id"]),
         sa.PrimaryKeyConstraint("id"),
     )
     op.create_table(
@@ -1644,10 +1546,6 @@ def upgrade():
         ),
         sa.Column("created_at", sa.DateTime(timezone=False)),
         sa.Column("updated_at", sa.DateTime(timezone=False)),
-        sa.ForeignKeyConstraint(["task_id"], ["task.id"]),
-        sa.ForeignKeyConstraint(["task_type_id"], ["task_type.id"]),
-        sa.ForeignKeyConstraint(["entity_id"], ["entity.id"]),
-        sa.ForeignKeyConstraint(["person_id"], ["person.id"]),
         sa.PrimaryKeyConstraint("id"),
         sa.UniqueConstraint(
             "person_id",
@@ -1673,8 +1571,6 @@ def upgrade():
             default=uuid.uuid4,
             nullable=False,
         ),
-        sa.ForeignKeyConstraint(["task_id"], ["task.id"]),
-        sa.ForeignKeyConstraint(["person_id"], ["person.id"]),
         sa.PrimaryKeyConstraint("task_id", "person_id"),
     )
     op.create_table(
@@ -1691,8 +1587,6 @@ def upgrade():
             default=uuid.uuid4,
             nullable=False,
         ),
-        sa.ForeignKeyConstraint(["task_type_id"], ["task_type.id"]),
-        sa.ForeignKeyConstraint(["asset_type_id"], ["entity_type.id"]),
         sa.PrimaryKeyConstraint("asset_type_id", "task_type_id"),
         sa.UniqueConstraint(
             "asset_type_id",
@@ -1722,8 +1616,6 @@ def upgrade():
         ),
         sa.Column("created_at", sa.DateTime(timezone=False)),
         sa.Column("updated_at", sa.DateTime(timezone=False)),
-        sa.ForeignKeyConstraint(["person_id"], ["person.id"]),
-        sa.ForeignKeyConstraint(["task_id"], ["task.id"]),
         sa.PrimaryKeyConstraint("id"),
         sa.UniqueConstraint(
             "person_id", "task_id", "date", name="time_spent_uc"
@@ -1758,8 +1650,6 @@ def upgrade():
         ),
         sa.Column("created_at", sa.DateTime(timezone=False)),
         sa.Column("updated_at", sa.DateTime(timezone=False)),
-        sa.ForeignKeyConstraint(["chat_message_id"], ["chat_message.id"]),
-        sa.ForeignKeyConstraint(["comment_id"], ["comment.id"]),
         sa.PrimaryKeyConstraint("id"),
     )
     op.create_table(
@@ -1784,8 +1674,8 @@ def upgrade():
         sa.Column("start_date", sa.Date(), nullable=False),
         sa.Column("months_duration", sa.Integer(), nullable=False),
         sa.Column("daily_salary", sa.Float(), nullable=False),
-        sa.Column("position", ChoiceType(length=255)),
-        sa.Column("seniority", ChoiceType(length=255)),
+        sa.Column("position", sa.String(length=255)),
+        sa.Column("seniority", sa.String(length=255)),
         sa.Column("exceptions", postgresql.JSONB(astext_type=sa.Text())),
         sa.Column(
             "id",
@@ -1795,15 +1685,12 @@ def upgrade():
         ),
         sa.Column("created_at", sa.DateTime(timezone=False)),
         sa.Column("updated_at", sa.DateTime(timezone=False)),
-        sa.ForeignKeyConstraint(["budget_id"], ["budget.id"]),
-        sa.ForeignKeyConstraint(["person_id"], ["person.id"]),
-        sa.ForeignKeyConstraint(["department_id"], ["department.id"]),
         sa.PrimaryKeyConstraint("id"),
     )
     op.create_table(
         "build_job",
-        sa.Column("status", ChoiceType(length=255), nullable=False),
-        sa.Column("job_type", ChoiceType(length=255), nullable=False),
+        sa.Column("status", sa.String(length=255), nullable=False),
+        sa.Column("job_type", sa.String(length=255), nullable=False),
         sa.Column("ended_at", sa.DateTime(timezone=False)),
         sa.Column(
             "playlist_id",
@@ -1819,7 +1706,6 @@ def upgrade():
         ),
         sa.Column("created_at", sa.DateTime(timezone=False)),
         sa.Column("updated_at", sa.DateTime(timezone=False)),
-        sa.ForeignKeyConstraint(["playlist_id"], ["playlist.id"]),
         sa.PrimaryKeyConstraint("id"),
     )
     op.create_table(
@@ -1836,8 +1722,6 @@ def upgrade():
             default=uuid.uuid4,
             nullable=False,
         ),
-        sa.ForeignKeyConstraint(["comment"], ["comment.id"]),
-        sa.ForeignKeyConstraint(["person"], ["person.id"]),
         sa.PrimaryKeyConstraint("comment", "person"),
     )
     op.create_table(
@@ -1854,8 +1738,6 @@ def upgrade():
             default=uuid.uuid4,
             nullable=False,
         ),
-        sa.ForeignKeyConstraint(["department"], ["department.id"]),
-        sa.ForeignKeyConstraint(["comment"], ["comment.id"]),
         sa.PrimaryKeyConstraint("comment", "department"),
     )
     op.create_table(
@@ -1872,8 +1754,6 @@ def upgrade():
             default=uuid.uuid4,
             nullable=False,
         ),
-        sa.ForeignKeyConstraint(["person"], ["person.id"]),
-        sa.ForeignKeyConstraint(["comment"], ["comment.id"]),
         sa.PrimaryKeyConstraint("comment", "person"),
     )
     op.create_table(
@@ -1890,8 +1770,6 @@ def upgrade():
             default=uuid.uuid4,
             nullable=False,
         ),
-        sa.ForeignKeyConstraint(["preview_file"], ["preview_file.id"]),
-        sa.ForeignKeyConstraint(["comment"], ["comment.id"]),
         sa.PrimaryKeyConstraint("comment", "preview_file"),
     )
     op.create_table(
@@ -1907,10 +1785,6 @@ def upgrade():
             sqlalchemy_utils.types.uuid.UUIDType(binary=False),
             default=uuid.uuid4,
             nullable=False,
-        ),
-        sa.ForeignKeyConstraint(["department_id"], ["department.id"]),
-        sa.ForeignKeyConstraint(
-            ["metadata_descriptor_id"], ["metadata_descriptor.id"]
         ),
         sa.PrimaryKeyConstraint("metadata_descriptor_id", "department_id"),
         sa.UniqueConstraint(
@@ -1952,17 +1826,13 @@ def upgrade():
         ),
         sa.Column("created_at", sa.DateTime(timezone=False)),
         sa.Column("updated_at", sa.DateTime(timezone=False)),
-        sa.ForeignKeyConstraint(["author_id"], ["person.id"]),
-        sa.ForeignKeyConstraint(["task_id"], ["task.id"]),
-        sa.ForeignKeyConstraint(["preview_file_id"], ["preview_file.id"]),
-        sa.ForeignKeyConstraint(["comment_id"], ["comment.id"]),
         sa.PrimaryKeyConstraint("id"),
     )
     op.create_table(
         "notification",
         sa.Column("read", sa.Boolean(), nullable=False),
         sa.Column("change", sa.Boolean(), nullable=False),
-        sa.Column("type", ChoiceType(length=255), nullable=False),
+        sa.Column("type", sa.String(length=255), nullable=False),
         sa.Column(
             "person_id",
             sqlalchemy_utils.types.uuid.UUIDType(binary=False),
@@ -2003,11 +1873,6 @@ def upgrade():
         ),
         sa.Column("created_at", sa.DateTime(timezone=False)),
         sa.Column("updated_at", sa.DateTime(timezone=False)),
-        sa.ForeignKeyConstraint(["person_id"], ["person.id"]),
-        sa.ForeignKeyConstraint(["author_id"], ["person.id"]),
-        sa.ForeignKeyConstraint(["task_id"], ["task.id"]),
-        sa.ForeignKeyConstraint(["comment_id"], ["comment.id"]),
-        sa.ForeignKeyConstraint(["playlist_id"], ["playlist.id"]),
         sa.PrimaryKeyConstraint("id"),
         sa.UniqueConstraint(
             "person_id",
@@ -2044,11 +1909,6 @@ def upgrade():
         ),
         sa.Column("created_at", sa.DateTime(timezone=False)),
         sa.Column("updated_at", sa.DateTime(timezone=False)),
-        sa.ForeignKeyConstraint(
-            ["production_schedule_version_id"],
-            ["production_schedule_version.id"],
-        ),
-        sa.ForeignKeyConstraint(["task_id"], ["task.id"]),
         sa.PrimaryKeyConstraint("id"),
         sa.UniqueConstraint(
             "production_schedule_version_id",
@@ -2069,10 +1929,6 @@ def upgrade():
             sqlalchemy_utils.types.uuid.UUIDType(binary=False),
             default=uuid.uuid4,
             nullable=False,
-        ),
-        sa.ForeignKeyConstraint(["project_id"], ["project.id"]),
-        sa.ForeignKeyConstraint(
-            ["status_automation_id"], ["status_automation.id"]
         ),
         sa.PrimaryKeyConstraint("project_id", "status_automation_id"),
     )
@@ -2116,12 +1972,6 @@ def upgrade():
         ),
         sa.Column("created_at", sa.DateTime(timezone=False)),
         sa.Column("updated_at", sa.DateTime(timezone=False)),
-        sa.ForeignKeyConstraint(
-            ["search_filter_group_id"], ["search_filter_group.id"]
-        ),
-        sa.ForeignKeyConstraint(["project_id"], ["project.id"]),
-        sa.ForeignKeyConstraint(["department_id"], ["department.id"]),
-        sa.ForeignKeyConstraint(["person_id"], ["person.id"]),
         sa.PrimaryKeyConstraint("id"),
     )
     op.create_table(
@@ -2138,14 +1988,455 @@ def upgrade():
             default=uuid.uuid4,
             nullable=False,
         ),
-        sa.ForeignKeyConstraint(["person_id"], ["person.id"]),
-        sa.ForeignKeyConstraint(
-            ["production_schedule_version_task_link_id"],
-            ["production_schedule_version_task_link.id"],
-        ),
         sa.PrimaryKeyConstraint(
             "production_schedule_version_task_link_id", "person_id"
         ),
+    )
+    op.create_foreign_key(
+        None, "asset_instance", "entity", ["scene_id"], ["id"]
+    )
+    op.create_foreign_key(
+        None, "asset_instance", "entity_type", ["entity_type_id"], ["id"]
+    )
+    op.create_foreign_key(
+        None, "asset_instance", "entity", ["asset_id"], ["id"]
+    )
+    op.create_foreign_key(
+        None, "asset_instance", "entity", ["entity_id"], ["id"]
+    )
+    op.create_foreign_key(
+        None, "asset_instance", "entity", ["target_asset_id"], ["id"]
+    )
+    op.create_foreign_key(None, "entity", "entity", ["parent_id"], ["id"])
+    op.create_foreign_key(None, "entity", "person", ["created_by"], ["id"])
+    op.create_foreign_key(
+        None, "entity", "preview_file", ["preview_file_id"], ["id"]
+    )
+    op.create_foreign_key(
+        None, "entity", "entity_type", ["entity_type_id"], ["id"]
+    )
+    op.create_foreign_key(None, "entity", "task_type", ["ready_for"], ["id"])
+    op.create_foreign_key(None, "entity", "entity", ["source_id"], ["id"])
+    op.create_foreign_key(None, "entity", "project", ["project_id"], ["id"])
+    op.create_foreign_key(
+        None, "output_file", "task_type", ["task_type_id"], ["id"]
+    )
+    op.create_foreign_key(None, "output_file", "entity", ["entity_id"], ["id"])
+    op.create_foreign_key(
+        None, "output_file", "working_file", ["source_file_id"], ["id"]
+    )
+    op.create_foreign_key(
+        None, "output_file", "file_status", ["file_status_id"], ["id"]
+    )
+    op.create_foreign_key(
+        None, "output_file", "output_type", ["output_type_id"], ["id"]
+    )
+    op.create_foreign_key(None, "output_file", "person", ["person_id"], ["id"])
+    op.create_foreign_key(
+        None, "output_file", "asset_instance", ["asset_instance_id"], ["id"]
+    )
+    op.create_foreign_key(
+        None, "output_file", "entity", ["temporal_entity_id"], ["id"]
+    )
+    op.create_foreign_key(None, "preview_file", "task", ["task_id"], ["id"])
+    op.create_foreign_key(
+        None, "preview_file", "person", ["person_id"], ["id"]
+    )
+    op.create_foreign_key(
+        None, "preview_file", "output_file", ["source_file_id"], ["id"]
+    )
+    op.create_foreign_key(
+        None, "task", "task_status", ["task_status_id"], ["id"]
+    )
+    op.create_foreign_key(None, "task", "person", ["assigner_id"], ["id"])
+    op.create_foreign_key(None, "task", "project", ["project_id"], ["id"])
+    op.create_foreign_key(None, "task", "task_type", ["task_type_id"], ["id"])
+    op.create_foreign_key(None, "task", "entity", ["entity_id"], ["id"])
+    op.create_foreign_key(
+        None, "working_file", "person", ["person_id"], ["id"]
+    )
+    op.create_foreign_key(None, "working_file", "task", ["task_id"], ["id"])
+    op.create_foreign_key(
+        None, "working_file", "entity", ["entity_id"], ["id"]
+    )
+    op.create_foreign_key(
+        None, "working_file", "software", ["software_id"], ["id"]
+    )
+    op.create_foreign_key(
+        None,
+        "asset_instance_link",
+        "asset_instance",
+        ["asset_instance_id"],
+        ["id"],
+    )
+    op.create_foreign_key(
+        None, "asset_instance_link", "entity", ["entity_id"], ["id"]
+    )
+    op.create_foreign_key(
+        None, "entity_concept_link", "entity", ["entity_out_id"], ["id"]
+    )
+    op.create_foreign_key(
+        None, "entity_concept_link", "entity", ["entity_in_id"], ["id"]
+    )
+    op.create_foreign_key(
+        None, "entity_link", "entity", ["entity_out_id"], ["id"]
+    )
+    op.create_foreign_key(
+        None, "entity_link", "entity", ["entity_in_id"], ["id"]
+    )
+    op.create_foreign_key(
+        None,
+        "hardware_item_department_link",
+        "hardware_item",
+        ["hardware_item_id"],
+        ["id"],
+    )
+    op.create_foreign_key(
+        None,
+        "hardware_item_department_link",
+        "department",
+        ["department_id"],
+        ["id"],
+    )
+    op.create_foreign_key(None, "person", "studio", ["studio_id"], ["id"])
+    op.create_foreign_key(
+        None, "project", "project_status", ["project_status_id"], ["id"]
+    )
+    op.create_foreign_key(
+        None,
+        "project",
+        "production_schedule_version",
+        ["from_schedule_version_id"],
+        ["id"],
+    )
+    op.create_foreign_key(
+        None,
+        "project",
+        "preview_background_file",
+        ["default_preview_background_file_id"],
+        ["id"],
+    )
+    op.create_foreign_key(
+        None, "salary_scale", "department", ["department_id"], ["id"]
+    )
+    op.create_foreign_key(
+        None,
+        "software_department_link",
+        "department",
+        ["department_id"],
+        ["id"],
+    )
+    op.create_foreign_key(
+        None, "software_department_link", "software", ["software_id"], ["id"]
+    )
+    op.create_foreign_key(
+        None, "task_type", "department", ["department_id"], ["id"]
+    )
+    op.create_foreign_key(None, "api_event", "project", ["project_id"], ["id"])
+    op.create_foreign_key(None, "api_event", "person", ["user_id"], ["id"])
+    op.create_foreign_key(None, "budget", "project", ["project_id"], ["id"])
+    op.create_foreign_key(
+        None, "chat_message", "person", ["person_id"], ["id"]
+    )
+    op.create_foreign_key(None, "chat_message", "chat", ["chat_id"], ["id"])
+    op.create_foreign_key(
+        None, "chat_participant", "chat", ["chat_id"], ["id"]
+    )
+    op.create_foreign_key(
+        None, "chat_participant", "person", ["person_id"], ["id"]
+    )
+    op.create_foreign_key(
+        None, "comment", "task_status", ["task_status_id"], ["id"]
+    )
+    op.create_foreign_key(None, "comment", "person", ["editor_id"], ["id"])
+    op.create_foreign_key(None, "comment", "person", ["person_id"], ["id"])
+    op.create_foreign_key(
+        None, "comment", "preview_file", ["preview_file_id"], ["id"]
+    )
+    op.create_foreign_key(None, "day_off", "person", ["person_id"], ["id"])
+    op.create_foreign_key(
+        None, "department_link", "person", ["person_id"], ["id"]
+    )
+    op.create_foreign_key(
+        None, "department_link", "department", ["department_id"], ["id"]
+    )
+    op.create_foreign_key(
+        None, "desktop_login_log", "person", ["person_id"], ["id"]
+    )
+    op.create_foreign_key(
+        None, "entity_version", "person", ["person_id"], ["id"]
+    )
+    op.create_foreign_key(
+        None, "entity_version", "entity", ["entity_id"], ["id"]
+    )
+    op.create_foreign_key(None, "login_log", "person", ["person_id"], ["id"])
+    op.create_foreign_key(
+        None, "metadata_descriptor", "project", ["project_id"], ["id"]
+    )
+    op.create_foreign_key(
+        None, "milestone", "task_type", ["task_type_id"], ["id"]
+    )
+    op.create_foreign_key(None, "milestone", "project", ["project_id"], ["id"])
+    op.create_foreign_key(None, "playlist", "entity", ["episode_id"], ["id"])
+    op.create_foreign_key(
+        None, "playlist", "task_type", ["task_type_id"], ["id"]
+    )
+    op.create_foreign_key(None, "playlist", "project", ["project_id"], ["id"])
+    op.create_foreign_key(
+        None, "production_schedule_version", "project", ["project_id"], ["id"]
+    )
+    op.create_foreign_key(
+        None,
+        "production_schedule_version",
+        "production_schedule_version",
+        ["production_schedule_from"],
+        ["id"],
+    )
+    op.create_foreign_key(
+        None,
+        "project_asset_type_link",
+        "entity_type",
+        ["asset_type_id"],
+        ["id"],
+    )
+    op.create_foreign_key(
+        None, "project_asset_type_link", "project", ["project_id"], ["id"]
+    )
+    op.create_foreign_key(
+        None, "project_person_link", "project", ["project_id"], ["id"]
+    )
+    op.create_foreign_key(
+        None, "project_person_link", "person", ["person_id"], ["id"]
+    )
+    op.create_foreign_key(
+        None,
+        "project_preview_background_file_link",
+        "project",
+        ["project_id"],
+        ["id"],
+    )
+    op.create_foreign_key(
+        None,
+        "project_preview_background_file_link",
+        "preview_background_file",
+        ["preview_background_file_id"],
+        ["id"],
+    )
+    op.create_foreign_key(
+        None,
+        "project_task_status_link",
+        "task_status",
+        ["task_status_id"],
+        ["id"],
+    )
+    op.create_foreign_key(
+        None, "project_task_status_link", "project", ["project_id"], ["id"]
+    )
+    op.create_foreign_key(
+        None, "project_task_type_link", "project", ["project_id"], ["id"]
+    )
+    op.create_foreign_key(
+        None, "project_task_type_link", "task_type", ["task_type_id"], ["id"]
+    )
+    op.create_foreign_key(
+        None, "schedule_item", "project", ["project_id"], ["id"]
+    )
+    op.create_foreign_key(
+        None, "schedule_item", "task_type", ["task_type_id"], ["id"]
+    )
+    op.create_foreign_key(
+        None, "search_filter_group", "department", ["department_id"], ["id"]
+    )
+    op.create_foreign_key(
+        None, "search_filter_group", "person", ["person_id"], ["id"]
+    )
+    op.create_foreign_key(
+        None, "search_filter_group", "project", ["project_id"], ["id"]
+    )
+    op.create_foreign_key(
+        None, "status_automation", "task_status", ["in_task_status_id"], ["id"]
+    )
+    op.create_foreign_key(
+        None, "status_automation", "task_type", ["out_task_type_id"], ["id"]
+    )
+    op.create_foreign_key(
+        None,
+        "status_automation",
+        "task_status",
+        ["out_task_status_id"],
+        ["id"],
+    )
+    op.create_foreign_key(
+        None, "status_automation", "task_type", ["in_task_type_id"], ["id"]
+    )
+    op.create_foreign_key(None, "subscription", "task", ["task_id"], ["id"])
+    op.create_foreign_key(
+        None, "subscription", "task_type", ["task_type_id"], ["id"]
+    )
+    op.create_foreign_key(
+        None, "subscription", "entity", ["entity_id"], ["id"]
+    )
+    op.create_foreign_key(
+        None, "subscription", "person", ["person_id"], ["id"]
+    )
+    op.create_foreign_key(
+        None, "task_person_link", "task", ["task_id"], ["id"]
+    )
+    op.create_foreign_key(
+        None, "task_person_link", "person", ["person_id"], ["id"]
+    )
+    op.create_foreign_key(
+        None,
+        "task_type_asset_type_link",
+        "task_type",
+        ["task_type_id"],
+        ["id"],
+    )
+    op.create_foreign_key(
+        None,
+        "task_type_asset_type_link",
+        "entity_type",
+        ["asset_type_id"],
+        ["id"],
+    )
+    op.create_foreign_key(None, "time_spent", "person", ["person_id"], ["id"])
+    op.create_foreign_key(None, "time_spent", "task", ["task_id"], ["id"])
+    op.create_foreign_key(
+        None, "attachment_file", "chat_message", ["chat_message_id"], ["id"]
+    )
+    op.create_foreign_key(
+        None, "attachment_file", "comment", ["comment_id"], ["id"]
+    )
+    op.create_foreign_key(
+        None, "budget_entry", "budget", ["budget_id"], ["id"]
+    )
+    op.create_foreign_key(
+        None, "budget_entry", "person", ["person_id"], ["id"]
+    )
+    op.create_foreign_key(
+        None, "budget_entry", "department", ["department_id"], ["id"]
+    )
+    op.create_foreign_key(
+        None, "build_job", "playlist", ["playlist_id"], ["id"]
+    )
+    op.create_foreign_key(
+        None, "comment_acknoledgments", "comment", ["comment"], ["id"]
+    )
+    op.create_foreign_key(
+        None, "comment_acknoledgments", "person", ["person"], ["id"]
+    )
+    op.create_foreign_key(
+        None,
+        "comment_department_mentions",
+        "department",
+        ["department"],
+        ["id"],
+    )
+    op.create_foreign_key(
+        None, "comment_department_mentions", "comment", ["comment"], ["id"]
+    )
+    op.create_foreign_key(
+        None, "comment_mentions", "person", ["person"], ["id"]
+    )
+    op.create_foreign_key(
+        None, "comment_mentions", "comment", ["comment"], ["id"]
+    )
+    op.create_foreign_key(
+        None, "comment_preview_link", "preview_file", ["preview_file"], ["id"]
+    )
+    op.create_foreign_key(
+        None, "comment_preview_link", "comment", ["comment"], ["id"]
+    )
+    op.create_foreign_key(
+        None,
+        "department_metadata_descriptor_link",
+        "department",
+        ["department_id"],
+        ["id"],
+    )
+    op.create_foreign_key(
+        None,
+        "department_metadata_descriptor_link",
+        "metadata_descriptor",
+        ["metadata_descriptor_id"],
+        ["id"],
+    )
+    op.create_foreign_key(None, "news", "person", ["author_id"], ["id"])
+    op.create_foreign_key(None, "news", "task", ["task_id"], ["id"])
+    op.create_foreign_key(
+        None, "news", "preview_file", ["preview_file_id"], ["id"]
+    )
+    op.create_foreign_key(None, "news", "comment", ["comment_id"], ["id"])
+    op.create_foreign_key(
+        None, "notification", "person", ["person_id"], ["id"]
+    )
+    op.create_foreign_key(
+        None, "notification", "person", ["author_id"], ["id"]
+    )
+    op.create_foreign_key(None, "notification", "task", ["task_id"], ["id"])
+    op.create_foreign_key(
+        None, "notification", "comment", ["comment_id"], ["id"]
+    )
+    op.create_foreign_key(
+        None, "notification", "playlist", ["playlist_id"], ["id"]
+    )
+    op.create_foreign_key(
+        None,
+        "production_schedule_version_task_link",
+        "production_schedule_version",
+        ["production_schedule_version_id"],
+        ["id"],
+    )
+    op.create_foreign_key(
+        None,
+        "production_schedule_version_task_link",
+        "task",
+        ["task_id"],
+        ["id"],
+    )
+    op.create_foreign_key(
+        None,
+        "project_status_automation_link",
+        "project",
+        ["project_id"],
+        ["id"],
+    )
+    op.create_foreign_key(
+        None,
+        "project_status_automation_link",
+        "status_automation",
+        ["status_automation_id"],
+        ["id"],
+    )
+    op.create_foreign_key(
+        None,
+        "search_filter",
+        "search_filter_group",
+        ["search_filter_group_id"],
+        ["id"],
+    )
+    op.create_foreign_key(
+        None, "search_filter", "project", ["project_id"], ["id"]
+    )
+    op.create_foreign_key(
+        None, "search_filter", "department", ["department_id"], ["id"]
+    )
+    op.create_foreign_key(
+        None, "search_filter", "person", ["person_id"], ["id"]
+    )
+    op.create_foreign_key(
+        None,
+        "production_schedule_version_task_link_person_link",
+        "person",
+        ["person_id"],
+        ["id"],
+    )
+    op.create_foreign_key(
+        None,
+        "production_schedule_version_task_link_person_link",
+        "production_schedule_version_task_link",
+        ["production_schedule_version_task_link_id"],
+        ["id"],
     )
     op.create_index(
         "ix_asset_instance_asset_id",
@@ -2730,7 +3021,7 @@ def upgrade():
         unique=False,
     )
     op.create_index(
-        "ix_production_schedule_version_task_link_production_schedule_version_id",
+        "ix_production_schedule_version_task_link_production_sch_9cee",
         "production_schedule_version_task_link",
         ["production_schedule_version_id"],
         unique=False,
@@ -2789,7 +3080,7 @@ def downgrade():
     )
     op.drop_table("project_status_automation_link")
     op.drop_index(
-        "ix_production_schedule_version_task_link_production_schedule_version_id",
+        "ix_production_schedule_version_task_link_production_sch_9cee",
         table_name="production_schedule_version_task_link",
     )
     op.drop_index(

--- a/zou/migrations/versions/25d2d8dba46f_drop_legacy_asset_types_table.py
+++ b/zou/migrations/versions/25d2d8dba46f_drop_legacy_asset_types_table.py
@@ -1,0 +1,28 @@
+"""drop legacy asset_types table
+
+The asset_types table is a pre-Alembic relic: a 2-column M2M without a primary
+key, holding the same shape as the modern task_type_asset_type_link table that
+fully replaced it. No application code references it. It survives only on
+databases that existed before Alembic tracking. Drop it where it still exists.
+
+Revision ID: 25d2d8dba46f
+Revises: a1bc96e68661
+Create Date: 2026-04-28 00:00:00.000000
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "25d2d8dba46f"
+down_revision = "a1bc96e68661"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("DROP TABLE IF EXISTS asset_types CASCADE")
+
+
+def downgrade():
+    pass

--- a/zou/migrations/versions/2b8f88aa610f_reconcile_squash_schema_with_legacy.py
+++ b/zou/migrations/versions/2b8f88aa610f_reconcile_squash_schema_with_legacy.py
@@ -1,0 +1,254 @@
+"""reconcile squash schema with legacy state
+
+The pre-1.0.0 squash migration was auto-generated from a live model snapshot
+and lost several DDL details that the historical chain had set:
+
+- description/text/comment columns rendered as VARCHAR instead of TEXT
+- server defaults dropped on several boolean/numeric columns
+- CHECK constraints dropped on task.difficulty, day_off date range, time_spent
+- import_source_enum ENUM type collapsed to character varying(7)
+- 3 composite indexes lost (entity, task perf indexes from legacy
+  71d546ace0ee / 0c05b22194f3)
+- only_one_email_by_person index lost its WHERE (is_bot IS NOT TRUE) clause
+- legacy FK names (fk_main_preview, fk_ready_for) and PK name (assignations_pkey)
+  replaced by SQLAlchemy auto-generated ones
+- PK+UC pairs on link tables collapsed into a single constraint named *_uc
+
+This migration brings fresh installs back in line with the legacy schema.
+Every operation is idempotent: it is no-op on databases that already match
+prod and corrective on databases coming from the squash.
+
+Revision ID: 2b8f88aa610f
+Revises: 25d2d8dba46f
+Create Date: 2026-04-28 00:00:00.000000
+
+"""
+
+from alembic import op
+
+revision = "2b8f88aa610f"
+down_revision = "25d2d8dba46f"
+branch_labels = None
+depends_on = None
+
+
+# (table, column) pairs whose squash type "character varying" must become TEXT.
+TEXT_COLUMNS = [
+    ("chat_message", "text"),
+    ("comment", "text"),
+    ("day_off", "description"),
+    ("entity", "description"),
+    ("entity_type", "description"),
+    ("output_file", "comment"),
+    ("output_file", "description"),
+    ("plugin", "description"),
+    ("preview_file", "description"),
+    ("project", "description"),
+    ("task", "description"),
+    ("task_status", "description"),
+    ("task_type", "description"),
+    ("working_file", "comment"),
+    ("working_file", "description"),
+]
+
+# (table, column, default_sql) — set/restore server defaults.
+SERVER_DEFAULTS = [
+    ("entity", "is_shared", "false"),
+    ("person", "contract_type", "'open-ended'::character varying"),
+    ("person", "is_bot", "false"),
+    ("status_automation", "import_last_revision", "false"),
+    ("task", "difficulty", "3"),
+]
+
+# Defaults the squash added that prod does not have.
+DEFAULTS_TO_DROP = [
+    ("task_status", "is_wip"),
+]
+
+# (constraint_name, table, definition) — CHECK constraints lost in squash.
+CHECK_CONSTRAINTS = [
+    (
+        "check_difficulty",
+        "task",
+        "(((difficulty > 0) AND (difficulty < 6)))",
+    ),
+    (
+        "day_off_date_check",
+        "day_off",
+        "((date <= end_date))",
+    ),
+    (
+        "check_duration_positive",
+        "time_spent",
+        "((duration > (0)::double precision))",
+    ),
+]
+
+# Indexes that legacy had but the squash dropped.
+MISSING_INDEXES = [
+    (
+        "ix_entity_entity_type_parent",
+        "entity",
+        "(entity_type_id, parent_id)",
+    ),
+    (
+        "ix_entity_entity_type_project",
+        "entity",
+        "(entity_type_id, project_id)",
+    ),
+    (
+        "ix_task_entity_project",
+        "task",
+        "(entity_id, project_id)",
+    ),
+]
+
+# (old_name, new_name, table) — constraint renames that fresh DBs need.
+# Conditional on old_name existing → no-op on legacy DBs.
+CONSTRAINT_RENAMES = [
+    ("entity_preview_file_id_fkey", "fk_main_preview", "entity"),
+    ("entity_ready_for_fkey", "fk_ready_for", "entity"),
+    ("task_person_link_pkey", "assignations_pkey", "task_person_link"),
+]
+
+# Tables where fresh DBs collapsed PK and UC into a single constraint named
+# *_uc. We need to rename it to *_pkey and re-add a UC alongside.
+PK_UC_SPLIT = [
+    ("department_link", "person_id, department_id"),
+    (
+        "department_metadata_descriptor_link",
+        "metadata_descriptor_id, department_id",
+    ),
+    ("task_type_asset_type_link", "asset_type_id, task_type_id"),
+]
+
+
+def upgrade():
+    # 1. Ensure import_source_enum exists, then convert the column.
+    op.execute("""
+        DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_type WHERE typname = 'import_source_enum'
+            ) THEN
+                CREATE TYPE public.import_source_enum AS ENUM ('csv', 'shotgun');
+            END IF;
+        END
+        $$;
+        """)
+    op.execute("""
+        DO $$
+        BEGIN
+            IF EXISTS (
+                SELECT 1
+                FROM information_schema.columns
+                WHERE table_schema = 'public'
+                  AND table_name = 'data_import_error'
+                  AND column_name = 'source'
+                  AND data_type = 'character varying'
+            ) THEN
+                ALTER TABLE data_import_error
+                    ALTER COLUMN source TYPE public.import_source_enum
+                    USING source::public.import_source_enum;
+            END IF;
+        END
+        $$;
+        """)
+
+    # 2. Restore TEXT column types.
+    for table, column in TEXT_COLUMNS:
+        op.execute(f"ALTER TABLE {table} ALTER COLUMN {column} TYPE text")
+
+    # 3. Restore server defaults.
+    for table, column, default_sql in SERVER_DEFAULTS:
+        op.execute(
+            f"ALTER TABLE {table} ALTER COLUMN {column} "
+            f"SET DEFAULT {default_sql}"
+        )
+
+    # 4. Drop unwanted defaults that the squash added.
+    for table, column in DEFAULTS_TO_DROP:
+        op.execute(f"ALTER TABLE {table} ALTER COLUMN {column} DROP DEFAULT")
+
+    # 5. Add missing CHECK constraints (idempotent via pg_constraint check).
+    for cname, table, expr in CHECK_CONSTRAINTS:
+        op.execute(f"""
+            DO $$
+            BEGIN
+                IF NOT EXISTS (
+                    SELECT 1 FROM pg_constraint WHERE conname = '{cname}'
+                ) THEN
+                    ALTER TABLE {table}
+                        ADD CONSTRAINT {cname} CHECK {expr};
+                END IF;
+            END
+            $$;
+            """)
+
+    # 6. Add missing indexes.
+    for idx_name, table, columns in MISSING_INDEXES:
+        op.execute(
+            f"CREATE INDEX IF NOT EXISTS {idx_name} ON {table} {columns}"
+        )
+
+    # 7. Replace only_one_email_by_person with its partial version.
+    op.execute("""
+        DO $$
+        BEGIN
+            IF EXISTS (
+                SELECT 1 FROM pg_indexes
+                WHERE schemaname = 'public'
+                  AND indexname = 'only_one_email_by_person'
+                  AND indexdef NOT LIKE '%WHERE%'
+            ) THEN
+                DROP INDEX only_one_email_by_person;
+                CREATE UNIQUE INDEX only_one_email_by_person
+                    ON person (email, is_bot)
+                    WHERE (is_bot IS NOT TRUE);
+            END IF;
+        END
+        $$;
+        """)
+
+    # 8. Rename constraints that fresh DBs got with auto-generated names.
+    for old, new, table in CONSTRAINT_RENAMES:
+        op.execute(f"""
+            DO $$
+            BEGIN
+                IF EXISTS (
+                    SELECT 1 FROM pg_constraint WHERE conname = '{old}'
+                ) AND NOT EXISTS (
+                    SELECT 1 FROM pg_constraint WHERE conname = '{new}'
+                ) THEN
+                    ALTER TABLE {table} RENAME CONSTRAINT {old} TO {new};
+                END IF;
+            END
+            $$;
+            """)
+
+    # 9. Split collapsed PK+UC constraints on link tables.
+    # On fresh DBs, the constraint named <table>_uc is actually the PK; in
+    # prod, <table>_pkey is the PK and <table>_uc is a separate UNIQUE.
+    for table, cols in PK_UC_SPLIT:
+        op.execute(f"""
+            DO $$
+            BEGIN
+                IF EXISTS (
+                    SELECT 1 FROM pg_constraint
+                    WHERE conname = '{table}_uc' AND contype = 'p'
+                ) AND NOT EXISTS (
+                    SELECT 1 FROM pg_constraint
+                    WHERE conname = '{table}_pkey'
+                ) THEN
+                    ALTER TABLE {table}
+                        RENAME CONSTRAINT {table}_uc TO {table}_pkey;
+                    ALTER TABLE {table}
+                        ADD CONSTRAINT {table}_uc UNIQUE ({cols});
+                END IF;
+            END
+            $$;
+            """)
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
Summary

  - Repair 0001_squash_pre_1_0_0.py so it runs on a fresh PostgreSQL database (FK ordering, missing imports, invalid sqlalchemy_utils syntax, dangling FK on playlist.created_by,
   over-63-char index name).
  - Add migration 25d2d8dba46f to drop the legacy asset_types orphan table and migration 2b8f88aa610f to reconcile 35 schema divergences between the squash output and what
  legacy databases hold.
  - Add scripts/check_squash_schema.py to detect and optionally repair drifts on any existing database.

  Details

  The squash was auto-generated from a model snapshot and silently dropped DDL details that the legacy migration chain had set: TEXT vs VARCHAR on description/text/comment
  columns, server defaults on entity.is_shared/person.contract_type/person.is_bot/status_automation.import_last_revision/task.difficulty, the import_source_enum ENUM, three perf
   indexes, the partial only_one_email_by_person predicate, three CHECK constraints (check_difficulty, day_off_date_check, check_duration_positive), legacy FK names
  (fk_main_preview, fk_ready_for), the assignations_pkey PK name, and three PK+UC pairs collapsed into a single *_uc constraint.

  It also could not run on a fresh database at all: tables were created in alphabetical order with inline sa.ForeignKeyConstraint references to tables not yet created (e.g.
  asset_instance -> entity), and several types were rendered as ChoiceType(length=N) / EmailType(length=N) / IPAddressType(length=N) / etc., which those sqlalchemy_utils classes
   do not accept and which raise TypeError before any DDL is emitted.

  The fix splits into three pieces. The squash is patched to be runnable: every inline ForeignKeyConstraint is extracted and re-emitted as op.create_foreign_key() after every
  op.create_table(), missing imports are added, custom-type kwargs are replaced with sa.String(length=N) / sa.Text() matching the DDL convention of the legacy initial migration
  b4dd0add5f79, the dangling playlist.created_by FK is removed (the column lives in a0f668430352), and the index name
  ix_production_schedule_version_task_link_production_sch_9cee (60 chars, the value PostgreSQL+SQLAlchemy actually stored under op.f()) replaces the unprocessed 71-char name.
  Migration 25d2d8dba46f then drops the asset_types orphan via DROP TABLE IF EXISTS (no-op on fresh installs). Migration 2b8f88aa610f performs the 35-step reconciliation
  entirely in idempotent SQL: every operation guards itself with IF NOT EXISTS / pg_constraint lookups / pg_type lookups, so it is a complete no-op on legacy databases that
  already match prod and a full corrective pass on databases that ran the squash. After upgrading both endpoints to 2b8f88aa610f, a legacy database and a brand-new fresh
  database produce byte-identical schemas.