### PR TITLE
[sync] Clean sync-push command and import kitsu data routes

### DIFF
--- a/tests/services/test_preview_files_service.py
+++ b/tests/services/test_preview_files_service.py
@@ -6,7 +6,6 @@ from tests.base import ApiDBTestCase
 
 
 from zou.app.services import files_service, preview_files_service
-from zou.app.services.exception import WrongParameterException
 from zou.app.services.preview_files_service import (
     _is_valid_resolution,
     _is_valid_partial_resolution,
@@ -418,16 +417,14 @@ class PlaylistTestCase(ApiDBTestCase):
             if os.path.exists(p):
                 os.remove(p)
 
-    def test_extract_frame_refuses_metadata_only(self):
-        """Imported-only previews have no local binary — extracting a
-        frame must short-circuit with a clear 400 rather than crash on
-        FileNotFoundError."""
+    def test_extract_skips_metadata_only_previews(self):
+        """Imported-only previews have no local binary — extract functions
+        must short-circuit silently (return None) so callers can no-op
+        instead of crashing on FileNotFoundError."""
         preview_file = {
             "id": "some-uuid",
             "extension": "mp4",
             "data": {"imported_only": True},
         }
-        with self.assertRaises(WrongParameterException):
-            extract_frame_from_preview_file(preview_file, 1)
-        with self.assertRaises(WrongParameterException):
-            extract_tile_from_preview_file(preview_file)
+        self.assertIsNone(extract_frame_from_preview_file(preview_file, 1))
+        self.assertIsNone(extract_tile_from_preview_file(preview_file))

--- a/tests/services/test_preview_files_service.py
+++ b/tests/services/test_preview_files_service.py
@@ -6,9 +6,12 @@ from tests.base import ApiDBTestCase
 
 
 from zou.app.services import files_service, preview_files_service
+from zou.app.services.exception import WrongParameterException
 from zou.app.services.preview_files_service import (
     _is_valid_resolution,
     _is_valid_partial_resolution,
+    extract_frame_from_preview_file,
+    extract_tile_from_preview_file,
     get_preview_file_dimensions,
     get_preview_file_fps,
 )
@@ -414,3 +417,17 @@ class PlaylistTestCase(ApiDBTestCase):
         for p in (uploaded_path, norm_path, norm_low_path):
             if os.path.exists(p):
                 os.remove(p)
+
+    def test_extract_frame_refuses_metadata_only(self):
+        """Imported-only previews have no local binary — extracting a
+        frame must short-circuit with a clear 400 rather than crash on
+        FileNotFoundError."""
+        preview_file = {
+            "id": "some-uuid",
+            "extension": "mp4",
+            "data": {"imported_only": True},
+        }
+        with self.assertRaises(WrongParameterException):
+            extract_frame_from_preview_file(preview_file, 1)
+        with self.assertRaises(WrongParameterException):
+            extract_tile_from_preview_file(preview_file)

--- a/tests/source/test_import_kitsu.py
+++ b/tests/source/test_import_kitsu.py
@@ -171,6 +171,27 @@ class ImportKitsuRoutesTestCase(ApiDBTestCase):
         self.assertIsNotNone(News.get(new_id))
         self._post_kitsu("/import/kitsu/news", payload)
 
+    def test_import_preview_files_flags_imported_only(self):
+        """Imported previews are flagged so frame/tile extraction skips them
+        — the push only sends metadata, not the binary."""
+        new_id = str(fields.gen_uuid())
+        payload = [
+            {
+                "id": new_id,
+                "task_id": self.task_id,
+                "name": "v002",
+                "revision": 1,
+                "position": 1,
+                "extension": "mp4",
+                "status": "ready",
+                "validation_status": "neutral",
+            }
+        ]
+        self._post_kitsu("/import/kitsu/preview-files", payload)
+        stored = PreviewFile.get(new_id)
+        self.assertIsNotNone(stored)
+        self.assertTrue((stored.data or {}).get("imported_only"))
+
     def test_import_preview_files(self):
         new_id = str(fields.gen_uuid())
         payload = [

--- a/zou/app/blueprints/previews/resources.py
+++ b/zou/app/blueprints/previews/resources.py
@@ -1,7 +1,7 @@
 import os
 import orjson as json
 
-from flask import abort, request, current_app
+from flask import request, current_app
 from flask import send_file as flask_send_file
 from flask_restful import Resource
 from flask_jwt_extended import jwt_required
@@ -1704,6 +1704,8 @@ class ExtractFrameFromPreview(Resource, ArgsMixin):
                 preview_file, args["frame_number"]
             )
         )
