### PR TITLE
Sentry triage (admin/playlists/shots/previews) + comment move

### DIFF
--- a/tests/admin/test_config_check.py
+++ b/tests/admin/test_config_check.py
@@ -1,4 +1,7 @@
 import orjson as json
+from unittest.mock import patch
+
+from sqlalchemy.exc import ProgrammingError
 
 from tests.base import ApiDBTestCase
 from zou.app import config
@@ -116,3 +119,20 @@ class ConfigCheckTestCase(ApiDBTestCase):
 
         self.assertIsInstance(data["active_users"], int)
         self.assertGreaterEqual(data["active_users"], 1)
+
+    def test_active_users_unavailable_when_db_schema_broken(self):
+        error = ProgrammingError(
+            "stmt", {}, Exception('relation "person" does not exist')
+        )
+        with patch(
+            "zou.app.blueprints.admin.resources.Person"
+        ) as mock_person:
+            mock_person.query.filter.return_value.count.side_effect = error
+            response = self.app.get(
+                "admin/config/check",
+                headers={"Authorization": f"Bearer {TEST_TOKEN}"},
+            )
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data)
+        self.assertIn("active_users", data)
+        self.assertIsNone(data["active_users"])

--- a/tests/comments/test_route_comments.py
+++ b/tests/comments/test_route_comments.py
@@ -1,6 +1,9 @@
 from tests.base import ApiDBTestCase
 
+from zou.app.models.attachment_file import AttachmentFile
+from zou.app.models.notification import Notification
 from zou.app.models.person import Person
+from zou.app.models.task import Task
 from zou.app.services import comments_service, tasks_service
 
 
@@ -153,3 +156,140 @@ class CommentRoutesTestCase(ApiDBTestCase):
             },
         )
         self.assertFalse(result["for_client"])
