### PR TITLE
Pin PyJWT explicitly to prevent stale transitive version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -67,6 +67,7 @@ install_requires =
     pillow==12.2.0
     psutil==7.2.2
     psycopg[binary]==3.3.4
+    PyJWT==2.12.1
     pyotp==2.9.0
     pysaml2==7.5.4
     python-nomad==2.1.0


### PR DESCRIPTION
**Problem**
- `flask-jwt-extended==4.7.3` needs `PyJWT >= 2.10` (`jwt.types.Options`) but declares no floor, so pip keeps a stale transitive PyJWT on upgrade and startup fails with `ImportError`

**Solution**
- Pin `PyJWT==2.12.1` directly in `setup.cfg` so pip bumps it on upgrade
