### PR TITLE
Embed author data in comments, replies and news

### DIFF
--- a/tests/comments/test_route_comments.py
+++ b/tests/comments/test_route_comments.py
@@ -1,6 +1,7 @@
 from tests.base import ApiDBTestCase
 
 from zou.app.models.attachment_file import AttachmentFile
+from zou.app.models.comment import Comment
 from zou.app.models.notification import Notification
 from zou.app.models.person import Person
 from zou.app.models.task import Task
@@ -48,6 +49,220 @@ class CommentRoutesTestCase(ApiDBTestCase):
             {"task_status_id": str(self.task_status.id)},
         )
         self.assertIsNotNone(result["id"])
+
+    def test_get_comment_embeds_author(self):
+        comment = self.get(f"/data/comments/{self.comment['id']}")
+        self.assertEqual(comment["person"]["id"], comment["person_id"])
+        self.assertEqual(comment["person"]["full_name"], "John Did")
+        self.assertEqual(comment["person"]["role"], "admin")
+        self.assertIn("has_avatar", comment["person"])
+
+    def test_comments_list_embeds_author_full_name(self):
+        comments = tasks_service.get_comments(str(self.task.id))
+        self.assertEqual(comments[0]["person"]["full_name"], "John Did")
+        self.assertEqual(comments[0]["person"]["role"], "admin")
+
+    def test_get_comment_embeds_reply_author(self):
+        comments_service.reply_comment(
+            self.comment["id"], "My reply", person_id=str(self.user["id"])
+        )
+        comment = self.get(f"/data/comments/{self.comment['id']}")
+        reply = comment["replies"][0]
+        self.assertEqual(reply["person"]["id"], reply["person_id"])
+        self.assertEqual(reply["person"]["full_name"], "John Did")
+
+    def test_reply_comment_response_embeds_author(self):
+        reply = self.post(
+            f"/data/tasks/{self.task.id}"
+            f"/comments/{self.comment['id']}/reply",
+            {"text": "My reply"},
+            200,
+        )
+        self.assertEqual(reply["person"]["id"], reply["person_id"])
+        self.assertEqual(reply["person"]["full_name"], "John Did")
+
+    def test_reply_author_hidden_from_client(self):
+        """Studio members' identities must not be exposed to clients on
+        replies, matching the comment author behavior."""
+        client_person = Person.get(self.user_client["id"])
+        self.project.team = [client_person, self.person]
+        self.project.save()
+        comment = self.post(
+            f"/actions/tasks/{self.task.id}/comment",
+            {
+                "task_status_id": str(self.task_status.id),
+                "comment": "Visible to client",
+                "for_client": True,
+            },
+        )
+        comments_service.reply_comment(
+            comment["id"], "Studio reply", person_id=str(self.user["id"])
+        )
+
+        self.log_in_client()
+        comments = tasks_service.get_comments(
+            str(self.task.id), is_client=True
+        )
+        target = next(c for c in comments if c["id"] == comment["id"])
+        self.assertIsNone(target["replies"][0]["person"])
+
+    def test_comment_author_hidden_from_client_in_list(self):
+        """The comment list must not embed a studio author for a client,
+        matching the single-comment and reply author behavior, while the
+        comment content stays visible."""
+        client_person = Person.get(self.user_client["id"])
+        self.project.team = [client_person, self.person]
+        self.project.save()
+        comment = self.post(
+            f"/actions/tasks/{self.task.id}/comment",
+            {
+                "task_status_id": str(self.task_status.id),
+                "comment": "Visible to client",
+                "for_client": True,
+            },
+        )
+
+        self.log_in_client()
+        comments = tasks_service.get_comments(
+            str(self.task.id), is_client=True
+        )
+        target = next(c for c in comments if c["id"] == comment["id"])
+        self.assertTrue(target["for_client"])
+        self.assertEqual(target["text"], "Visible to client")
+        self.assertIsNone(target["person"])
+
+    def test_client_author_embedded_for_client_in_list(self):
+        """A client's own comment must keep its embedded author so it renders
+        with a name and avatar."""
+        client_person = Person.get(self.user_client["id"])
+        self.project.team = [client_person, self.person]
+        self.project.save()
+
+        self.log_in_client()
+        comment = self.post(
+            f"/actions/tasks/{self.task.id}/comment",
+            {
+                "task_status_id": str(self.task_status.id),
+                "comment": "Client question",
+            },
+        )
+        comments = tasks_service.get_comments(
+            str(self.task.id), is_client=True
+        )
+        target = next(c for c in comments if c["id"] == comment["id"])
+        self.assertEqual(target["person"]["id"], str(client_person.id))
+        self.assertEqual(target["person"]["role"], "client")
+
+    def test_comment_author_hidden_from_client(self):
+        """The single-comment endpoint must not embed a studio author for a
+        client, matching the reply author behavior."""
+        client_person = Person.get(self.user_client["id"])
+        self.project.team = [client_person, self.person]
+        self.project.save()
+        comment = self.post(
+            f"/actions/tasks/{self.task.id}/comment",
+            {
+                "task_status_id": str(self.task_status.id),
+                "comment": "Visible to client",
+                "for_client": True,
+            },
+        )
+
+        self.log_in_client()
+        result = self.get(f"/data/comments/{comment['id']}")
+        self.assertEqual(result["text"], "Visible to client")
+        self.assertIsNone(result["person"])
+
+    def test_internal_comment_forbidden_for_client(self):
+        """A client must not reach an internal studio comment (not for_client)
+        on the single-comment endpoint. check_comment_access is the sole gate
+        now that clean_get_result no longer blanks the text."""
+        client_person = Person.get(self.user_client["id"])
+        self.project.team = [client_person, self.person]
+        self.project.save()
+        comment = self.post(
+            f"/actions/tasks/{self.task.id}/comment",
+            {
+                "task_status_id": str(self.task_status.id),
+                "comment": "Internal only",
+            },
+        )
+
+        self.log_in_client()
+        self.get(f"/data/comments/{comment['id']}", 403)
+
+    def test_editor_hidden_from_client_in_list(self):
+        """A studio editor identity must not leak to clients in the comment
+        list, matching the comment author behavior."""
+        client_person = Person.get(self.user_client["id"])
+        self.project.team = [client_person, self.person]
+        self.project.save()
+        comment = self.post(
+            f"/actions/tasks/{self.task.id}/comment",
+            {
+                "task_status_id": str(self.task_status.id),
+                "comment": "Visible to client",
+                "for_client": True,
+            },
+        )
+        comment_model = Comment.get(comment["id"])
+        comment_model.editor_id = self.person.id
+        comment_model.save()
+
+        self.log_in_client()
+        comments = tasks_service.get_comments(
+            str(self.task.id), is_client=True
+        )
+        target = next(c for c in comments if c["id"] == comment["id"])
+        self.assertIsNone(target["editor"])
+        self.assertIsNone(target["editor_id"])
+
+    def test_client_editor_kept_in_list(self):
+        """A client editor stays visible, mirroring the author behavior."""
+        client_person = Person.get(self.user_client["id"])
+        self.project.team = [client_person, self.person]
+        self.project.save()
+        comment = self.post(
+            f"/actions/tasks/{self.task.id}/comment",
+            {
+                "task_status_id": str(self.task_status.id),
+                "comment": "Visible to client",
+                "for_client": True,
+            },
+        )
+        comment_model = Comment.get(comment["id"])
+        comment_model.editor_id = client_person.id
+        comment_model.save()
+
+        self.log_in_client()
+        comments = tasks_service.get_comments(
+            str(self.task.id), is_client=True
+        )
+        target = next(c for c in comments if c["id"] == comment["id"])
+        self.assertEqual(target["editor"]["id"], str(client_person.id))
+        self.assertEqual(target["editor"]["role"], "client")
+
+    def test_editor_hidden_from_client(self):
+        """The single-comment endpoint must not expose a studio editor to a
+        client, matching the comment author behavior."""
+        client_person = Person.get(self.user_client["id"])
+        self.project.team = [client_person, self.person]
+        self.project.save()
+        comment = self.post(
+            f"/actions/tasks/{self.task.id}/comment",
+            {
+                "task_status_id": str(self.task_status.id),
+                "comment": "Visible to client",
+                "for_client": True,
+            },
+        )
+        comment_model = Comment.get(comment["id"])
+        comment_model.editor_id = self.person.id
+        comment_model.save()
+
+        self.log_in_client()
+        result = self.get(f"/data/comments/{comment['id']}")
+        self.assertIsNone(result["editor_id"])
 
     def test_reply_comment(self):
         result = self.post(
@@ -102,29 +317,6 @@ class CommentRoutesTestCase(ApiDBTestCase):
         comments = tasks_service.get_comments(str(self.task.id))
         texts = [c["text"] for c in comments]
         self.assertIn("Batch comment", texts)
-
-    def test_comment_for_client_visible_to_client(self):
-        """A manager-authored comment marked for_client must be visible to
-        client users (text not blanked, listed in comments endpoint)."""
-        client_person = Person.get(self.user_client["id"])
-        self.project.team = [client_person, self.person]
-        self.project.save()
-        result = self.post(
-            f"/actions/tasks/{self.task.id}/comment",
-            {
-                "task_status_id": str(self.task_status.id),
-                "comment": "Visible to client",
-                "for_client": True,
-            },
-        )
-        self.assertTrue(result["for_client"])
-
-        self.log_in_client()
-        comments = tasks_service.get_comments(
-            str(self.task.id), is_client=True
-        )
-        texts = [c["text"] for c in comments]
-        self.assertIn("Visible to client", texts)
 
     def test_comment_without_for_client_hidden_from_client(self):
         """A manager-authored comment without for_client stays hidden from

--- a/tests/models/test_comments.py
+++ b/tests/models/test_comments.py
@@ -31,6 +31,10 @@ class CommentTestCase(ApiDBTestCase):
     def test_get_comment(self):
         comment = self.get_first("data/comments?relations=true")
         comment_again = self.get("data/comments/%s" % comment["id"])
+        # The single-comment endpoint embeds the author so guest commenters
+        # render with a name and avatar; the list endpoint does not.
+        person = comment_again.pop("person")
+        self.assertEqual(person["id"], comment["person_id"])
         self.assertEqual(comment, comment_again)
         self.get_404("data/comments/%s/" % fields.gen_uuid())
 

--- a/tests/news/test_route_news.py
+++ b/tests/news/test_route_news.py
@@ -73,3 +73,16 @@ class NewsRoutesTestCase(ApiDBTestCase):
         )
         news_list = self.get("/data/projects/news")
         self.assertEqual(len(news_list["data"]), 1)
+
+    def test_news_embeds_author(self):
+        self.generate_fixture_comment()
+        news_service.create_news_for_task_and_comment(
+            self.task_dict, self.comment
+        )
+        news_list = self.get(
+            "/data/projects/%s/news" % self.task_dict["project_id"]
+        )
+        news = news_list["data"][0]
+        self.assertEqual(news["person"]["id"], news["author_id"])
+        self.assertEqual(news["person"]["full_name"], "John Did")
+        self.assertIn("has_avatar", news["person"])

--- a/zou/app/blueprints/crud/comments.py
+++ b/zou/app/blueprints/crud/comments.py
@@ -343,14 +343,22 @@ class CommentResource(BaseModelResource):
 
     def clean_get_result(self, result):
         is_client = permissions.has_client_permissions()
-        if is_client:
-            person = persons_service.get_person(result["person_id"])
-            if person["role"] != "client" and not result.get(
-                "for_client", False
-            ):
-                result["text"] = ""
-                result["attachment_files"] = []
-                result["checklist"] = []
+        # Embed the author so guest commenters render with a name and avatar.
+        # Keep studio members' identities hidden from clients, matching the
+        # reply author behavior.
+        if result.get("person_id"):
+            author = persons_service.get_short_person(result["person_id"])
+            if is_client and author.get("role") != "client":
+                author = None
+            result["person"] = author
+        # Hide the editor identity from clients when a studio member edited
+        # the comment, matching the author behavior.
+        editor_id = result.get("editor_id")
+        if is_client and editor_id and editor_id != result.get("person_id"):
+            editor = persons_service.get_short_person(editor_id)
+            if editor.get("role") != "client":
+                result["editor_id"] = None
+        tasks_service.embed_reply_authors([result], is_client=is_client)
         if (
             "attachment_files" in result
             and len(result["attachment_files"]) > 0

--- a/zou/app/services/comments_service.py
+++ b/zou/app/services/comments_service.py
@@ -673,6 +673,8 @@ def reply_comment(comment_id, text, person_id=None, files=None):
     notifications_service.create_notifications_for_task_and_reply(
         task, comment_dict, reply
     )
+    # Embed the author so the just-posted reply renders with name and avatar.
+    reply["person"] = persons_service.get_short_person(reply["person_id"])
     return reply
 
 

--- a/zou/app/services/news_service.py
+++ b/zou/app/services/news_service.py
@@ -11,7 +11,7 @@ from zou.app.models.project import Project
 from zou.app.models.task import Task
 
 from zou.app.utils import cache, events, fields
-from zou.app.services import names_service, tasks_service
+from zou.app.services import names_service, persons_service, tasks_service
 
 
 def create_news(
@@ -227,6 +227,14 @@ def get_last_news_for_project(
                 }
             )
         )
+
+    # Embed the author so guest authors render directly.
+    author_ids = list(
+        {news["author_id"] for news in result if news.get("author_id")}
+    )
+    author_map = persons_service.get_short_persons_map(author_ids)
+    for news in result:
+        news["person"] = author_map.get(news["author_id"])
 
     if only_preview:
         task_ids = [

--- a/zou/app/services/persons_service.py
+++ b/zou/app/services/persons_service.py
@@ -181,6 +181,35 @@ def get_persons_by_ids(person_ids):
     return [person.serialize_safe() for person in persons]
 
 
+def build_short_person(person):
+    """Return minimal author data to embed a comment or news author, including guests."""
+    return {
+        "id": str(person.id),
+        "first_name": person.first_name,
+        "last_name": person.last_name,
+        "full_name": person.full_name,
+        "has_avatar": person.has_avatar,
+        "role": getattr(person.role, "code", person.role),
+    }
+
+
+def get_short_person(person_id):
+    """
+    Return the minimal author dict for the person matching given id.
+    """
+    return build_short_person(get_person_raw(person_id))
+
+
+def get_short_persons_map(person_ids):
+    """
+    Return a {id: minimal author dict} map for given ids in a single query.
+    """
+    if not person_ids:
+        return {}
+    persons = Person.query.filter(Person.id.in_(person_ids)).all()
+    return {str(person.id): build_short_person(person) for person in persons}
+
+
 def get_person_by_email_raw(email):
     """
     Return person that matches given email as an active record.

--- a/zou/app/services/tasks_service.py
+++ b/zou/app/services/tasks_service.py
@@ -673,6 +673,7 @@ def get_comments(task_id, is_client=False, is_manager=False):
             comment["attachment_files"] = attachment_file_map.get(
                 comment["id"], []
             )
+        embed_reply_authors(comments, is_client=is_client)
 
     if is_client:
         tmp_comments = []
@@ -690,6 +691,14 @@ def get_comments(task_id, is_client=False, is_manager=False):
             person = persons_map.get(comment["person_id"], {})
             is_author = comment["person_id"] == current_user["id"]
             is_author_client = person.get("role") == "client"
+            # Hide studio members' identities from clients, like replies.
+            if not is_author_client:
+                comment["person"] = None
+            # Hide the editor identity too when a studio member edited it.
+            editor = comment.get("editor")
+            if editor and editor.get("role") != "client":
+                comment["editor"] = None
+                comment["editor_id"] = None
             is_for_client = comment.get("for_client", False)
             is_allowed = (
                 is_for_client
@@ -726,15 +735,41 @@ def _prepare_query(task_id, is_client, is_manager):
             TaskStatus.color,
             Person.first_name,
             Person.last_name,
+            Person.full_name,
             Person.has_avatar,
+            Person.role,
             Editor.first_name,
             Editor.last_name,
             Editor.has_avatar,
+            Editor.role,
         )
     )
     if not is_manager and not is_client:
         query = query.filter(Person.role != "client")
     return query
