### PR TITLE
[fixes] Sentry-driven fixes and small perf wins

### DIFF
--- a/tests/models/test_person.py
+++ b/tests/models/test_person.py
@@ -119,6 +119,25 @@ class PersonTestCase(ApiDBTestCase):
             set(departments),
         )
 
+    def test_create_person_with_duplicate_email(self):
+        data = {
+            "first_name": "John2",
+            "last_name": "Doe",
+            "email": "ema.doe@gmail.com",
+        }
+        response = self.post("data/persons", data, 400)
+        self.assertIn("Email already in use", response["message"])
+
+    def test_create_bot_can_share_email_with_person(self):
+        data = {
+            "first_name": "Bot",
+            "last_name": "Bot",
+            "email": "ema.doe@gmail.com",
+            "is_bot": True,
+        }
+        person = self.post("data/persons", data)
+        self.assertIsNotNone(person["id"])
+
     def test_update_person(self):
         person = self.get_first("data/persons")
         data = {
@@ -128,6 +147,27 @@ class PersonTestCase(ApiDBTestCase):
         person_again = self.get("data/persons/%s" % person["id"])
         self.assertEqual(data["first_name"], person_again["first_name"])
         self.put_404("data/persons/%s" % fields.gen_uuid(), data)
+
+    def test_update_person_with_duplicate_email(self):
+        persons = sorted(self.get("data/persons"), key=itemgetter("email"))
+        target = persons[0]
+        other = next(p for p in persons if p["id"] != target["id"])
+        response = self.put(
+            "data/persons/%s" % target["id"],
+            {"email": other["email"]},
+            400,
+        )
+        self.assertIn("Email already in use", response["message"])
+
+    def test_update_person_keep_own_email(self):
+        person = self.get_first("data/persons")
+        self.put(
+            "data/persons/%s" % person["id"],
+            {"email": person["email"], "first_name": "Johnny"},
+        )
+        person_again = self.get("data/persons/%s" % person["id"])
+        self.assertEqual(person_again["first_name"], "Johnny")
+        self.assertEqual(person_again["email"], person["email"])
 
     def test_update_person_with_departments(self):
         self.generate_fixture_department()

--- a/tests/playlists/test_playlists.py
+++ b/tests/playlists/test_playlists.py
@@ -1,7 +1,12 @@
 from tests.base import ApiDBTestCase
 
 from zou.app.models.notification import Notification
-from zou.app.services import playlists_service, projects_service
+from zou.app.models.playlist_share_link import PlaylistShareLink
+from zou.app.services import (
+    playlist_sharing_service,
+    playlists_service,
+    projects_service,
+)
 
 
 class PlaylistTestCase(ApiDBTestCase):
@@ -90,6 +95,19 @@ class PlaylistTestCase(ApiDBTestCase):
             playlist_id=self.playlist.id
         ).all()
         self.assertEqual(len(notifications), 0)
+
+    def test_remove_playlist_with_share_links(self):
+        self.generate_fixture_playlist("Playlist 1")
+        playlist_sharing_service.create_share_link(
+            str(self.playlist.id), self.user["id"]
+        )
+        playlists_service.remove_playlist(str(self.playlist.id))
+        playlists = self.get("data/projects/%s/playlists" % self.project_id)
+        self.assertEqual(len(playlists), 0)
+        share_links = PlaylistShareLink.query.filter_by(
+            playlist_id=self.playlist.id
+        ).all()
+        self.assertEqual(len(share_links), 0)
 
     def test_download_playlist(self):
         self.generate_fixture_playlist("Playlist 1", for_client=False)

--- a/tests/services/test_assets_service.py
+++ b/tests/services/test_assets_service.py
@@ -20,6 +20,16 @@ class AssetServiceTestCase(ApiDBTestCase):
         self.assertEqual(len(assets), 1)
         self.assertEqual(assets[0]["name"], "Tree")
 
