### PR TITLE
Fix supervisor rights to edit their playlist

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -118,6 +118,9 @@ class ApiTestCase(unittest.TestCase):
     def log_in_vendor(self):
         self.log_in(self.user_vendor["email"])
 
+    def log_in_supervisor(self):
+        self.log_in(self.user_supervisor["email"])
+
     def log_out(self):
         try:
             self.get("auth/logout")
@@ -650,6 +653,30 @@ class ApiDBTestCase(ApiTestCase):
             password=_CACHED_PASSWORD_HASH,
         ).serialize()
         return self.user_vendor
+
+    def generate_fixture_user_supervisor(self):
+        if hasattr(self, "user_supervisor"):
+            return self.user_supervisor
+        self.user_supervisor = Person.create(
+            first_name="John",
+            last_name="Did6",
+            role="supervisor",
+            email="john.did.supervisor@gmail.com",
+            password=_CACHED_PASSWORD_HASH,
+        ).serialize()
+        return self.user_supervisor
+
+    def generate_fixture_user_supervisor_2(self):
+        if hasattr(self, "user_supervisor_2"):
+            return self.user_supervisor_2
+        self.user_supervisor_2 = Person.create(
+            first_name="John",
+            last_name="Did7",
+            role="supervisor",
+            email="john.did.supervisor2@gmail.com",
+            password=_CACHED_PASSWORD_HASH,
+        ).serialize()
+        return self.user_supervisor_2
 
     def generate_fixture_person(
         self,

--- a/tests/playlists/test_playlist_routes.py
+++ b/tests/playlists/test_playlist_routes.py
@@ -1,5 +1,6 @@
 from tests.base import ApiDBTestCase
 
+from zou.app.models.playlist import Playlist
 from zou.app.services import projects_service
 
 
@@ -79,3 +80,85 @@ class PlaylistRoutesTestCase(ApiDBTestCase):
         )
         shot_ids = [s["entity_id"] for s in playlist.get("shots", [])]
         self.assertIn(str(self.shot.id), shot_ids)
+
+    def _create_playlist(self, name, creator_id=None):
+        return Playlist.create(
+            name=name,
+            project_id=self.project.id,
+            for_entity="shot",
+            is_for_all=False,
+            for_client=False,
+            shots=[],
+            created_by=creator_id,
+        ).serialize()
+
+    def test_add_entity_as_supervisor_creator(self):
+        self.generate_fixture_user_supervisor()
+        playlist = self._create_playlist(
+            "Supervisor Playlist", creator_id=self.user_supervisor["id"]
+        )
+        self.log_in_supervisor()
+        self.post(
+            f"/actions/playlists/{playlist['id']}/add-entity",
+            {"entity_id": str(self.shot.id)},
+            200,
+        )
+
+    def test_add_entity_as_supervisor_non_creator_is_forbidden(self):
+        self.generate_fixture_user_supervisor()
+        self.generate_fixture_user_supervisor_2()
+        playlist = self._create_playlist(
+            "Other Supervisor Playlist",
+            creator_id=self.user_supervisor_2["id"],
+        )
+        self.log_in_supervisor()
+        self.post(
+            f"/actions/playlists/{playlist['id']}/add-entity",
+            {"entity_id": str(self.shot.id)},
+            403,
+        )
+
+    def test_add_entity_as_artist_is_forbidden(self):
+        self.generate_fixture_user_cg_artist()
+        playlist = self._create_playlist(
+            "Artist Playlist", creator_id=self.user_cg_artist["id"]
+        )
+        self.log_in_cg_artist()
+        self.post(
+            f"/actions/playlists/{playlist['id']}/add-entity",
+            {"entity_id": str(self.shot.id)},
+            403,
+        )
+
+    def test_update_playlist_as_supervisor_creator(self):
+        self.generate_fixture_user_supervisor()
+        playlist = self._create_playlist(
+            "Supervisor Playlist", creator_id=self.user_supervisor["id"]
+        )
+        self.log_in_supervisor()
+        self.put(
+            f"/data/playlists/{playlist['id']}",
+            {"name": "Renamed by supervisor"},
+            200,
+        )
+
+    def test_update_playlist_as_supervisor_non_creator_is_forbidden(self):
+        self.generate_fixture_user_supervisor()
+        self.generate_fixture_user_supervisor_2()
+        playlist = self._create_playlist(
+            "Other Playlist", creator_id=self.user_supervisor_2["id"]
+        )
+        self.log_in_supervisor()
+        self.put(
+            f"/data/playlists/{playlist['id']}",
+            {"name": "Should fail"},
+            403,
+        )
+
+    def test_delete_playlist_as_supervisor_creator(self):
+        self.generate_fixture_user_supervisor()
+        playlist = self._create_playlist(
+            "Supervisor Playlist", creator_id=self.user_supervisor["id"]
+        )
+        self.log_in_supervisor()
+        self.delete(f"/data/playlists/{playlist['id']}")

