### PR TITLE
Ensure Concept task type is always seeded

### DIFF
--- a/tests/misc/test_commands.py
+++ b/tests/misc/test_commands.py
@@ -36,8 +36,14 @@ class CommandsTestCase(ApiDBTestCase):
         commands.init_data()
         task_types = TaskType.get_all()
         entity_types = EntityType.get_all()
-        self.assertEqual(len(task_types), 12)
+        self.assertEqual(len(task_types), 13)
         self.assertEqual(len(entity_types), 8)
+
+    def test_init_data_creates_concept_task_type(self):
+        commands.init_data()
+        concept_task_types = TaskType.get_all_by(for_entity="Concept")
+        self.assertEqual(len(concept_task_types), 1)
+        self.assertEqual(concept_task_types[0].name, "Concept")
 
 
 class DisableTwoFactorAuthenticationCommandTestCase(ApiDBTestCase):

--- a/tests/services/test_tasks_service.py
+++ b/tests/services/test_tasks_service.py
@@ -557,3 +557,40 @@ class TaskServiceTestCase(ApiDBTestCase):
         for i, preview_file in enumerate(preview_files):
             self.assertEqual(preview_file.position, i + 1)
         self.assertEqual(str(preview_files[2].id), preview_file_id)
+
+
+class GetOrCreateTaskTypeTestCase(ApiDBTestCase):
+    def setUp(self):
+        super().setUp()
+        self.department = tasks_service.get_or_create_department(
+            "Concept", "#8D6E63"
+        )
+
+    def test_create_when_missing(self):
+        task_type = tasks_service.get_or_create_task_type(
+            self.department, "Concept", "#8D6E63", 1
+        )
+        self.assertIsNotNone(task_type["id"])
+        self.assertEqual(task_type["for_entity"], "Asset")
+
+    def test_return_existing_with_same_name_and_entity(self):
+        first = tasks_service.get_or_create_task_type(
+            self.department, "Concept", "#8D6E63", 1
+        )
+        second = tasks_service.get_or_create_task_type(
+            self.department, "Concept", "#8D6E63", 1
+        )
+        self.assertEqual(first["id"], second["id"])
+        self.assertEqual(len(TaskType.get_all_by(name="Concept")), 1)
+
+    def test_same_name_different_for_entity_coexist(self):
+        asset_type = tasks_service.get_or_create_task_type(
+            self.department, "Concept", "#8D6E63", 1
+        )
+        concept_type = tasks_service.get_or_create_task_type(
+            self.department, "Concept", "#8D6E63", 1, for_entity="Concept"
+        )
+        self.assertNotEqual(asset_type["id"], concept_type["id"])
+        self.assertEqual(asset_type["for_entity"], "Asset")
+        self.assertEqual(concept_type["for_entity"], "Concept")
+        self.assertEqual(len(TaskType.get_all_by(name="Concept")), 2)

--- a/tests/services/test_user_service.py
+++ b/tests/services/test_user_service.py
@@ -100,6 +100,49 @@ class UserServiceTestCase(ApiDBTestCase):
         tasks_service.assign_task(self.task_id, person_id)
         self.assertTrue(user_service.check_entity_access(str(self.asset_id)))
 
+    def _log_in_cg_artist_as_current_user(self, team_member=True):
+        """
+        Log in an unassigned CG artist and make get_current_user return it.
+        Returns the artist id. The artist is added to the project team unless
+        team_member is False.
+        """
+        self.generate_fixture_user_cg_artist()
+        artist_id = self.user_cg_artist["id"]
+        if team_member:
+            projects_service.add_team_member(self.project_id, artist_id)
+        self.log_in_cg_artist()
+        persons_service.get_current_user = (
+            lambda relations=False: self.user_cg_artist
+        )
+        return artist_id
+
+    def test_check_task_action_access_granted_for_entity_creator(self):
+        artist_id = self._log_in_cg_artist_as_current_user()
+        self.asset.update({"created_by": artist_id})
+        self.assertTrue(
+            user_service.check_task_action_access(str(self.task_id))
+        )
+
+    def test_check_task_action_access_denied_for_non_creator(self):
+        self._log_in_cg_artist_as_current_user()
+        # Created by someone else, not assigned -> no access.
+        self.asset.update({"created_by": self.user["id"]})
+        with self.assertRaises(permissions.PermissionDenied):
+            user_service.check_task_action_access(str(self.task_id))
+
+    def test_check_task_action_access_denied_without_creator(self):
+        self._log_in_cg_artist_as_current_user()
+        # Entity has no creator (created_by is None) -> no access.
+        with self.assertRaises(permissions.PermissionDenied):
+            user_service.check_task_action_access(str(self.task_id))
+
+    def test_check_task_action_access_denied_for_creator_not_in_team(self):
+        # The creator must still belong to the project team to act on a task.
+        artist_id = self._log_in_cg_artist_as_current_user(team_member=False)
+        self.asset.update({"created_by": artist_id})
+        with self.assertRaises(permissions.PermissionDenied):
+            user_service.check_task_action_access(str(self.task_id))
+
     def test_get_last_notifications(self):
         persons_service.get_current_user = self.get_current_user_artist
         self.generate_fixture_user_cg_artist()

