### PR TITLE
fix(index): tolerate orphan shots in reset-search-index

### DIFF
--- a/tests/services/test_index_service.py
+++ b/tests/services/test_index_service.py
@@ -1,6 +1,9 @@
+from unittest.mock import patch
+
 from tests.base import ApiDBTestCase
 
 from zou.app.services import assets_service, index_service
+from zou.app.services.exception import SequenceNotFoundException
 
 
 class IndexServiceTestCase(ApiDBTestCase):
@@ -65,3 +68,11 @@ class IndexServiceTestCase(ApiDBTestCase):
         assets_service.remove_asset(asset["id"])
         assets = index_service.search_assets("girafe")
         self.assertEqual(len(assets), 0)
+
+    def test_reset_index_with_orphan_shot(self):
+        with patch.object(
+            index_service.shots_service,
+            "get_sequence",
+            side_effect=SequenceNotFoundException,
+        ):
+            index_service.reset_index()

--- a/zou/app/services/index_service.py
+++ b/zou/app/services/index_service.py
@@ -13,6 +13,10 @@ from zou.app.services import (
     projects_service,
     shots_service,
 )
+from zou.app.services.exception import (
+    EpisodeNotFoundException,
+    SequenceNotFoundException,
+)
 
 
 def get_index(index_name):
@@ -414,18 +418,26 @@ def prepare_shot(shot, index=None):
 
     episode_id = ""
     episode = None
+    sequence = None
     sequence_id = shot_serialized.get("parent_id", "")
     if sequence_id != "":
-        sequence = shots_service.get_sequence(sequence_id)
-        episode_id = sequence.get("parent_id", "")
-        if episode_id not in ["", "None", None]:
-            episode = shots_service.get_episode(episode_id)
+        try:
+            sequence = shots_service.get_sequence(sequence_id)
+        except SequenceNotFoundException:
+            sequence_id = ""
+        else:
+            episode_id = sequence.get("parent_id", "") or ""
+            if episode_id not in ["", "None", None]:
+                try:
+                    episode = shots_service.get_episode(episode_id)
+                except EpisodeNotFoundException:
+                    episode_id = ""
 
     shot_name = shot_serialized["name"]
     name = shot_name + " " + shot_name.replace("_", " ").replace("-", " ")
     if episode is not None:
         shot_name = f'{episode["name"]} {sequence["name"]} {name}'
-    else:
+    elif sequence is not None:
         shot_name = f'{sequence["name"]} {name}'
 
     metadatas = {}


### PR DESCRIPTION
**Problem**
- zou reset-search-index crashes with SequenceNotFoundException on some instances that contain orphan shots (their parent_id points to a sequence that no longer exists). The exception bubbles up to the CLI, the shot index is never rebuilt, and everything after it is skipped.

**Solution**
- prepare_shot (zou/app/services/index_service.py) now catches SequenceNotFoundException and EpisodeNotFoundException. When the parent sequence or episode is missing, the shot is still indexed with its id, name, and project_id — keeping it discoverable in Kitsu so users can spot and fix the DB inconsistency.
- Initialize sequence = None to close the NameError path.
- Add a test (tests/services/test_index_service.py::test_reset_index_with_orphan_shot) that mocks get_sequence to simulate the orphan case and verifies that reset_index() completes without error.