### PR TITLE
Cascade share-link cleanup on CRUD playlist delete

### DIFF
--- a/tests/playlists/test_playlists.py
+++ b/tests/playlists/test_playlists.py
@@ -96,6 +96,20 @@ class PlaylistTestCase(ApiDBTestCase):
         ).all()
         self.assertEqual(len(notifications), 0)
 
+    def test_delete_playlist_with_share_links(self):
+        self.generate_fixture_playlist("Playlist 1")
+        playlist_sharing_service.create_share_link(
+            str(self.playlist.id), self.user["id"]
+        )
+        playlists = self.get("data/projects/%s/playlists" % self.project_id)
+        self.delete("data/playlists/%s" % playlists[0]["id"])
+        playlists = self.get("data/projects/%s/playlists" % self.project_id)
+        self.assertEqual(len(playlists), 0)
+        share_links = PlaylistShareLink.query.filter_by(
+            playlist_id=self.playlist.id
+        ).all()
+        self.assertEqual(len(share_links), 0)
+
     def test_remove_playlist_with_share_links(self):
         self.generate_fixture_playlist("Playlist 1")
         playlist_sharing_service.create_share_link(

--- a/zou/app/blueprints/crud/playlist.py
+++ b/zou/app/blueprints/crud/playlist.py
@@ -3,6 +3,7 @@ from flask_jwt_extended import jwt_required
 from zou.app.models.playlist import Playlist
 from zou.app.models.build_job import BuildJob
 from zou.app.models.notification import Notification
+from zou.app.models.playlist_share_link import PlaylistShareLink
 from zou.app.services import user_service, playlists_service, persons_service
 from zou.app.services.exception import WrongParameterException
 
@@ -382,6 +383,11 @@ class PlaylistResource(BaseModelResource):
         query = BuildJob.query.filter_by(playlist_id=playlist["id"])
         for job in query.all():
             playlists_service.remove_build_job(playlist, job.id)
+        share_links = PlaylistShareLink.query.filter_by(
+            playlist_id=playlist["id"]
+        ).all()
+        for share_link in share_links:
+            share_link.delete()
 
     def check_update_permissions(self, playlist, data):
         return user_service.check_playlist_update_access(playlist)


### PR DESCRIPTION
**Problem**
- Deleting a playlist that owns share links surfaces a ForeignKeyViolation on `playlist_share_link_playlist_id_fkey`; the previous fix only covered `playlists_service.remove_playlist()`, but Kitsu deletes via `DELETE /api/data/playlists/<id>` which bypasses the service

**Solution**
- Delete share links in `PlaylistResource.pre_delete` alongside notifications and build jobs
