### PR TITLE
[playlists] Fix invalid RQ job_id when building playlist movie

### DIFF
--- a/zou/app/blueprints/playlists/resources.py
+++ b/zou/app/blueprints/playlists/resources.py
@@ -3,7 +3,6 @@ import slugify
 import os
 
 from flask import (
-    abort,
     after_this_request,
     request,
     send_file as flask_send_file,
@@ -541,7 +540,7 @@ class BuildPlaylistMovieResource(Resource, ArgsMixin):
                     ),
                     job_timeout=int(config.JOB_QUEUE_TIMEOUT),
                     unique=True,
-                    job_id=f"build_playlist:{playlist['id']}",
+                    job_id=f"build_playlist_{playlist['id']}",
                     result_ttl=60,
                     failure_ttl=60,
                 )


### PR DESCRIPTION
## Problems

- Building a playlist movie failed with ``ValueError: Job ID must only contain letters, numbers, underscores and dashes`` on instances with ``ENABLE_JOB_QUEUE`` enabled
- ``job_id`` was built as ``build_playlist:<uuid>`` and recent RQ versions reject the ``:``

## Solutions

- Switch the separator to ``_`` so the job_id passes ``validate_job_id``