+
+    def _make_sibling_task(self):
+        """Create a second task on the same asset with a different task type."""
+        return Task.create(
+            name="Modeling task",
+            project_id=self.project.id,
+            task_type_id=self.task_type_modeling.id,
+            task_status_id=self.task_status.id,
+            entity_id=self.asset.id,
+            assignees=[self.person],
+            assigner_id=self.assigner.id,
+        )
+
+    def test_move_comment_between_tasks(self):
+        sibling = self._make_sibling_task()
+        original_created_at = self.comment["created_at"]
+        original_status_id = self.comment["task_status_id"]
+        result = self.post(
+            f"/actions/tasks/{self.task.id}"
+            f"/comments/{self.comment['id']}/move",
+            {"target_task_id": str(sibling.id)},
+            200,
+        )
+        self.assertEqual(result["object_id"], str(sibling.id))
+        self.assertEqual(result["created_at"], original_created_at)
+        self.assertEqual(result["task_status_id"], original_status_id)
+
+        source_comments = tasks_service.get_comments(str(self.task.id))
+        target_comments = tasks_service.get_comments(str(sibling.id))
+        self.assertNotIn(
+            self.comment["id"], [c["id"] for c in source_comments]
+        )
+        self.assertIn(self.comment["id"], [c["id"] for c in target_comments])
+
+    def test_move_comment_preserves_attachment(self):
+        sibling = self._make_sibling_task()
+        AttachmentFile.create(
+            name="brief.pdf",
+            size=0,
+            extension="pdf",
+            mimetype="application/pdf",
+            comment_id=self.comment["id"],
+        )
+        self.post(
+            f"/actions/tasks/{self.task.id}"
+            f"/comments/{self.comment['id']}/move",
+            {"target_task_id": str(sibling.id)},
+            200,
+        )
+        attachments = AttachmentFile.get_all_by(comment_id=self.comment["id"])
+        self.assertEqual(len(attachments), 1)
+        self.assertEqual(attachments[0].name, "brief.pdf")
+
+    def test_move_comment_rebuilds_notifications(self):
+        self.generate_fixture_user_manager()
+        self.generate_fixture_user_cg_artist()
+        cg_person = Person.get(self.user_cg_artist["id"])
+        self.project.team = [
+            cg_person,
+            self.person,
+            Person.get(self.user["id"]),
+        ]
+        self.project.save()
+        sibling = self._make_sibling_task()
+        sibling.assignees = [cg_person]
+        sibling.save()
+
+        Notification.delete_all_by(comment_id=self.comment["id"])
+        Notification.create(
+            person_id=self.person.id,
+            author_id=self.user["id"],
+            comment_id=self.comment["id"],
+            task_id=self.task.id,
+            type="comment",
+        )
+        self.post(
+            f"/actions/tasks/{self.task.id}"
+            f"/comments/{self.comment['id']}/move",
+            {"target_task_id": str(sibling.id)},
+            200,
+        )
+        notifications = Notification.get_all_by(comment_id=self.comment["id"])
+        recipient_ids = {str(n.person_id) for n in notifications}
+        task_ids = {str(n.task_id) for n in notifications}
+        self.assertIn(self.user_cg_artist["id"], recipient_ids)
+        self.assertEqual(task_ids, {str(sibling.id)})
+
+    def test_move_comment_rejects_cross_entity(self):
+        self.generate_fixture_asset(name="Tree2")
+        other_asset_id = self.asset.id
+        other_task = Task.create(
+            name="Other entity task",
+            project_id=self.project.id,
+            task_type_id=self.task_type.id,
+            task_status_id=self.task_status.id,
+            entity_id=other_asset_id,
+            assignees=[self.person],
+            assigner_id=self.assigner.id,
+        )
+        response = self.app.post(
+            f"/actions/tasks/{self.task_id}"
+            f"/comments/{self.comment['id']}/move",
+            data='{"target_task_id": "%s"}' % str(other_task.id),
+            headers=self.post_headers,
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_move_comment_rejects_same_task(self):
+        response = self.app.post(
+            f"/actions/tasks/{self.task.id}"
+            f"/comments/{self.comment['id']}/move",
+            data='{"target_task_id": "%s"}' % str(self.task.id),
+            headers=self.post_headers,
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_move_comment_rejects_mismatched_source_task(self):
+        sibling = self._make_sibling_task()
+        response = self.app.post(
+            f"/actions/tasks/{sibling.id}"
+            f"/comments/{self.comment['id']}/move",
+            data='{"target_task_id": "%s"}' % str(sibling.id),
+            headers=self.post_headers,
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_move_comment_rejects_non_manager(self):
+        self.generate_fixture_user_cg_artist()
+        sibling = self._make_sibling_task()
+        self.log_in_cg_artist()
+        response = self.app.post(
+            f"/actions/tasks/{self.task.id}"
+            f"/comments/{self.comment['id']}/move",
+            data='{"target_task_id": "%s"}' % str(sibling.id),
+            headers=self.post_headers,
+        )
+        self.assertEqual(response.status_code, 403)

--- a/tests/comments/test_route_comments.py
+++ b/tests/comments/test_route_comments.py
@@ -282,6 +282,31 @@ class CommentRoutesTestCase(ApiDBTestCase):
         )
         self.assertEqual(response.status_code, 400)
 
+    def test_move_comment_resets_task_status_on_both_tasks(self):
+        self.generate_fixture_task_status_wip()
+        sibling = self._make_sibling_task()
+        source_initial_status = self.task.task_status_id
+        wip_comment = comments_service.new_comment(
+            self.task.id,
+            self.task_status_wip.id,
+            self.user["id"],
+            "wip note posted on the wrong task",
+        )
+        self.post(
+            f"/actions/tasks/{self.task.id}"
+            f"/comments/{wip_comment['id']}/move",
+            {"target_task_id": str(sibling.id)},
+            200,
+        )
+        source_after = tasks_service.get_task(str(self.task.id))
+        target_after = tasks_service.get_task(str(sibling.id))
+        self.assertEqual(
+            source_after["task_status_id"], str(source_initial_status)
+        )
+        self.assertEqual(
+            target_after["task_status_id"], str(self.task_status_wip.id)
+        )
+
     def test_move_comment_rejects_non_manager(self):
         self.generate_fixture_user_cg_artist()
         sibling = self._make_sibling_task()

--- a/tests/services/test_files_service.py
+++ b/tests/services/test_files_service.py
@@ -5,6 +5,7 @@ from tests.base import ApiDBTestCase
 from zou.app import app
 from zou.app.services import files_service, preview_files_service
 from zou.app.models.software import Software
+from zou.app.utils import fields
 from zou.app.services.exception import (
     EntryAlreadyExistsException,
     OutputFileNotFoundException,
@@ -510,6 +511,23 @@ class FileServiceTestCase(ApiDBTestCase):
             PreviewFileNotFoundException,
             files_service.get_preview_file,
             preview_file_id,
+        )
+
+    def test_get_preview_file_for_access(self):
+        self.generate_fixture_preview_file()
+        preview_file_id = self.preview_file.id
+        result = files_service.get_preview_file_for_access(preview_file_id)
+        self.assertEqual(
+            set(result.keys()), {"id", "task_id", "updated_at", "extension"}
+        )
+        self.assertEqual(result["id"], str(preview_file_id))
+        self.assertEqual(result["task_id"], str(self.preview_file.task_id))
+
+    def test_get_preview_file_for_access_missing(self):
+        self.assertRaises(
+            PreviewFileNotFoundException,
+            files_service.get_preview_file_for_access,
+            fields.gen_uuid(),
         )
 
     def test_get_preview_files_for_project(self):

--- a/tests/services/test_playlists_service.py
+++ b/tests/services/test_playlists_service.py
@@ -159,3 +159,20 @@ class PlaylistsServiceTestCase(ApiDBTestCase):
         playlist_dict = playlists_service.build_playlist_dict(playlist)
         self.assertTrue("shots" not in playlist_dict)
         self.assertEqual(playlist_dict["for_entity"], "shot")
+
+    def test_set_preview_files_skips_empty_entity_ids(self):
+        self.generate_fixture_preview_files()
+        playlist_dict = {
+            "shots": [
+                {"id": ""},
+                {"shot_id": ""},
+                {"entity_id": None},
+                {},
+                {"id": str(self.shot.id)},
+            ]
+        }
+        result, _ = playlists_service.set_preview_files_for_entities(
+            playlist_dict
+        )
+        self.assertEqual(len(result["shots"]), 5)
+        self.assertEqual(result["shots"][-1]["id"], str(self.shot.id))

--- a/tests/services/test_shots_service.py
+++ b/tests/services/test_shots_service.py
@@ -1,4 +1,7 @@
+from unittest.mock import patch
+
 import pytest
+from sqlalchemy.exc import IntegrityError
 
 from tests.base import ApiDBTestCase
 
@@ -205,6 +208,46 @@ class ShotUtilsTestCase(ApiDBTestCase):
         shot = shots_service.create_shot(self.project.id, parent_id, shot_name)
         self.assertEqual(shot["name"], shot_name)
         self.assertEqual(shot["parent_id"], parent_id)
+
+    def test_create_shot_recovers_from_concurrent_duplicate(self):
+        shot_name = "RACE_SHOT"
+        parent_id = str(self.sequence.id)
+        shot_type = shots_service.get_shot_type()
+        existing = Entity.create(
+            entity_type_id=shot_type["id"],
+            project_id=self.project.id,
+            parent_id=self.sequence.id,
+            name=shot_name,
+        )
+        existing_id = str(existing.id)
+
+        real_get_by = Entity.get_by
+        state = {"first_shot_lookup": True, "create_called": False}
+
+        def fake_get_by(**kw):
+            if (
+                kw.get("name") == shot_name
+                and kw.get("entity_type_id") == shot_type["id"]
+                and state["first_shot_lookup"]
+            ):
+                state["first_shot_lookup"] = False
+                return None
+            return real_get_by(**kw)
+
+        def fake_create(**kw):
+            state["create_called"] = True
+            raise IntegrityError("INSERT", {}, Exception("duplicate"))
+
+        with (
+            patch.object(Entity, "get_by", side_effect=fake_get_by),
+            patch.object(Entity, "create", side_effect=fake_create),
+        ):
+            shot = shots_service.create_shot(
+                self.project.id, parent_id, shot_name
+            )
+
+        self.assertTrue(state["create_called"])
+        self.assertEqual(shot["id"], existing_id)
 
     def test_create_scene(self):
         scene_name = "NSC01"

--- a/tests/services/test_tasks_service.py
+++ b/tests/services/test_tasks_service.py
@@ -223,6 +223,51 @@ class TaskServiceTestCase(ApiDBTestCase):
         self.assertEqual(len(task_types), 1)
         self.assertEqual(task_types[0]["id"], str(self.task_type.id))
 
+    def test_get_task_dicts_for_entity_with_relations_attaches_assignees(
+        self,
+    ):
+        self.generate_fixture_task(name="Secondary")
+        person_id = str(self.person.id)
+        tasks = tasks_service.get_task_dicts_for_entity(
+            self.asset.id, relations=True
+        )
+        self.assertEqual(len(tasks), 2)
+        for task in tasks:
+            self.assertEqual(task["assignees"], [person_id])
+            self.assertTrue(all(isinstance(a, str) for a in task["assignees"]))
+
+    def test_get_task_dicts_for_entity_relations_avoids_n_plus_one(self):
+        from sqlalchemy import event
+        from zou.app import db
+
+        self.generate_fixture_task(name="Secondary")
+        self.generate_fixture_task(name="Tertiary")
+
+        statements = []
+
+        def collect(conn, cursor, statement, *args, **kwargs):
+            statements.append(statement)
+
+        engine = db.session.get_bind()
+        event.listen(engine, "before_cursor_execute", collect)
+        try:
+            tasks = tasks_service.get_task_dicts_for_entity(
+                self.asset.id, relations=True
+            )
+        finally:
+            event.remove(engine, "before_cursor_execute", collect)
+
+        self.assertEqual(len(tasks), 3)
+        link_statements = [
+            s for s in statements if "task_person_link" in s.lower()
+        ]
+        self.assertLessEqual(
+            len(link_statements),
+            1,
+            f"Expected at most 1 task_person_link query, got "
+            f"{len(link_statements)}: {link_statements}",
+        )
+
     def test_get_task_dicts_for_entity_utf8(self):
         start_date = fields.get_date_object("2017-02-20")
         due_date = fields.get_date_object("2017-02-28")

--- a/tests/shared/test_playlist_sharing.py
+++ b/tests/shared/test_playlist_sharing.py
@@ -1,5 +1,7 @@
 from tests.base import ApiDBTestCase
 
+from zou.app.utils import events
+
 
 class PlaylistSharingTestCase(ApiDBTestCase):
     def setUp(self):
@@ -214,6 +216,38 @@ class PlaylistSharingTestCase(ApiDBTestCase):
         )
         self.assertEqual(guest["first_name"], "John")
         self.assertTrue(guest["is_guest"])
+
+    def test_create_guest_emits_person_new(self):
+        """Connected clients (e.g. a reviewing manager) rely on the
+        ``person:new`` event to learn about a freshly minted guest, so
+        their personMap can resolve the person_id carried by the guest's
+        first comment. Without this the comment renders blank."""
+        link = self.post(
+            f"/data/playlists/{self.playlist['id']}/share",
+            {},
+            201,
+        )
+        self.log_out()
+        events.unregister_all()
+        received = []
+
+        class _Sink:
+            __name__ = "guest_person_new_sink"
+
+            def handle_event(self_sink, data):
+                received.append(data)
+
+        events.register("person:new", "guest_person_new_sink", _Sink())
+        try:
+            guest = self.post(
+                f"/shared/playlists/{link['token']}/guest",
+                {"first_name": "Lena"},
+                201,
+            )
+            self.assertEqual(len(received), 1)
+            self.assertEqual(received[0]["person_id"], guest["id"])
+        finally:
+            events.unregister("person:new", "guest_person_new_sink")
 
     def test_reuse_guest(self):
         link = self.post(

--- a/tests/user/test_route_context.py
+++ b/tests/user/test_route_context.py
@@ -1,3 +1,5 @@
+import orjson as json
+
 from tests.base import ApiDBTestCase
 
 from zou.app.services import (
@@ -257,6 +259,21 @@ class UserContextRoutesTestCase(ApiDBTestCase):
         path = "data/user/tasks/"
         tasks = self.get(path)
         self.assertEqual(len(tasks), 1)
+
+    def test_get_todos_bearer_only(self):
+        # Regression for issue #1059: /data/user/tasks must work with a
+        # bare JWT Bearer header, without any Flask-Principal session
+        # cookie. Reproduces a script-style call (curl / gazu) where the
+        # decorator ordering used to make permissions.require_person
+        # raise 403 before jwt_required() had loaded the identity.
+        self.assign_user(self.task.id)
+
+        bearer_client = self.flask_app.test_client()
+        headers = dict(self.base_headers)
+        response = bearer_client.get("data/user/tasks", headers=headers)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(json.loads(response.data.decode("utf-8"))), 1)
 
     def test_get_done_tasks(self):
         task_id = self.task.id

--- a/zou/app/blueprints/admin/resources.py
+++ b/zou/app/blueprints/admin/resources.py
@@ -1,5 +1,6 @@
-from flask import abort, request
+from flask import abort, current_app, request
 from flask_restful import Resource
+from sqlalchemy.exc import OperationalError, ProgrammingError
 
 from zou.app import config
 from zou.app.models.person import Person
@@ -14,9 +15,15 @@ class ConfigCheckResource(Resource):
             abort(403)
 
         comparison = config_store.get_config_comparison()
-        comparison["active_users"] = Person.query.filter(
-            Person.active,
-            Person.is_bot.isnot(True),
-            Person.is_guest.isnot(True),
-        ).count()
+        try:
+            comparison["active_users"] = Person.query.filter(
+              Person.active,
+              Person.is_bot.isnot(True),
+              Person.is_guest.isnot(True),
+            ).count()
+        except (ProgrammingError, OperationalError) as exc:
+            current_app.logger.warning(
+                f"Config check could not count active users: {exc}"
+            )
+            comparison["active_users"] = None
         return comparison

--- a/zou/app/blueprints/comments/__init__.py
+++ b/zou/app/blueprints/comments/__init__.py
@@ -9,6 +9,7 @@ from zou.app.blueprints.comments.resources import (
     CommentTaskResource,
     CommentManyTasksResource,
     DownloadAttachmentResource,
+    MoveCommentResource,
     ProjectAttachmentFiles,
     TaskAttachmentFiles,
     ReplyCommentResource,
@@ -36,6 +37,10 @@ routes = [
     (
         "/actions/tasks/<task_id>/comments/<comment_id>/add-attachment",
         AddAttachmentToCommentResource,
+    ),
+    (
+        "/actions/tasks/<task_id>/comments/<comment_id>/move",
+        MoveCommentResource,
     ),
     ("/data/projects/<project_id>/attachment-files", ProjectAttachmentFiles),
     ("/data/tasks/<task_id>/attachment-files", TaskAttachmentFiles),

--- a/zou/app/blueprints/comments/resources.py
+++ b/zou/app/blueprints/comments/resources.py
@@ -10,7 +10,10 @@ from zou.app.services.exception import (
     WrongParameterException,
 )
 from zou.app.utils import permissions, date_helpers, validation
-from zou.app.blueprints.comments.schemas import CommentReplySchema
+from zou.app.blueprints.comments.schemas import (
+    CommentReplySchema,
+    MoveCommentSchema,
+)
 
 from zou.app.services import (
     chats_service,
@@ -884,3 +887,77 @@ class TaskAttachmentFiles(Resource):
         """
         permissions.check_admin_permissions()
         return comments_service.get_all_attachment_files_for_task(task_id)
+
+
+class MoveCommentResource(Resource):
+
+    @jwt_required()
+    def post(self, task_id, comment_id):
+        """
+        Move a comment to another task of the same entity
+        ---
+        description: Move an existing comment from its current task to
+          another task that belongs to the same entity (shot, asset,
+          sequence, episode or edit). The comment text, attachments,
+          mentions, original creation date and the task status change it
+          carries are preserved. Notifications and news linked to the
+          comment on the source task are removed and recreated against the
+          target task, so the target task's watchers get notified as if a
+          new comment was posted. Reserved to production managers and
+          studio admins. Comments tied to a preview revision cannot be
+          moved.
+        tags:
+          - Comments
+        parameters:
+          - in: path
+            name: task_id
+            required: true
+            type: string
+            format: uuid
+            description: Unique identifier of the comment's current task
+            example: a24a6ea4-ce75-4665-a070-57453082c25
+          - in: path
+            name: comment_id
+            required: true
+            type: string
+            format: uuid
+            description: Unique identifier of the comment to move
+            example: b35b7fb5-df86-5776-b181-68564193d36
+        requestBody:
+          required: true
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - target_task_id
+                properties:
+                  target_task_id:
+                    type: string
+                    format: uuid
+                    description: Unique identifier of the task to move the
+                      comment to. Must belong to the same entity as the
+                      current task.
+                    example: c46c8gc6-eg97-6887-c292-79675204e47
+        responses:
+          200:
+            description: Comment successfully moved to the target task. The
+              returned payload is the comment with its updated object_id.
+          400:
+            description: Source and target tasks differ in entity, are the
+              same task, or the comment is tied to a preview revision.
+          403:
+            description: Caller is not a manager or admin.
+        """
+        permissions.check_manager_permissions()
+        body = validation.validate_request_body(MoveCommentSchema)
+        user_service.check_task_access(task_id)
+        user_service.check_task_access(body.target_task_id)
+        comment = tasks_service.get_comment(comment_id)
+        if str(comment["object_id"]) != str(task_id):
+            raise WrongParameterException(
+                "Comment does not belong to the given task."
+            )
+        return comments_service.move_comment_to_task(
+            comment_id, body.target_task_id
+        )

--- a/zou/app/blueprints/comments/schemas.py
+++ b/zou/app/blueprints/comments/schemas.py
@@ -13,3 +13,11 @@ class CommentReplySchema(BaseSchema):
     """Body for replying to a comment."""
 
     text: Optional[str] = Field("", description="Reply text content")
+
+
+class MoveCommentSchema(BaseSchema):
+    """Body for moving a comment to another task of the same entity."""
+
+    target_task_id: str = Field(
+        ..., description="Identifier of the task to move the comment to"
+    )

--- a/zou/app/blueprints/previews/resources.py
+++ b/zou/app/blueprints/previews/resources.py
@@ -656,7 +656,9 @@ class BasePreviewFileResource(Resource):
         self.last_modified = None
 
     def is_allowed(self, preview_file_id):
-        self.preview_file = files_service.get_preview_file(preview_file_id)
+        self.preview_file = files_service.get_preview_file_for_access(
+            preview_file_id
+        )
         user_service.check_task_access(self.preview_file["task_id"])
         self.last_modified = date_helpers.get_datetime_from_string(
             self.preview_file["updated_at"]
@@ -1082,7 +1084,9 @@ class BasePreviewFileThumbnailResource(BasePreviewPictureResource):
     """
 
     def is_allowed(self, preview_file_id):
-        self.preview_file = files_service.get_preview_file(preview_file_id)
+        self.preview_file = files_service.get_preview_file_for_access(
+            preview_file_id
+        )
         task = tasks_service.get_task(self.preview_file["task_id"])
         entity = entities_service.get_entity(task["entity_id"])
         if (

--- a/zou/app/blueprints/user/__init__.py
+++ b/zou/app/blueprints/user/__init__.py
@@ -120,7 +120,7 @@ api = configure_api_from_blueprint(
     blueprint,
     routes,
     decorators=[
-        jwt_required(),
         permissions.require_person,
+        jwt_required(),
     ],
 )

--- a/zou/app/services/comments_service.py
+++ b/zou/app/services/comments_service.py
@@ -421,6 +421,79 @@ def new_comment(
     return comment
 
 
+def move_comment_to_task(comment_id, target_task_id):
+    """
+    Move a comment from its current task to another task that belongs to the
+    same entity. The original creation date, text, attachments, mentions and
+    status change carried by the comment are preserved. Notifications and
+    news linked to the comment on the source task are removed and recreated
+    against the target task so the target task's watchers are notified as if
+    they received a new comment.
+
+    Comments tied to a preview revision (preview_file_id set or previews
+    populated) cannot be moved: previews stay attached to the task that
+    owns the revision.
+    """
+    comment = tasks_service.get_comment_raw(comment_id)
+    source_task = tasks_service.get_task(str(comment.object_id))
+    target_task = tasks_service.get_task(target_task_id, relations=True)
+
+    if str(source_task["id"]) == str(target_task["id"]):
+        raise WrongParameterException(
+            "Source and target tasks must be different."
+        )
+    if source_task["entity_id"] != target_task["entity_id"]:
+        raise WrongParameterException(
+            "A comment can only be moved between tasks of the same entity."
+        )
+    if comment.preview_file_id is not None or (
+        comment.previews is not None and len(comment.previews) > 0
+    ):
+        raise WrongParameterException(
+            "A comment attached to a preview revision cannot be moved."
+        )
+
+    Notification.delete_all_by(comment_id=comment.id)
+    news_service.delete_news_for_comment(comment.id)
+
+    comment.update({"object_id": target_task["id"]})
+    tasks_service.clear_comment_cache(str(comment.id))
+    tasks_service.clear_task_cache(str(source_task["id"]))
+    tasks_service.clear_task_cache(str(target_task["id"]))
+
+    comment_dict = comment.serialize(relations=True)
+
+    events.emit(
+        "comment:delete",
+        {"comment_id": str(comment.id)},
+        project_id=source_task["project_id"],
+    )
+    events.emit(
+        "comment:new",
+        {
+            "comment_id": str(comment.id),
+            "task_id": str(target_task["id"]),
+            "task_status_id": comment_dict["task_status_id"],
+        },
+        project_id=target_task["project_id"],
+    )
+
+    notifications_service.create_notifications_for_task_and_comment(
+        target_task, comment_dict, change=False
+    )
+    if (
+        entities_service.get_entity(target_task["entity_id"])["entity_type_id"]
+        != concepts_service.get_concept_type()["id"]
+    ):
+        news_service.create_news_for_task_and_comment(
+            target_task,
+            comment_dict,
+            created_at=comment_dict["created_at"],
+        )
+
+    return comment_dict
+
+
 def reset_mentions(comment):
     task = tasks_service.get_task(comment["object_id"])
     mentions = get_comment_mentions(task["project_id"], comment["text"])

--- a/zou/app/services/comments_service.py
+++ b/zou/app/services/comments_service.py
@@ -458,8 +458,9 @@ def move_comment_to_task(comment_id, target_task_id):
 
     comment.update({"object_id": target_task["id"]})
     tasks_service.clear_comment_cache(str(comment.id))
-    tasks_service.clear_task_cache(str(source_task["id"]))
-    tasks_service.clear_task_cache(str(target_task["id"]))
+
+    tasks_service.reset_task_data(str(source_task["id"]))
+    target_task = tasks_service.reset_task_data(str(target_task["id"]))
 
     comment_dict = comment.serialize(relations=True)
 

--- a/zou/app/services/files_service.py
+++ b/zou/app/services/files_service.py
@@ -40,6 +40,7 @@ from sqlalchemy.sql.expression import and_
 
 def clear_preview_file_cache(preview_file_id):
     cache.cache.delete_memoized(get_preview_file, preview_file_id)
+    cache.cache.delete_memoized(get_preview_file_for_access, preview_file_id)
 
 
 def clear_output_file_cache(output_file_id):
@@ -758,6 +759,38 @@ def get_preview_file(preview_file_id):
     """
     preview_file = get_preview_file_raw(preview_file_id)
     return preview_file.serialize()
+
+
+@cache.memoize_function(240)
+def get_preview_file_for_access(preview_file_id):
+    """
+    Lightweight lookup used by picture/movie download endpoints that only
+    need to check permissions and emit a Last-Modified header. Avoids
+    loading the JSONB annotations and data columns, which can weigh
+    several MB on long shots and dominate query time when the response
+    is a static file served from disk.
+    """
+    try:
+        row = (
+            PreviewFile.query.with_entities(
+                PreviewFile.id,
+                PreviewFile.task_id,
+                PreviewFile.updated_at,
+                PreviewFile.extension,
+            )
+            .filter_by(id=preview_file_id)
+            .first()
+        )
+    except StatementError:
+        raise PreviewFileNotFoundException()
+    if row is None:
+        raise PreviewFileNotFoundException()
+    return {
+        "id": str(row.id),
+        "task_id": str(row.task_id) if row.task_id else None,
+        "updated_at": fields.serialize_value(row.updated_at),
+        "extension": row.extension,
+    }
 
 
 def get_preview_files_for_task(task_id):

--- a/zou/app/services/playlist_sharing_service.py
+++ b/zou/app/services/playlist_sharing_service.py
@@ -1,7 +1,7 @@
 import datetime
 import uuid
 
-from zou.app.utils import auth
+from zou.app.utils import auth, events
 
 from zou.app.models.entity import Entity
 from zou.app.models.entity_type import EntityType
@@ -652,6 +652,8 @@ def create_guest(token, first_name, last_name=""):
         is_guest=True,
         data={"share_link_id": share_link_id},
     )
+    persons_service.clear_person_cache()
+    events.emit("person:new", {"person_id": str(guest.id)})
     return guest.serialize()
 
 

--- a/zou/app/services/playlists_service.py
+++ b/zou/app/services/playlists_service.py
@@ -276,13 +276,14 @@ def set_preview_files_for_entities(playlist_dict):
     """
     entity_ids = []
     for entity in playlist_dict["shots"]:
-        if "id" not in entity:
-            entity_id = entity.get("shot_id", entity.get("entity_id", None))
-            if entity_id is not None:
-                entity_ids.append(entity_id)
-                entity["id"] = entity_id
-        else:
-            entity_ids.append(entity["id"])
+        entity_id = (
+            entity.get("id")
+            or entity.get("shot_id")
+            or entity.get("entity_id")
+        )
+        if entity_id:
+            entity_ids.append(entity_id)
+            entity.setdefault("id", entity_id)
     previews = {}
     preview_file_map = {}
 
@@ -334,8 +335,9 @@ def set_preview_files_for_entities(playlist_dict):
             )
 
     for entity in playlist_dict["shots"]:
-        if str(entity["id"]) in previews:
-            entity["preview_files"] = previews[str(entity["id"])]
+        entity_id = entity.get("id")
+        if entity_id and str(entity_id) in previews:
+            entity["preview_files"] = previews[str(entity_id)]
         else:
             entity["preview_files"] = []
 

--- a/zou/app/services/shots_service.py
+++ b/zou/app/services/shots_service.py
@@ -1022,33 +1022,36 @@ def create_shot(
         # raises SequenceNotFound if it fails.
         sequence = get_sequence(sequence_id)
 
-    shot = Entity.get_by(
-        entity_type_id=shot_type["id"],
-        parent_id=sequence_id,
-        project_id=project_id,
-        name=name,
-    )
+    lookup = {
+        "entity_type_id": shot_type["id"],
+        "parent_id": sequence_id,
+        "project_id": project_id,
+        "name": name,
+    }
+    shot = Entity.get_by(**lookup)
     if shot is None:
-        shot = Entity.create(
-            entity_type_id=shot_type["id"],
-            project_id=project_id,
-            parent_id=sequence_id,
-            name=name,
-            data=data,
-            nb_frames=nb_frames,
-            description=description,
-            created_by=created_by,
-        )
-
-        index_service.index_shot(shot)
-        events.emit(
-            "shot:new",
-            {
-                "shot_id": shot.id,
-                "episode_id": sequence["parent_id"],
-            },
-            project_id=project_id,
-        )
+        try:
+            shot = Entity.create(
+                data=data,
+                nb_frames=nb_frames,
+                description=description,
+                created_by=created_by,
+                **lookup,
+            )
+        except IntegrityError:
+            shot = Entity.get_by(**lookup)
+            if shot is None:
+                raise
+        else:
+            index_service.index_shot(shot)
+            events.emit(
+                "shot:new",
+                {
+                    "shot_id": shot.id,
+                    "episode_id": sequence["parent_id"],
+                },
+                project_id=project_id,
+            )
 
     return shot.serialize(obj_type="Shot")
 

--- a/zou/app/services/tasks_service.py
+++ b/zou/app/services/tasks_service.py
@@ -359,11 +359,8 @@ def get_task_dicts_for_entity(entity_id, relations=True):
 
 
 def _get_entity_task_query(relations=False):
-    query = Task.query
-    if relations:
-        query = query.options(selectinload(Task.assignees))
     return (
-        query.order_by(Task.name)
+        Task.query.order_by(Task.name)
         .join(Project, Task.project_id == Project.id)
         .join(TaskType, Task.task_type_id == TaskType.id)
         .join(TaskStatus, TaskStatus.id == Task.task_status_id)
@@ -379,9 +376,9 @@ def _get_entity_task_query(relations=False):
 
 
 def _convert_rows_to_detailed_tasks(rows, relations=False):
-    return [
+    task_dicts = [
         {
-            **task_object.serialize(relations=relations),
+            **task_object.serialize(relations=False),
             "project_name": project_name,
             "task_type_name": task_type_name,
             "task_status_name": task_status_name,
@@ -390,6 +387,30 @@ def _convert_rows_to_detailed_tasks(rows, relations=False):
         }
         for task_object, project_name, task_type_name, task_status_name, entity_type_name, entity_name in rows
     ]
+    if relations and task_dicts:
+        _attach_assignee_ids(task_dicts)
+    return task_dicts
+
+
+def _attach_assignee_ids(task_dicts):
+    """
+    Fetch all assignees for the given tasks in a single query and inject the
+    list of person ids into each dict. Avoids the N+1 that occurs when each
+    Task row triggers a separate lazy load of its assignees relationship.
+    """
+    task_ids = [task["id"] for task in task_dicts]
+    links = (
+        db.session.query(
+            TaskPersonLink.task_id, TaskPersonLink.person_id
+        )
+        .filter(TaskPersonLink.task_id.in_(task_ids))
+        .all()
+    )
+    assignees_by_task = collections.defaultdict(list)
+    for task_id, person_id in links:
+        assignees_by_task[str(task_id)].append(str(person_id))
+    for task in task_dicts:
+        task["assignees"] = assignees_by_task.get(task["id"], [])
 
 
 def _resolve_episode_and_build_task_dict(


### PR DESCRIPTION
## Problems

- `/admin/config/check` crashes with a 500 when the `person` table is missing, defeating the endpoint's purpose (Sentry KITSU-API-4QQ)
- `GET /data/projects/<id>/playlists/<id>` raises `InvalidTextRepresentation` when the playlist contains entries with empty `entity_id`/`shot_id` (Sentry KITSU-API-4QK)
- Two concurrent shot creations both pass `get_by` and the loser raises an `entity_uc` `IntegrityError` (Sentry KITSU-API-4QZ)
- Thumbnail/picture/movie endpoints load the full `preview_file` row including multi-MB JSONB columns just to enforce permissions and emit `Last-Modified` — the largest performance hotspot in Sentry (Sentry KITSU-API-4DN)
- A comment cannot be moved between tasks of the same entity
- Task data (last_comment_date, etc.) is not refreshed on source/target tasks when a comment is moved

## Solutions

- Wrap `Person.query.count()` in `try`/`except` on `ProgrammingError`/`OperationalError`, log a warning, return `active_users: null`
- Filter falsy `entity_id`/`shot_id`/`id` in `set_preview_files_for_entities`; tolerate entries without an `id` when enriching `preview_files`
- Catch `IntegrityError` in `create_shot`, re-lookup the shot, raise only if truly absent
- Add a lightweight `get_preview_file_for_access` (id/task_id/updated_at/extension only, memoized) and use it from the picture/thumbnail/movie base resources
- Add `POST /data/comments/<id>/move-to-task` to move a comment between tasks of the same entity
- Recompute source and target task data after a comment move