+    def test_get_assets_with_episode_and_project_filters(self):
+        self.generate_fixture_episode()
+        assets = assets_service.get_assets(
+            criterions={
+                "episode_id": str(self.episode.id),
+                "project_id": str(self.project.id),
+            }
+        )
+        self.assertIsInstance(assets, list)
+
     def test_get_full_assets(self):
         assets = assets_service.get_full_assets()
         self.assertEqual(len(assets), 1)

--- a/tests/services/test_index_service.py
+++ b/tests/services/test_index_service.py
@@ -3,7 +3,10 @@ from unittest.mock import patch
 from tests.base import ApiDBTestCase
 
 from zou.app.services import assets_service, index_service
-from zou.app.services.exception import SequenceNotFoundException
+from zou.app.services.exception import (
+    EpisodeNotFoundException,
+    SequenceNotFoundException,
+)
 
 
 class IndexServiceTestCase(ApiDBTestCase):
@@ -69,10 +72,27 @@ class IndexServiceTestCase(ApiDBTestCase):
         assets = index_service.search_assets("girafe")
         self.assertEqual(len(assets), 0)
 
-    def test_reset_index_with_orphan_shot(self):
+    def test_prepare_shot_with_missing_sequence(self):
         with patch.object(
             index_service.shots_service,
             "get_sequence",
             side_effect=SequenceNotFoundException,
         ):
-            index_service.reset_index()
+            data = index_service.prepare_shot(self.shot, index="dummy")
+        self.assertEqual(data["sequence_id"], "")
+        self.assertEqual(data["episode_id"], "")
+
+    def test_prepare_shot_with_missing_episode(self):
+        fake_sequence = {"name": "S01", "parent_id": "missing-episode-id"}
+        with patch.object(
+            index_service.shots_service,
+            "get_sequence",
+            return_value=fake_sequence,
+        ), patch.object(
+            index_service.shots_service,
+            "get_episode",
+            side_effect=EpisodeNotFoundException,
+        ):
+            data = index_service.prepare_shot(self.shot, index="dummy")
+        self.assertEqual(data["sequence_id"], str(self.shot.parent_id))
+        self.assertEqual(data["episode_id"], "")

--- a/tests/shared/test_playlist_sharing.py
+++ b/tests/shared/test_playlist_sharing.py
@@ -565,3 +565,98 @@ class PlaylistSharingTestCase(ApiDBTestCase):
                 400,
             )
         self.assertEqual(send_mock.call_count, 0)
+
+    # --- Shared preview file downloads ---
+
+    def _attach_zip_preview_to_playlist(self):
+        """Create a non-mp4 preview file with real bytes on disk and wire
+        it into the playlist's shots so that the shared preview-file
+        guard recognises it."""
+        import tempfile
+
+        from zou.app.models.playlist import Playlist as PlaylistModel
+        from zou.app.models.preview_file import PreviewFile
+        from zou.app.stores import file_store
+
+        preview_file = PreviewFile.create(
+            name="assets.zip",
+            revision=1,
+            extension="zip",
+            task_id=self.task.id,
+            person_id=self.person.id,
+        )
+        payload = b"PK\x03\x04fake-zip-payload"
+        with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as tmp:
+            tmp.write(payload)
+            tmp_path = tmp.name
+        file_store.add_file("previews", str(preview_file.id), tmp_path)
+        self.addCleanup(
+            file_store.remove_file, "previews", str(preview_file.id)
+        )
+
+        PlaylistModel.get(self.playlist["id"]).update(
+            {
+                "shots": [
+                    {
+                        "id": str(self.asset.id),
+                        "preview_file_id": str(preview_file.id),
+                        "preview_file_task_id": str(self.task.id),
+                    }
+                ]
+            }
+        )
+        return preview_file, payload
+
+    def test_shared_preview_file_download(self):
+        """Any non-mp4 preview file in a shared playlist must be
+        downloadable through the share link. Before this endpoint
+        existed, Kitsu built the download URL on the movies/originals
+        streaming path with the file's actual extension, which only
+        matched ``.mp4`` and 404'd for every other extension."""
+        preview_file, payload = self._attach_zip_preview_to_playlist()
+        link = self.post(
+            f"/data/playlists/{self.playlist['id']}/share",
+            {},
+            201,
+        )
+        self.log_out()
+        response = self.app.get(
+            f"/shared/playlists/{link['token']}"
+            f"/preview-files/{preview_file.id}/download"
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data, payload)
+
+    def test_shared_preview_file_download_invalid_token(self):
+        preview_file, _ = self._attach_zip_preview_to_playlist()
+        self.log_out()
+        response = self.app.get(
+            f"/shared/playlists/invalid-token"
+            f"/preview-files/{preview_file.id}/download"
+        )
+        self.assertEqual(response.status_code, 404)
+
+    def test_shared_preview_file_download_not_in_playlist(self):
+        """A preview file that is not exposed by the shared playlist
+        cannot be fetched through its share link, even when the token
+        is valid."""
+        from zou.app.models.preview_file import PreviewFile
+
+        foreign = PreviewFile.create(
+            name="foreign.zip",
+            revision=1,
+            extension="zip",
+            task_id=self.task.id,
+            person_id=self.person.id,
+        )
+        link = self.post(
+            f"/data/playlists/{self.playlist['id']}/share",
+            {},
+            201,
+        )
+        self.log_out()
+        response = self.app.get(
+            f"/shared/playlists/{link['token']}"
+            f"/preview-files/{foreign.id}/download"
+        )
+        self.assertEqual(response.status_code, 403)