+        if extracted_frame_path is None:
+            return {"error": "preview file binary is not available"}, 404
         try:
             return flask_send_file(
                 extracted_frame_path,
@@ -1752,6 +1754,8 @@ class ExtractTileFromPreview(Resource):
         extracted_tile_path = (
             preview_files_service.extract_tile_from_preview_file(preview_file)
         )
+        if extracted_tile_path is None:
+            return {"error": "preview file binary is not available"}, 404
         file_store.add_picture("tiles", preview_file_id, extracted_tile_path)
         try:
             return flask_send_file(

--- a/zou/app/blueprints/source/kitsu.py
+++ b/zou/app/blueprints/source/kitsu.py
@@ -628,6 +628,21 @@ class ImportKitsuPreviewFilesResource(_TaskScopedImportResource):
     def __init__(self):
         BaseImportKitsuResource.__init__(self, PreviewFile)
 
+    @jwt_required()
+    def post(self):
+        # Flag every imported entry as binary-not-available so downstream
+        # services (thumbnail regen, frame extraction) know not to touch
+        # the local filesystem. The push only transfers metadata.
+        entries = request.json
+        if isinstance(entries, list):
+            for entry in entries:
+                if not isinstance(entry, dict):
+                    continue
+                data = entry.get("data") or {}
+                data["imported_only"] = True
+                entry["data"] = data
+        return super().post()
+
 
 class ImportKitsuTimeSpentsResource(_TaskScopedImportResource):
     event_name = "time-spent"

--- a/zou/app/services/preview_files_service.py
+++ b/zou/app/services/preview_files_service.py
@@ -789,10 +789,9 @@ def get_last_preview_file_for_task(task_id):
 
 def extract_frame_from_preview_file(preview_file, frame_number):
     if (preview_file.get("data") or {}).get("imported_only"):
-        raise WrongParameterException(
-            "Preview file is metadata-only (imported via sync-push). "
-            "Transfer the binary before extracting frames."
-        )
+        # Imported via sync-push: only metadata is here, the binary lives
+        # elsewhere and will arrive via the file sync. Skip silently.
+        return None
     try:
         project = get_project_from_preview_file(preview_file["id"])
     except PreviewFileNotFoundException:
@@ -824,6 +823,8 @@ def replace_extracted_frame_for_preview_file(preview_file, frame_number):
     extracted_frame_path = extract_frame_from_preview_file(
         preview_file, frame_number
     )
+    if extracted_frame_path is None:
+        return
     extracted_frame_path = thumbnail_utils.turn_into_thumbnail(
         extracted_frame_path
     )
@@ -832,10 +833,8 @@ def replace_extracted_frame_for_preview_file(preview_file, frame_number):
 
 def extract_tile_from_preview_file(preview_file):
     if (preview_file.get("data") or {}).get("imported_only"):
-        raise WrongParameterException(
-            "Preview file is metadata-only (imported via sync-push). "
-            "Transfer the binary before extracting tiles."
-        )
+        # Imported via sync-push: metadata only. Skip silently.
+        return None
     if preview_file["extension"] == "mp4":
         preview_file_path = fs.get_file_path_and_file(
             config,

--- a/zou/app/services/preview_files_service.py
+++ b/zou/app/services/preview_files_service.py
@@ -788,6 +788,11 @@ def get_last_preview_file_for_task(task_id):
 
 
 def extract_frame_from_preview_file(preview_file, frame_number):
+    if (preview_file.get("data") or {}).get("imported_only"):
+        raise WrongParameterException(
+            "Preview file is metadata-only (imported via sync-push). "
+            "Transfer the binary before extracting frames."
+        )
     try:
         project = get_project_from_preview_file(preview_file["id"])
     except PreviewFileNotFoundException:
@@ -826,6 +831,11 @@ def replace_extracted_frame_for_preview_file(preview_file, frame_number):
 
 
 def extract_tile_from_preview_file(preview_file):
+    if (preview_file.get("data") or {}).get("imported_only"):
+        raise WrongParameterException(
+            "Preview file is metadata-only (imported via sync-push). "
+            "Transfer the binary before extracting tiles."
+        )
     if preview_file["extension"] == "mp4":
         preview_file_path = fs.get_file_path_and_file(
             config,

--- a/zou/app/services/sync_service.py
+++ b/zou/app/services/sync_service.py
@@ -325,13 +325,24 @@ def run_other_sync(project=None, with_events=False):
         sync_entries("events", ApiEvent, project=project)
 
 
-def push_project_data(target, login, password, project_name, batch_size=200):
+def push_project_data(
+    target,
+    login,
+    password,
+    project_name,
+    batch_size=200,
+    throttle=0.0,
+):
     """
     Push a single project's data to a target zou instance via the
     /import/kitsu/* routes. Reference data (persons, departments, task
     types/statuses, asset types, studios) is assumed to already exist on
     the target with matching UUIDs — the routes will fail on foreign-key
     violation if it doesn't.
+
+    ``throttle`` is a pause (in seconds) between every batch POST. Useful
+    to spare the target instance under load — set to 0.5 or 1.0 if the
+    default rate causes timeouts or saturates request workers.
     """
     gazu.set_host(target)
     gazu.log_in(login, password)
@@ -352,12 +363,14 @@ def push_project_data(target, login, password, project_name, batch_size=200):
         "/import/kitsu/metadata-descriptors",
         MetadataDescriptor.query.filter_by(project_id=project_id),
         batch_size=batch_size,
+        throttle=throttle,
         relations=True,
     )
     _push_query(
         "/import/kitsu/milestones",
         Milestone.query.filter_by(project_id=project_id),
         batch_size=batch_size,
+        throttle=throttle,
     )
 
     # Entities in hierarchy order so FKs (parent_id) resolve as we go.
@@ -377,6 +390,7 @@ def push_project_data(target, login, password, project_name, batch_size=200):
                 project_id=project_id, entity_type_id=entity_type.id
             ),
             batch_size=batch_size,
+            throttle=throttle,
             label=f"/import/kitsu/entities ({entity_type_name})",
         )
 
@@ -384,6 +398,7 @@ def push_project_data(target, login, password, project_name, batch_size=200):
         "/import/kitsu/schedule-items",
         ScheduleItem.query.filter_by(project_id=project_id),
         batch_size=batch_size,
+        throttle=throttle,
     )
     _push_query(
         "/import/kitsu/entity-links",
@@ -391,27 +406,32 @@ def push_project_data(target, login, password, project_name, batch_size=200):
             Entity, EntityLink.entity_in_id == Entity.id
         ).filter(Entity.project_id == project_id),
         batch_size=batch_size,
