### PR TITLE
Improve shared playlist

### DIFF
--- a/zou/app/services/playlist_sharing_service.py
+++ b/zou/app/services/playlist_sharing_service.py
@@ -708,6 +708,7 @@ def get_shared_playlist_context(token):
             for ts in task_statuses
         ],
         "entities": list(entity_names.values()),
+        "team": [],  # required by Kitsu
     }
 
 


### PR DESCRIPTION
**Problem**
- The `/shared/playlists/<token>/context` payload does not include a `team` field, which crashes several front-end widgets that assume it exists.

**Solution**
- Return an empty `team` array in `get_shared_playlist_context` to satisfy the contract expected by the front-end.