--- a/zou/app/blueprints/crud/person.py
+++ b/zou/app/blueprints/crud/person.py
@@ -300,6 +300,14 @@ class PersonsResource(BaseModelsResource):
             except auth.EmailNotValidException as e:
                 raise WrongParameterException(str(e))
 
+            if not data.get("is_bot", False):
+                existing = Person.query.filter(
+                    Person.email == data["email"],
+                    Person.is_bot.isnot(True),
+                ).first()
+                if existing is not None:
+                    raise WrongParameterException("Email already in use.")
+
         return data
 
     def update_data(self, data):
@@ -585,6 +593,14 @@ class PersonResource(BaseModelResource, ArgsMixin):
                 data["email"] = auth.validate_email(data["email"])
             except auth.EmailNotValidException as e:
                 raise WrongParameterException(str(e))
+
+            existing = Person.query.filter(
+                Person.email == data["email"],
+                Person.id != instance_id,
+                Person.is_bot.isnot(True),
+            ).first()
+            if existing is not None:
+                raise WrongParameterException("Email already in use.")
 
         return data
 

--- a/zou/app/blueprints/shared/__init__.py
+++ b/zou/app/blueprints/shared/__init__.py
@@ -16,6 +16,7 @@ from zou.app.blueprints.shared.resources import (
     SharedPlaylistPreviewFileThumbnailResource,
     SharedPlaylistPreviewFileOriginalResource,
     SharedPlaylistPreviewFileTileResource,
+    SharedPlaylistPreviewFileDownloadResource,
     SharedPlaylistContextResource,
 )
 