+        throttle=throttle,
     )
 
     _push_query(
         "/import/kitsu/tasks",
         Task.query.filter_by(project_id=project_id),
         batch_size=batch_size,
+        throttle=throttle,
     )
     _push_query(
         "/import/kitsu/subscriptions",
         Subscription.query.join(Task).filter(Task.project_id == project_id),
         batch_size=batch_size,
+        throttle=throttle,
     )
     _push_query(
         "/import/kitsu/notifications",
         Notification.query.join(Task).filter(Task.project_id == project_id),
         batch_size=batch_size,
+        throttle=throttle,
     )
     _push_query(
         "/import/kitsu/time-spents",
         TimeSpent.query.join(Task).filter(Task.project_id == project_id),
         batch_size=batch_size,
+        throttle=throttle,
     )
 
     _push_query(
@@ -420,12 +440,14 @@ def push_project_data(target, login, password, project_name, batch_size=200):
             Task.project_id == project_id
         ),
         batch_size=batch_size,
+        throttle=throttle,
         relations=True,
     )
     _push_query(
         "/import/kitsu/preview-files",
         PreviewFile.query.join(Task).filter(Task.project_id == project_id),
         batch_size=batch_size,
+        throttle=throttle,
         # source_file_id -> OutputFile.id, and OutputFile is out of scope
         # for sync-push (see the verify "NOT SYNCED" rows). Strip it so the
         # FK doesn't blow up the whole batch on the target side.
@@ -438,17 +460,20 @@ def push_project_data(target, login, password, project_name, batch_size=200):
         .join(Task, Comment.object_id == Task.id)
         .filter(Task.project_id == project_id),
         batch_size=batch_size,
+        throttle=throttle,
     )
     _push_query(
         "/import/kitsu/news",
         News.query.join(Task).filter(Task.project_id == project_id),
         batch_size=batch_size,
+        throttle=throttle,
     )
 
     _push_query(
         "/import/kitsu/playlists",
         Playlist.query.filter_by(project_id=project_id),
         batch_size=batch_size,
+        throttle=throttle,
         relations=True,
     )
     _push_query(
@@ -457,6 +482,7 @@ def push_project_data(target, login, password, project_name, batch_size=200):
             Playlist.project_id == project_id
         ),
         batch_size=batch_size,