--- a/zou/app/blueprints/crud/playlist.py
+++ b/zou/app/blueprints/crud/playlist.py
@@ -6,7 +6,7 @@ from zou.app.models.notification import Notification
 from zou.app.services import user_service, playlists_service, persons_service
 
 from zou.app.blueprints.crud.base import BaseModelResource, BaseModelsResource
-from zou.app.utils import fields, permissions
+from zou.app.utils import fields
 
 
 class PlaylistsResource(BaseModelsResource):
@@ -372,15 +372,7 @@ class PlaylistResource(BaseModelResource):
             playlists_service.remove_build_job(playlist, job.id)
 
     def check_update_permissions(self, playlist, data):
-        if user_service.has_manager_project_access(playlist["project_id"]):
-            return True
-        elif permissions.has_supervisor_permissions() and (
-            playlist["created_by"]
-            in [None, persons_service.get_current_user()["id"]]
-        ):
-            return True
-        else:
-            raise permissions.PermissionDenied()
+        return user_service.check_playlist_update_access(playlist)
 
     def pre_update(self, instance_dict, data):
         if "shots" in data:
@@ -396,12 +388,4 @@ class PlaylistResource(BaseModelResource):
         return data
 
     def check_delete_permissions(self, playlist):
-        if user_service.has_manager_project_access(playlist["project_id"]):
-            return True
-        elif permissions.has_supervisor_permissions() and (
-            playlist["created_by"]
-            in [None, persons_service.get_current_user()["id"]]
-        ):
-            return True
-        else:
-            raise permissions.PermissionDenied()
+        return user_service.check_playlist_update_access(playlist)

--- a/zou/app/blueprints/playlists/resources.py
+++ b/zou/app/blueprints/playlists/resources.py
@@ -351,7 +351,7 @@ class PlaylistAddEntityResource(Resource, ArgsMixin):
                   type: object
         """
         playlist = playlists_service.get_playlist(playlist_id)
-        user_service.check_manager_project_access(playlist["project_id"])
+        user_service.check_playlist_update_access(playlist)
 
         body = validation.validate_request_body(AddEntityToPlaylistSchema)
         updated_playlist = playlists_service.add_entity_to_playlist(

--- a/zou/app/services/user_service.py
+++ b/zou/app/services/user_service.py
@@ -914,6 +914,23 @@ def check_playlist_access(playlist, supervisor_access=False):
     return True
 
 
+def check_playlist_update_access(playlist):
+    """
+    Allow manager with project access, or supervisor who created the
+    playlist (or playlist with no creator).
+    """
+    is_manager = has_manager_project_access(playlist["project_id"])
+    is_creator_supervisor = (
+        permissions.has_supervisor_permissions()
+        and playlist["created_by"]
+        in [None, persons_service.get_current_user()["id"]]
+    )
+    is_allowed = is_manager or is_creator_supervisor
+    if not is_allowed:
+        raise permissions.PermissionDenied
+    return True
+
+
 def check_day_off_access(day_off):
     """
     Return true if current user is admin or day_off is for itself


### PR DESCRIPTION
**Problem**
- Supervisors could not add entities to a playlist they had created: the `/actions/playlists/<id>/add-entity` endpoint required manager-level project access, while PUT/DELETE on the same playlist already accepted the creator-supervisor case.
- The manager-or-creator-supervisor rule was duplicated across `PlaylistResource.check_update_permissions` and `check_delete_permissions`.

**Solution**
- Move the rule to a single `user_service.check_playlist_update_access` helper and reuse it on add-entity, PUT, and DELETE.
- Improve test coverage for the supervisor role on playlist endpoints.