@@ -77,6 +78,11 @@ routes = [
         "/shared/playlists/<token>/movies/tiles/"
         "preview-files/<preview_file_id>.png",
         SharedPlaylistPreviewFileTileResource,
+    ),
+    (
+        "/shared/playlists/<token>/preview-files/"
+        "<preview_file_id>/download",
+        SharedPlaylistPreviewFileDownloadResource,
     ),
     (
         "/shared/playlists/<token>/context",

--- a/zou/app/blueprints/shared/resources.py
+++ b/zou/app/blueprints/shared/resources.py
@@ -5,6 +5,7 @@ from flask_restful import Resource
 from zou.app.blueprints.previews.resources import (
     send_movie_file,
     send_picture_file,
+    send_standard_file,
 )
 from zou.app.blueprints.shared.decorators import (
     require_valid_playlist_share_link,
@@ -24,7 +25,8 @@ from zou.app.services import (
     preview_files_service,
     tasks_service,
 )
-from zou.app.utils import validation
+from zou.app.services.exception import PreviewFileNotFoundException
+from zou.app.utils import permissions, validation
 
 
 class SharedPlaylistResource(Resource):
@@ -824,6 +826,71 @@ class SharedPlaylistPreviewFileTileResource(Resource):
             return send_picture_file("tiles", preview_file_id)
         except FileNotFound:
             return {"error": "Tile not found"}, 404
+
+
+class SharedPlaylistPreviewFileDownloadResource(Resource):
+    @require_valid_playlist_share_link()
+    def get(self, token, preview_file_id):
+        """
+        Download shared preview file
+        ---
+        description: Download a preview file (any extension) attached to
+          the shared playlist as an attachment. Mirrors the authenticated
+          ``/pictures/originals/preview-files/<id>/download`` route but
+          gated by the playlist share token instead of JWT.
+        tags:
+          - Playlists
+        parameters:
+          - in: path
+            name: token
+            required: true
+            schema:
+              type: string
+            description: Share link token
+          - in: path
+            name: preview_file_id
+            required: true
+            schema:
+              type: string
+              format: uuid
+            description: Preview file unique identifier
+        responses:
+          200:
+            description: Preview file downloaded as attachment
+            content:
+              application/octet-stream:
+                schema:
+                  type: string
+                  format: binary
+          403:
+            description: Preview file is not part of this shared playlist
+          404:
+            description: Preview file not on disk
+        """
+        if not _is_preview_file_in_shared_playlist(token, preview_file_id):
+            raise permissions.PermissionDenied
+        preview_file = files_service.get_preview_file(preview_file_id)
+        extension = preview_file["extension"]
+        try:
+            if extension == "png":
+                return send_picture_file(
+                    "original", preview_file_id, as_attachment=True
+                )
+            elif extension == "pdf":
+                return send_standard_file(
+                    preview_file_id,
+                    extension,
+                    "application/pdf",
+                    as_attachment=True,
+                )
+            elif extension == "mp4":
+                return send_movie_file(preview_file_id, as_attachment=True)
+            else:
+                return send_standard_file(
+                    preview_file_id, extension, as_attachment=True
+                )
+        except FileNotFound:
+            raise PreviewFileNotFoundException
 
 
 class SharedPlaylistContextResource(Resource):

--- a/zou/app/services/concepts_service.py
+++ b/zou/app/services/concepts_service.py
@@ -1,4 +1,5 @@
 from sqlalchemy.exc import StatementError
+from sqlalchemy.orm import selectinload
 
 from zou.app.utils import (
     cache,
@@ -138,7 +139,7 @@ def get_concepts(criterions=None):
     if is_only_assignation:
         del criterions["assigned_to"]
 
-    query = Entity.query
+    query = Entity.query.options(selectinload(Entity.entity_concept_links))
     query = query_utils.apply_criterions_to_db_query(Entity, query, criterions)
     query = (
         query.join(Project, Project.id == Entity.project_id)

--- a/zou/app/services/entities_service.py
+++ b/zou/app/services/entities_service.py
@@ -1,3 +1,5 @@
+from sqlalchemy.exc import IntegrityError
+
 from zou.app.services import (
     assets_service,
     base_service,
@@ -116,7 +118,10 @@ def update_entity_preview(entity_id, preview_file_id):
     if preview_file is None:
         raise PreviewFileNotFoundException
 
-    entity.update({"preview_file_id": preview_file.id})
+    try:
+        entity.update({"preview_file_id": preview_file.id})
+    except IntegrityError:
+        raise PreviewFileNotFoundException
     clear_entity_cache(entity_id)
     events.emit(
         "preview-file:set-main",

--- a/zou/app/services/index_service.py
+++ b/zou/app/services/index_service.py
@@ -426,7 +426,7 @@ def prepare_shot(shot, index=None):
         except SequenceNotFoundException:
             sequence_id = ""
         else:
-            episode_id = sequence.get("parent_id", "") or ""
+            episode_id = sequence.get("parent_id", "")
             if episode_id not in ["", "None", None]:
                 try:
                     episode = shots_service.get_episode(episode_id)

--- a/zou/app/services/playlists_service.py
+++ b/zou/app/services/playlists_service.py
@@ -22,6 +22,7 @@ from zou.app.stores import config_store, file_store
 from zou.app.models.build_job import BuildJob
 from zou.app.models.notification import Notification
 from zou.app.models.playlist import Playlist
+from zou.app.models.playlist_share_link import PlaylistShareLink
 from zou.app.models.preview_file import PreviewFile
 from zou.app.models.task import Task
 from zou.app.models.task_type import TaskType
@@ -920,6 +921,11 @@ def remove_playlist(playlist_id):
     jobs = BuildJob.query.filter_by(playlist_id=playlist_id).all()
     for job in jobs:
         _remove_build_job_impl(playlist_dict, job.serialize())
+    share_links = PlaylistShareLink.query.filter_by(
+        playlist_id=playlist_id
+    ).all()
+    for share_link in share_links:
+        share_link.delete()
     playlist.delete()
     events.emit(
         "playlist:delete",

--- a/zou/app/services/tasks_service.py
+++ b/zou/app/services/tasks_service.py
@@ -318,7 +318,7 @@ def get_shot_tasks_for_sequence(sequence_id, relations=False):
     """
     Get all shot tasks for given sequence.
     """
-    query = _get_entity_task_query()
+    query = _get_entity_task_query(relations=relations)
     query = query.filter(Entity.parent_id == sequence_id)
     return _convert_rows_to_detailed_tasks(query.all(), relations)
 
@@ -327,7 +327,7 @@ def get_shot_tasks_for_episode(episode_id, relations=False):
     """
     Get all shots tasks for given episode.
     """
-    query = _get_entity_task_query()
+    query = _get_entity_task_query(relations=relations)
     Sequence = aliased(Entity, name="sequence")
     query = query.join(Sequence, Entity.parent_id == Sequence.id).filter(
         Sequence.parent_id == episode_id
@@ -340,7 +340,7 @@ def get_asset_tasks_for_episode(episode_id, relations=False):
     Get all assets tasks for given episode.
     """
     query = (
-        _get_entity_task_query()
+        _get_entity_task_query(relations=relations)
         .filter(assets_service.build_asset_type_filter())
         .filter(Entity.source_id == episode_id)
     )
@@ -352,15 +352,17 @@ def get_task_dicts_for_entity(entity_id, relations=True):
     Return all tasks related to given entity. Add extra information like
     project name, task type name, etc.
     """
-    query = _get_entity_task_query()
+    query = _get_entity_task_query(relations=relations)
     query = query.filter(Task.entity_id == entity_id)
     return _convert_rows_to_detailed_tasks(query.all(), relations)
 
 
-def _get_entity_task_query():
+def _get_entity_task_query(relations=False):
+    query = Task.query
+    if relations:
+        query = query.options(selectinload(Task.assignees))
     return (
-        Task.query.options(selectinload(Task.assignees))
-        .order_by(Task.name)
+        query.order_by(Task.name)
         .join(Project, Task.project_id == Project.id)
         .join(TaskType, Task.task_type_id == TaskType.id)
         .join(TaskStatus, TaskStatus.id == Task.task_status_id)

--- a/zou/app/utils/monitoring.py
+++ b/zou/app/utils/monitoring.py
@@ -1,9 +1,17 @@
+from babel.core import UnknownLocaleError
 from flask_jwt_extended.exceptions import NoAuthorizationError
 from jwt import ExpiredSignatureError
 from werkzeug.exceptions import Forbidden, NotFound
 from flask_fs.errors import FileNotFound
 
 from zou.app import config
+from zou.app.services.exception import (
+    ModelWithRelationsDeletionException,
+    TwoFactorAuthenticationRequiredException,
+    WrongIdFormatException,
+    WrongParameterException,
+    WrongTaskTypeForEntityException,
+)
 from zou.app.utils import permissions
 from zou import __version__ as zou_version
 
@@ -40,6 +48,12 @@ def init_monitoring(app):
                 Forbidden,
                 ExpiredSignatureError,
                 FileNotFound,
+                ModelWithRelationsDeletionException,
+                TwoFactorAuthenticationRequiredException,
+                UnknownLocaleError,
+                WrongIdFormatException,
+                WrongParameterException,
+                WrongTaskTypeForEntityException,
             ],
         )
 

--- a/zou/app/utils/query.py
+++ b/zou/app/utils/query.py
@@ -31,7 +31,7 @@ def apply_criterions_to_db_query(model, db_query, criterions):
     many_join_filter = []
     in_filter = []
     name_filter = []
-    filters = {}
+    eq_filter = []
 
     column_names = inspect(model).all_orm_descriptors.keys()
     for key, value in criterions.items():
@@ -63,10 +63,10 @@ def apply_criterions_to_db_query(model, db_query, criterions):
                     )
                 )
             else:
-                filters[key] = cast_value(value, field_key)
+                eq_filter.append(field_key == cast_value(value, field_key))
 
-    if filters:
-        db_query = db_query.filter_by(**filters)
+    for filter_clause in eq_filter:
+        db_query = db_query.filter(filter_clause)
 
     for value in name_filter:
         db_query = db_query.filter(model.name.ilike(value))

--- a/zou/utils/movie.py
+++ b/zou/utils/movie.py
@@ -205,6 +205,8 @@ def get_movie_duration(movie_path=None, video_track=None):
 def normalize_encoding(
     movie_path, task, file_target_path, fps, b, width, height, keyframes=1
 ):
+    # ffmpeg's color_primaries/trc/colorspace output flags only tag the
+    # metadata; they shift perceived colors on untagged sources.
     logger.info(task)
     stream = ffmpeg.input(movie_path)
     stream = ffmpeg.output(
@@ -217,9 +219,6 @@ def normalize_encoding(
         b=b,
         preset="slow",
         vcodec="libx264",
-        color_primaries=1,
-        color_trc=1,
-        colorspace=1,
         movflags="+faststart",
         x264opts=f"keyint={keyframes}:scenecut=0",
         s="%sx%s" % (width, height),
@@ -382,9 +381,6 @@ def add_empty_soundtrack(file_path, try_count=1):
                 format="mp4",
                 preset="slow",
                 vcodec="libx264",
-                color_primaries=1,
-                color_trc=1,
-                colorspace=1,
                 movflags="+faststart",
                 s="%sx%s" % (width, height),
             )


### PR DESCRIPTION
## Problems

- N+1 queries on concepts and tasks lists (Sentry)
- Duplicate-email Person create/update bypassed CRUD checks and crashed
- `prepare_shot` crashed on orphan shots (deleted parent sequence/episode)
- 4xx exceptions (WrongParameterException etc.) flooded Sentry
- `apply_criterions_to_db_query` broke `filter_by` on joined Entity queries
- Normalized movies falsely tagged BT.709, shifting colors on untagged sources (Fix #1071)
- Concurrent preview-file deletion during `prepare_and_store_movie` raised FK violation
- Deleting a playlist with active share links raised FK violation
- Shared playlists had no download endpoint for non-mp4 source previews

## Solutions

- Eager-load `entity_concept_links`; skip `Task.assignees` selectinload when `relations=False`
- Reject duplicate emails up-front in Persons CRUD
- Tolerate missing sequence/episode in `prepare_shot`
- Add expected 4xx exceptions to Sentry `ignore_errors`
- Use explicit model-bound filters instead of `filter_by` in `apply_criterions_to_db_query`
- Drop `color_primaries/trc/colorspace` ffmpeg output flags
- Convert `IntegrityError` to `PreviewFileNotFoundException` in `update_entity_preview`
- Delete share links before removing playlist
- Add download route for shared playlist source previews