### PR TITLE
[fixes] Dependency refresh, lock hardening, entity tasks endpoint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,7 @@ HTTP → Flask routing → Resource method → @jwt_required()
 - Services are **module-level functions**, not classes
 - Models inherit `db.Model, BaseMixin, SerializerMixin`
 - UUIDs everywhere for primary keys (`UUIDType(binary=False)`)
+- **String formatting: f-strings only** for any new or edited code. Do not introduce `"... %s" % x` or `.format(...)`. Pre-existing `%`-formatted lines in a file you're editing can stay — don't scope-creep — but every new line you add should use f-strings.
 
 ### Naming
 - Model class: `PascalCase` (e.g., `TaskStatus`)

--- a/scripts/check_squash_schema.py
+++ b/scripts/check_squash_schema.py
@@ -116,13 +116,11 @@ def index_missing(name: str) -> Callable:
 
 def email_index_not_partial(conn) -> bool:
     with conn.cursor() as cur:
-        cur.execute(
-            """
+        cur.execute("""
             SELECT indexdef FROM pg_indexes
             WHERE schemaname = 'public'
               AND indexname = 'only_one_email_by_person'
-            """
-        )
+            """)
         row = cur.fetchone()
         return row is not None and "WHERE" not in row[0]
 
@@ -168,12 +166,10 @@ def pk_uc_collapsed(table: str) -> Callable:
 
 def asset_types_present(conn) -> bool:
     with conn.cursor() as cur:
-        cur.execute(
-            """
+        cur.execute("""
             SELECT 1 FROM information_schema.tables
             WHERE table_schema = 'public' AND table_name = 'asset_types'
-            """
-        )
+            """)
         return cur.fetchone() is not None
 
 

--- a/scripts/check_squash_schema.py
+++ b/scripts/check_squash_schema.py
@@ -116,11 +116,13 @@ def index_missing(name: str) -> Callable:
 
 def email_index_not_partial(conn) -> bool:
     with conn.cursor() as cur:
-        cur.execute("""
+        cur.execute(
+            """
             SELECT indexdef FROM pg_indexes
             WHERE schemaname = 'public'
               AND indexname = 'only_one_email_by_person'
-            """)
+            """
+        )
         row = cur.fetchone()
         return row is not None and "WHERE" not in row[0]
 
@@ -166,10 +168,12 @@ def pk_uc_collapsed(table: str) -> Callable:
 
 def asset_types_present(conn) -> bool:
     with conn.cursor() as cur:
-        cur.execute("""
+        cur.execute(
+            """
             SELECT 1 FROM information_schema.tables
             WHERE table_schema = 'public' AND table_name = 'asset_types'
-            """)
+            """
+        )
         return cur.fetchone() is not None
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,7 +58,7 @@ install_requires =
     ldap3==2.9.1
     matterhook-nlz==0.3
     meilisearch==0.41.0
-    numpy==2.4.4
+    numpy==2.2.6
     opencv-python==4.13.0.92
     OpenTimelineIO==0.18.1
     OpenTimelineIO-Plugins==0.18.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ install_requires =
     bcrypt==4.3.0
     flask_bcrypt==1.0.1
     flask_caching==2.4.0
-    flask-cors==5.0.1
+    flask-cors==6.0.2
     flask_fixtures==0.3.8
     flask_mail==0.10.0
     flask_principal==0.4.0
@@ -81,7 +81,7 @@ install_requires =
     spdx-license-list==3.28.0
     sqlalchemy_utils==0.42.1
     sqlalchemy==2.0.49
-    tabulate==0.9.0
+    tabulate==0.10.0
     tomlkit==0.15.0
     ua-parser==1.0.2
     werkzeug==3.1.8

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ install_requires =
     ffmpeg-python==0.2.0
     fido2==2.2.0
     flasgger==0.9.7.1
-    bcrypt==4.3.0
+    bcrypt==5.0.0
     flask_bcrypt==1.0.1
     flask_caching==2.4.0
     flask-cors==6.0.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,15 +28,15 @@ zip_safe = False
 packages = find:
 install_requires =
     babel==2.18.0
-    click==8.3.1
-    discord.py==2.6.4
+    click==8.3.3
+    discord.py==2.7.1
     email-validator==2.3.0
     ffmpeg-python==0.2.0
-    fido2==2.1.1
+    fido2==2.2.0
     flasgger==0.9.7.1
     bcrypt==4.3.0
     flask_bcrypt==1.0.1
-    flask_caching==2.3.1
+    flask_caching==2.4.0
     flask-cors==5.0.1
     flask_fixtures==0.3.8
     flask_mail==0.10.0
@@ -44,47 +44,47 @@ install_requires =
     flask_restful==0.3.10
     flask_sqlalchemy==3.1.1
     flask-fs2[swift, s3]==0.7.33
-    flask-jwt-extended==4.7.1
+    flask-jwt-extended==4.7.3
     flask-migrate==4.1.0
-    flask-socketio==5.6.0
-    flask==3.1.2
-    gazu==1.1.3
+    flask-socketio==5.6.1
+    flask==3.1.3
+    gazu==1.1.6
     gevent-websocket==0.10.1
-    gevent==25.9.1
-    gunicorn==25.0.0
+    gevent==26.4.0
+    gunicorn==26.0.0
     isoweek==1.3.3
     itsdangerous==2.2.0
     Jinja2==3.1.6
     ldap3==2.9.1
     matterhook-nlz==0.3
-    meilisearch==0.40.0
-    numpy==2.2.6
-    opencv-python==4.13.0.90
+    meilisearch==0.41.0
+    numpy==2.4.4
+    opencv-python==4.13.0.92
     OpenTimelineIO==0.18.1
     OpenTimelineIO-Plugins==0.18.1
-    orjson==3.11.6
-    pydantic==2.12.5
-    pillow==12.1.0
+    orjson==3.11.9
+    pydantic==2.13.4
+    pillow==12.2.0
     psutil==7.2.2
-    psycopg[binary]==3.3.2
+    psycopg[binary]==3.3.4
     pyotp==2.9.0
     pysaml2==7.5.4
     python-nomad==2.1.0
     python-slugify==8.0.4
-    python-socketio==5.16.0
-    pytz==2025.2
+    python-socketio==5.16.1
+    pytz==2026.2
     redis==5.2.1
-    requests==2.32.5
-    rq==2.6.1
+    requests==2.34.0
+    rq==2.8.0
     semver==3.0.4
     slackclient==2.9.4
-    spdx-license-list==3.27.0
+    spdx-license-list==3.28.0
     sqlalchemy_utils==0.42.1
-    sqlalchemy==2.0.46
+    sqlalchemy==2.0.49
     tabulate==0.9.0