+
+
+def embed_reply_authors(comments, is_client=False):
+    """Attach a minimal author to each reply so guest repliers render too.
+
+    For clients, only client authors are embedded to keep studio members'
+    identities hidden, matching the comment author behavior.
+    """
+    reply_person_ids = {
+        reply.get("person_id")
+        for comment in comments
+        for reply in (comment.get("replies") or [])
+        if reply.get("person_id")
+    }
+    if not reply_person_ids:
+        return
+    persons_map = persons_service.get_short_persons_map(list(reply_person_ids))
+    for comment in comments:
+        for reply in comment.get("replies") or []:
+            author = persons_map.get(reply.get("person_id"))
+            if is_client and author and author.get("role") != "client":
+                author = None
+            reply["person"] = author
 
 
 def _run_task_comments_query(query):
@@ -748,17 +783,22 @@ def _run_task_comments_query(query):
             task_status_color,
             person_first_name,
             person_last_name,
+            person_full_name,
             person_has_avatar,
+            person_role,
             editor_first_name,
             editor_last_name,
             editor_has_avatar,
+            editor_role,
         ) = result
 
         comment_dict = comment.serialize()
         comment_dict["person"] = {
             "first_name": person_first_name,
             "last_name": person_last_name,
+            "full_name": person_full_name,
             "has_avatar": person_has_avatar,
+            "role": getattr(person_role, "code", person_role),
             "id": str(comment.person_id),
         }
         if comment.editor_id is not None:
@@ -766,6 +806,7 @@ def _run_task_comments_query(query):
                 "first_name": editor_first_name,
                 "last_name": editor_last_name,
                 "has_avatar": editor_has_avatar,
+                "role": getattr(editor_role, "code", editor_role),
                 "id": str(comment.editor_id),
             }
         comment_dict["task_status"] = {
@@ -1181,9 +1222,7 @@ def get_last_comment_map(task_ids):
     return task_comment_map
 
 
-def _build_task_no_commit(
-    task_type, task_status, entity, current_user_id
-):
+def _build_task_no_commit(task_type, task_status, entity, current_user_id):
     """
     Insert a new task (without committing) using the zou defaults for
     name, durations, dates and assignees.
@@ -1276,8 +1315,7 @@ def create_tasks_for_entity(entity, task_types=None):
         enabled_in_workflow = {
             str(link.task_type_id)
             for link in TaskTypeAssetTypeLink.query.filter(
-                TaskTypeAssetTypeLink.asset_type_id
-                == entity["entity_type_id"]
+                TaskTypeAssetTypeLink.asset_type_id == entity["entity_type_id"]
             ).all()
         }
 
@@ -1292,8 +1330,7 @@ def create_tasks_for_entity(entity, task_types=None):
             for task_type in TaskType.query.filter(
                 TaskType.id.in_(candidate_ids)
             ).all()
-            if not task_type.for_entity
-            or task_type.for_entity == entity_kind
+            if not task_type.for_entity or task_type.for_entity == entity_kind
         ]
         if not task_types:
             return []


### PR DESCRIPTION
**Problem**

Guest authors (e.g., shared-playlist guests) are deliberately absent from the
front-end person store, so comments, replies, and news they wrote are rendered with
no name and no avatar.

**Solution**

- Embed a minimal author (full name, avatar flag, role) directly in comments,
  replies, and news, so guests render without being preloaded.
- Hide studio members' identities from clients on comment authors, reply
  authors, and the comment editor ("Edited by"); client authors stay visible.
- Remove the unreachable client text-blanking in the single-comment endpoint:
  It duplicated a check already enforced upstream by `check_comment_access`,
  which stays the single gate against clients reading internal studio comments.
  No behavior change — the branch was dead code.