+        throttle=throttle,
     )
 
     logger.info(f"Push of {project.name} complete.")
@@ -469,6 +495,7 @@ def _push_query(
     relations=False,
     label=None,
     strip_fields=None,
+    throttle=0.0,
 ):
     """
     Page through a query (offset+limit) and POST one batch at a time.
@@ -517,6 +544,8 @@ def _push_query(
             f"  {display}: {total}/{total_expected} ({percent:.1f}%){suffix}"
         )
         offset += batch_size
+        if throttle > 0 and total < total_expected:
+            time.sleep(throttle)
 
     if failed:
         logger.warning(

--- a/zou/app/services/sync_service.py
+++ b/zou/app/services/sync_service.py
@@ -481,6 +481,13 @@ def _push_query(
     which yield_per refuses to combine with.
     """
     display = label or path
+    total_expected = query.count()
+    if total_expected == 0:
+        logger.info(f"  {display}: nothing to push")
+        return
+
+    logger.info(f"  {display}: pushing {total_expected} rows...")
+
     offset = 0
     total = 0
     failed = 0
@@ -504,11 +511,14 @@ def _push_query(
             )
             failed += len(items)
         total += len(items)
+        percent = 100.0 * total / total_expected
+        suffix = f" [{failed} failed]" if failed else ""
+        logger.info(
+            f"  {display}: {total}/{total_expected} ({percent:.1f}%){suffix}"
+        )
         offset += batch_size
 