-    tomlkit==0.14.0
-    ua-parser==1.0.1
-    werkzeug==3.1.5
+    tomlkit==0.15.0
+    ua-parser==1.0.2
+    werkzeug==3.1.8
 
 [options.package_data]
 * = app/*.json,app/file_trees/*.json,migrations/*,migrations/versions/*.py,app/utils/plugin_alembic_template/*
@@ -98,10 +98,10 @@ dev =
     wheel
 
 test =
-    fakeredis==2.33.0
+    fakeredis==2.35.1
     mixer==7.2.2
-    pytest-cov==7.0.0
-    pytest==9.0.2
+    pytest-cov==7.1.0
+    pytest==9.0.3
 
 monitoring =
     prometheus-flask-exporter==0.23.2
@@ -110,7 +110,7 @@ monitoring =
 
 lint =
     autoflake==2.3.1
-    black==26.1.0
+    black==26.3.1
     pre-commit==4.5.1
 
 [options.entry_points]

--- a/setup.cfg
+++ b/setup.cfg
@@ -73,7 +73,7 @@ install_requires =
     python-slugify==8.0.4
     python-socketio==5.16.1
     pytz==2026.2
-    redis==5.2.1
+    redis==7.4.0
     requests==2.34.0
     rq==2.8.0
     semver==3.0.4

--- a/tests/events/test_event_routes.py
+++ b/tests/events/test_event_routes.py
@@ -88,9 +88,7 @@ class LoginLogsRoutesTestCase(ApiDBTestCase):
                 created_at=now - timedelta(seconds=3 - i),
             )
         before = (now - timedelta(seconds=1)).isoformat()
-        logs = self.get(
-            "/data/events/login-logs/last?before=%s" % before
-        )
+        logs = self.get("/data/events/login-logs/last?before=%s" % before)
         self.assertEqual(len(logs), 2)
 
     def test_get_last_login_logs_after(self):
@@ -103,9 +101,7 @@ class LoginLogsRoutesTestCase(ApiDBTestCase):
                 created_at=now - timedelta(seconds=3 - i),
             )
         after = (now - timedelta(seconds=2)).isoformat()
-        logs = self.get(
-            "/data/events/login-logs/last?after=%s" % after
-        )
+        logs = self.get("/data/events/login-logs/last?after=%s" % after)
         self.assertEqual(len(logs), 1)
 
     def test_get_last_login_logs_cursor(self):

--- a/tests/models/test_project_template.py
+++ b/tests/models/test_project_template.py
@@ -13,9 +13,7 @@ class ProjectTemplateTestCase(ApiDBTestCase):
         ProjectTemplate.create(
             name="TV Show", description="Episodic show setup"
         )
-        ProjectTemplate.create(
-            name="VFX Bid", description="Bidding template"
-        )
+        ProjectTemplate.create(name="VFX Bid", description="Bidding template")
 
     def test_get_project_templates(self):
         templates = self.get("data/project-templates")
@@ -23,9 +21,7 @@ class ProjectTemplateTestCase(ApiDBTestCase):
 
     def test_get_project_template(self):
         template = self.get_first("data/project-templates")
-        again = self.get(
-            "data/project-templates/%s" % template["id"]
-        )
+        again = self.get("data/project-templates/%s" % template["id"])
         self.assertEqual(template["id"], again["id"])
         self.get_404("data/project-templates/%s" % fields.gen_uuid())
 
@@ -60,9 +56,7 @@ class ProjectTemplateTestCase(ApiDBTestCase):
             "data/project-templates/%s" % template["id"],
             {"description": "Updated description"},
         )
-        again = self.get(
-            "data/project-templates/%s" % template["id"]
-        )
+        again = self.get("data/project-templates/%s" % template["id"])
         self.assertEqual(again["description"], "Updated description")
 
     def test_delete_project_template(self):

--- a/tests/playlists/test_playlists.py
+++ b/tests/playlists/test_playlists.py
@@ -116,7 +116,7 @@ class PlaylistTestCase(ApiDBTestCase):
         set so a stray value cannot land in storage; this test pins the
         contract for each accepted value.
         """
-        for for_entity in ("shot", "asset", "sequence", "edit"):
+        for for_entity in ("shot", "asset", "sequence", "edit", "episode"):
             created = self.post(
                 "data/playlists/",
                 {

--- a/tests/playlists/test_playlists.py
+++ b/tests/playlists/test_playlists.py
@@ -112,9 +112,9 @@ class PlaylistTestCase(ApiDBTestCase):
     def test_create_playlist_for_each_entity_type(self):
         """`for_entity` round-trips for every supported entity type.
 
-        The column is `String(10)` with no whitelist; this test pins the
-        contract so widening the set (e.g. adding `edit`) stays a one-line
-        change in consumers.
+        The column is permissive `String(10)` but the CRUD whitelists the
+        set so a stray value cannot land in storage; this test pins the
+        contract for each accepted value.
         """
         for for_entity in ("shot", "asset", "sequence", "edit"):
             created = self.post(
@@ -129,6 +129,25 @@ class PlaylistTestCase(ApiDBTestCase):
             self.assertEqual(created["for_entity"], for_entity)
             fetched = self.get("data/playlists/%s" % created["id"])
             self.assertEqual(fetched["for_entity"], for_entity)
+
+    def test_create_playlist_rejects_unknown_for_entity(self):
+        self.post(
+            "data/playlists/",
+            {
+                "name": "Bad playlist",
+                "project_id": self.project_id,
+                "for_entity": "banana",
+            },
+            400,
+        )
+
+    def test_update_playlist_rejects_unknown_for_entity(self):
+        self.generate_fixture_playlist("Playlist 1")
+        self.put(
+            "data/playlists/%s" % self.playlist.id,
+            {"for_entity": "banana"},
+            400,
+        )
 
     def test_download_playlist(self):
         self.generate_fixture_playlist("Playlist 1", for_client=False)

--- a/tests/playlists/test_playlists.py
+++ b/tests/playlists/test_playlists.py
@@ -109,6 +109,27 @@ class PlaylistTestCase(ApiDBTestCase):
         ).all()
         self.assertEqual(len(share_links), 0)
 
+    def test_create_playlist_for_each_entity_type(self):
+        """`for_entity` round-trips for every supported entity type.
+
+        The column is `String(10)` with no whitelist; this test pins the
+        contract so widening the set (e.g. adding `edit`) stays a one-line
+        change in consumers.
+        """
+        for for_entity in ("shot", "asset", "sequence", "edit"):
+            created = self.post(
+                "data/playlists/",
+                {
+                    "name": "Playlist %s" % for_entity,
+                    "project_id": self.project_id,
+                    "for_entity": for_entity,
+                },
+                201,
+            )
+            self.assertEqual(created["for_entity"], for_entity)
+            fetched = self.get("data/playlists/%s" % created["id"])
+            self.assertEqual(fetched["for_entity"], for_entity)
+
     def test_download_playlist(self):
         self.generate_fixture_playlist("Playlist 1", for_client=False)
         result_file_path = self.get_file_path("playlist.zip")

--- a/tests/projects/test_route_project_templates.py
+++ b/tests/projects/test_route_project_templates.py
@@ -53,9 +53,7 @@ class ProjectTemplatesRoutesTestCase(ApiDBTestCase):
         self.assertEqual(self.get("/data/project-templates"), [])
 
     def test_create_template_duplicate_name_returns_400(self):
-        self.post(
-            "/data/project-templates", {"name": "Series Setup"}
-        )
+        self.post("/data/project-templates", {"name": "Series Setup"})
         self.post(
             "/data/project-templates",
             {"name": "Series Setup"},
@@ -142,11 +140,7 @@ class ProjectTemplatesRoutesTestCase(ApiDBTestCase):
         template = self._create_template()
         self.post(
             "/data/project-templates/%s/status-automations" % template["id"],
-            {
-                "status_automation_id": str(
-                    self.status_automation_to_status.id
-                )
-            },
+            {"status_automation_id": str(self.status_automation_to_status.id)},
         )
         items = self.get(
             "/data/project-templates/%s/status-automations" % template["id"]
@@ -175,8 +169,7 @@ class ProjectTemplatesRoutesTestCase(ApiDBTestCase):
             }
         ]
         result = self.put(
-            "/data/project-templates/%s/metadata-descriptors"
-            % template["id"],
+            "/data/project-templates/%s/metadata-descriptors" % template["id"],
             {"metadata_descriptors": descriptors},
         )
         self.assertEqual(len(result["metadata_descriptors"]), 1)
@@ -226,9 +219,7 @@ class ProjectTemplatesRoutesTestCase(ApiDBTestCase):
         )
         self.assertEqual(result["id"], target["id"])
         # Verify task type link materialized on the project
-        links = self.get(
-            "/data/projects/%s" % target["id"]
-        )
+        links = self.get("/data/projects/%s" % target["id"])
         self.assertIn(
             str(self.task_type_modeling.id), links.get("task_types", [])
         )
@@ -288,8 +279,7 @@ class ProjectTemplatesRoutesTestCase(ApiDBTestCase):
             {"name": "Template With Metadata"},
         )
         self.put(
-            "/data/project-templates/%s/metadata-descriptors"
-            % template["id"],
+            "/data/project-templates/%s/metadata-descriptors" % template["id"],
             {
                 "metadata_descriptors": [
                     {

--- a/tests/services/test_auth_service.py
+++ b/tests/services/test_auth_service.py
@@ -45,11 +45,12 @@ class AuthTestCase(ApiDBTestCase):
         self.assertTrue(bcrypt.check_password_hash(pass_hash, password))
 
     def test_encrypt_password_long(self):
-        """Ensure passwords longer than 72 bytes don't raise ValueError."""
+        """Ensure passwords longer than 72 bytes don't raise ValueError
+        and can still be verified end-to-end."""
         long_password = "password " * 10  # 100 chars
         self.assertGreater(len(long_password), 72)
         pass_hash = auth.encrypt_password(long_password)
-        self.assertTrue(bcrypt.check_password_hash(pass_hash, long_password))
+        self.assertTrue(auth.check_password(pass_hash, long_password))
 
     def test_validate_email(self):
         self.assertEqual(

--- a/tests/services/test_breakdown_service.py
+++ b/tests/services/test_breakdown_service.py
@@ -178,7 +178,9 @@ class BreakdownServiceTestCase(ApiDBTestCase):
 
         events.unregister_all()
         handler = _Handler(captured)
-        events.register("shot:casting-update", "casting_update_handler", handler)
+        events.register(
+            "shot:casting-update", "casting_update_handler", handler
+        )
 
         shot_id = str(self.shot.id)
         asset_id = str(self.asset.id)

--- a/tests/services/test_comments_service.py
+++ b/tests/services/test_comments_service.py
@@ -95,12 +95,12 @@ class CommentsServiceTestCase(ApiDBTestCase):
         retake_status = self.generate_fixture_task_status_retake().serialize()
         task = self.task.serialize()
         comment = self.comment
-        (task, status_changed) = comments_service._manage_status_change(
+        task, status_changed = comments_service._manage_status_change(
             task_status, task, comment
         )
         self.assertFalse(status_changed)
         self.assertEqual(task["retake_count"], 0)
-        (task, status_changed) = comments_service._manage_status_change(
+        task, status_changed = comments_service._manage_status_change(
             retake_status, task, comment
         )
         self.assertTrue(status_changed)
@@ -113,14 +113,14 @@ class CommentsServiceTestCase(ApiDBTestCase):
             "old comment",
             created_at="1999-12-23 10:00:00",
         )
-        (task, status_changed) = comments_service._manage_status_change(
+        task, status_changed = comments_service._manage_status_change(
             retake_status, task, old_comment
         )
 
         self.assertFalse(status_changed)
         self.assertEqual(task["retake_count"], 1)
 
-        (task, status_changed) = comments_service._manage_status_change(
+        task, status_changed = comments_service._manage_status_change(
             self.wfa_status, task, comment
         )
         self.assertTrue(task["end_date"] is not None)

--- a/tests/services/test_comments_service.py
+++ b/tests/services/test_comments_service.py
@@ -156,9 +156,7 @@ class CommentsServiceTestCase(ApiDBTestCase):
         self.assertEqual(len(self.fired_events), 1)
         payload = self.fired_events[0]
         self.assertEqual(payload["task_id"], str(self.task.id))
-        self.assertEqual(
-            payload["new_task_status_id"], self.wfa_status["id"]
-        )
+        self.assertEqual(payload["new_task_status_id"], self.wfa_status["id"])
         self.assertEqual(payload["comment_id"], comment["id"])
 
     def test_manage_subscriptions(self):

--- a/tests/services/test_emails_service.py
+++ b/tests/services/test_emails_service.py
@@ -32,7 +32,7 @@ class EmailsServiceTestCase(ApiDBTestCase):
         self.assertIn("Saludos cordiales", signature_es)
 
     def test_get_task_descriptors(self):
-        (author, task_name, task_url) = emails_service.get_task_descriptors(
+        author, task_name, task_url = emails_service.get_task_descriptors(
             self.person.id, self.task.serialize()
         )
         self.assertEqual(
@@ -44,7 +44,7 @@ class EmailsServiceTestCase(ApiDBTestCase):
             % (self.project.id, self.task.id),
         )
         self.generate_fixture_shot_task()
-        (author, task_name, task_url) = emails_service.get_task_descriptors(
+        author, task_name, task_url = emails_service.get_task_descriptors(
             self.person.id, self.shot_task.serialize()
         )
         self.assertEqual(

--- a/tests/services/test_preview_files_service.py
+++ b/tests/services/test_preview_files_service.py
@@ -223,6 +223,48 @@ class PlaylistTestCase(ApiDBTestCase):
             persisted_preview_file["annotations"],
         )
 
+    def test_update_annotations_aborts_when_lock_unavailable(self):
+        """When the Redis lock can't be acquired (Redis down or wait
+        timeout exceeded), the service must surface a 503 instead of
+        silently racing through the read-modify-write without
+        serialization."""
+        from contextlib import contextmanager
+
+        from zou.app.services.exception import AnnotationLockTimeoutException
+
+        preview_file = self.generate_fixture_preview_file().serialize()
+        preview_files_service.update_preview_file_annotations(
+            self.user_id,
+            self.project_id,
+            preview_file["id"],
+            additions=self.annotations_1,
+        )
+
+        @contextmanager
+        def unavailable_lock(*args, **kwargs):
+            yield False
+
+        with patch(
+            "zou.app.services.preview_files_service." "with_preview_file_lock",
+            side_effect=unavailable_lock,
+        ):
+            self.assertRaises(
+                AnnotationLockTimeoutException,
+                preview_files_service.update_preview_file_annotations,
+                self.user_id,
+                self.project_id,
+                preview_file["id"],
+                additions=self.annotations_2,
+            )
+
+        persisted_preview_file = files_service.get_preview_file(
+            preview_file["id"]
+        )
+        self.assertEqual(
+            self.annotations_1,
+            persisted_preview_file["annotations"],
+        )
+
     def test_get_preview_file_dimensions(self):
         self.assertFalse(_is_valid_resolution(""))
         self.assertFalse(_is_valid_resolution(None))
@@ -290,9 +332,7 @@ class PlaylistTestCase(ApiDBTestCase):
         mock_save_variants,
         mock_gen_tile,
     ):
-        preview_file = self.generate_fixture_preview_file(
-            status="processing"
-        )
+        preview_file = self.generate_fixture_preview_file(status="processing")
         preview_file_id = str(preview_file.id)
 
         # Create a small temp file to act as the uploaded movie
@@ -364,9 +404,7 @@ class PlaylistTestCase(ApiDBTestCase):
         # The data field preserves the original metadata
         self.assertIsNotNone(persisted["data"])
         self.assertEqual(persisted["data"]["original_width"], original_width)
-        self.assertEqual(
-            persisted["data"]["original_height"], original_height
-        )
+        self.assertEqual(persisted["data"]["original_height"], original_height)
         self.assertEqual(
             persisted["data"]["original_duration"], original_duration
         )

--- a/tests/services/test_project_templates_service.py
+++ b/tests/services/test_project_templates_service.py
@@ -210,18 +210,14 @@ class ProjectTemplateServiceTestCase(ApiDBTestCase):
                 "departments": [str(self.department.id)],
             },
         ]
-        updated = (
-            project_templates_service.set_template_metadata_descriptors(
-                template["id"], descriptors
-            )
+        updated = project_templates_service.set_template_metadata_descriptors(
+            template["id"], descriptors
         )
         snapshot = updated["metadata_descriptors"]
         self.assertEqual(len(snapshot), 2)
         self.assertEqual(snapshot[0]["field_name"], "difficulty")
         self.assertEqual(snapshot[1]["field_name"], "approval_status")
-        self.assertEqual(
-            snapshot[1]["departments"], [str(self.department.id)]
-        )
+        self.assertEqual(snapshot[1]["departments"], [str(self.department.id)])
 
     # ----- Snapshot from project ------------------------------------------
 
@@ -277,10 +273,10 @@ class ProjectTemplateServiceTestCase(ApiDBTestCase):
             project_template_id=template["id"]
         )
         self.assertEqual(len(task_type_links), 2)
-        priorities = {link.task_type_id: link.priority for link in task_type_links}
-        self.assertEqual(
-            priorities[self.task_type_modeling.id], 3
-        )
+        priorities = {
+            link.task_type_id: link.priority for link in task_type_links
+        }
+        self.assertEqual(priorities[self.task_type_modeling.id], 3)
 
         task_status_links = ProjectTemplateTaskStatusLink.get_all_by(
             project_template_id=template["id"]
@@ -288,11 +284,9 @@ class ProjectTemplateServiceTestCase(ApiDBTestCase):
         self.assertEqual(len(task_status_links), 1)
         self.assertEqual(task_status_links[0].priority, 1)
 
-        asset_type_links = (
-            ProjectTemplateAssetTypeLink.query.filter_by(
-                project_template_id=template["id"]
-            ).all()
-        )
+        asset_type_links = ProjectTemplateAssetTypeLink.query.filter_by(
+            project_template_id=template["id"]
+        ).all()
         self.assertEqual(len(asset_type_links), 1)
 
         # Metadata descriptor snapshot

--- a/tests/services/test_status_automation_service.py
+++ b/tests/services/test_status_automation_service.py
@@ -148,9 +148,7 @@ class StatusAutomationServiceTestCase(ApiDBTestCase):
 
         # Verify the target task status was changed
         task_seq_review = Task.get(task_seq_review.id)
-        self.assertEqual(
-            str(task_seq_review.task_status_id), wip_status["id"]
-        )
+        self.assertEqual(str(task_seq_review.task_status_id), wip_status["id"])
 
     def test_status_automation_episode(self):
         """Test that a status automation fires for episode tasks."""
@@ -222,9 +220,7 @@ class StatusAutomationServiceTestCase(ApiDBTestCase):
 
         # Verify the target task status was changed
         task_ep_final = Task.get(task_ep_final.id)
-        self.assertEqual(
-            str(task_ep_final.task_status_id), wip_status["id"]
-        )
+        self.assertEqual(str(task_ep_final.task_status_id), wip_status["id"])
 
     def test_status_automation_entity_type_mismatch(self):
         """Test that an asset automation does NOT fire on a sequence task."""
@@ -281,4 +277,3 @@ class StatusAutomationServiceTestCase(ApiDBTestCase):
         self.assertEqual(
             str(self.task_modeling.task_status_id), initial_status
         )
-

--- a/tests/shared/test_playlist_sharing.py
+++ b/tests/shared/test_playlist_sharing.py
@@ -660,3 +660,67 @@ class PlaylistSharingTestCase(ApiDBTestCase):
             f"/preview-files/{foreign.id}/download"
         )
         self.assertEqual(response.status_code, 403)
+
+    def test_shared_preview_file_download_sibling_position(self):
+        """A revision can carry multiple PreviewFile rows (different
+        positions). The shared share link exposes all positions of the
+        positioned revision, not only the one stored on the shot."""
+        import tempfile
+
+        from zou.app.models.playlist import Playlist as PlaylistModel
+        from zou.app.models.preview_file import PreviewFile
+        from zou.app.stores import file_store
+
+        positioned, payload = self._attach_zip_preview_to_playlist()
+        sibling = PreviewFile.create(
+            name="sibling.zip",
+            revision=positioned.revision,
+            position=positioned.position + 1,
+            extension="zip",
+            task_id=positioned.task_id,
+            person_id=self.person.id,
+        )
+        sibling_payload = b"PK\x03\x04sibling-position"
+        with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as tmp:
+            tmp.write(sibling_payload)
+            tmp_path = tmp.name
+        file_store.add_file("previews", str(sibling.id), tmp_path)
+        self.addCleanup(file_store.remove_file, "previews", str(sibling.id))
+
+        link = self.post(
+            f"/data/playlists/{self.playlist['id']}/share",
+            {},
+            201,
+        )
+        self.log_out()
+        response = self.app.get(
+            f"/shared/playlists/{link['token']}"
+            f"/preview-files/{sibling.id}/download"
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data, sibling_payload)
+
+    def test_shared_preview_file_download_other_revision_rejected(self):
+        """A different revision of the same task is *not* exposed,
+        only the positioned revision and its sibling positions."""
+        from zou.app.models.preview_file import PreviewFile
+
+        positioned, _ = self._attach_zip_preview_to_playlist()
+        other_revision = PreviewFile.create(
+            name="other.zip",
+            revision=positioned.revision + 1,
+            extension="zip",
+            task_id=positioned.task_id,
+            person_id=self.person.id,
+        )
+        link = self.post(
+            f"/data/playlists/{self.playlist['id']}/share",
+            {},
+            201,
+        )
+        self.log_out()
+        response = self.app.get(
+            f"/shared/playlists/{link['token']}"
+            f"/preview-files/{other_revision.id}/download"
+        )
+        self.assertEqual(response.status_code, 403)

--- a/tests/shots/test_episodes.py
+++ b/tests/shots/test_episodes.py
@@ -142,16 +142,10 @@ class EpisodeTestCase(ApiDBTestCase):
 
     def test_get_episodes_vendor_filters(self):
         self._setup_vendor()
-        episodes = self.get(
-            "data/episodes?project_id=%s" % self.project_id
-        )
+        episodes = self.get("data/episodes?project_id=%s" % self.project_id)
         self.assertEqual(len(episodes), 0)
-        tasks_service.assign_task(
-            self.shot_task.id, self.user_vendor["id"]
-        )
-        episodes = self.get(
-            "data/episodes?project_id=%s" % self.project_id
-        )
+        tasks_service.assign_task(self.shot_task.id, self.user_vendor["id"])
+        episodes = self.get("data/episodes?project_id=%s" % self.project_id)
         self.assertEqual(len(episodes), 1)
 
     def test_get_episode_vendor_no_task(self):

--- a/tests/shots/test_sequences.py
+++ b/tests/shots/test_sequences.py
@@ -114,19 +114,13 @@ class SequenceTestCase(ApiDBTestCase):
 
     def test_get_sequences_vendor_unassigned(self):
         self._setup_vendor()
-        sequences = self.get(
-            "data/sequences?project_id=%s" % self.project_id
-        )
+        sequences = self.get("data/sequences?project_id=%s" % self.project_id)
         self.assertEqual(len(sequences), 0)
 
     def test_get_sequences_vendor_assigned(self):
         self._setup_vendor()
-        tasks_service.assign_task(
-            self.shot_task.id, self.user_vendor["id"]
-        )
-        sequences = self.get(
-            "data/sequences?project_id=%s" % self.project_id
-        )
+        tasks_service.assign_task(self.shot_task.id, self.user_vendor["id"])
+        sequences = self.get("data/sequences?project_id=%s" % self.project_id)
         self.assertEqual(len(sequences), 1)
 
     def test_get_sequence_vendor_no_task(self):

--- a/tests/tasks/test_route_tasks.py
+++ b/tests/tasks/test_route_tasks.py
@@ -162,6 +162,53 @@ class TaskRoutesTestCase(ApiDBTestCase):
         self.assertEqual(tasks[0]["task_type_id"], self.task_type_id)
         self.assertEqual(tasks[0]["entity_id"], self.asset_id)
 
+    def test_create_entity_tasks_defaults_to_project_task_types_on_shot(
+        self,
+    ):
+        # Link two shot task types + one asset task type to the project.
+        # An empty body should default to the project's shot task types
+        # only (filtered by for_entity).
+        for task_type_id in (
+            self.task_type_animation.id,
+            self.task_type_layout.id,
+            self.task_type.id,
+        ):
+            ProjectTaskTypeLink.create(
+                project_id=self.project.id, task_type_id=task_type_id
+            )
+
+        path = f"/data/entities/{self.shot_id}/tasks"
+        tasks = self.post(path, {}, code=201)
+
+        created_type_ids = {task["task_type_id"] for task in tasks}
+        self.assertEqual(
+            created_type_ids,
+            {
+                str(self.task_type_animation.id),
+                str(self.task_type_layout.id),
+            },
+        )
+
+    def test_create_entity_tasks_defaults_to_asset_workflow_on_asset(self):
+        # Link two asset task types to the project but only one is in
+        # the asset type's workflow. An empty body should create just
+        # that one.
+        for task_type_id in (
+            self.task_type.id,
+            self.task_type_modeling.id,
+        ):
+            ProjectTaskTypeLink.create(
+                project_id=self.project.id, task_type_id=task_type_id
+            )
+        self.asset_type.task_types = [self.task_type]
+        self.asset_type.save()
+
+        path = f"/data/entities/{self.asset_id}/tasks"
+        tasks = self.post(path, {}, code=201)
+
+        self.assertEqual(len(tasks), 1)
+        self.assertEqual(tasks[0]["task_type_id"], self.task_type_id)
+
     def test_task_assign(self):
         self.generate_fixture_task()
         person_id = str(self.person.id)

--- a/tests/tasks/test_route_tasks.py
+++ b/tests/tasks/test_route_tasks.py
@@ -90,6 +90,78 @@ class TaskRoutesTestCase(ApiDBTestCase):
         self.assertEqual(task["task_type_id"], self.task_type_id)
         self.assertEqual(task["entity_id"], self.shot_id)
 
+    def test_create_entity_tasks_for_shot(self):
+        ProjectTaskTypeLink.create(
+            project_id=self.project.id,
+            task_type_id=self.task_type_animation.id,
+        )
+        path = "/data/entities/%s/tasks" % self.shot_id
+        tasks = self.post(
+            path,
+            {"task_type_ids": [str(self.task_type_animation.id)]},
+            code=201,
+        )
+        self.assertEqual(len(tasks), 1)
+        self.assertEqual(
+            tasks[0]["task_type_id"], str(self.task_type_animation.id)
+        )
+        self.assertEqual(tasks[0]["entity_id"], self.shot_id)
+
+    def test_create_entity_tasks_rejects_task_type_not_in_project(self):
+        # task_type_animation is for_entity=Shot, never linked to project
+        path = "/data/entities/%s/tasks" % self.shot_id
+        self.post(
+            path,
+            {"task_type_ids": [str(self.task_type_animation.id)]},
+            code=400,
+        )
+
+    def test_create_entity_tasks_rejects_wrong_for_entity(self):
+        # task_type has for_entity="Asset", shot has wrong kind
+        ProjectTaskTypeLink.create(
+            project_id=self.project.id,
+            task_type_id=self.task_type.id,
+        )
+        path = "/data/entities/%s/tasks" % self.shot_id
+        self.post(
+            path,
+            {"task_type_ids": [self.task_type_id]},
+            code=400,
+        )
+
+    def test_create_entity_tasks_rejects_task_type_not_in_asset_workflow(
+        self,
+    ):
+        # task_type is in project, but asset_type workflow is empty
+        ProjectTaskTypeLink.create(
+            project_id=self.project.id,
+            task_type_id=self.task_type.id,
+        )
+        path = "/data/entities/%s/tasks" % self.asset_id
+        self.post(
+            path,
+            {"task_type_ids": [self.task_type_id]},
+            code=400,
+        )
+
+    def test_create_entity_tasks_for_asset(self):
+        ProjectTaskTypeLink.create(
+            project_id=self.project.id,
+            task_type_id=self.task_type.id,
+        )
+        self.asset_type.task_types = [self.task_type]
+        self.asset_type.save()
+
+        path = "/data/entities/%s/tasks" % self.asset_id
+        tasks = self.post(
+            path,
+            {"task_type_ids": [self.task_type_id]},
+            code=201,
+        )
+        self.assertEqual(len(tasks), 1)
+        self.assertEqual(tasks[0]["task_type_id"], self.task_type_id)
+        self.assertEqual(tasks[0]["entity_id"], self.asset_id)
+
     def test_task_assign(self):
         self.generate_fixture_task()
         person_id = str(self.person.id)

--- a/tests/tasks/test_route_tasks.py
+++ b/tests/tasks/test_route_tasks.py
@@ -95,7 +95,7 @@ class TaskRoutesTestCase(ApiDBTestCase):
             project_id=self.project.id,
             task_type_id=self.task_type_animation.id,
         )
-        path = "/data/entities/%s/tasks" % self.shot_id
+        path = f"/data/entities/{self.shot_id}/tasks"
         tasks = self.post(
             path,
             {"task_type_ids": [str(self.task_type_animation.id)]},
@@ -109,7 +109,7 @@ class TaskRoutesTestCase(ApiDBTestCase):
 
     def test_create_entity_tasks_rejects_task_type_not_in_project(self):
         # task_type_animation is for_entity=Shot, never linked to project
-        path = "/data/entities/%s/tasks" % self.shot_id
+        path = f"/data/entities/{self.shot_id}/tasks"
         self.post(
             path,
             {"task_type_ids": [str(self.task_type_animation.id)]},
@@ -122,7 +122,7 @@ class TaskRoutesTestCase(ApiDBTestCase):
             project_id=self.project.id,
             task_type_id=self.task_type.id,
         )
-        path = "/data/entities/%s/tasks" % self.shot_id
+        path = f"/data/entities/{self.shot_id}/tasks"
         self.post(
             path,
             {"task_type_ids": [self.task_type_id]},
@@ -137,7 +137,7 @@ class TaskRoutesTestCase(ApiDBTestCase):
             project_id=self.project.id,
             task_type_id=self.task_type.id,
         )
-        path = "/data/entities/%s/tasks" % self.asset_id
+        path = f"/data/entities/{self.asset_id}/tasks"
         self.post(
             path,
             {"task_type_ids": [self.task_type_id]},
@@ -152,7 +152,7 @@ class TaskRoutesTestCase(ApiDBTestCase):
         self.asset_type.task_types = [self.task_type]
         self.asset_type.save()
 
-        path = "/data/entities/%s/tasks" % self.asset_id
+        path = f"/data/entities/{self.asset_id}/tasks"
         tasks = self.post(
             path,
             {"task_type_ids": [self.task_type_id]},

--- a/tests/utils/test_thumbnail.py
+++ b/tests/utils/test_thumbnail.py
@@ -39,13 +39,13 @@ class ThumbnailTestCase(unittest.TestCase):
 
         thumbnail.turn_into_thumbnail(full_path)
         im = Image.open(full_path)
-        (width, height) = im.size
+        width, height = im.size
         self.assertEqual(width, 180)
         self.assertEqual(height, 101)
 
         thumbnail.turn_into_thumbnail(full_path, thumbnail.RECTANGLE_SIZE)
         im = Image.open(full_path)
-        (width, height) = im.size
+        width, height = im.size
         self.assertEqual(width, 150)
         self.assertEqual(height, 100)
 
@@ -71,7 +71,7 @@ class ThumbnailTestCase(unittest.TestCase):
 
         thumbnail.turn_into_thumbnail(full_path, thumbnail.RECTANGLE_SIZE)
         im = Image.open(full_path)
-        (width, height) = im.size
+        width, height = im.size
         self.assertEqual(width, 150)
         self.assertEqual(height, 100)
 
@@ -142,6 +142,6 @@ class ThumbnailTestCase(unittest.TestCase):
 
         thumbnail_path = thumbnail.turn_hdr_into_thumbnail(full_path)
         im = Image.open(thumbnail_path)
-        (width, height) = im.size
+        width, height = im.size
         self.assertEqual(width, 300)
         self.assertEqual(height, 200)

--- a/zou/app/blueprints/assets/__init__.py
+++ b/zou/app/blueprints/assets/__init__.py
@@ -28,7 +28,6 @@ from zou.app.blueprints.assets.resources import (
     ProjectEpisodeAssetsSharedUsedResource,
 )
 
-
 routes = [
     ("/data/asset-types", AssetTypesResource),
     ("/data/asset-types/<asset_type_id>", AssetTypeResource),

--- a/zou/app/blueprints/breakdown/__init__.py
+++ b/zou/app/blueprints/breakdown/__init__.py
@@ -16,7 +16,6 @@ from zou.app.blueprints.breakdown.resources import (
     SequenceAllCastingResource,
 )
 
-
 routes = [
     (
         "/data/projects/<project_id>/entities/<entity_id>/casting",

--- a/zou/app/blueprints/chats/__init__.py
+++ b/zou/app/blueprints/chats/__init__.py
@@ -8,7 +8,6 @@ from zou.app.blueprints.chats.resources import (
     ChatMessageResource,
 )
 
-
 routes = [
     ("/data/entities/<entity_id>/chat", ChatResource),
     ("/data/entities/<entity_id>/chat/messages", ChatMessagesResource),

--- a/zou/app/blueprints/comments/__init__.py
+++ b/zou/app/blueprints/comments/__init__.py
@@ -15,7 +15,6 @@ from zou.app.blueprints.comments.resources import (
     DeleteReplyCommentResource,
 )
 
-
 routes = [
     ("/data/tasks/<task_id>/comments/<comment_id>/ack", AckCommentResource),
     (

--- a/zou/app/blueprints/crud/comments.py
+++ b/zou/app/blueprints/crud/comments.py
@@ -442,10 +442,9 @@ class CommentResource(BaseModelResource):
                 "checklist" in data.keys()
                 and data["checklist"] != instance["checklist"]
             )
-            change_for_client = (
-                "for_client" in data.keys()
-                and data["for_client"] != instance.get("for_client", False)
-            )
+            change_for_client = "for_client" in data.keys() and data[
+                "for_client"
+            ] != instance.get("for_client", False)
             if change_for_client:
                 # Only managers (handled above) may toggle for_client.
                 raise permissions.PermissionDenied

--- a/zou/app/blueprints/crud/playlist.py
+++ b/zou/app/blueprints/crud/playlist.py
@@ -4,9 +4,20 @@ from zou.app.models.playlist import Playlist
 from zou.app.models.build_job import BuildJob
 from zou.app.models.notification import Notification
 from zou.app.services import user_service, playlists_service, persons_service
+from zou.app.services.exception import WrongParameterException
 
 from zou.app.blueprints.crud.base import BaseModelResource, BaseModelsResource
 from zou.app.utils import fields
+
+
+def _check_for_entity(data):
+    """Reject unknown for_entity values at the CRUD boundary."""
+    if "for_entity" in data and data["for_entity"] is not None:
+        if data["for_entity"] not in playlists_service.VALID_FOR_ENTITY_VALUES:
+            raise WrongParameterException(
+                "for_entity must be one of %s"
+                % ", ".join(playlists_service.VALID_FOR_ENTITY_VALUES)
+            )
 
 
 class PlaylistsResource(BaseModelsResource):
@@ -168,6 +179,7 @@ class PlaylistsResource(BaseModelsResource):
 
     def update_data(self, data):
         data = super().update_data(data)
+        _check_for_entity(data)
         if "episode_id" in data and data["episode_id"] in ["all", "main"]:
             data["episode_id"] = None
         if "task_type_id" in data and not fields.is_valid_id(
@@ -375,6 +387,7 @@ class PlaylistResource(BaseModelResource):
         return user_service.check_playlist_update_access(playlist)
 
     def pre_update(self, instance_dict, data):
+        _check_for_entity(data)
         if "shots" in data:
             shots = [
                 {

--- a/zou/app/blueprints/crud/project.py
+++ b/zou/app/blueprints/crud/project.py
@@ -220,9 +220,7 @@ class ProjectsResource(BaseModelsResource):
         self._template_id_to_apply = data.pop("project_template_id", None)
         if self._template_id_to_apply:
             self._template_overrides = {
-                key: value
-                for key, value in data.items()
-                if value is not None
+                key: value for key, value in data.items() if value is not None
             }
 
         if "project_status_id" not in data:

--- a/zou/app/blueprints/entities/__init__.py
+++ b/zou/app/blueprints/entities/__init__.py
@@ -4,6 +4,7 @@ from zou.app.utils.api import configure_api_from_blueprint
 from zou.app.blueprints.entities.resources import (
     EntityPreviewFilesResource,
     EntityNewsResource,
+    EntityTaskCreationResource,
     EntityTimeSpentsResource,
     EntitiesLinkedWithTasksResource,
 )
@@ -11,6 +12,7 @@ from zou.app.blueprints.entities.resources import (
 routes = [
     ("/data/entities/<entity_id>/news", EntityNewsResource),
     ("/data/entities/<entity_id>/preview-files", EntityPreviewFilesResource),
+    ("/data/entities/<entity_id>/tasks", EntityTaskCreationResource),
     ("/data/entities/<entity_id>/time-spents", EntityTimeSpentsResource),
     (
         "/data/entities/<entity_id>/entities-linked/with-tasks",

--- a/zou/app/blueprints/entities/__init__.py
+++ b/zou/app/blueprints/entities/__init__.py
@@ -8,7 +8,6 @@ from zou.app.blueprints.entities.resources import (
     EntitiesLinkedWithTasksResource,
 )
 
-
 routes = [
     ("/data/entities/<entity_id>/news", EntityNewsResource),
     ("/data/entities/<entity_id>/preview-files", EntityPreviewFilesResource),

--- a/zou/app/blueprints/entities/resources.py
+++ b/zou/app/blueprints/entities/resources.py
@@ -305,8 +305,11 @@ class EntityTaskCreationResource(Resource):
         ---
         description: Create one task per provided task type for the given
           entity. Each task type is validated against the entity's project
-          and (for assets) the entity's asset type workflow. Existing tasks
-          for the same (entity, task_type) pair are skipped.
+          and (for assets) the entity's asset type workflow. When
+          task_type_ids is omitted or empty, default to every task type
+          valid for the entity (project workflow, asset-type workflow if
+          asset, and matching for_entity). Existing tasks for the same
+          (entity, task_type) pair are skipped.
         tags:
           - Entities
         parameters:
@@ -319,7 +322,7 @@ class EntityTaskCreationResource(Resource):
             description: Unique identifier of the entity
             example: a24a6ea4-ce75-4665-a070-57453082c25
         requestBody:
-          required: true
+          required: false
           content:
             application/json:
               schema:
@@ -330,7 +333,9 @@ class EntityTaskCreationResource(Resource):
                     items:
                       type: string
                       format: uuid
-                    description: List of task type IDs to create on the entity
+                    description: Optional list of task type IDs to create.
+                      Omit or pass an empty list to default to every task
+                      type valid for the entity.
                 example:
                   task_type_ids:
                     - b24a6ea4-ce75-4665-a070-57453082c25

--- a/zou/app/blueprints/entities/resources.py
+++ b/zou/app/blueprints/entities/resources.py
@@ -2,13 +2,16 @@ from flask_restful import Resource
 
 from flask_jwt_extended import jwt_required
 
+from zou.app.blueprints.entities.schemas import CreateEntityTasksSchema
 from zou.app.services import (
     entities_service,
     news_service,
     preview_files_service,
+    tasks_service,
     time_spents_service,
     user_service,
 )
+from zou.app.utils import permissions, validation
 
 
 class EntityNewsResource(Resource):
@@ -292,3 +295,65 @@ class EntitiesLinkedWithTasksResource(Resource):
         user_service.check_project_access(entity["project_id"])
         user_service.check_entity_access(entity_id)
         return entities_service.get_linked_entities_with_tasks(entity_id)
+
+
+class EntityTaskCreationResource(Resource):
+    @jwt_required()
+    def post(self, entity_id):
+        """
+        Create tasks for an entity
+        ---
+        description: Create one task per provided task type for the given
+          entity. Each task type is validated against the entity's project
+          and (for assets) the entity's asset type workflow. Existing tasks
+          for the same (entity, task_type) pair are skipped.
+        tags:
+          - Entities
+        parameters:
+          - in: path
+            name: entity_id
+            required: true
+            schema:
+              type: string
+              format: uuid
+            description: Unique identifier of the entity
+            example: a24a6ea4-ce75-4665-a070-57453082c25
+        requestBody:
+          required: true
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  task_type_ids:
+                    type: array
+                    items:
+                      type: string
+                      format: uuid
+                    description: List of task type IDs to create on the entity
+                example:
+                  task_type_ids:
+                    - b24a6ea4-ce75-4665-a070-57453082c25
+        responses:
+          201:
+            description: Created tasks
+          400:
+            description: A task type is not enabled in the project, not in
+              the asset type workflow, or does not target this kind of
+              entity
+        """
+        entity = entities_service.get_entity(entity_id)
+        user_service.check_project_access(entity["project_id"])
+        user_service.check_entity_access(entity_id)
+        if (
+            permissions.has_vendor_permissions()
+            or permissions.has_client_permissions()
+        ):
+            raise permissions.PermissionDenied
+        body = validation.validate_request_body(CreateEntityTasksSchema)
+        task_types = [
+            tasks_service.get_task_type(task_type_id)
+            for task_type_id in body.task_type_ids
+        ]
+        tasks = tasks_service.create_tasks_for_entity(entity, task_types)
+        return tasks, 201

--- a/zou/app/blueprints/entities/schemas.py
+++ b/zou/app/blueprints/entities/schemas.py
@@ -1,0 +1,9 @@
+from typing import List
+
+from pydantic import Field
+
+from zou.app.utils.validation import BaseSchema
+
+
+class CreateEntityTasksSchema(BaseSchema):
+    task_type_ids: List[str] = Field(..., min_length=1)

--- a/zou/app/blueprints/entities/schemas.py
+++ b/zou/app/blueprints/entities/schemas.py
@@ -6,4 +6,4 @@ from zou.app.utils.validation import BaseSchema
 
 
 class CreateEntityTasksSchema(BaseSchema):
-    task_type_ids: List[str] = Field(..., min_length=1)
+    task_type_ids: List[str] = Field(default_factory=list)

--- a/zou/app/blueprints/export/csv/projects.py
+++ b/zou/app/blueprints/export/csv/projects.py
@@ -43,5 +43,5 @@ class ProjectsCsvExport(BaseCsvExport):
         return query
 
     def build_row(self, project_data):
-        (project, project_status_name) = project_data
+        project, project_status_name = project_data
         return [project.name, project_status_name]

--- a/zou/app/blueprints/export/csv/task_types.py
+++ b/zou/app/blueprints/export/csv/task_types.py
@@ -43,5 +43,5 @@ class TaskTypesCsvExport(BaseCsvExport):
         return query
 
     def build_row(self, task_type_row):
-        (task_type, department_name) = task_type_row
+        task_type, department_name = task_type_row
         return [department_name, task_type.name]

--- a/zou/app/blueprints/news/__init__.py
+++ b/zou/app/blueprints/news/__init__.py
@@ -7,7 +7,6 @@ from zou.app.blueprints.news.resources import (
     ProjectSingleNewsResource,
 )
 
-
 routes = [
     ("/data/projects/news", NewsResource),
     ("/data/projects/<project_id>/news", ProjectNewsResource),

--- a/zou/app/blueprints/persons/resources.py
+++ b/zou/app/blueprints/persons/resources.py
@@ -862,7 +862,7 @@ class PersonQuotaMixin(ArgsMixin):
     @jwt_required()
     def get(self, person_id, *args, **kwargs):
         user_service.check_person_is_not_bot(person_id)
-        (project_id, task_type_id, feedback, weighted) = (
+        project_id, task_type_id, feedback, weighted = (
             self.get_quota_arguments()
         )
         self.check_permissions(person_id, project_id)

--- a/zou/app/blueprints/playlists/__init__.py
+++ b/zou/app/blueprints/playlists/__init__.py
@@ -21,7 +21,6 @@ from zou.app.blueprints.playlists.resources import (
     TempPlaylistResource,
 )
 
-
 routes = [
     ("/data/projects/<project_id>/playlists", ProjectPlaylistsResource),
     ("/data/projects/<project_id>/playlists/all", ProjectAllPlaylistsResource),

--- a/zou/app/blueprints/playlists/resources.py
+++ b/zou/app/blueprints/playlists/resources.py
@@ -36,6 +36,7 @@ from zou.app.services.exception import (
     BuildJobNotFoundException,
     PlaylistShareLinkNotFoundException,
 )
+from rq.exceptions import DuplicateJobError
 from zou.app.stores import file_store, queue_store
 from zou.app.utils import fs, permissions, validation
 from zou.utils.movie import EncodingParameters
@@ -528,19 +529,30 @@ class BuildPlaylistMovieResource(Resource, ArgsMixin):
                 }, 400
 
             current_user = persons_service.get_current_user()
-            queue_store.job_queue.enqueue(
-                playlists_service.build_playlist_job,
-                args=(
-                    playlist,
-                    job,
-                    shots,
-                    params,
-                    current_user["email"],
-                    full,
-                    remote,
-                ),
-                job_timeout=int(config.JOB_QUEUE_TIMEOUT),
-            )
+            try:
+                queue_store.job_queue.enqueue(
+                    playlists_service.build_playlist_job,
+                    args=(
+                        playlist,
+                        job,
+                        shots,
+                        params,
+                        current_user["email"],
+                        full,
+                        remote,
+                    ),
+                    job_timeout=int(config.JOB_QUEUE_TIMEOUT),
+                    unique=True,
+                    job_id=f"build_playlist:{playlist['id']}",
+                    result_ttl=60,
+                    failure_ttl=60,
+                )
+            except DuplicateJobError:
+                playlists_service.remove_build_job(playlist, job["id"])
+                return {
+                    "error": True,
+                    "message": "A build is already in progress for this playlist",
+                }, 409
             return job
         else:
             job = playlists_service.build_playlist_movie_file(

--- a/zou/app/blueprints/playlists/resources.py
+++ b/zou/app/blueprints/playlists/resources.py
@@ -505,7 +505,7 @@ class BuildPlaylistMovieResource(Resource, ArgsMixin):
         user_service.check_manager_project_access(playlist["project_id"])
 
         project = projects_service.get_project(playlist["project_id"])
-        (width, height) = preview_files_service.get_preview_file_dimensions(
+        width, height = preview_files_service.get_preview_file_dimensions(
             project
         )
         fps = preview_files_service.get_preview_file_fps(project)

--- a/zou/app/blueprints/previews/resources.py
+++ b/zou/app/blueprints/previews/resources.py
@@ -46,7 +46,6 @@ from zou.app.services.exception import (
     WrongParameterException,
 )
 
-
 ALLOWED_PICTURE_EXTENSION = {"jpe", "jpeg", "jpg", "png"}
 ALLOWED_MOVIE_EXTENSION = {
     "avi",

--- a/zou/app/blueprints/project_templates/resources.py
+++ b/zou/app/blueprints/project_templates/resources.py
@@ -215,10 +215,8 @@ class ProjectTemplateStatusAutomationsResource(Resource, ArgsMixin):
         """
         permissions.check_manager_permissions()
         try:
-            return (
-                project_templates_service.get_template_status_automations(
-                    template_id
-                )
+            return project_templates_service.get_template_status_automations(
+                template_id
             )
         except ProjectTemplateNotFoundException:
             return {"message": "Project template not found"}, 404
@@ -276,10 +274,8 @@ class ProjectTemplateBackgroundsResource(Resource, ArgsMixin):
         """
         permissions.check_manager_permissions()
         try:
-            return (
-                project_templates_service.get_template_preview_background_files(
-                    template_id
-                )
+            return project_templates_service.get_template_preview_background_files(
+                template_id
             )
         except ProjectTemplateNotFoundException:
             return {"message": "Project template not found"}, 404
@@ -295,10 +291,8 @@ class ProjectTemplateBackgroundsResource(Resource, ArgsMixin):
         permissions.check_admin_permissions()
         args = self.get_args([("preview_background_file_id", "", True)])
         try:
-            entry = (
-                project_templates_service.add_preview_background_file_to_template(
-                    template_id, args["preview_background_file_id"]
-                )
+            entry = project_templates_service.add_preview_background_file_to_template(
+                template_id, args["preview_background_file_id"]
             )
         except ProjectTemplateNotFoundException:
             return {"message": "Project template not found"}, 404
@@ -339,10 +333,8 @@ class ProjectTemplateDefaultBackgroundResource(Resource):
         data = request.json or {}
         background_id = data.get("default_preview_background_file_id")
         try:
-            template = (
-                project_templates_service.set_template_default_preview_background_file(
-                    template_id, background_id
-                )
+            template = project_templates_service.set_template_default_preview_background_file(
+                template_id, background_id
             )
         except ProjectTemplateNotFoundException:
             return {"message": "Project template not found"}, 404
@@ -402,12 +394,10 @@ class ProjectTemplateFromProjectResource(Resource, ArgsMixin):
             ]
         )
         try:
-            template = (
-                project_templates_service.create_template_from_project(
-                    project_id,
-                    args["name"],
-                    description=args["description"],
-                )
+            template = project_templates_service.create_template_from_project(
+                project_id,
+                args["name"],
+                description=args["description"],
             )
         except ProjectNotFoundException:
             return {"message": "Project not found"}, 404

--- a/zou/app/blueprints/project_templates/resources.py
+++ b/zou/app/blueprints/project_templates/resources.py
@@ -11,7 +11,6 @@ from zou.app.services.exception import (
 )
 from zou.app.utils import permissions
 
-
 # ---------------------------------------------------------------------------
 # Link management
 # ---------------------------------------------------------------------------

--- a/zou/app/blueprints/shared/resources.py
+++ b/zou/app/blueprints/shared/resources.py
@@ -523,10 +523,10 @@ class SharedPlaylistAnnotationsResource(Resource):
         except Exception:
             return {"error": "Guest not part of this shared playlist"}, 403
 
-        if not _is_preview_file_in_shared_playlist(token, preview_file_id):
-            return {
-                "error": "Preview file not part of this shared playlist"
-            }, 403
+        if not playlist_sharing_service.is_preview_file_in_shared_playlist(
+            token, preview_file_id
+        ):
+            raise permissions.PermissionDenied
 
         preview_file = files_service.get_preview_file(preview_file_id)
         task = tasks_service.get_task(preview_file["task_id"])
@@ -538,22 +538,6 @@ class SharedPlaylistAnnotationsResource(Resource):
             updates=updates,
             deletions=deletions,
         )
-
-
-def _is_preview_file_in_shared_playlist(token, preview_file_id):
-    """
-    Ensure the given preview file id belongs to a shot (or one of its
-    revisions) of the playlist exposed by the share token.
-    """
-    playlist = playlist_sharing_service.get_shared_playlist(token)
-    pid = str(preview_file_id)
-    for shot in playlist.get("shots", []) or []:
-        if str(shot.get("preview_file_id") or "") == pid:
-            return True
-        for sub in shot.get("preview_file_previews", []) or []:
-            if str(sub.get("id") or "") == pid:
-                return True
-    return False
 
 
 def _is_task_in_shared_playlist(token, task_id):
@@ -604,10 +588,10 @@ class SharedPlaylistPreviewFileResource(Resource):
           403:
             description: Preview file is not part of this shared playlist
         """
-        if not _is_preview_file_in_shared_playlist(token, preview_file_id):
-            return {
-                "error": "Preview file not part of this shared playlist"
-            }, 403
+        if not playlist_sharing_service.is_preview_file_in_shared_playlist(
+            token, preview_file_id
+        ):
+            raise permissions.PermissionDenied
         return files_service.get_preview_file(preview_file_id)
 
 
@@ -656,14 +640,14 @@ class SharedPlaylistPreviewFileMovieResource(Resource):
                     error:
                       type: string
         """
-        if not _is_preview_file_in_shared_playlist(token, preview_file_id):
-            return {
-                "error": "Preview file not part of this shared playlist"
-            }, 403
+        if not playlist_sharing_service.is_preview_file_in_shared_playlist(
+            token, preview_file_id
+        ):
+            raise permissions.PermissionDenied
         try:
             return send_movie_file(preview_file_id)
         except FileNotFound:
-            return {"error": "Preview file not found"}, 404
+            raise PreviewFileNotFoundException
 
 
 class SharedPlaylistPreviewFileThumbnailResource(Resource):
@@ -710,14 +694,14 @@ class SharedPlaylistPreviewFileThumbnailResource(Resource):
                     error:
                       type: string
         """
-        if not _is_preview_file_in_shared_playlist(token, preview_file_id):
-            return {
-                "error": "Preview file not part of this shared playlist"
-            }, 403
+        if not playlist_sharing_service.is_preview_file_in_shared_playlist(
+            token, preview_file_id
+        ):
+            raise permissions.PermissionDenied
         try:
             return send_picture_file("thumbnails", preview_file_id)
         except FileNotFound:
-            return {"error": "Thumbnail not found"}, 404
+            raise PreviewFileNotFoundException
 
 
 class SharedPlaylistPreviewFileOriginalResource(Resource):
@@ -764,14 +748,14 @@ class SharedPlaylistPreviewFileOriginalResource(Resource):
                     error:
                       type: string
         """
-        if not _is_preview_file_in_shared_playlist(token, preview_file_id):
-            return {
-                "error": "Preview file not part of this shared playlist"
-            }, 403
+        if not playlist_sharing_service.is_preview_file_in_shared_playlist(
+            token, preview_file_id
+        ):
+            raise permissions.PermissionDenied
         try:
             return send_picture_file("original", preview_file_id)
         except FileNotFound:
-            return {"error": "Original not found"}, 404
+            raise PreviewFileNotFoundException
 
 
 class SharedPlaylistPreviewFileTileResource(Resource):
@@ -818,14 +802,14 @@ class SharedPlaylistPreviewFileTileResource(Resource):
                     error:
                       type: string
         """
-        if not _is_preview_file_in_shared_playlist(token, preview_file_id):
-            return {
-                "error": "Preview file not part of this shared playlist"
-            }, 403
+        if not playlist_sharing_service.is_preview_file_in_shared_playlist(
+            token, preview_file_id
+        ):
+            raise permissions.PermissionDenied
         try:
             return send_picture_file("tiles", preview_file_id)
         except FileNotFound:
-            return {"error": "Tile not found"}, 404
+            raise PreviewFileNotFoundException
 
 
 class SharedPlaylistPreviewFileDownloadResource(Resource):
@@ -867,7 +851,9 @@ class SharedPlaylistPreviewFileDownloadResource(Resource):
           404:
             description: Preview file not on disk
         """
-        if not _is_preview_file_in_shared_playlist(token, preview_file_id):
+        if not playlist_sharing_service.is_preview_file_in_shared_playlist(
+            token, preview_file_id
+        ):
             raise permissions.PermissionDenied
         preview_file = files_service.get_preview_file(preview_file_id)
         extension = preview_file["extension"]

--- a/zou/app/blueprints/source/kitsu.py
+++ b/zou/app/blueprints/source/kitsu.py
@@ -92,9 +92,7 @@ class BaseImportKitsuResource(Resource, ArgsMixin):
         for entry in kitsu_entries:
             if self.check_access(entry):
                 try:
-                    (instance, is_updated) = self.model.create_from_import(
-                        entry
-                    )
+                    instance, is_updated = self.model.create_from_import(entry)
                     if is_updated:
                         self.emit_event("update", entry)
                     else:

--- a/zou/app/blueprints/source/shotgun/shot.py
+++ b/zou/app/blueprints/source/shotgun/shot.py
@@ -144,7 +144,7 @@ class ImportShotgunShotsResource(BaseImportShotgunResource):
         return {x["sg_status"] for x in sg_projects}
 
     def extract_data(self, sg_shot):
-        (frame_in, frame_out) = self.extract_frame_range(sg_shot)
+        frame_in, frame_out = self.extract_frame_range(sg_shot)
         custom_fields = self.extract_custom_data(sg_shot)
         project_id = self.get_project(sg_shot, self.project_map)
         sequence_id = self.get_sequence(sg_shot)

--- a/zou/app/blueprints/tasks/__init__.py
+++ b/zou/app/blueprints/tasks/__init__.py
@@ -38,7 +38,6 @@ from zou.app.blueprints.tasks.resources import (
     OpenTasksStatsResource,
 )
 
-
 routes = [
     ("/data/tasks/open-tasks", OpenTasksResource),
     ("/data/tasks/open-tasks/stats", OpenTasksStatsResource),

--- a/zou/app/mixin.py
+++ b/zou/app/mixin.py
@@ -27,15 +27,15 @@ class ArgsMixin(object):
 
             if isinstance(descriptor, (list, tuple)):
                 if len(descriptor) == 5:
-                    (name, default, required, data_type, action) = descriptor
+                    name, default, required, data_type, action = descriptor
                 elif len(descriptor) == 4:
-                    (name, default, required, data_type) = descriptor
+                    name, default, required, data_type = descriptor
                 elif len(descriptor) == 3:
-                    (name, default, required) = descriptor
+                    name, default, required = descriptor
                 elif len(descriptor) == 2:
-                    (name, default) = descriptor
+                    name, default = descriptor
                 elif len(descriptor) == 1:
-                    (name) = descriptor
+                    name = descriptor
                 else:
                     raise ValueError
             elif isinstance(descriptor, str):

--- a/zou/app/models/entity.py
+++ b/zou/app/models/entity.py
@@ -198,7 +198,7 @@ class Entity(db.Model, BaseMixin, SerializerMixin):
     def create_from_import(cls, data):
         is_update = False
         previous_entity = cls.get(data["id"])
-        (data, entity_ids) = cls.sanitize_import_data(data)
+        data, entity_ids = cls.sanitize_import_data(data)
 
         if previous_entity is None:
             previous_entity = cls.create(**data)

--- a/zou/app/models/playlist_share_link.py
+++ b/zou/app/models/playlist_share_link.py
@@ -15,9 +15,7 @@ class PlaylistShareLink(db.Model, BaseMixin, SerializerMixin):
     never reflect the credential back to callers.
     """
 
-    token = db.Column(
-        db.String(64), unique=True, nullable=False, index=True
-    )
+    token = db.Column(db.String(64), unique=True, nullable=False, index=True)
     playlist_id = db.Column(
         UUIDType(binary=False),
         db.ForeignKey("playlist.id"),

--- a/zou/app/models/task.py
+++ b/zou/app/models/task.py
@@ -66,9 +66,7 @@ class Task(db.Model, BaseMixin, SerializerMixin):
     assigner_id = db.Column(
         UUIDType(binary=False), db.ForeignKey("person.id"), index=True
     )
-    assignees = db.relationship(
-        "Person", secondary=TaskPersonLink.__table__
-    )
+    assignees = db.relationship("Person", secondary=TaskPersonLink.__table__)
 
     __table_args__ = (
         db.UniqueConstraint(

--- a/zou/app/services/auth_service.py
+++ b/zou/app/services/auth_service.py
@@ -718,7 +718,7 @@ def hash_recovery_codes(recovery_codes):
     Hash recovery codes given as argument and return them.
     """
     return [
-        flask_bcrypt.generate_password_hash(recovery_code)
+        auth.encrypt_password(recovery_code)
         for recovery_code in recovery_codes
     ]
 

--- a/zou/app/services/auth_service.py
+++ b/zou/app/services/auth_service.py
@@ -1,7 +1,6 @@
 import pyotp
 import random
 import string
-import flask_bcrypt
 
 from datetime import timedelta
 
@@ -36,7 +35,7 @@ from zou.app.services.exception import (
 )
 from zou.app import config
 from zou.app.stores import auth_tokens_store
-from zou.app.utils import date_helpers, emails
+from zou.app.utils import auth, date_helpers, emails
 from zou.app.utils.email_i18n import get_email_translation
 
 from fido2.webauthn import (
@@ -148,9 +147,7 @@ def local_auth_strategy(person, password, app=None):
     """
     try:
         password_hash = person["password"] or ""
-        if password_hash and flask_bcrypt.check_password_hash(
-            password_hash, password
-        ):
+        if password_hash and auth.check_password(password_hash, password):
             return person
         else:
             raise WrongPasswordException()
@@ -325,7 +322,7 @@ def check_recovery_code(person, recovery_code):
     Check recovery code for a person.
     """
     for recovery_hash in person["otp_recovery_codes"]:
-        if flask_bcrypt.check_password_hash(recovery_hash, recovery_code):
+        if auth.check_password(recovery_hash, recovery_code):
             remove_otp_revovery_code(person["id"], recovery_hash)
             return True
     return False

--- a/zou/app/services/exception.py
+++ b/zou/app/services/exception.py
@@ -1,4 +1,10 @@
-from werkzeug.exceptions import NotFound, Forbidden, BadRequest, Unauthorized
+from werkzeug.exceptions import (
+    NotFound,
+    Forbidden,
+    BadRequest,
+    Unauthorized,
+    ServiceUnavailable,
+)
 
 
 class EpisodeNotFoundException(NotFound):
@@ -106,6 +112,10 @@ class PreviewFileNotFoundException(NotFound):
 
 
 class PreviewFileReuploadNotAllowedException(BadRequest):
+    pass
+
+
+class AnnotationLockTimeoutException(ServiceUnavailable):
     pass
 
 

--- a/zou/app/services/playlist_sharing_service.py
+++ b/zou/app/services/playlist_sharing_service.py
@@ -1,7 +1,7 @@
 import datetime
 import uuid
 
-import flask_bcrypt
+from zou.app.utils import auth
 
 from zou.app.models.entity import Entity
 from zou.app.models.entity_type import EntityType
@@ -119,9 +119,7 @@ def validate_share_token(token, password=None):
         if not password:
             raise PlaylistShareLinkNotFoundException
         try:
-            if not flask_bcrypt.check_password_hash(
-                share_link.password, password
-            ):
+            if not auth.check_password(share_link.password, password):
                 raise PlaylistShareLinkNotFoundException
         except (ValueError, TypeError):
             raise PlaylistShareLinkNotFoundException

--- a/zou/app/services/playlist_sharing_service.py
+++ b/zou/app/services/playlist_sharing_service.py
@@ -6,11 +6,14 @@ import flask_bcrypt
 from zou.app.models.entity import Entity
 from zou.app.models.entity_type import EntityType
 from zou.app.models.person import Person
+from zou.app.models.playlist import Playlist
 from zou.app.models.playlist_share_link import PlaylistShareLink
+from zou.app.models.preview_file import PreviewFile
 from zou.app.models.task import Task
 from zou.app.models.task_status import TaskStatus
 from zou.app.models.task_type import TaskType
 from zou.app.services import (
+    files_service,
     persons_service,
     playlists_service,
     tasks_service,
@@ -142,6 +145,41 @@ def get_shared_playlist(token):
     return playlists_service.get_playlist_with_preview_file_revisions(
         share_link["playlist_id"]
     )
+
+
+def is_preview_file_in_shared_playlist(token, preview_file_id):
+    """
+    Membership check used by every shared-playlist file-serving
+    endpoint (thumbnail, original, movie, download…).
+
+    A shared playlist is read-only for the viewer, so the only previews
+    legitimately served through the share link are those tied to the
+    positioned revision of each shot. We accept either the exact
+    preview_file_id stored on a shot, or another preview file that
+    shares its (task, revision) with the positioned one — a single
+    revision may carry several previews (different positions).
+    """
+    share_link = validate_share_token(token)
+    playlist = Playlist.get(share_link["playlist_id"])
+    if playlist is None or not playlist.shots:
+        return False
+    preview_file = files_service.get_preview_file(preview_file_id)
+    task = tasks_service.get_task(preview_file["task_id"])
+    entity_id_map = {
+        str(shot.get("entity_id") or shot.get("id")): shot.get(
+            "preview_file_id"
+        )
+        for shot in playlist.shots
+    }
+
+    main_preview_file_id = entity_id_map.get(str(task["entity_id"]))
+    if main_preview_file_id is None:
+        return False
+    if main_preview_file_id == preview_file_id:
+        return True
+
+    main_preview_file = files_service.get_preview_file(main_preview_file_id)
+    return main_preview_file["revision"] == preview_file["revision"]
 
 
 class GuestCommentForbidden(Exception):

--- a/zou/app/services/playlists_service.py
+++ b/zou/app/services/playlists_service.py
@@ -60,7 +60,7 @@ PLAYLISTS_PAGE_SIZE = 20
 # permissive String(10) for historical reasons; this set is what consumers
 # (gazu Literal, kitsu UI branches, docs) actually handle. Validate at the
 # CRUD boundary so a stray value cannot land in storage.
-VALID_FOR_ENTITY_VALUES = ("shot", "asset", "sequence", "edit")
+VALID_FOR_ENTITY_VALUES = ("shot", "asset", "sequence", "edit", "episode")
 
 # First entry's preview_file_id for list rows (PostgreSQL jsonb path), avoids
 # loading the full `shots` column when paired with defer(Playlist.shots).

--- a/zou/app/services/playlists_service.py
+++ b/zou/app/services/playlists_service.py
@@ -58,9 +58,9 @@ PLAYLISTS_PAGE_SIZE = 20
 
 # First entry's preview_file_id for list rows (PostgreSQL jsonb path), avoids
 # loading the full `shots` column when paired with defer(Playlist.shots).
-_FIRST_SHOT_PREVIEW_FILE_ID_SQL = Playlist.shots[0]["preview_file_id"].astext.label(
-    "first_preview_file_id"
-)
+_FIRST_SHOT_PREVIEW_FILE_ID_SQL = Playlist.shots[0][
+    "preview_file_id"
+].astext.label("first_preview_file_id")
 
 # Sentinel: build_playlist_dict() should read shots on the model (tests / legacy).
 _FIRST_PREVIEW_FILE_ID_FROM_QUERY_UNSET = object()
@@ -114,7 +114,9 @@ def all_playlists_for_project(
     )
     for playlist, first_preview_file_id in query.all():
         result.append(
-            build_playlist_dict(playlist, first_preview_file_id=first_preview_file_id)
+            build_playlist_dict(
+                playlist, first_preview_file_id=first_preview_file_id
+            )
         )
     return result
 
@@ -161,7 +163,9 @@ def all_playlists_for_episode(
     )
     for playlist, first_preview_file_id in query.all():
         result.append(
-            build_playlist_dict(playlist, first_preview_file_id=first_preview_file_id)
+            build_playlist_dict(
+                playlist, first_preview_file_id=first_preview_file_id
+            )
         )
     return result
 

--- a/zou/app/services/playlists_service.py
+++ b/zou/app/services/playlists_service.py
@@ -56,6 +56,12 @@ logger = logging.getLogger(__name__)
 # Page size for playlist list endpoints
 PLAYLISTS_PAGE_SIZE = 20
 
+# Whitelist of accepted Playlist.for_entity values. The column itself is a
+# permissive String(10) for historical reasons; this set is what consumers
+# (gazu Literal, kitsu UI branches, docs) actually handle. Validate at the
+# CRUD boundary so a stray value cannot land in storage.
+VALID_FOR_ENTITY_VALUES = ("shot", "asset", "sequence", "edit")
+
 # First entry's preview_file_id for list rows (PostgreSQL jsonb path), avoids
 # loading the full `shots` column when paired with defer(Playlist.shots).
 _FIRST_SHOT_PREVIEW_FILE_ID_SQL = Playlist.shots[0][

--- a/zou/app/services/preview_files_service.py
+++ b/zou/app/services/preview_files_service.py
@@ -36,6 +36,7 @@ from zou.app.utils import (
     thumbnail as thumbnail_utils,
 )
 from zou.app.services.exception import (
+    AnnotationLockTimeoutException,
     WrongParameterException,
     PreviewFileNotFoundException,
     ProjectNotFoundException,
@@ -100,9 +101,7 @@ def _is_valid_partial_resolution(resolution):
     """
     Return true if the dimension follows the x1080 pattern.
     """
-    return resolution is not None and bool(
-        re.match(r"^x\d{3,4}$", resolution)
-    )
+    return resolution is not None and bool(re.match(r"^x\d{3,4}$", resolution))
 
 
 def validate_resolution(resolution):
@@ -553,7 +552,13 @@ def update_preview_file_annotations(
         updates = []
     if deletions is None:
         deletions = []
-    with with_preview_file_lock(preview_file_id, timeout=30, wait_timeout=35):
+    with with_preview_file_lock(
+        preview_file_id, timeout=30, wait_timeout=35
+    ) as acquired:
+        if not acquired:
+            raise AnnotationLockTimeoutException(
+                "Could not acquire annotation lock for preview file"
+            )
         preview_file = files_service.get_preview_file_raw(preview_file_id)
         previous_annotations = copy.deepcopy(preview_file.annotations or [])
         annotations = _clean_annotations(previous_annotations)

--- a/zou/app/services/project_templates_service.py
+++ b/zou/app/services/project_templates_service.py
@@ -26,7 +26,6 @@ from zou.app.services.exception import (
 
 from zou.app.utils import events, fields
 
-
 # Production-setting fields that are copied between Project and
 # ProjectTemplate. Excluded on purpose: name, description (set explicitly),
 # any team / dates / production-data fields, and the JSONB columns

--- a/zou/app/services/project_templates_service.py
+++ b/zou/app/services/project_templates_service.py
@@ -191,9 +191,7 @@ def get_template_task_types(template_id):
     links = ProjectTemplateTaskTypeLink.get_all_by(
         project_template_id=template_id
     )
-    link_map = {
-        str(link.task_type_id): link for link in links
-    }
+    link_map = {str(link.task_type_id): link for link in links}
     result = []
     for task_type in template.task_types:
         data = task_type.serialize()
@@ -254,9 +252,7 @@ def get_template_task_statuses(template_id):
     links = ProjectTemplateTaskStatusLink.get_all_by(
         project_template_id=template_id
     )
-    link_map = {
-        str(link.task_status_id): link for link in links
-    }
+    link_map = {str(link.task_status_id): link for link in links}
     result = []
     for task_status in template.task_statuses:
         data = task_status.serialize()
@@ -268,9 +264,7 @@ def get_template_task_statuses(template_id):
                 for role in (link.roles_for_board or [])
             ]
         result.append(data)
-    result.sort(
-        key=lambda s: (s.get("priority") or 0, s.get("name", ""))
-    )
+    result.sort(key=lambda s: (s.get("priority") or 0, s.get("name", "")))
     return result
 
 
@@ -516,9 +510,7 @@ def set_template_metadata_descriptors(template_id, descriptors):
     if descriptors is None:
         descriptors = []
     if not isinstance(descriptors, list):
-        raise WrongParameterException(
-            "metadata_descriptors must be a list"
-        )
+        raise WrongParameterException("metadata_descriptors must be a list")
     cleaned = []
     for entry in descriptors:
         if not isinstance(entry, dict):
@@ -609,9 +601,7 @@ def create_template_from_project(project_id, name, description=None):
             priority=link.priority,
         )
 
-    task_status_links = ProjectTaskStatusLink.get_all_by(
-        project_id=project_id
-    )
+    task_status_links = ProjectTaskStatusLink.get_all_by(project_id=project_id)
     for link in task_status_links:
         ProjectTemplateTaskStatusLink.create(
             project_template_id=template.id,
@@ -681,9 +671,7 @@ def _snapshot_descriptors(project_id):
                 ),
                 "choices": descriptor.choices or [],
                 "for_client": bool(descriptor.for_client),
-                "departments": [
-                    str(dep.id) for dep in descriptor.departments
-                ],
+                "departments": [str(dep.id) for dep in descriptor.departments],
                 "position": descriptor.position,
             }
         )
@@ -695,9 +683,7 @@ def _snapshot_descriptors(project_id):
 # ---------------------------------------------------------------------------
 
 
-def apply_template_to_project(
-    project_id, template_id, override_settings=None
-):
+def apply_template_to_project(project_id, template_id, override_settings=None):
     """
     Apply a template's configuration to a project. Existing links are kept;
     duplicates are skipped (additive strategy). Production settings are
@@ -837,9 +823,7 @@ def apply_template_to_project(
         _create_descriptor_from_snapshot(project.id, descriptor)
 
     projects_service.clear_project_cache(str(project.id))
-    events.emit(
-        "project:update", {}, project_id=str(project.id)
-    )
+    events.emit("project:update", {}, project_id=str(project.id))
     return project.serialize()
 
 

--- a/zou/app/services/stats_service.py
+++ b/zou/app/services/stats_service.py
@@ -12,7 +12,6 @@ from zou.app.models.task_status import TaskStatus
 
 from zou.app.services import user_service
 
-
 DEFAULT_RETAKE_STATS = {
     "max_retake_count": 0,
     "evolution": {},

--- a/zou/app/services/sync_service.py
+++ b/zou/app/services/sync_service.py
@@ -50,7 +50,6 @@ from zou.app.stores import file_store
 from zou.app.utils import events, date_helpers
 from zou.app import app, config
 
-
 logger = logging.getLogger()
 logger.setLevel(os.environ.get("LOGLEVEL", "INFO").upper())
 console_handler = logging.StreamHandler(sys.stdout)

--- a/zou/app/services/tasks_service.py
+++ b/zou/app/services/tasks_service.py
@@ -19,11 +19,11 @@ from zou.app.models.comment import (
 )
 from zou.app.models.department import Department
 from zou.app.models.entity import Entity, EntityLink
-from zou.app.models.entity_type import EntityType
+from zou.app.models.entity_type import EntityType, TaskTypeAssetTypeLink
 from zou.app.models.news import News
 from zou.app.models.person import Person
 from zou.app.models.preview_file import PreviewFile
-from zou.app.models.project import Project
+from zou.app.models.project import Project, ProjectTaskTypeLink
 from zou.app.models.project_status import ProjectStatus
 from zou.app.models.task import Task, TaskPersonLink
 from zou.app.models.task_type import TaskType
@@ -48,6 +48,7 @@ from zou.app.services.exception import (
     TaskNotFoundException,
     TaskStatusNotFoundException,
     TaskTypeNotFoundException,
+    WrongParameterException,
     DepartmentNotFoundException,
     StudioNotFoundException,
     WrongDateFormatException,
@@ -1212,6 +1213,71 @@ def create_tasks(task_type, entities):
         task_dicts.append(task_dict)
 
     return task_dicts
+
+
+def check_task_type_compatible_with_entity(task_type, entity):
+    """
+    Verify a task type can be applied to a given entity:
+    - task_type.for_entity matches the entity kind (Asset / Shot / ...).
+    - task_type is enabled in the entity's project.
+    - if the entity is an asset, task_type belongs to the entity's
+      asset type workflow.
+    Raises WrongParameterException on any failure.
+    """
+    is_asset = assets_service.is_asset_dict(entity)
+    expected = task_type.get("for_entity")
+    if expected:
+        if is_asset:
+            entity_kind = "Asset"
+        else:
+            entity_type = entities_service.get_entity_type(
+                entity["entity_type_id"]
+            )
+            entity_kind = entity_type["name"]
+        if expected != entity_kind:
+            raise WrongParameterException(
+                "Task type %s is for %s entities, got %s."
+                % (task_type["id"], expected, entity_kind)
+            )
+
+    project_link = ProjectTaskTypeLink.query.filter_by(
+        project_id=entity["project_id"],
+        task_type_id=task_type["id"],
+    ).first()
+    if project_link is None:
+        raise WrongParameterException(
+            "Task type %s is not enabled in project %s."
+            % (task_type["id"], entity["project_id"])
+        )
+
+    if is_asset:
+        asset_link = TaskTypeAssetTypeLink.query.filter_by(
+            asset_type_id=entity["entity_type_id"],
+            task_type_id=task_type["id"],
+        ).first()
+        if asset_link is None:
+            raise WrongParameterException(
+                "Task type %s is not in the workflow of asset type %s."
+                % (task_type["id"], entity["entity_type_id"])
+            )
+
+
+def create_tasks_for_entity(entity, task_types):
+    """
+    Create tasks of multiple types for a single entity.
+    Each task type is validated against the entity (project link, asset
+    workflow link, for_entity) before any creation.
+    Existing tasks for the same (entity, task_type, name="main") are
+    skipped, mirroring create_tasks behaviour.
+    """
+    if not task_types:
+        return []
+    for task_type in task_types:
+        check_task_type_compatible_with_entity(task_type, entity)
+    created = []
+    for task_type in task_types:
+        created.extend(create_tasks(task_type, [entity]))
+    return created
 
 
 def create_task(task_type, entity, name="main"):

--- a/zou/app/services/tasks_service.py
+++ b/zou/app/services/tasks_service.py
@@ -1257,21 +1257,22 @@ def create_tasks_for_entity(entity, task_types):
         }
 
     for task_type in task_types:
+        type_id = task_type["id"]
         expected = task_type.get("for_entity")
         if expected and expected != entity_kind:
             raise WrongParameterException(
-                "Task type %s is for %s entities, got %s."
-                % (task_type["id"], expected, entity_kind)
+                f"Task type {type_id} is for {expected} entities, "
+                f"got {entity_kind}."
             )
-        if str(task_type["id"]) not in enabled_in_project:
+        if str(type_id) not in enabled_in_project:
             raise WrongParameterException(
-                "Task type %s is not enabled in project %s."
-                % (task_type["id"], project_id)
+                f"Task type {type_id} is not enabled in project "
+                f"{project_id}."
             )
-        if is_asset and str(task_type["id"]) not in enabled_in_workflow:
+        if is_asset and str(type_id) not in enabled_in_workflow:
             raise WrongParameterException(
-                "Task type %s is not in the workflow of asset type %s."
-                % (task_type["id"], entity["entity_type_id"])
+                f"Task type {type_id} is not in the workflow of asset "
+                f"type {entity['entity_type_id']}."
             )
 
     existing_type_ids = {
@@ -1283,10 +1284,7 @@ def create_tasks_for_entity(entity, task_types):
         ).all()
     }
 
-    task_status = get_default_status(
-        for_concept=entity["entity_type_id"]
-        == concepts_service.get_concept_type()["id"]
-    )
+    task_status = get_default_status(for_concept=False)
     current_user_id = None
     try:
         current_user_id = persons_service.get_current_user()["id"]

--- a/zou/app/services/tasks_service.py
+++ b/zou/app/services/tasks_service.py
@@ -1160,19 +1160,43 @@ def get_last_comment_map(task_ids):
     return task_comment_map
 
 
+def _build_task_no_commit(
+    task_type, task_status, entity, current_user_id
+):
+    """
+    Insert a new task (without committing) using the zou defaults for
+    name, durations, dates and assignees.
+    """
+    return Task.create_no_commit(
+        name="main",
+        duration=0,
+        estimation=0,
+        completion_rate=0,
+        start_date=None,
+        end_date=None,
+        due_date=None,
+        real_start_date=None,
+        project_id=entity["project_id"],
+        task_type_id=task_type["id"],
+        task_status_id=task_status["id"],
+        entity_id=entity["id"],
+        assigner_id=current_user_id,
+        assignees=[],
+    )
+
+
 def create_tasks(task_type, entities):
     """
     Create a new task for given task type and for each entity.
     """
+    if not entities:
+        return []
+
     current_user_id = None
     try:
         current_user_id = persons_service.get_current_user()["id"]
     except RuntimeError:
         pass
-
-    # Batch query existing tasks to avoid N+1 query problem
-    if not entities:
-        return []
 
     entity_ids = [entity["id"] for entity in entities]
     existing_tasks = Task.query.filter(
@@ -1188,48 +1212,30 @@ def create_tasks(task_type, entities):
     tasks = []
     for entity in entities:
         if str(entity["id"]) not in existing_entity_ids:
-            task = Task.create_no_commit(
-                name="main",
-                duration=0,
-                estimation=0,
-                completion_rate=0,
-                start_date=None,
-                end_date=None,
-                due_date=None,
-                real_start_date=None,
-                project_id=entity["project_id"],
-                task_type_id=task_type["id"],
-                task_status_id=task_status["id"],
-                entity_id=entity["id"],
-                assigner_id=current_user_id,
-                assignees=[],
+            tasks.append(
+                _build_task_no_commit(
+                    task_type, task_status, entity, current_user_id
+                )
             )
-            tasks.append(task)
     Task.commit()
 
-    task_dicts = []
-    for task in tasks:
-        task_dict = _finalize_task_creation(task_type, task_status, task)
-        task_dicts.append(task_dict)
-
-    return task_dicts
+    return [
+        _finalize_task_creation(task_type, task_status, task) for task in tasks
+    ]
 
 
-def create_tasks_for_entity(entity, task_types):
+def create_tasks_for_entity(entity, task_types=None):
     """
     Create tasks of multiple types for a single entity in one batch.
-    Each task type is validated against the entity (for_entity match,
-    project workflow membership, and asset-type workflow membership when
-    relevant) before any creation. Existing tasks for the same
-    (entity, task_type, name="main") are skipped.
+    When task_types is empty or None, default to every task type valid
+    for the entity: enabled in the project, in the asset-type workflow
+    (for assets), and whose for_entity matches the entity kind. When a
+    list is provided, each task type is validated against those same
+    constraints. Existing tasks for the same (entity, task_type,
+    name="main") are skipped.
     """
-    if not task_types:
-        return []
-
-    type_ids = [task_type["id"] for task_type in task_types]
     project_id = entity["project_id"]
     is_asset = assets_service.is_asset_dict(entity)
-
     if is_asset:
         entity_kind = "Asset"
     else:
@@ -1241,8 +1247,7 @@ def create_tasks_for_entity(entity, task_types):
     enabled_in_project = {
         str(link.task_type_id)
         for link in ProjectTaskTypeLink.query.filter(
-            ProjectTaskTypeLink.project_id == project_id,
-            ProjectTaskTypeLink.task_type_id.in_(type_ids),
+            ProjectTaskTypeLink.project_id == project_id
         ).all()
     }
     enabled_in_workflow = None
@@ -1251,30 +1256,47 @@ def create_tasks_for_entity(entity, task_types):
             str(link.task_type_id)
             for link in TaskTypeAssetTypeLink.query.filter(
                 TaskTypeAssetTypeLink.asset_type_id
-                == entity["entity_type_id"],
-                TaskTypeAssetTypeLink.task_type_id.in_(type_ids),
+                == entity["entity_type_id"]
             ).all()
         }
 
-    for task_type in task_types:
-        type_id = task_type["id"]
-        expected = task_type.get("for_entity")
-        if expected and expected != entity_kind:
-            raise WrongParameterException(
-                f"Task type {type_id} is for {expected} entities, "
-                f"got {entity_kind}."
-            )
-        if str(type_id) not in enabled_in_project:
-            raise WrongParameterException(
-                f"Task type {type_id} is not enabled in project "
-                f"{project_id}."
-            )
-        if is_asset and str(type_id) not in enabled_in_workflow:
-            raise WrongParameterException(
-                f"Task type {type_id} is not in the workflow of asset "
-                f"type {entity['entity_type_id']}."
-            )
+    if not task_types:
+        candidate_ids = enabled_in_project
+        if is_asset:
+            candidate_ids = candidate_ids & enabled_in_workflow
+        if not candidate_ids:
+            return []
+        task_types = [
+            task_type.serialize()
+            for task_type in TaskType.query.filter(
+                TaskType.id.in_(candidate_ids)
+            ).all()
+            if not task_type.for_entity
+            or task_type.for_entity == entity_kind
+        ]
+        if not task_types:
+            return []
+    else:
+        for task_type in task_types:
+            type_id = task_type["id"]
+            expected = task_type.get("for_entity")
+            if expected and expected != entity_kind:
+                raise WrongParameterException(
+                    f"Task type {type_id} is for {expected} entities, "
+                    f"got {entity_kind}."
+                )
+            if str(type_id) not in enabled_in_project:
+                raise WrongParameterException(
+                    f"Task type {type_id} is not enabled in project "
+                    f"{project_id}."
+                )
+            if is_asset and str(type_id) not in enabled_in_workflow:
+                raise WrongParameterException(
+                    f"Task type {type_id} is not in the workflow of "
+                    f"asset type {entity['entity_type_id']}."
+                )
 
+    type_ids = [task_type["id"] for task_type in task_types]
     existing_type_ids = {
         str(task.task_type_id)
         for task in Task.query.filter(
@@ -1284,7 +1306,10 @@ def create_tasks_for_entity(entity, task_types):
         ).all()
     }
 
-    task_status = get_default_status(for_concept=False)
+    task_status = get_default_status(
+        for_concept=entity["entity_type_id"]
+        == concepts_service.get_concept_type()["id"]
+    )
     current_user_id = None
     try:
         current_user_id = persons_service.get_current_user()["id"]
@@ -1295,21 +1320,8 @@ def create_tasks_for_entity(entity, task_types):
     for task_type in task_types:
         if str(task_type["id"]) in existing_type_ids:
             continue
-        task = Task.create_no_commit(
-            name="main",
-            duration=0,
-            estimation=0,
-            completion_rate=0,
-            start_date=None,
-            end_date=None,
-            due_date=None,
-            real_start_date=None,
-            project_id=project_id,
-            task_type_id=task_type["id"],
-            task_status_id=task_status["id"],
-            entity_id=entity["id"],
-            assigner_id=current_user_id,
-            assignees=[],
+        task = _build_task_no_commit(
+            task_type, task_status, entity, current_user_id
         )
         new_tasks.append((task_type, task))
     Task.commit()

--- a/zou/app/services/tasks_service.py
+++ b/zou/app/services/tasks_service.py
@@ -1215,69 +1215,111 @@ def create_tasks(task_type, entities):
     return task_dicts
 
 
-def check_task_type_compatible_with_entity(task_type, entity):
+def create_tasks_for_entity(entity, task_types):
     """
-    Verify a task type can be applied to a given entity:
-    - task_type.for_entity matches the entity kind (Asset / Shot / ...).
-    - task_type is enabled in the entity's project.
-    - if the entity is an asset, task_type belongs to the entity's
-      asset type workflow.
-    Raises WrongParameterException on any failure.
+    Create tasks of multiple types for a single entity in one batch.
+    Each task type is validated against the entity (for_entity match,
+    project workflow membership, and asset-type workflow membership when
+    relevant) before any creation. Existing tasks for the same
+    (entity, task_type, name="main") are skipped.
     """
+    if not task_types:
+        return []
+
+    type_ids = [task_type["id"] for task_type in task_types]
+    project_id = entity["project_id"]
     is_asset = assets_service.is_asset_dict(entity)
-    expected = task_type.get("for_entity")
-    if expected:
-        if is_asset:
-            entity_kind = "Asset"
-        else:
-            entity_type = entities_service.get_entity_type(
-                entity["entity_type_id"]
-            )
-            entity_kind = entity_type["name"]
-        if expected != entity_kind:
+
+    if is_asset:
+        entity_kind = "Asset"
+    else:
+        entity_type = entities_service.get_entity_type(
+            entity["entity_type_id"]
+        )
+        entity_kind = entity_type["name"]
+
+    enabled_in_project = {
+        str(link.task_type_id)
+        for link in ProjectTaskTypeLink.query.filter(
+            ProjectTaskTypeLink.project_id == project_id,
+            ProjectTaskTypeLink.task_type_id.in_(type_ids),
+        ).all()
+    }
+    enabled_in_workflow = None
+    if is_asset:
+        enabled_in_workflow = {
+            str(link.task_type_id)
+            for link in TaskTypeAssetTypeLink.query.filter(
+                TaskTypeAssetTypeLink.asset_type_id
+                == entity["entity_type_id"],
+                TaskTypeAssetTypeLink.task_type_id.in_(type_ids),
+            ).all()
+        }
+
+    for task_type in task_types:
+        expected = task_type.get("for_entity")
+        if expected and expected != entity_kind:
             raise WrongParameterException(
                 "Task type %s is for %s entities, got %s."
                 % (task_type["id"], expected, entity_kind)
             )
-
-    project_link = ProjectTaskTypeLink.query.filter_by(
-        project_id=entity["project_id"],
-        task_type_id=task_type["id"],
-    ).first()
-    if project_link is None:
-        raise WrongParameterException(
-            "Task type %s is not enabled in project %s."
-            % (task_type["id"], entity["project_id"])
-        )
-
-    if is_asset:
-        asset_link = TaskTypeAssetTypeLink.query.filter_by(
-            asset_type_id=entity["entity_type_id"],
-            task_type_id=task_type["id"],
-        ).first()
-        if asset_link is None:
+        if str(task_type["id"]) not in enabled_in_project:
+            raise WrongParameterException(
+                "Task type %s is not enabled in project %s."
+                % (task_type["id"], project_id)
+            )
+        if is_asset and str(task_type["id"]) not in enabled_in_workflow:
             raise WrongParameterException(
                 "Task type %s is not in the workflow of asset type %s."
                 % (task_type["id"], entity["entity_type_id"])
             )
 
+    existing_type_ids = {
+        str(task.task_type_id)
+        for task in Task.query.filter(
+            Task.entity_id == entity["id"],
+            Task.task_type_id.in_(type_ids),
+            Task.name == "main",
+        ).all()
+    }
 
-def create_tasks_for_entity(entity, task_types):
-    """
-    Create tasks of multiple types for a single entity.
-    Each task type is validated against the entity (project link, asset
-    workflow link, for_entity) before any creation.
-    Existing tasks for the same (entity, task_type, name="main") are
-    skipped, mirroring create_tasks behaviour.
-    """
-    if not task_types:
-        return []
+    task_status = get_default_status(
+        for_concept=entity["entity_type_id"]
+        == concepts_service.get_concept_type()["id"]
+    )
+    current_user_id = None
+    try:
+        current_user_id = persons_service.get_current_user()["id"]
+    except RuntimeError:
+        pass
+
+    new_tasks = []
     for task_type in task_types:
-        check_task_type_compatible_with_entity(task_type, entity)
-    created = []
-    for task_type in task_types:
-        created.extend(create_tasks(task_type, [entity]))
-    return created
+        if str(task_type["id"]) in existing_type_ids:
+            continue
+        task = Task.create_no_commit(
+            name="main",
+            duration=0,
+            estimation=0,
+            completion_rate=0,
+            start_date=None,
+            end_date=None,
+            due_date=None,
+            real_start_date=None,
+            project_id=project_id,
+            task_type_id=task_type["id"],
+            task_status_id=task_status["id"],
+            entity_id=entity["id"],
+            assigner_id=current_user_id,
+            assignees=[],
+        )
+        new_tasks.append((task_type, task))
+    Task.commit()
+
+    return [
+        _finalize_task_creation(task_type, task_status, task)
+        for task_type, task in new_tasks
+    ]
 
 
 def create_task(task_type, entity, name="main"):

--- a/zou/app/services/user_service.py
+++ b/zou/app/services/user_service.py
@@ -593,15 +593,13 @@ def check_comment_access(comment_id):
             current_user = persons_service.get_current_user()
             project = projects_service.get_project(task["project_id"])
             if project.get("is_clients_isolated", False):
-                if (
-                    comment["person_id"] != current_user["id"]
-                    and not comment.get("for_client", False)
-                ):
+                if comment["person_id"] != current_user[
+                    "id"
+                ] and not comment.get("for_client", False):
                     raise permissions.PermissionDenied
-            if (
-                persons_service.get_person(person_id)["role"] == "client"
-                or comment.get("for_client", False)
-            ):
+            if persons_service.get_person(person_id)[
+                "role"
+            ] == "client" or comment.get("for_client", False):
                 return True
             else:
                 raise permissions.PermissionDenied

--- a/zou/app/stores/auth_tokens_store.py
+++ b/zou/app/stores/auth_tokens_store.py
@@ -3,7 +3,6 @@ import redis
 
 from zou.app import config
 
-
 try:
     revoked_tokens_store = redis.StrictRedis(
         host=config.KEY_VALUE_STORE["host"],

--- a/zou/app/stores/queue_store.py
+++ b/zou/app/stores/queue_store.py
@@ -4,7 +4,6 @@ import sys
 from rq import Queue
 from zou.app import config
 
-
 try:
     if config.ENABLE_JOB_QUEUE:
         queue_store = redis.StrictRedis(

--- a/zou/app/stores/redis_lock.py
+++ b/zou/app/stores/redis_lock.py
@@ -28,12 +28,14 @@ def get_redis_client():
 def with_lock(lock_key, timeout=30, wait_timeout=35):
     """
     Context manager: acquire a Redis lock by key, yield, then release.
-    Yields True if lock was acquired, False if Redis unavailable or lock
-    not acquired in time.
+    Yields True if the lock was acquired or Redis is unavailable
+    (degraded mode: the operation proceeds without distributed
+    serialization). Yields False only when Redis is reachable but
+    the lock acquisition timed out (genuine contention).
     """
     client = get_redis_client()
     if client is None:
-        yield False
+        yield True
         return
     lock = client.lock(lock_key, timeout=timeout, blocking_timeout=wait_timeout)
     acquired = lock.acquire()
@@ -51,7 +53,7 @@ def with_lock(lock_key, timeout=30, wait_timeout=35):
 def with_playlist_lock(playlist_id, timeout=30, wait_timeout=35):
     """
     Context manager: acquire playlist lock, yield, then release.
-    Yields True if lock was acquired, False if Redis unavailable or lock not acquired in time.
+    See `with_lock` for the True/False contract.
     """
     with with_lock(
         f"playlist_lock:{playlist_id}", timeout, wait_timeout
@@ -62,8 +64,9 @@ def with_playlist_lock(playlist_id, timeout=30, wait_timeout=35):
 @contextmanager
 def with_preview_file_lock(preview_file_id, timeout=30, wait_timeout=35):
     """
-    Context manager: acquire lock for preview file (e.g. annotation changes), yield, then release.
-    Yields True if lock was acquired, False if Redis unavailable or lock not acquired in time.
+    Context manager: acquire lock for preview file (e.g. annotation
+    changes), yield, then release. See `with_lock` for the True/False
+    contract.
     """
     with with_lock(
         f"preview_file_annotations_lock:{preview_file_id}",

--- a/zou/app/stores/redis_lock.py
+++ b/zou/app/stores/redis_lock.py
@@ -1,21 +1,11 @@
 """
-Redis-based distributed lock: set a key with an identifier, release only if we own it.
+Redis-based distributed lock: thin wrapper around redis-py's native Lock.
 """
 
-import time
-import uuid
 import redis
 from contextlib import contextmanager
 
 from zou.app import config
-
-# Lua script for atomic check-and-delete (kept for atomicity, but non-atomic version would also work)
-_RELEASE_SCRIPT = """
-if redis.call("get", KEYS[1]) == ARGV[1] then
-    return redis.call("del", KEYS[1])
-end
-return 0
-"""
 
 
 def get_redis_client():
@@ -34,67 +24,27 @@ def get_redis_client():
         return None
 
 
-def acquire_lock(lock_key, timeout=30, wait_timeout=35):
-    """
-    Acquire a lock for the given key.
-    - Value: unique identifier (so we only release our own lock)
-    - Lock expires after `timeout` seconds so it can't be held forever.
-
-    Returns (redis_client, key, identifier) or (None, None, None) if Redis unavailable.
-    If the lock is held by someone else, waits up to `wait_timeout` seconds then returns (None, None, None).
-    """
-    client = get_redis_client()
-    if client is None:
-        return None, None, None
-
-    identifier = str(uuid.uuid4())
-    deadline = time.time() + wait_timeout
-
-    while time.time() < deadline:
-        if client.set(lock_key, identifier, nx=True, ex=timeout):
-            return client, lock_key, identifier
-        time.sleep(0.1)
-
-    return None, None, None
-
-
-def release_lock(client, key, identifier):
-    """
-    Release the lock only if we still own it (key value == identifier).
-
-    Uses a Lua script to atomically check and delete in a single Redis operation.
-    This ensures GET+DEL happens atomically (no other Redis command can interleave).
-
-    Note: A non-atomic version would also work correctly:
-        current_value = client.get(key)
-        if current_value == identifier:
-            client.delete(key)
-
-    The identifier check prevents deleting someone else's lock. Lua just makes it atomic.
-    """
-    if client is None or key is None or identifier is None:
-        return
-    try:
-        # Atomic: GET + check + DEL all in one Redis operation
-        client.eval(_RELEASE_SCRIPT, 1, key, identifier)
-    except Exception:
-        pass  # Lock will expire on its own
-
-
 @contextmanager
 def with_lock(lock_key, timeout=30, wait_timeout=35):
     """
-    Context manager: acquire lock by key, yield, then release.
-    Yields True if lock was acquired, False if Redis unavailable or lock not acquired in time.
+    Context manager: acquire a Redis lock by key, yield, then release.
+    Yields True if lock was acquired, False if Redis unavailable or lock
+    not acquired in time.
     """
-    client, key, identifier = acquire_lock(lock_key, timeout, wait_timeout)
-    if client is None and key is None and identifier is None:
+    client = get_redis_client()
+    if client is None:
         yield False
         return
+    lock = client.lock(lock_key, timeout=timeout, blocking_timeout=wait_timeout)
+    acquired = lock.acquire()
     try:
-        yield True
+        yield acquired
     finally:
-        release_lock(client, key, identifier)
+        if acquired:
+            try:
+                lock.release()
+            except redis.exceptions.LockError:
+                pass
 
 
 @contextmanager

--- a/zou/app/utils/api.py
+++ b/zou/app/utils/api.py
@@ -18,7 +18,7 @@ def configure_api_from_blueprint(blueprint, route_tuples, decorators=None):
     }
 
     for route_tuple in route_tuples:
-        (path, resource) = route_tuple
+        path, resource = route_tuple
         api.add_resource(resource, path)
 
     return api

--- a/zou/app/utils/auth.py
+++ b/zou/app/utils/auth.py
@@ -27,6 +27,18 @@ def encrypt_password(password):
     return flask_bcrypt.generate_password_hash(password[:72])
 
 
+def check_password(password_hash, password):
+    """
+    Check a password against a bcrypt hash. Mirrors `encrypt_password`
+    truncation so that users whose password exceeds 72 bytes can still
+    log in (bcrypt 5+ raises ValueError on overlong input instead of
+    silently truncating).
+    """
+    if isinstance(password, str):
+        password = password.encode("utf-8")
+    return flask_bcrypt.check_password_hash(password_hash, password[:72])
+
+
 def validate_email(
     email, check_deliverability=config.MAIL_CHECK_DELIVERABILITY
 ):

--- a/zou/app/utils/events.py
+++ b/zou/app/utils/events.py
@@ -6,7 +6,6 @@ from zou.app.stores import publisher_store
 from zou.app.models.event import ApiEvent
 from zou.app.utils import fields
 
-
 handlers = {}
 
 publisher_store.init()

--- a/zou/app/utils/plugin_alembic_template/env.py
+++ b/zou/app/utils/plugin_alembic_template/env.py
@@ -22,7 +22,6 @@ from sqlalchemy import create_engine, pool
 from zou.app import db
 from zou.app.utils.plugins import PluginManifest
 
-
 config = context.config
 
 # The plugin path is injected by zou.app.utils.plugins.run_plugin_migrations.

--- a/zou/app/utils/plugin_alembic_template/env.py
+++ b/zou/app/utils/plugin_alembic_template/env.py
@@ -49,9 +49,7 @@ already_loaded = any(
 if not already_loaded:
     models_path = plugin_path / "models.py"
     if models_path.exists():
-        spec = importlib.util.spec_from_file_location(
-            module_name, models_path
-        )
+        spec = importlib.util.spec_from_file_location(module_name, models_path)
         module = importlib.util.module_from_spec(spec)
         sys.modules[module_name] = module
         spec.loader.exec_module(module)

--- a/zou/app/utils/thumbnail.py
+++ b/zou/app/utils/thumbnail.py
@@ -10,7 +10,6 @@ from PIL import Image, ImageFile
 
 from zou.app.utils import fs
 
-
 ImageFile.LOAD_TRUNCATED_IMAGES = True
 
 Image.MAX_IMAGE_PIXELS = 20000 * 20000
@@ -111,7 +110,7 @@ def turn_into_thumbnail(file_path, size=None):
     im = Image.open(file_path)
 
     if size is not None:
-        (width, height) = size
+        width, height = size
         if height == 0:
             size = get_full_size_from_width(im, width)
     else:
@@ -191,7 +190,7 @@ def generate_preview_variants(original_path, instance_id):
 
     result = []
     for picture_data in variants:
-        (picture_type, size) = picture_data
+        picture_type, size = picture_data
         folder_path = os.path.dirname(original_path)
         picture_path = os.path.join(
             folder_path, "%s-%s" % (picture_type, file_name)

--- a/zou/debug.py
+++ b/zou/debug.py
@@ -6,7 +6,6 @@ from zou.app import app, config
 from flask_socketio import SocketIO
 import logging
 
-
 FORMAT = "%(message)s"
 logging.basicConfig(level=logging.INFO, format=FORMAT)
 socketio = SocketIO(app, cors_allowed_origins=[], cors_credentials=False)

--- a/zou/migrations/versions/2b8f88aa610f_reconcile_squash_schema_with_legacy.py
+++ b/zou/migrations/versions/2b8f88aa610f_reconcile_squash_schema_with_legacy.py
@@ -125,7 +125,8 @@ PK_UC_SPLIT = [
 
 def upgrade():
     # 1. Ensure import_source_enum exists, then convert the column.
-    op.execute("""
+    op.execute(
+        """
         DO $$
         BEGIN
             IF NOT EXISTS (
@@ -135,8 +136,10 @@ def upgrade():
             END IF;
         END
         $$;
-        """)
-    op.execute("""
+        """
+    )
+    op.execute(
+        """
         DO $$
         BEGIN
             IF EXISTS (
@@ -153,7 +156,8 @@ def upgrade():
             END IF;
         END
         $$;
-        """)
+        """
+    )
 
     # 2. Restore TEXT column types.
     for table, column in TEXT_COLUMNS:
@@ -172,7 +176,8 @@ def upgrade():
 
     # 5. Add missing CHECK constraints (idempotent via pg_constraint check).
     for cname, table, expr in CHECK_CONSTRAINTS:
-        op.execute(f"""
+        op.execute(
+            f"""
             DO $$
             BEGIN
                 IF NOT EXISTS (
@@ -183,7 +188,8 @@ def upgrade():
                 END IF;
             END
             $$;
-            """)
+            """
+        )
 
     # 6. Add missing indexes.
     for idx_name, table, columns in MISSING_INDEXES:
@@ -192,7 +198,8 @@ def upgrade():
         )
 
     # 7. Replace only_one_email_by_person with its partial version.
-    op.execute("""
+    op.execute(
+        """
         DO $$
         BEGIN
             IF EXISTS (
@@ -208,11 +215,13 @@ def upgrade():
             END IF;
         END
         $$;
-        """)
+        """
+    )
 
     # 8. Rename constraints that fresh DBs got with auto-generated names.
     for old, new, table in CONSTRAINT_RENAMES:
-        op.execute(f"""
+        op.execute(
+            f"""
             DO $$
             BEGIN
                 IF EXISTS (
@@ -224,13 +233,15 @@ def upgrade():
                 END IF;
             END
             $$;
-            """)
+            """
+        )
 
     # 9. Split collapsed PK+UC constraints on link tables.
     # On fresh DBs, the constraint named <table>_uc is actually the PK; in
     # prod, <table>_pkey is the PK and <table>_uc is a separate UNIQUE.
     for table, cols in PK_UC_SPLIT:
-        op.execute(f"""
+        op.execute(
+            f"""
             DO $$
             BEGIN
                 IF EXISTS (
@@ -247,7 +258,8 @@ def upgrade():
                 END IF;
             END
             $$;
-            """)
+            """
+        )
 
 
 def downgrade():

--- a/zou/migrations/versions/2b8f88aa610f_reconcile_squash_schema_with_legacy.py
+++ b/zou/migrations/versions/2b8f88aa610f_reconcile_squash_schema_with_legacy.py
@@ -125,8 +125,7 @@ PK_UC_SPLIT = [
 
 def upgrade():
     # 1. Ensure import_source_enum exists, then convert the column.
-    op.execute(
-        """
+    op.execute("""
         DO $$
         BEGIN
             IF NOT EXISTS (
@@ -136,10 +135,8 @@ def upgrade():
             END IF;
         END
         $$;
-        """
-    )
-    op.execute(
-        """
+        """)
+    op.execute("""
         DO $$
         BEGIN
             IF EXISTS (
@@ -156,8 +153,7 @@ def upgrade():
             END IF;
         END
         $$;
-        """
-    )
+        """)
 
     # 2. Restore TEXT column types.
     for table, column in TEXT_COLUMNS:
@@ -176,8 +172,7 @@ def upgrade():
 
     # 5. Add missing CHECK constraints (idempotent via pg_constraint check).
     for cname, table, expr in CHECK_CONSTRAINTS:
-        op.execute(
-            f"""
+        op.execute(f"""
             DO $$
             BEGIN
                 IF NOT EXISTS (
@@ -188,8 +183,7 @@ def upgrade():
                 END IF;
             END
             $$;
-            """
-        )
+            """)
 
     # 6. Add missing indexes.
     for idx_name, table, columns in MISSING_INDEXES:
@@ -198,8 +192,7 @@ def upgrade():
         )
 
     # 7. Replace only_one_email_by_person with its partial version.
-    op.execute(
-        """
+    op.execute("""
         DO $$
         BEGIN
             IF EXISTS (
@@ -215,13 +208,11 @@ def upgrade():
             END IF;
         END
         $$;
-        """
-    )
+        """)
 
     # 8. Rename constraints that fresh DBs got with auto-generated names.
     for old, new, table in CONSTRAINT_RENAMES:
-        op.execute(
-            f"""
+        op.execute(f"""
             DO $$
             BEGIN
                 IF EXISTS (
@@ -233,15 +224,13 @@ def upgrade():
                 END IF;
             END
             $$;
-            """
-        )
+            """)
 
     # 9. Split collapsed PK+UC constraints on link tables.
     # On fresh DBs, the constraint named <table>_uc is actually the PK; in
     # prod, <table>_pkey is the PK and <table>_uc is a separate UNIQUE.
     for table, cols in PK_UC_SPLIT:
-        op.execute(
-            f"""
+        op.execute(f"""
             DO $$
             BEGIN
                 IF EXISTS (
@@ -258,8 +247,7 @@ def upgrade():
                 END IF;
             END
             $$;
-            """
-        )
+            """)
 
 
 def downgrade():

--- a/zou/migrations/versions/35ebb38695cd_add_icon_field_to_plugins.py
+++ b/zou/migrations/versions/35ebb38695cd_add_icon_field_to_plugins.py
@@ -10,7 +10,6 @@ from alembic import op
 import sqlalchemy as sa
 import sqlalchemy_utils
 
-
 # revision identifiers, used by Alembic.
 revision = "35ebb38695cd"
 down_revision = "9a9df20ea5a7"

--- a/zou/migrations/versions/68bae7fcd569_add_indexes_for_better_performance.py
+++ b/zou/migrations/versions/68bae7fcd569_add_indexes_for_better_performance.py
@@ -10,7 +10,6 @@ from alembic import op
 import sqlalchemy as sa
 import sqlalchemy_utils
 
-
 # revision identifiers, used by Alembic.
 revision = "68bae7fcd569"
 down_revision = "6f4088b109fc"

--- a/zou/migrations/versions/6f4088b109fc_change_attachment_file_size_to_bigint.py
+++ b/zou/migrations/versions/6f4088b109fc_change_attachment_file_size_to_bigint.py
@@ -10,7 +10,6 @@ from alembic import op
 import sqlalchemy as sa
 import sqlalchemy_utils
 
-
 # revision identifiers, used by Alembic.
 revision = "6f4088b109fc"
 down_revision = "f45eed2a3ba6"

--- a/zou/migrations/versions/7c91a4b3d2e0_add_project_template_tables.py
+++ b/zou/migrations/versions/7c91a4b3d2e0_add_project_template_tables.py
@@ -14,7 +14,6 @@ import uuid
 from zou.app.models.person import ROLE_TYPES
 from zou.app.models.project import PROJECT_STYLES
 
-
 # revision identifiers, used by Alembic.
 revision = "7c91a4b3d2e0"
 down_revision = "68bae7fcd569"

--- a/zou/migrations/versions/7c91a4b3d2e0_add_project_template_tables.py
+++ b/zou/migrations/versions/7c91a4b3d2e0_add_project_template_tables.py
@@ -113,7 +113,9 @@ def upgrade():
         "project_template_task_type_link", schema=None
     ) as batch_op:
         batch_op.create_index(
-            batch_op.f("ix_project_template_task_type_link_project_template_id"),
+            batch_op.f(
+                "ix_project_template_task_type_link_project_template_id"
+            ),
             ["project_template_id"],
             unique=False,
         )
@@ -228,9 +230,7 @@ def upgrade():
         sa.ForeignKeyConstraint(
             ["status_automation_id"], ["status_automation.id"]
         ),
-        sa.PrimaryKeyConstraint(
-            "project_template_id", "status_automation_id"
-        ),
+        sa.PrimaryKeyConstraint("project_template_id", "status_automation_id"),
     )
     with op.batch_alter_table(
         "project_template_status_automation_link", schema=None

--- a/zou/migrations/versions/8d42b9e1f7a3_add_project_template_backgrounds.py
+++ b/zou/migrations/versions/8d42b9e1f7a3_add_project_template_backgrounds.py
@@ -10,7 +10,6 @@ from alembic import op
 import sqlalchemy as sa
 import sqlalchemy_utils
 
-
 # revision identifiers, used by Alembic.
 revision = "8d42b9e1f7a3"
 down_revision = "7c91a4b3d2e0"

--- a/zou/migrations/versions/9a9df20ea5a7_add_frontend_options_to_plugins.py
+++ b/zou/migrations/versions/9a9df20ea5a7_add_frontend_options_to_plugins.py
@@ -10,7 +10,6 @@ from alembic import op
 import sqlalchemy as sa
 import sqlalchemy_utils
 
-
 # revision identifiers, used by Alembic.
 revision = "9a9df20ea5a7"
 down_revision = "12208e50bf18"

--- a/zou/migrations/versions/a1bc96e68661_add_playlist_sharing_support.py
+++ b/zou/migrations/versions/a1bc96e68661_add_playlist_sharing_support.py
@@ -5,50 +5,90 @@ Revises: c4e7f9a3b8d2
 Create Date: 2026-04-21 11:28:32.322788
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 import sqlalchemy_utils
 import uuid
 
 # revision identifiers, used by Alembic.
-revision = 'a1bc96e68661'
-down_revision = 'c4e7f9a3b8d2'
+revision = "a1bc96e68661"
+down_revision = "c4e7f9a3b8d2"
 branch_labels = None
 depends_on = None
 
 
 def upgrade():
-    op.create_table('playlist_share_link',
-    sa.Column('token', sa.String(length=64), nullable=False),
-    sa.Column('playlist_id', sqlalchemy_utils.types.uuid.UUIDType(binary=False), default=uuid.uuid4, nullable=False),
-    sa.Column('created_by', sqlalchemy_utils.types.uuid.UUIDType(binary=False), default=uuid.uuid4, nullable=False),
-    sa.Column('expiration_date', sa.DateTime(), nullable=True),
-    sa.Column('is_active', sa.Boolean(), nullable=False),
-    sa.Column('can_comment', sa.Boolean(), nullable=False),
-    sa.Column('password', sa.String(length=255), nullable=True),
-    sa.Column('id', sqlalchemy_utils.types.uuid.UUIDType(binary=False), default=uuid.uuid4, nullable=False),
-    sa.Column('created_at', sa.DateTime(), nullable=True),
-    sa.Column('updated_at', sa.DateTime(), nullable=True),
-    sa.ForeignKeyConstraint(['created_by'], ['person.id'], ),
-    sa.ForeignKeyConstraint(['playlist_id'], ['playlist.id'], ),
-    sa.PrimaryKeyConstraint('id')
+    op.create_table(
+        "playlist_share_link",
+        sa.Column("token", sa.String(length=64), nullable=False),
+        sa.Column(
+            "playlist_id",
+            sqlalchemy_utils.types.uuid.UUIDType(binary=False),
+            default=uuid.uuid4,
+            nullable=False,
+        ),
+        sa.Column(
+            "created_by",
+            sqlalchemy_utils.types.uuid.UUIDType(binary=False),
+            default=uuid.uuid4,
+            nullable=False,
+        ),
+        sa.Column("expiration_date", sa.DateTime(), nullable=True),
+        sa.Column("is_active", sa.Boolean(), nullable=False),
+        sa.Column("can_comment", sa.Boolean(), nullable=False),
+        sa.Column("password", sa.String(length=255), nullable=True),
+        sa.Column(
+            "id",
+            sqlalchemy_utils.types.uuid.UUIDType(binary=False),
+            default=uuid.uuid4,
+            nullable=False,
+        ),
+        sa.Column("created_at", sa.DateTime(), nullable=True),
+        sa.Column("updated_at", sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["created_by"],
+            ["person.id"],
+        ),
+        sa.ForeignKeyConstraint(
+            ["playlist_id"],
+            ["playlist.id"],
+        ),
+        sa.PrimaryKeyConstraint("id"),
     )
-    with op.batch_alter_table('playlist_share_link', schema=None) as batch_op:
-        batch_op.create_index('ix_playlist_share_link_playlist_active', ['playlist_id', 'is_active'], unique=False)
-        batch_op.create_index(batch_op.f('ix_playlist_share_link_playlist_id'), ['playlist_id'], unique=False)
-        batch_op.create_index(batch_op.f('ix_playlist_share_link_token'), ['token'], unique=True)
+    with op.batch_alter_table("playlist_share_link", schema=None) as batch_op:
+        batch_op.create_index(
+            "ix_playlist_share_link_playlist_active",
+            ["playlist_id", "is_active"],
+            unique=False,
+        )
+        batch_op.create_index(
+            batch_op.f("ix_playlist_share_link_playlist_id"),
+            ["playlist_id"],
+            unique=False,
+        )
+        batch_op.create_index(
+            batch_op.f("ix_playlist_share_link_token"), ["token"], unique=True
+        )
 
-    with op.batch_alter_table('person', schema=None) as batch_op:
-        batch_op.add_column(sa.Column('is_guest', sa.Boolean(), nullable=False, server_default=sa.false()))
+    with op.batch_alter_table("person", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "is_guest",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.false(),
+            )
+        )
 
 
 def downgrade():
-    with op.batch_alter_table('person', schema=None) as batch_op:
-        batch_op.drop_column('is_guest')
+    with op.batch_alter_table("person", schema=None) as batch_op:
+        batch_op.drop_column("is_guest")
 
-    with op.batch_alter_table('playlist_share_link', schema=None) as batch_op:
-        batch_op.drop_index(batch_op.f('ix_playlist_share_link_token'))
-        batch_op.drop_index(batch_op.f('ix_playlist_share_link_playlist_id'))
-        batch_op.drop_index('ix_playlist_share_link_playlist_active')
+    with op.batch_alter_table("playlist_share_link", schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f("ix_playlist_share_link_token"))
+        batch_op.drop_index(batch_op.f("ix_playlist_share_link_playlist_id"))
+        batch_op.drop_index("ix_playlist_share_link_playlist_active")
 
-    op.drop_table('playlist_share_link')
+    op.drop_table("playlist_share_link")

--- a/zou/migrations/versions/c4e7f9a3b8d2_add_for_client_to_comments.py
+++ b/zou/migrations/versions/c4e7f9a3b8d2_add_for_client_to_comments.py
@@ -9,7 +9,6 @@ Create Date: 2026-04-16 10:00:00.000000
 from alembic import op
 import sqlalchemy as sa
 
-
 # revision identifiers, used by Alembic.
 revision = "c4e7f9a3b8d2"
 down_revision = "8d42b9e1f7a3"

--- a/zou/migrations/versions/f45eed2a3ba6_add_index_to_assignation_table.py
+++ b/zou/migrations/versions/f45eed2a3ba6_add_index_to_assignation_table.py
@@ -10,7 +10,6 @@ from alembic import op
 import sqlalchemy as sa
 import sqlalchemy_utils
 
-
 # revision identifiers, used by Alembic.
 revision = "f45eed2a3ba6"
 down_revision = "35ebb38695cd"

--- a/zou/plugin_template/__init__.py
+++ b/zou/plugin_template/__init__.py
@@ -1,6 +1,5 @@
 from . import resources
 
-
 routes = [(f"/hello-world", resources.HelloWorld)]
 
 

--- a/zou/utils/movie.py
+++ b/zou/utils/movie.py
@@ -10,7 +10,6 @@ import tempfile
 import ffmpeg
 import opentimelineio as otio
 
-
 logger = logging.getLogger(__name__)
 loghandler = logging.StreamHandler()
 loghandler.setLevel(logging.INFO)
@@ -244,7 +243,7 @@ def normalize_movie(movie_path, fps, width, height):
         tempfile.gettempdir(), low_file_target_name
     )
 
-    (w, h) = get_movie_size(movie_path)
+    w, h = get_movie_size(movie_path)
     resize_factor = w / h
 
     if width is None:
@@ -370,7 +369,7 @@ def add_empty_soundtrack(file_path, try_count=1):
         logger.error(f"Err in soundtrack: {err}")
         logger.error(f"Err code: {sp.returncode}")
         if try_count <= 1:
-            (width, height) = get_movie_size(file_path)
+            width, height = get_movie_size(file_path)
             if height % 2 == 1:
                 height = height + 1
             stream = ffmpeg.input(file_path)
@@ -420,9 +419,9 @@ def build_playlist_movie(
     result = {"message": "", "success": False}
     if len(tmp_file_paths) > 0:
         # Get movie dimensions
-        (first_movie_file_path, _) = tmp_file_paths[0]
+        first_movie_file_path, _ = tmp_file_paths[0]
         if width is None:
-            (width, height) = get_movie_size(first_movie_file_path)
+            width, height = get_movie_size(first_movie_file_path)
 
         # Clean empty audio tracks
         for tmp_file_path, file_name in tmp_file_paths:


### PR DESCRIPTION
## Problems

- Pinned dependencies were drifting from latest stable (security + bug fixes left on the table)
- Custom Redis lock duplicated logic redis-py 7.x now provides natively, and annotation/playlist-build paths weren't lock-safe
- Playlist shared-membership endpoint loaded full preview-file payloads on every check
- `for_entity` on playlists accepted arbitrary values, and "episode" was missing from the allowed set
- No bulk endpoint to create multiple tasks on an entity in one call

## Solutions

- Bumped redis, bcrypt, flask-cors, tabulate plus all PATCH/MINOR/year-cal pins; ran black 26
- Replaced custom Lua lock with redis-py's native `Lock`; abort annotation update on lock failure; reject concurrent playlist build enqueues
- Drop preview-file enrichment from the shared-membership check
- Validate `for_entity` against the supported set and add "episode" to it
- Add `POST /data/entities/<id>/tasks` validating against project + asset-type workflows