--- a/zou/app/services/tasks_service.py
+++ b/zou/app/services/tasks_service.py
@@ -1549,7 +1549,7 @@ def get_or_create_task_type(
     Create a new task type if it doesn't exist. If it exists, it returns the
     type from database.
     """
-    task_type = TaskType.get_by(name=name)
+    task_type = TaskType.get_by(name=name, for_entity=for_entity)
     if task_type is None:
         task_type = TaskType.create(
             name=name,

--- a/zou/app/services/user_service.py
+++ b/zou/app/services/user_service.py
@@ -536,6 +536,10 @@ def check_task_action_access(task_id):
                     ]
                     in user["departments"]
                 )
+            if not is_allowed:
+                # The entity creator keeps task action access (e.g. an artist's concept).
+                entity = entities_service.get_entity(task["entity_id"])
+                is_allowed = entity["created_by"] == user["id"]
 
     if not is_allowed:
         raise permissions.PermissionDenied

--- a/zou/migrations/versions/e7a4c2b9f1d3_seed_missing_concept_task_type.py
+++ b/zou/migrations/versions/e7a4c2b9f1d3_seed_missing_concept_task_type.py
@@ -1,0 +1,94 @@
+"""Seed missing Concept task type
+
+The pre-1.0.0 squash migration (a1b2c3d4e5f6) dropped the data injection that
+the legacy "introduce concepts" migration (feffd3c5b806) used to perform, and
+init-data never created it because of a name-only lookup. As a result, the
+Concept task type (for_entity="Concept") was missing on instances deployed
+between the squash and the fix.
+
+This migration recreates that task type, but only on instances that are
+missing it: it is a no-op wherever a Concept task type already exists.
+
+Revision ID: e7a4c2b9f1d3
+Revises: 2b8f88aa610f
+Create Date: 2026-05-22 00:00:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import orm
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy_utils import UUIDType
+from zou.migrations.utils.base import BaseMixin
+
+# revision identifiers, used by Alembic.
+revision = "e7a4c2b9f1d3"
+down_revision = "2b8f88aa610f"
+branch_labels = None
+depends_on = None
+
+base = declarative_base()
+
+
+class TaskType(base, BaseMixin):
+    __tablename__ = "task_type"
+    name = sa.Column(sa.String(40), nullable=False)
+    short_name = sa.Column(sa.String(20))
+    color = sa.Column(sa.String(7), default="#FFFFFF")
+    priority = sa.Column(sa.Integer, default=1)
+    for_entity = sa.Column(sa.String(30), default="Asset")
+    allow_timelog = sa.Column(sa.Boolean, default=True)
+    archived = sa.Column(sa.Boolean(), default=False)
+    shotgun_id = sa.Column(sa.Integer, index=True)
+    department_id = sa.Column(
+        UUIDType(binary=False), sa.ForeignKey("department.id"), index=True
+    )
+
+
+class Department(base, BaseMixin):
+    __tablename__ = "department"
+    name = sa.Column(sa.String(80), unique=True, nullable=False)
+    color = sa.Column(sa.String(7), nullable=False)
+    archived = sa.Column(sa.Boolean(), default=False)
+
+
+def upgrade():
+    bind = op.get_bind()
+    session = orm.Session(bind=bind)
+
+    # No-op on instances that already have the Concept task type (those that
+    # ran the legacy migration). It is hidden in Kitsu and cannot be renamed,
+    # so matching on name + for_entity is reliable.
+    already_present = (
+        session.query(TaskType)
+        .filter_by(name="Concept", for_entity="Concept")
+        .first()
+    )
+    if already_present is not None:
+        return
+
+    concept_department = (
+        session.query(Department).filter_by(name="Concept").one_or_none()
+    )
+    session.add(
+        TaskType(
+            name="Concept",
+            short_name="",
+            color="#8D6E63",
+            priority=1,
+            for_entity="Concept",
+            department_id=(
+                concept_department.id
+                if concept_department is not None
+                else None
+            ),
+        )
+    )
+    session.commit()
+
+
+def downgrade():
+    # No-op: we cannot tell whether the Concept task type pre-existed this
+    # migration, so we never delete it on downgrade.
+    pass


### PR DESCRIPTION
**Problem**
- `get_or_create_task_type` matched existing task types by name only, so the Concept (`for_entity="Concept"`) task type was shadowed by the concept-art Concept (`for_entity="Asset"`) and never created by `init-data`.
- The pre-1.0.0 squash dropped the data injection that previously created it, leaving instances deployed before the fix without any Concept task type.

**Solution**
- Match on name + for_entity in `get_or_create_task_type` so both Concept task types coexist, as the `task_type` unique constraint already allows.
- Add an idempotent data migration that recreates the Concept task type only on instances where it is missing.