### PR TITLE
Exclude guests from user-limit and studio-team queries

### DIFF
--- a/tests/services/test_persons_service.py
+++ b/tests/services/test_persons_service.py
@@ -114,13 +114,24 @@ class PersonServiceTestCase(ApiDBTestCase):
         self.assertEqual(logs[0]["date"], date_2)
 
     def test_is_user_limit_reached(self):
-        is_reached = persons_service.is_user_limit_reached()
-        self.assertEqual(is_reached, False)
         from zou.app import config
+        from zou.app.models.person import Person
+
+        self.assertFalse(persons_service.is_user_limit_reached())
 
         config.USER_LIMIT = 2
-        is_reached = persons_service.is_user_limit_reached()
-        self.assertEqual(is_reached, True)
+        self.assertTrue(persons_service.is_user_limit_reached())
+
+        config.USER_LIMIT = 3
+        Person.create(
+            first_name="Guest",
+            last_name="Reviewer",
+            email="guest-reviewer@guest.kitsu",
+            role="client",
+            is_guest=True,
+        )
+        self.assertFalse(persons_service.is_user_limit_reached())
+
         config.USER_LIMIT = 100
 
     def test_add_to_department(self):

--- a/tests/services/test_persons_service.py
+++ b/tests/services/test_persons_service.py
@@ -165,6 +165,23 @@ class PersonServiceTestCase(ApiDBTestCase):
         for person in persons:
             self.assertTrue(person.active)
 
+    def test_active_persons_exclude_guests(self):
+        from zou.app.models.person import Person
+
+        Person.create(
+            first_name="Guest",
+            last_name="Reviewer",
+            email="guest-reviewer@guest.kitsu",
+            role="client",
+            is_guest=True,
+        )
+        raw_persons = persons_service.get_all_raw_active_persons()
+        self.assertGreater(len(raw_persons), 0)
+        self.assertFalse(any(p.is_guest for p in raw_persons))
+        persons = persons_service.get_active_persons()
+        self.assertGreater(len(persons), 0)
+        self.assertFalse(any(p.get("is_guest") for p in persons))
+
     def test_get_person_raw(self):
         person = persons_service.get_person_raw(self.person_id)
         self.assertEqual(str(person.id), self.person_id)

--- a/zou/app/blueprints/admin/resources.py
+++ b/zou/app/blueprints/admin/resources.py
@@ -15,6 +15,8 @@ class ConfigCheckResource(Resource):
 
         comparison = config_store.get_config_comparison()
         comparison["active_users"] = Person.query.filter(
-            Person.active, Person.is_bot.isnot(True)
+            Person.active,
+            Person.is_bot.isnot(True),
+            Person.is_guest.isnot(True),
         ).count()
         return comparison

--- a/zou/app/blueprints/export/csv/persons.py
+++ b/zou/app/blueprints/export/csv/persons.py
@@ -44,9 +44,9 @@ class PersonsCsvExport(BaseCsvExport):
         ]
 
     def build_query(self):
-        return Person.query.filter(Person.is_bot == False).order_by(
-            Person.last_name, Person.first_name
-        )
+        return Person.query.filter(
+            Person.is_bot.isnot(True), Person.is_guest.isnot(True)
+        ).order_by(Person.last_name, Person.first_name)
 
     def build_row(self, person):
         active = "yes"

--- a/zou/app/services/persons_service.py
+++ b/zou/app/services/persons_service.py
@@ -70,18 +70,20 @@ def get_persons(minimal=False, include_guests=False):
 
 def get_all_raw_active_persons():
     """
-    Return all person stored in database without serialization.
+    Return all active persons without serialization. Guests are excluded.
     """
-    return Person.get_all_by(active=True)
+    return Person.query.filter(
+        Person.active, Person.is_guest.isnot(True)
+    ).all()
 
 
 @cache.memoize_function(120)
 def get_active_persons():
     """
-    Return all persons with flag active set to True.
+    Return all persons with flag active set to True. Guests are excluded.
     """
     persons = (
-        Person.query.filter_by(active=True)
+        Person.query.filter(Person.active, Person.is_guest.isnot(True))
         .order_by(Person.first_name)
         .order_by(Person.last_name)
         .all()

--- a/zou/app/services/persons_service.py
+++ b/zou/app/services/persons_service.py
@@ -714,10 +714,12 @@ def get_default_locale():
 def is_user_limit_reached():
     """
     Returns true if the number of active users is equal and superior to the
-    user limit set in the configuration.
+    user limit set in the configuration. Guests are excluded.
     """
     nb_active_users = Person.query.filter(
-        Person.active, Person.is_bot.isnot(True)
+        Person.active,
+        Person.is_bot.isnot(True),
+        Person.is_guest.isnot(True),
     ).count()
     return nb_active_users >= get_user_limit()
 

--- a/zou/app/services/telemetry_services.py
+++ b/zou/app/services/telemetry_services.py
@@ -19,7 +19,9 @@ def send_main_infos():
 
     organisation = persons_service.get_organisation()
     stats = stats_service.get_main_stats()
-    nb_active_users = Person.query.filter_by(active=True).count()
+    nb_active_users = Person.query.filter(
+        Person.active, Person.is_guest.isnot(True)
+    ).count()
 
     data = {
         "organisation_id": organisation["id"],


### PR DESCRIPTION
**Problem**
- Guest accounts created via shared playlist links were counted as active users and consumed license slots without appearing on the people page
- They also leaked into telemetry, the person search index, the admin active-users stat and the people CSV export

**Solution**
- Exclude `is_guest=True` from `is_user_limit_reached`, `get_active_persons`, `get_all_raw_active_persons`, the admin `ConfigCheckResource`, telemetry `send_main_infos` and the `PersonsCsvExport` query