-    if total == 0:
-        logger.info(f"  {display}: nothing to push")
-    elif failed:
+    if failed:
         logger.warning(
             f"  {display}: pushed {total - failed}/{total} rows "
             f"({failed} failed)"

--- a/zou/app/services/sync_service.py
+++ b/zou/app/services/sync_service.py
@@ -471,39 +471,40 @@ def _push_query(
     strip_fields=None,
 ):
     """
-    Stream a query and POST it batch by batch. Avoids loading the whole
-    project into memory and serializing it up-front, which is critical
-    for high-volume tables (comments, preview-files) where ``relations=True``
-    also triggers N joined lookups per row.
+    Page through a query (offset+limit) and POST one batch at a time.
+    Avoids loading the whole table into memory before the first POST,
+    which matters on high-volume tables (comments, preview-files)
+    especially with ``relations=True`` triggering joined lookups per row.
+
+    offset+limit is used rather than ``yield_per`` because several models
+    define eager loaders on their collections (joinedload/subqueryload),
+    which yield_per refuses to combine with.
     """
     display = label or path
-    pending = []
+    offset = 0
     total = 0
     failed = 0
 
-    def flush():
-        nonlocal pending, total, failed
-        if not pending:
-            return
+    while True:
+        instances = query.offset(offset).limit(batch_size).all()
+        if not instances:
+            break
+        items = []
+        for instance in instances:
+            item = instance.serialize(relations=relations)
+            if strip_fields:
+                for field in strip_fields:
+                    item.pop(field, None)
+            items.append(item)
         try:
-            gazu.client.post(path, pending)
+            gazu.client.post(path, items)
         except Exception:
             logger.error(
-                f"  {display}: batch at offset {total} failed", exc_info=1
+                f"  {display}: batch at offset {offset} failed", exc_info=1
             )
-            failed += len(pending)
-        total += len(pending)
-        pending = []
-
-    for instance in query.yield_per(batch_size):
-        item = instance.serialize(relations=relations)
-        if strip_fields:
-            for field in strip_fields:
-                item.pop(field, None)
-        pending.append(item)
-        if len(pending) >= batch_size:
-            flush()
-    flush()
+            failed += len(items)
+        total += len(items)
+        offset += batch_size
 
     if total == 0:
         logger.info(f"  {display}: nothing to push")

--- a/zou/app/services/sync_service.py
+++ b/zou/app/services/sync_service.py
@@ -470,20 +470,55 @@ def _push_query(
     label=None,
     strip_fields=None,
 ):
-    instances = query.all()
+    """
+    Stream a query and POST it batch by batch. Avoids loading the whole
+    project into memory and serializing it up-front, which is critical
+    for high-volume tables (comments, preview-files) where ``relations=True``
+    also triggers N joined lookups per row.
+    """
     display = label or path
-    if not instances:
-        logger.info(f"  {display}: nothing to push")
-        return
-    payload = [i.serialize(relations=relations) for i in instances]
-    if strip_fields:
-        for item in payload:
+    pending = []
+    total = 0
+    failed = 0
+
+    def flush():
+        nonlocal pending, total, failed
+        if not pending:
+            return
+        try:
+            gazu.client.post(path, pending)
+        except Exception:
+            logger.error(
+                f"  {display}: batch at offset {total} failed", exc_info=1
+            )
+            failed += len(pending)
+        total += len(pending)
+        pending = []
+
+    for instance in query.yield_per(batch_size):
+        item = instance.serialize(relations=relations)
+        if strip_fields:
             for field in strip_fields:
                 item.pop(field, None)
-    _push_batch(path, payload, batch_size, label=display)
+        pending.append(item)
+        if len(pending) >= batch_size:
+            flush()
+    flush()
+
+    if total == 0:
+        logger.info(f"  {display}: nothing to push")
+    elif failed:
+        logger.warning(
+            f"  {display}: pushed {total - failed}/{total} rows "
+            f"({failed} failed)"
+        )
+    else:
+        logger.info(f"  {display}: pushed {total} rows")
 
 
 def _push_batch(path, payload, batch_size=200, label=None):
+    """One-shot POST helper for the small pre-built lists (e.g. the
+    project itself). For query-driven pushes, use _push_query."""
     display = label or path
     total = len(payload)
     failed = 0

--- a/zou/app/utils/commands.py
+++ b/zou/app/utils/commands.py
@@ -715,7 +715,12 @@ def verify_project_against_target(target, login, password, project_name):
 
 
 def push_project_to_target(
-    target, login, password, project_name, batch_size=200
+    target,
+    login,
+    password,
+    project_name,
+    batch_size=200,
+    throttle=0.0,
 ):
     """
     Push the project named ``project_name`` from the local instance to
@@ -723,7 +728,12 @@ def push_project_to_target(
     """
     with app.app_context():
         sync_service.push_project_data(
-            target, login, password, project_name, batch_size=batch_size
+            target,
+            login,
+            password,
+            project_name,
+            batch_size=batch_size,
+            throttle=throttle,
         )
 
 

--- a/zou/cli.py
+++ b/zou/cli.py
@@ -640,7 +640,14 @@ def sync_verify(source, project):
 @click.option("--target", required=True)
 @click.option("--project", required=True)
 @click.option("--batch-size", default=200, show_default=True, type=int)
-def sync_push(target, project, batch_size):
+@click.option(
+    "--throttle",
+    default=0.0,
+    show_default=True,
+    type=float,
+    help="Seconds to sleep between batch POSTs (e.g. 0.5).",
+)
+def sync_push(target, project, batch_size, throttle):
     """
     Push a project from the current instance to a target zou instance via
     /import/kitsu/* routes. Reference data (persons, departments, task
@@ -653,7 +660,12 @@ def sync_push(target, project, batch_size):
     login = os.getenv("SYNC_LOGIN")
     password = os.getenv("SYNC_PASSWORD")
     commands.push_project_to_target(
-        target, login, password, project, batch_size=batch_size
+        target,
+        login,
+        password,
+        project,
+        batch_size=batch_size,
+        throttle=throttle,
     )
 
 


### PR DESCRIPTION
## Problems

- sync-push loaded the whole table into memory before the first POST, which pinned a lot of RAM and made the target instance receive bursty batches
- yield_per refused to combine with joinedload/subqueryload on collection relationships defined on several pushed models
- A push of a large table ran silently for minutes between the start and end log lines, with no way to gauge progress
- The default rate of back-to-back batch POSTs was hammering the target instance
- PreviewFile metadata flowed through sync-push but the binary did not, so any downstream call that tried to extract a frame crashed on FileNotFoundError on the target
- The 400 raised on imported previews was too noisy for the SetMainPreview flow — the operator just wanted the regen to no-op

## Solutions

- Stream queries page by page (offset+limit) so only one batch of rows lives in memory at a time
- Use plain offset+limit pagination instead of yield_per to dodge the eager-loader compatibility error
- Count the rows upfront and log a heartbeat after each batch (``N/Total (%)``); the trailing summary distinguishes pushed vs failed
- Add a ``--throttle`` option (seconds, default 0) to sleep between batches and pace the load
- Stamp every imported PreviewFile with ``data["imported_only"] = True`` at the import boundary
- Make ``extract_frame_from_preview_file`` and ``extract_tile_from_preview_file`` return None silently when the flag is set; ``replace_extracted_frame_for_preview_file`` no-ops, the two public extract endpoints surface a clean 404