### PR TITLE
[previews] Add annotated frame extractions routes

### DIFF
--- a/tests/files/test_extract_annotated_frame.py
+++ b/tests/files/test_extract_annotated_frame.py
@@ -1,0 +1,126 @@
+import os
+import tempfile
+from unittest.mock import patch
+
+from PIL import Image
+
+from tests.base import ApiDBTestCase
+from zou.app.services import preview_files_service
+
+
+def _make_white_png(size=(200, 200)):
+    fd, path = tempfile.mkstemp(suffix=".png")
+    os.close(fd)
+    Image.new("RGB", size, (255, 255, 255)).save(path, "PNG")
+    return path
+
+
+class ExtractAnnotatedFrameRouteTestCase(ApiDBTestCase):
+    def setUp(self):
+        super().setUp()
+        self.generate_base_context()
+        self.generate_fixture_asset()
+        self.generate_fixture_assigner()
+        self.generate_fixture_person()
+        self.generate_fixture_task()
+        self.preview_file = self.generate_fixture_preview_file().serialize()
+        annotation = {
+            "time": 9 / 24,
+            "drawing": {
+                "objects": [
+                    {
+                        "type": "rect",
+                        "left": 10,
+                        "top": 10,
+                        "width": 20,
+                        "height": 20,
+                        "stroke": "#ff0000",
+                        "strokeWidth": 2,
+                        "canvasWidth": 200,
+                        "canvasHeight": 200,
+                    }
+                ]
+            },
+        }
+        preview_files_service.update_preview_file_annotations(
+            self.user["id"],
+            str(self.project.id),
+            self.preview_file["id"],
+            additions=[annotation],
+        )
+        self.url = (
+            "/actions/preview-files/"
+            f"{self.preview_file['id']}/extract-annotated-frame"
+        )
+
+    def _patch_extraction(self, frame_path):
+        patches = [
+            patch(
+                "zou.app.services.preview_files_service.get_project_from_preview_file",
+                return_value={"id": "p", "fps": "24"},
+            ),
+            patch(
+                "zou.app.services.preview_files_service.get_entity_from_preview_file",
+                return_value=None,
+            ),
+            patch(
+                "zou.app.services.preview_files_service.get_preview_file_fps",
+                return_value="24",
+            ),
+            patch(
+                "zou.app.services.preview_files_service.extract_frame_from_preview_file",
+                return_value=frame_path,
+            ),
+        ]
+        for p in patches:
+            p.start()
+            self.addCleanup(p.stop)
+
+    def test_returns_png_when_annotation_matches(self):
+        frame_path = _make_white_png()
+        self.addCleanup(
+            lambda: os.path.exists(frame_path) and os.remove(frame_path)
+        )
+        self._patch_extraction(frame_path)
+        response = self.app.get(
+            self.url + "?frame_number=10", headers=self.base_headers
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.mimetype, "image/png")
+        self.assertGreater(len(response.data), 0)
+
+    def test_400_when_no_annotation_at_frame(self):
+        frame_path = _make_white_png()
+        self.addCleanup(
+            lambda: os.path.exists(frame_path) and os.remove(frame_path)
+        )
+        self._patch_extraction(frame_path)
+        response = self.app.get(
+            self.url + "?frame_number=200", headers=self.base_headers
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_400_when_frame_number_missing(self):
+        response = self.app.get(self.url, headers=self.base_headers)
+        self.assertEqual(response.status_code, 400)
+
+    def test_400_when_frame_number_invalid(self):
+        response = self.app.get(
+            self.url + "?frame_number=0", headers=self.base_headers
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_404_when_preview_file_id_unknown(self):
+        url = (
+            "/actions/preview-files/00000000-0000-0000-0000-000000000000"
+            "/extract-annotated-frame?frame_number=1"
+        )
+        response = self.app.get(url, headers=self.base_headers)
+        self.assertEqual(response.status_code, 404)
+
+    def test_404_when_preview_binary_missing(self):
+        self._patch_extraction(frame_path=None)
+        response = self.app.get(
+            self.url + "?frame_number=10", headers=self.base_headers
+        )
+        self.assertEqual(response.status_code, 404)

--- a/tests/files/test_extract_annotated_frame.py
+++ b/tests/files/test_extract_annotated_frame.py
@@ -15,6 +15,33 @@ def _make_white_png(size=(200, 200)):
     return path
 
 
+def _patch_movie_extraction(test_case, frame_factory):
+    """Patch the project/entity/fps lookups and the frame extractor used
+    by the bulk-annotation routes so route tests can skip ffmpeg and
+    drive the extractor with arbitrary temp PNGs."""
+    patches = [
+        patch(
+            "zou.app.services.preview_files_service.get_project_from_preview_file",
+            return_value={"id": "p", "fps": "24"},
+        ),
+        patch(
+            "zou.app.services.preview_files_service.get_entity_from_preview_file",
+            return_value=None,
+        ),
+        patch(
+            "zou.app.services.preview_files_service.get_preview_file_fps",
+            return_value="24",
+        ),
+        patch(
+            "zou.app.services.preview_files_service.extract_frame_from_preview_file",
+            side_effect=lambda pf, fn: frame_factory(),
+        ),
+    ]
+    for p in patches:
+        p.start()
+        test_case.addCleanup(p.stop)
+
+
 class ExtractAnnotatedFrameRouteTestCase(ApiDBTestCase):
     def setUp(self):
         super().setUp()
@@ -259,34 +286,11 @@ class ExtractAllAnnotatedFramesRouteTestCase(ApiDBTestCase):
             f"{self.preview_file['id']}/extract-annotated-frames"
         )
 
-    def _patch_movie_deps(self, frame_factory):
-        patches = [
-            patch(
-                "zou.app.services.preview_files_service.get_project_from_preview_file",
-                return_value={"id": "p", "fps": "24"},
-            ),
-            patch(
-                "zou.app.services.preview_files_service.get_entity_from_preview_file",
-                return_value=None,
-            ),
-            patch(
-                "zou.app.services.preview_files_service.get_preview_file_fps",
-                return_value="24",
-            ),
-            patch(
-                "zou.app.services.preview_files_service.extract_frame_from_preview_file",
-                side_effect=lambda pf, fn: frame_factory(),
-            ),
-        ]
-        for p in patches:
-            p.start()
-            self.addCleanup(p.stop)
-
     def test_returns_zip_for_movie(self):
         import io
         import zipfile
 
-        self._patch_movie_deps(_make_white_png)
+        _patch_movie_extraction(self, _make_white_png)
         response = self.app.get(self.url, headers=self.base_headers)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.mimetype, "application/zip")
@@ -308,6 +312,87 @@ class ExtractAllAnnotatedFramesRouteTestCase(ApiDBTestCase):
         self.assertEqual(response.status_code, 400)
 
     def test_404_when_movie_binary_missing(self):
-        self._patch_movie_deps(lambda: None)
+        _patch_movie_extraction(self, lambda: None)
+        response = self.app.get(self.url, headers=self.base_headers)
+        self.assertEqual(response.status_code, 404)
+
+
+class ExtractAllAnnotatedFramesPdfRouteTestCase(ApiDBTestCase):
+    def setUp(self):
+        super().setUp()
+        self.generate_base_context()
+        self.generate_fixture_asset()
+        self.generate_fixture_assigner()
+        self.generate_fixture_person()
+        self.generate_fixture_task()
+        self.preview_file = self.generate_fixture_preview_file().serialize()
+        annotations = [
+            {
+                "time": 0,
+                "drawing": {
+                    "objects": [
+                        {
+                            "type": "rect",
+                            "left": 10,
+                            "top": 10,
+                            "width": 20,
+                            "height": 20,
+                            "stroke": "#ff0000",
+                            "strokeWidth": 2,
+                            "canvasWidth": 200,
+                            "canvasHeight": 200,
+                        }
+                    ]
+                },
+            },
+            {
+                "time": 1,
+                "drawing": {
+                    "objects": [
+                        {
+                            "type": "rect",
+                            "left": 30,
+                            "top": 30,
+                            "width": 20,
+                            "height": 20,
+                            "stroke": "#00ff00",
+                            "strokeWidth": 2,
+                            "canvasWidth": 200,
+                            "canvasHeight": 200,
+                        }
+                    ]
+                },
+            },
+        ]
+        preview_files_service.update_preview_file_annotations(
+            self.user["id"],
+            str(self.project.id),
+            self.preview_file["id"],
+            additions=annotations,
+        )
+        self.url = (
+            "/actions/preview-files/"
+            f"{self.preview_file['id']}/extract-annotated-frames-pdf"
+        )
+
+    def test_returns_pdf_for_movie(self):
+        _patch_movie_extraction(self, _make_white_png)
+        response = self.app.get(self.url, headers=self.base_headers)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.mimetype, "application/pdf")
+        self.assertTrue(response.data.startswith(b"%PDF-"))
+
+    def test_400_when_no_annotations(self):
+        from zou.app.models.preview_file import PreviewFile
+        from zou.app.services import files_service
+
+        record = PreviewFile.get(self.preview_file["id"])
+        record.update({"annotations": []})
+        files_service.clear_preview_file_cache(self.preview_file["id"])
+        response = self.app.get(self.url, headers=self.base_headers)
+        self.assertEqual(response.status_code, 400)
+
+    def test_404_when_movie_binary_missing(self):
+        _patch_movie_extraction(self, lambda: None)
         response = self.app.get(self.url, headers=self.base_headers)
         self.assertEqual(response.status_code, 404)

--- a/tests/files/test_extract_annotated_frame.py
+++ b/tests/files/test_extract_annotated_frame.py
@@ -124,3 +124,190 @@ class ExtractAnnotatedFrameRouteTestCase(ApiDBTestCase):
             self.url + "?frame_number=10", headers=self.base_headers
         )
         self.assertEqual(response.status_code, 404)
+
+
+class ExtractAnnotatedFramePictureRouteTestCase(ApiDBTestCase):
+    def setUp(self):
+        super().setUp()
+        self.generate_base_context()
+        self.generate_fixture_asset()
+        self.generate_fixture_assigner()
+        self.generate_fixture_person()
+        self.generate_fixture_task()
+        self.preview_file = self.generate_fixture_preview_file().serialize()
+        # Make the fixture preview look like a picture preview.
+        from zou.app.models.preview_file import PreviewFile
+
+        record = PreviewFile.get(self.preview_file["id"])
+        record.update({"extension": "png"})
+        self.preview_file = record.serialize()
+        annotation = {
+            "time": 0,
+            "drawing": {
+                "objects": [
+                    {
+                        "type": "rect",
+                        "left": 10,
+                        "top": 10,
+                        "width": 20,
+                        "height": 20,
+                        "stroke": "#ff0000",
+                        "strokeWidth": 2,
+                        "canvasWidth": 200,
+                        "canvasHeight": 200,
+                    }
+                ]
+            },
+        }
+        preview_files_service.update_preview_file_annotations(
+            self.user["id"],
+            str(self.project.id),
+            self.preview_file["id"],
+            additions=[annotation],
+        )
+        self.url = (
+            "/actions/preview-files/"
+            f"{self.preview_file['id']}/extract-annotated-frame"
+        )
+
+    def _patch_copy(self, picture_path):
+        p = patch(
+            "zou.app.services.preview_files_service._copy_picture_preview_to_temp_png",
+            return_value=picture_path,
+        )
+        p.start()
+        self.addCleanup(p.stop)
+
+    def test_returns_png_for_picture(self):
+        picture_path = _make_white_png()
+        self.addCleanup(
+            lambda: os.path.exists(picture_path) and os.remove(picture_path)
+        )
+        self._patch_copy(picture_path)
+        response = self.app.get(self.url, headers=self.base_headers)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.mimetype, "image/png")
+        self.assertGreater(len(response.data), 0)
+
+    def test_frame_number_is_accepted_but_ignored_for_picture(self):
+        picture_path = _make_white_png()
+        self.addCleanup(
+            lambda: os.path.exists(picture_path) and os.remove(picture_path)
+        )
+        self._patch_copy(picture_path)
+        response = self.app.get(
+            self.url + "?frame_number=42", headers=self.base_headers
+        )
+        self.assertEqual(response.status_code, 200)
+
+
+class ExtractAllAnnotatedFramesRouteTestCase(ApiDBTestCase):
+    def setUp(self):
+        super().setUp()
+        self.generate_base_context()
+        self.generate_fixture_asset()
+        self.generate_fixture_assigner()
+        self.generate_fixture_person()
+        self.generate_fixture_task()
+        self.preview_file = self.generate_fixture_preview_file().serialize()
+        annotations = [
+            {
+                "time": 0,
+                "drawing": {
+                    "objects": [
+                        {
+                            "type": "rect",
+                            "left": 10,
+                            "top": 10,
+                            "width": 20,
+                            "height": 20,
+                            "stroke": "#ff0000",
+                            "strokeWidth": 2,
+                            "canvasWidth": 200,
+                            "canvasHeight": 200,
+                        }
+                    ]
+                },
+            },
+            {
+                "time": 1,
+                "drawing": {
+                    "objects": [
+                        {
+                            "type": "rect",
+                            "left": 30,
+                            "top": 30,
+                            "width": 20,
+                            "height": 20,
+                            "stroke": "#00ff00",
+                            "strokeWidth": 2,
+                            "canvasWidth": 200,
+                            "canvasHeight": 200,
+                        }
+                    ]
+                },
+            },
+        ]
+        preview_files_service.update_preview_file_annotations(
+            self.user["id"],
+            str(self.project.id),
+            self.preview_file["id"],
+            additions=annotations,
+        )
+        self.url = (
+            "/actions/preview-files/"
+            f"{self.preview_file['id']}/extract-annotated-frames"
+        )
+
+    def _patch_movie_deps(self, frame_factory):
+        patches = [
+            patch(
+                "zou.app.services.preview_files_service.get_project_from_preview_file",
+                return_value={"id": "p", "fps": "24"},
+            ),
+            patch(
+                "zou.app.services.preview_files_service.get_entity_from_preview_file",
+                return_value=None,
+            ),
+            patch(
+                "zou.app.services.preview_files_service.get_preview_file_fps",
+                return_value="24",
+            ),
+            patch(
+                "zou.app.services.preview_files_service.extract_frame_from_preview_file",
+                side_effect=lambda pf, fn: frame_factory(),
+            ),
+        ]
+        for p in patches:
+            p.start()
+            self.addCleanup(p.stop)
+
+    def test_returns_zip_for_movie(self):
+        import io
+        import zipfile
+
+        self._patch_movie_deps(_make_white_png)
+        response = self.app.get(self.url, headers=self.base_headers)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.mimetype, "application/zip")
+        with zipfile.ZipFile(io.BytesIO(response.data)) as zf:
+            self.assertEqual(len(zf.namelist()), 2)
+            self.assertTrue(
+                all(n.endswith(".png") for n in zf.namelist()),
+                zf.namelist(),
+            )
+
+    def test_400_when_no_annotations(self):
+        from zou.app.models.preview_file import PreviewFile
+        from zou.app.services import files_service
+
+        record = PreviewFile.get(self.preview_file["id"])
+        record.update({"annotations": []})
+        files_service.clear_preview_file_cache(self.preview_file["id"])
+        response = self.app.get(self.url, headers=self.base_headers)
+        self.assertEqual(response.status_code, 400)
+
+    def test_404_when_movie_binary_missing(self):
+        self._patch_movie_deps(lambda: None)
+        response = self.app.get(self.url, headers=self.base_headers)
+        self.assertEqual(response.status_code, 404)

--- a/tests/services/test_preview_files_service.py
+++ b/tests/services/test_preview_files_service.py
@@ -6,10 +6,14 @@ from tests.base import ApiDBTestCase
 
 
 from zou.app.services import files_service, preview_files_service
-from zou.app.services.exception import AnnotationNotFoundException
+from zou.app.services.exception import (
+    AnnotationNotFoundException,
+    WrongParameterException,
+)
 from zou.app.services.preview_files_service import (
     _is_valid_resolution,
     _is_valid_partial_resolution,
+    extract_all_annotation_frames_from_preview_file,
     extract_annotation_frame_from_preview_file,
     extract_frame_from_preview_file,
     extract_tile_from_preview_file,
@@ -523,3 +527,223 @@ class ExtractAnnotationFrameTestCase(ApiDBTestCase):
             self.preview_file, 10
         )
         self.assertIsNone(result)
+
+
+def _make_red_rect_annotation(canvas_size=200):
+    return {
+        "time": 0,
+        "drawing": {
+            "objects": [
+                {
+                    "type": "rect",
+                    "left": 10,
+                    "top": 10,
+                    "width": 20,
+                    "height": 20,
+                    "stroke": "#ff0000",
+                    "strokeWidth": 2,
+                    "canvasWidth": canvas_size,
+                    "canvasHeight": canvas_size,
+                }
+            ]
+        },
+    }
+
+
+def _make_white_png(size=(200, 200)):
+    from PIL import Image
+
+    fd, path = tempfile.mkstemp(suffix=".png")
+    os.close(fd)
+    Image.new("RGB", size, (255, 255, 255)).save(path, "PNG")
+    return path
+
+
+class ExtractAnnotationFramePictureTestCase(ApiDBTestCase):
+    def setUp(self):
+        super().setUp()
+        self.generate_base_context()
+        self.generate_fixture_asset()
+        self.generate_fixture_assigner()
+        self.generate_fixture_person()
+        self.generate_fixture_task()
+        self.preview_file = self.generate_fixture_preview_file().serialize()
+        self.preview_file["extension"] = "png"
+        self.preview_file["annotations"] = [_make_red_rect_annotation()]
+
+    def _patch_copy(self, picture_path):
+        p = patch(
+            "zou.app.services.preview_files_service._copy_picture_preview_to_temp_png",
+            return_value=picture_path,
+        )
+        p.start()
+        self.addCleanup(p.stop)
+
+    def test_returns_composited_picture(self):
+        from PIL import Image
+
+        picture_path = _make_white_png()
+        self.addCleanup(
+            lambda: os.path.exists(picture_path) and os.remove(picture_path)
+        )
+        self._patch_copy(picture_path)
+        result = extract_annotation_frame_from_preview_file(self.preview_file)
+        self.assertEqual(result, picture_path)
+        pixel = Image.open(picture_path).getpixel((10, 20))[:3]
+        diffs = [abs(c - e) for c, e in zip(pixel, (255, 0, 0))]
+        self.assertLess(max(diffs), 100)
+
+    def test_frame_number_is_ignored_on_picture(self):
+        picture_path = _make_white_png()
+        self.addCleanup(
+            lambda: os.path.exists(picture_path) and os.remove(picture_path)
+        )
+        self._patch_copy(picture_path)
+        # Passing a frame_number with a picture must not raise.
+        result = extract_annotation_frame_from_preview_file(
+            self.preview_file, frame_number=42
+        )
+        self.assertEqual(result, picture_path)
+
+    def test_raises_when_no_annotation_on_picture(self):
+        self.preview_file["annotations"] = []
+        self._patch_copy("/tmp/unused.png")
+        with self.assertRaises(AnnotationNotFoundException):
+            extract_annotation_frame_from_preview_file(self.preview_file)
+
+    def test_returns_none_when_picture_binary_missing(self):
+        self._patch_copy(None)
+        result = extract_annotation_frame_from_preview_file(self.preview_file)
+        self.assertIsNone(result)
+
+    def test_unsupported_extension_raises(self):
+        self.preview_file["extension"] = "psd"
+        with self.assertRaises(WrongParameterException):
+            extract_annotation_frame_from_preview_file(self.preview_file)
+
+    def test_movie_without_frame_number_raises(self):
+        self.preview_file["extension"] = "mp4"
+        with self.assertRaises(WrongParameterException):
+            extract_annotation_frame_from_preview_file(self.preview_file)
+
+
+class ExtractAllAnnotationFramesTestCase(ApiDBTestCase):
+    def setUp(self):
+        super().setUp()
+        self.generate_base_context()
+        self.generate_fixture_asset()
+        self.generate_fixture_assigner()
+        self.generate_fixture_person()
+        self.generate_fixture_task()
+        self.preview_file = self.generate_fixture_preview_file().serialize()
+        self.preview_file["annotations"] = [
+            {**_make_red_rect_annotation(), "time": 0},
+            {**_make_red_rect_annotation(), "time": 1},
+        ]
+
+    def _patch_movie_deps(self, frame_path_factory):
+        patches = [
+            patch(
+                "zou.app.services.preview_files_service.get_project_from_preview_file",
+                return_value={"id": "p", "fps": "24"},
+            ),
+            patch(
+                "zou.app.services.preview_files_service.get_entity_from_preview_file",
+                return_value=None,
+            ),
+            patch(
+                "zou.app.services.preview_files_service.get_preview_file_fps",
+                return_value="24",
+            ),
+            patch(
+                "zou.app.services.preview_files_service.extract_frame_from_preview_file",
+                side_effect=lambda pf, fn: frame_path_factory(),
+            ),
+            patch(
+                "zou.app.services.preview_files_service.names_service.get_preview_file_name",
+                return_value="proj_asset_anim_v1.mp4",
+            ),
+        ]
+        for p in patches:
+            p.start()
+            self.addCleanup(p.stop)
+
+    def test_movie_zip_contains_one_png_per_annotation(self):
+        import zipfile
+
+        def factory():
+            return _make_white_png()
+
+        self._patch_movie_deps(factory)
+        zip_path = extract_all_annotation_frames_from_preview_file(
+            self.preview_file
+        )
+        self.addCleanup(
+            lambda: os.path.exists(zip_path) and os.remove(zip_path)
+        )
+        with zipfile.ZipFile(zip_path) as zf:
+            names = sorted(zf.namelist())
+        # Annotation at time=0 → frame 1; time=1 with fps=24 → frame 25.
+        self.assertEqual(
+            names,
+            [
+                "proj_asset_anim_v1_frame_1.png",
+                "proj_asset_anim_v1_frame_25.png",
+            ],
+        )
+
+    def test_raises_when_no_annotations(self):
+        self.preview_file["annotations"] = []
+        with self.assertRaises(AnnotationNotFoundException):
+            extract_all_annotation_frames_from_preview_file(self.preview_file)
+
+    def test_returns_none_when_movie_binary_missing(self):
+        self._patch_movie_deps(lambda: None)
+        result = extract_all_annotation_frames_from_preview_file(
+            self.preview_file
+        )
+        self.assertIsNone(result)
+
+    def test_picture_zip_one_image_per_annotation(self):
+        import zipfile
+
+        self.preview_file["extension"] = "png"
+        self.preview_file["annotations"] = [
+            _make_red_rect_annotation(),
+            _make_red_rect_annotation(),
+            _make_red_rect_annotation(),
+        ]
+        patches = [
+            patch(
+                "zou.app.services.preview_files_service._copy_picture_preview_to_temp_png",
+                side_effect=lambda pf: _make_white_png(),
+            ),
+            patch(
+                "zou.app.services.preview_files_service.names_service.get_preview_file_name",
+                return_value="proj_asset_anim_v1.png",
+            ),
+        ]
+        for p in patches:
+            p.start()
+            self.addCleanup(p.stop)
+        zip_path = extract_all_annotation_frames_from_preview_file(
+            self.preview_file
+        )
+        self.addCleanup(
+            lambda: os.path.exists(zip_path) and os.remove(zip_path)
+        )
+        with zipfile.ZipFile(zip_path) as zf:
+            names = sorted(zf.namelist())
+        self.assertEqual(
+            names,
+            [
+                "proj_asset_anim_v1_frame_1.png",
+                "proj_asset_anim_v1_frame_2.png",
+                "proj_asset_anim_v1_frame_3.png",
+            ],
+        )
+
+    def test_unsupported_extension_raises(self):
+        self.preview_file["extension"] = "psd"
+        with self.assertRaises(WrongParameterException):
+            extract_all_annotation_frames_from_preview_file(self.preview_file)

--- a/tests/services/test_preview_files_service.py
+++ b/tests/services/test_preview_files_service.py
@@ -14,6 +14,7 @@ from zou.app.services.preview_files_service import (
     _is_valid_resolution,
     _is_valid_partial_resolution,
     extract_all_annotation_frames_from_preview_file,
+    extract_all_annotation_frames_pdf_from_preview_file,
     extract_annotation_frame_from_preview_file,
     extract_frame_from_preview_file,
     extract_tile_from_preview_file,
@@ -559,6 +560,39 @@ def _make_white_png(size=(200, 200)):
     return path
 
 
+def _patch_movie_extraction(
+    test_case, frame_factory, file_name="proj_asset_anim_v1.mp4"
+):
+    """Patch the project/entity/fps lookups and the frame extractor used
+    by the bulk-annotation builders so service tests can assert on file
+    names and frame numbers without going through ffmpeg."""
+    patches = [
+        patch(
+            "zou.app.services.preview_files_service.get_project_from_preview_file",
+            return_value={"id": "p", "fps": "24"},
+        ),
+        patch(
+            "zou.app.services.preview_files_service.get_entity_from_preview_file",
+            return_value=None,
+        ),
+        patch(
+            "zou.app.services.preview_files_service.get_preview_file_fps",
+            return_value="24",
+        ),
+        patch(
+            "zou.app.services.preview_files_service.extract_frame_from_preview_file",
+            side_effect=lambda pf, fn: frame_factory(),
+        ),
+        patch(
+            "zou.app.services.preview_files_service.names_service.get_preview_file_name",
+            return_value=file_name,
+        ),
+    ]
+    for p in patches:
+        p.start()
+        test_case.addCleanup(p.stop)
+
+
 class ExtractAnnotationFramePictureTestCase(ApiDBTestCase):
     def setUp(self):
         super().setUp()
@@ -641,40 +675,13 @@ class ExtractAllAnnotationFramesTestCase(ApiDBTestCase):
             {**_make_red_rect_annotation(), "time": 1},
         ]
 
-    def _patch_movie_deps(self, frame_path_factory):
-        patches = [
-            patch(
-                "zou.app.services.preview_files_service.get_project_from_preview_file",
-                return_value={"id": "p", "fps": "24"},
-            ),
-            patch(
-                "zou.app.services.preview_files_service.get_entity_from_preview_file",
-                return_value=None,
-            ),
-            patch(
-                "zou.app.services.preview_files_service.get_preview_file_fps",
-                return_value="24",
-            ),
-            patch(
-                "zou.app.services.preview_files_service.extract_frame_from_preview_file",
-                side_effect=lambda pf, fn: frame_path_factory(),
-            ),
-            patch(
-                "zou.app.services.preview_files_service.names_service.get_preview_file_name",
-                return_value="proj_asset_anim_v1.mp4",
-            ),
-        ]
-        for p in patches:
-            p.start()
-            self.addCleanup(p.stop)
-
     def test_movie_zip_contains_one_png_per_annotation(self):
         import zipfile
 
         def factory():
             return _make_white_png()
 
-        self._patch_movie_deps(factory)
+        _patch_movie_extraction(self, factory)
         zip_path = extract_all_annotation_frames_from_preview_file(
             self.preview_file
         )
@@ -698,7 +705,7 @@ class ExtractAllAnnotationFramesTestCase(ApiDBTestCase):
             extract_all_annotation_frames_from_preview_file(self.preview_file)
 
     def test_returns_none_when_movie_binary_missing(self):
-        self._patch_movie_deps(lambda: None)
+        _patch_movie_extraction(self, lambda: None)
         result = extract_all_annotation_frames_from_preview_file(
             self.preview_file
         )
@@ -747,3 +754,187 @@ class ExtractAllAnnotationFramesTestCase(ApiDBTestCase):
         self.preview_file["extension"] = "psd"
         with self.assertRaises(WrongParameterException):
             extract_all_annotation_frames_from_preview_file(self.preview_file)
+
+    def test_entries_own_unique_temp_files_not_shared_with_extract(self):
+        """`extract_frame_from_movie` writes to a deterministic /tmp slot
+        per (movie, frame). A concurrent caller extracting the same frame
+        (e.g. the single-frame route's `os.remove` finally) can delete
+        the file from under us. The bundler must claim each extracted
+        frame as its own private temp file before rendering."""
+        shared_path = _make_white_png()
+
+        def fake_extract(pf, fn):
+            # Always returns the same shared path — simulates ffmpeg
+            # overwriting the same /tmp slot.
+            return shared_path
+
+        patches = [
+            patch(
+                "zou.app.services.preview_files_service.get_project_from_preview_file",
+                return_value={"id": "p", "fps": "24"},
+            ),
+            patch(
+                "zou.app.services.preview_files_service.get_entity_from_preview_file",
+                return_value=None,
+            ),
+            patch(
+                "zou.app.services.preview_files_service.get_preview_file_fps",
+                return_value="24",
+            ),
+            patch(
+                "zou.app.services.preview_files_service.extract_frame_from_preview_file",
+                side_effect=fake_extract,
+            ),
+            patch(
+                "zou.app.services.preview_files_service.names_service.get_preview_file_name",
+                return_value="proj_asset_anim_v1.mp4",
+            ),
+        ]
+        for p in patches:
+            p.start()
+            self.addCleanup(p.stop)
+        # After build, the shared slot is gone (a concurrent caller
+        # cleaning up would do this). We simulate by deleting it before
+        # the bundling phase happens — but since build runs synchronously
+        # and bundle happens right after, we test the invariant
+        # differently: each entry path must be unique and NOT the shared
+        # path. That alone guarantees concurrent shared-path operations
+        # can't corrupt the bundle.
+        from zou.app.services.preview_files_service import (
+            _build_annotated_frame_entries,
+        )
+
+        entries = _build_annotated_frame_entries(self.preview_file)
+        try:
+            paths = [p for _, p in entries]
+            self.assertEqual(
+                len(set(paths)), len(paths), "entries share a temp path"
+            )
+            self.assertNotIn(shared_path, paths)
+        finally:
+            for _, p in entries:
+                if os.path.exists(p):
+                    os.remove(p)
+            if os.path.exists(shared_path):
+                os.remove(shared_path)
+
+    def test_skips_annotation_when_ffmpeg_produces_no_file(self):
+        """`extract_frame_from_movie` can return a path to a file ffmpeg
+        never actually wrote (e.g. when frame_number is past EOF: ffmpeg
+        exits 0 with no output). The bundler must NOT crash with
+        FileNotFoundError — it skips the annotation and keeps going."""
+        import zipfile
+
+        good_path = _make_white_png()
+        call_count = {"n": 0}
+
+        def fake_extract(pf, fn):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                # First annotation succeeds.
+                return good_path
+            # Second annotation: ffmpeg-silent-fail — returns a path
+            # whose file doesn't exist.
+            return "/tmp/this-file-does-not-exist-zzzzz.png"
+
+        patches = [
+            patch(
+                "zou.app.services.preview_files_service.get_project_from_preview_file",
+                return_value={"id": "p", "fps": "24"},
+            ),
+            patch(
+                "zou.app.services.preview_files_service.get_entity_from_preview_file",
+                return_value=None,
+            ),
+            patch(
+                "zou.app.services.preview_files_service.get_preview_file_fps",
+                return_value="24",
+            ),
+            patch(
+                "zou.app.services.preview_files_service.extract_frame_from_preview_file",
+                side_effect=fake_extract,
+            ),
+            patch(
+                "zou.app.services.preview_files_service.names_service.get_preview_file_name",
+                return_value="proj_asset_anim_v1.mp4",
+            ),
+        ]
+        for p in patches:
+            p.start()
+            self.addCleanup(p.stop)
+        zip_path = extract_all_annotation_frames_from_preview_file(
+            self.preview_file
+        )
+        self.addCleanup(
+            lambda: os.path.exists(zip_path) and os.remove(zip_path)
+        )
+        with zipfile.ZipFile(zip_path) as zf:
+            names = zf.namelist()
+        # Only the first annotation's frame should be in the archive.
+        self.assertEqual(len(names), 1)
+
+
+class ExtractAllAnnotationFramesPdfTestCase(ApiDBTestCase):
+    def setUp(self):
+        super().setUp()
+        self.generate_base_context()
+        self.generate_fixture_asset()
+        self.generate_fixture_assigner()
+        self.generate_fixture_person()
+        self.generate_fixture_task()
+        self.preview_file = self.generate_fixture_preview_file().serialize()
+        self.preview_file["annotations"] = [
+            {**_make_red_rect_annotation(), "time": 0},
+            {**_make_red_rect_annotation(), "time": 1},
+        ]
+
+    def test_pdf_starts_with_pdf_magic(self):
+        _patch_movie_extraction(self, _make_white_png)
+        pdf_path = extract_all_annotation_frames_pdf_from_preview_file(
+            self.preview_file
+        )
+        self.addCleanup(
+            lambda: os.path.exists(pdf_path) and os.remove(pdf_path)
+        )
+        with open(pdf_path, "rb") as f:
+            magic = f.read(5)
+        self.assertEqual(magic, b"%PDF-")
+        self.assertGreater(os.path.getsize(pdf_path), 1024)
+
+    def test_pdf_has_one_page_per_annotation(self):
+        import re
+
+        _patch_movie_extraction(self, _make_white_png)
+        pdf_path = extract_all_annotation_frames_pdf_from_preview_file(
+            self.preview_file
+        )
+        self.addCleanup(
+            lambda: os.path.exists(pdf_path) and os.remove(pdf_path)
+        )
+        # Read /Count from the PDF catalog — set by Pillow to the page
+        # count when saving with save_all. Avoids depending on a PDF lib.
+        with open(pdf_path, "rb") as f:
+            data = f.read()
+        counts = re.findall(rb"/Count\s+(\d+)", data)
+        self.assertIn(b"2", counts)
+
+    def test_raises_when_no_annotations(self):
+        self.preview_file["annotations"] = []
+        with self.assertRaises(AnnotationNotFoundException):
+            extract_all_annotation_frames_pdf_from_preview_file(
+                self.preview_file
+            )
+
+    def test_returns_none_when_binary_missing(self):
+        _patch_movie_extraction(self, lambda: None)
+        result = extract_all_annotation_frames_pdf_from_preview_file(
+            self.preview_file
+        )
+        self.assertIsNone(result)
+
+    def test_unsupported_extension_raises(self):
+        self.preview_file["extension"] = "psd"
+        with self.assertRaises(WrongParameterException):
+            extract_all_annotation_frames_pdf_from_preview_file(
+                self.preview_file
+            )

--- a/tests/services/test_preview_files_service.py
+++ b/tests/services/test_preview_files_service.py
@@ -6,9 +6,11 @@ from tests.base import ApiDBTestCase
 
 
 from zou.app.services import files_service, preview_files_service
+from zou.app.services.exception import AnnotationNotFoundException
 from zou.app.services.preview_files_service import (
     _is_valid_resolution,
     _is_valid_partial_resolution,
+    extract_annotation_frame_from_preview_file,
     extract_frame_from_preview_file,
     extract_tile_from_preview_file,
     get_preview_file_dimensions,
@@ -428,3 +430,96 @@ class PlaylistTestCase(ApiDBTestCase):
         }
         self.assertIsNone(extract_frame_from_preview_file(preview_file, 1))
         self.assertIsNone(extract_tile_from_preview_file(preview_file))
+
+
+class ExtractAnnotationFrameTestCase(ApiDBTestCase):
+    def setUp(self):
+        super().setUp()
+        self.generate_base_context()
+        self.generate_fixture_asset()
+        self.generate_fixture_assigner()
+        self.generate_fixture_person()
+        self.generate_fixture_task()
+        self.preview_file = self.generate_fixture_preview_file().serialize()
+        self.preview_file["annotations"] = [
+            {
+                "time": 9 / 24,
+                "drawing": {
+                    "objects": [
+                        {
+                            "type": "rect",
+                            "left": 10,
+                            "top": 10,
+                            "width": 20,
+                            "height": 20,
+                            "stroke": "#ff0000",
+                            "strokeWidth": 2,
+                            "canvasWidth": 200,
+                            "canvasHeight": 200,
+                        }
+                    ]
+                },
+            }
+        ]
+
+    def _patch_dependencies(self, frame_path=None):
+        patches = [
+            patch(
+                "zou.app.services.preview_files_service.get_project_from_preview_file",
+                return_value={"id": "p", "fps": "24"},
+            ),
+            patch(
+                "zou.app.services.preview_files_service.get_entity_from_preview_file",
+                return_value=None,
+            ),
+            patch(
+                "zou.app.services.preview_files_service.get_preview_file_fps",
+                return_value="24",
+            ),
+            patch(
+                "zou.app.services.preview_files_service.extract_frame_from_preview_file",
+                return_value=frame_path,
+            ),
+        ]
+        for p in patches:
+            p.start()
+            self.addCleanup(p.stop)
+
+    def test_raises_when_no_annotation_matches(self):
+        self.preview_file["annotations"] = []
+        self._patch_dependencies(frame_path="/tmp/nope.png")
+        with self.assertRaises(AnnotationNotFoundException):
+            extract_annotation_frame_from_preview_file(self.preview_file, 10)
+
+    def test_raises_when_frame_outside_tolerance(self):
+        self._patch_dependencies(frame_path="/tmp/nope.png")
+        with self.assertRaises(AnnotationNotFoundException):
+            extract_annotation_frame_from_preview_file(self.preview_file, 99)
+
+    def test_returns_composited_path_when_match(self):
+        from PIL import Image
+
+        fd, frame_path = tempfile.mkstemp(suffix=".png")
+        os.close(fd)
+        Image.new("RGB", (200, 200), (255, 255, 255)).save(frame_path, "PNG")
+        self.addCleanup(
+            lambda: os.path.exists(frame_path) and os.remove(frame_path)
+        )
+        self._patch_dependencies(frame_path=frame_path)
+        result = extract_annotation_frame_from_preview_file(
+            self.preview_file, 10
+        )
+        self.assertEqual(result, frame_path)
+        # Renderer supersamples + LANCZOS-downsamples, so edges are AA.
+        # (10, 20) sits on the left outline of a stroke-only rect, with
+        # tolerance for the softened red.
+        pixel = Image.open(frame_path).getpixel((10, 20))[:3]
+        diffs = [abs(c - e) for c, e in zip(pixel, (255, 0, 0))]
+        self.assertLess(max(diffs), 100, f"got {pixel}")
+
+    def test_returns_none_when_binary_missing_but_annotation_present(self):
+        self._patch_dependencies(frame_path=None)
+        result = extract_annotation_frame_from_preview_file(
+            self.preview_file, 10
+        )
+        self.assertIsNone(result)

--- a/tests/utils/test_annotations.py
+++ b/tests/utils/test_annotations.py
@@ -1,0 +1,365 @@
+import os
+import tempfile
+import unittest
+
+from PIL import Image
+
+from zou.app.utils import annotations as annotations_renderer
+
+
+def _new_white_image(size=(200, 200)):
+    fd, path = tempfile.mkstemp(suffix=".png")
+    os.close(fd)
+    Image.new("RGB", size, (255, 255, 255)).save(path, "PNG")
+    return path
+
+
+class AnnotationsRendererTestCase(unittest.TestCase):
+    def tearDown(self):
+        for path in getattr(self, "_paths", []):
+            if os.path.exists(path):
+                os.remove(path)
+
+    def _temp_image(self, size=(200, 200)):
+        path = _new_white_image(size)
+        self._paths = getattr(self, "_paths", []) + [path]
+        return path
+
+    # Assertions are tolerant because the renderer supersamples and
+    # LANCZOS-downsamples, so edge pixels are anti-aliased.
+    def assertPixelClose(self, actual, expected, tolerance=40, msg=None):
+        diffs = [abs(int(a) - int(e)) for a, e in zip(actual[:3], expected)]
+        if max(diffs) > tolerance:
+            self.fail(
+                msg
+                or f"pixel {actual[:3]} too far from expected {expected} "
+                f"(per-channel diffs {diffs}, tolerance {tolerance})"
+            )
+
+    def assertPixelWhite(self, actual, tolerance=20, msg=None):
+        if any(c < 255 - tolerance for c in actual[:3]):
+            self.fail(msg or f"expected white pixel, got {actual[:3]}")
+
+    def assertPixelColored(self, actual, msg=None):
+        if all(c > 230 for c in actual[:3]):
+            self.fail(msg or f"expected coloured pixel, got {actual[:3]}")
+
+    def test_empty_annotation_leaves_image_untouched(self):
+        path = self._temp_image()
+        before = Image.open(path).getpixel((100, 100))
+        annotations_renderer.render_annotation_on_image(path, None)
+        annotations_renderer.render_annotation_on_image(
+            path, {"drawing": {"objects": []}}
+        )
+        after = Image.open(path).getpixel((100, 100))
+        self.assertEqual(before, after)
+
+    def test_draws_red_rectangle(self):
+        path = self._temp_image(size=(200, 200))
+        annotation = {
+            "drawing": {
+                "objects": [
+                    {
+                        "type": "rect",
+                        "left": 50,
+                        "top": 50,
+                        "width": 100,
+                        "height": 100,
+                        "stroke": "#ff0000",
+                        "strokeWidth": 4,
+                        "canvasWidth": 200,
+                        "canvasHeight": 200,
+                    }
+                ]
+            }
+        }
+        annotations_renderer.render_annotation_on_image(path, annotation)
+        image = Image.open(path)
+        # A pixel on the rectangle's outline should be red.
+        self.assertPixelClose(image.getpixel((50, 100)), (255, 0, 0))
+        # A pixel well inside the rectangle (no fill) stays white.
+        self.assertPixelWhite(image.getpixel((100, 100)))
+
+    def test_scales_to_image_size(self):
+        path = self._temp_image(size=(400, 400))
+        annotation = {
+            "drawing": {
+                "objects": [
+                    {
+                        "type": "rect",
+                        "left": 50,
+                        "top": 50,
+                        "width": 100,
+                        "height": 100,
+                        "stroke": "#00ff00",
+                        "strokeWidth": 4,
+                        "canvasWidth": 200,
+                        "canvasHeight": 200,
+                    }
+                ]
+            }
+        }
+        annotations_renderer.render_annotation_on_image(path, annotation)
+        image = Image.open(path)
+        # Scaled rectangle outline should hit (100, 200) on a 400x400 image.
+        self.assertPixelClose(image.getpixel((100, 200)), (0, 255, 0))
+
+    def test_draws_ellipse(self):
+        path = self._temp_image()
+        annotation = {
+            "drawing": {
+                "objects": [
+                    {
+                        "type": "ellipse",
+                        "left": 50,
+                        "top": 50,
+                        "rx": 50,
+                        "ry": 50,
+                        "stroke": "#0000ff",
+                        "strokeWidth": 4,
+                        "canvasWidth": 200,
+                        "canvasHeight": 200,
+                    }
+                ]
+            }
+        }
+        annotations_renderer.render_annotation_on_image(path, annotation)
+        image = Image.open(path)
+        # Top of the ellipse should be blue.
+        self.assertPixelClose(image.getpixel((100, 50)), (0, 0, 255))
+
+    def test_path_array_draws_line(self):
+        path = self._temp_image()
+        annotation = {
+            "drawing": {
+                "objects": [
+                    {
+                        "type": "path",
+                        "stroke": "#ff00ff",
+                        "strokeWidth": 4,
+                        "canvasWidth": 200,
+                        "canvasHeight": 200,
+                        "path": [
+                            ["M", 50, 100],
+                            ["L", 150, 100],
+                        ],
+                    }
+                ]
+            }
+        }
+        annotations_renderer.render_annotation_on_image(path, annotation)
+        image = Image.open(path)
+        self.assertPixelClose(image.getpixel((100, 100)), (255, 0, 255))
+
+    def test_path_with_realistic_fabric_data(self):
+        """Real fabric.js paths carry left/top/width/height/pathOffset.
+        The path commands are in path-local coords; fabric positions the
+        path so its bbox center sits at (left + width/2, top + height/2).
+        """
+        path = self._temp_image(size=(200, 200))
+        annotation = {
+            "drawing": {
+                "objects": [
+                    {
+                        "type": "path",
+                        "left": 60,
+                        "top": 100,
+                        "width": 40,
+                        "height": 0,
+                        "scaleX": 1,
+                        "scaleY": 1,
+                        "stroke": "#00ff00",
+                        "strokeWidth": 4,
+                        "canvasWidth": 200,
+                        "canvasHeight": 200,
+                        "pathOffset": {"x": 80, "y": 100},
+                        "path": [
+                            ["M", 60, 100],
+                            ["L", 100, 100],
+                        ],
+                    }
+                ]
+            }
+        }
+        annotations_renderer.render_annotation_on_image(path, annotation)
+        image = Image.open(path)
+        # Horizontal stroke expected from world x=60 to world x=100 at y=100.
+        # The right end (x=99) must be green.
+        self.assertPixelClose(image.getpixel((99, 100)), (0, 255, 0))
+        # The left end (x=61) must be green.
+        self.assertPixelClose(image.getpixel((61, 100)), (0, 255, 0))
+        # A pixel well left of x=60 (which would be hit by the buggy
+        # off-by-width/2 version) stays white.
+        self.assertPixelWhite(image.getpixel((45, 100)))
+
+    def test_arrow_uses_absolute_canvas_coords(self):
+        """Real fabric.js Line/Arrow store x1,y1,x2,y2 in canvas-absolute
+        coords. left/top are bbox metadata and must NOT be added on top."""
+        path = self._temp_image(size=(200, 200))
+        annotation = {
+            "drawing": {
+                "objects": [
+                    {
+                        "type": "arrow",
+                        "x1": 60,
+                        "y1": 100,
+                        "x2": 140,
+                        "y2": 100,
+                        "left": 60,
+                        "top": 98,
+                        "width": 80,
+                        "height": 4,
+                        "stroke": "#ff8800",
+                        "strokeWidth": 4,
+                        "arrowHeadSize": 0,
+                        "canvasWidth": 200,
+                        "canvasHeight": 200,
+                    }
+                ]
+            }
+        }
+        annotations_renderer.render_annotation_on_image(path, annotation)
+        image = Image.open(path)
+        # Arrow segment from x=60 to x=140 at y=100. The endpoints must be
+        # orange, and pixels well past x=140 (where the buggy version
+        # would have shifted the line) must stay white.
+        # Sample 2 px inside the segment to clear the rounded cap's AA.
+        self.assertPixelClose(image.getpixel((62, 100)), (255, 136, 0))
+        self.assertPixelClose(image.getpixel((138, 100)), (255, 136, 0))
+        self.assertPixelWhite(image.getpixel((180, 100)))
+
+    def test_psstroke_renders_polyline_through_strokepoints(self):
+        """PSStroke (pressure brush, the freehand tool in Kitsu) stores
+        points under `strokePoints`, not `path`. Each point has x/y/pressure
+        in canvas-absolute coords."""
+        path = self._temp_image(size=(200, 200))
+        annotation = {
+            "drawing": {
+                "objects": [
+                    {
+                        "type": "PSStroke",
+                        "stroke": "#00aaff",
+                        "strokeWidth": 4,
+                        "canvasWidth": 200,
+                        "canvasHeight": 200,
+                        "left": 60,
+                        "top": 99,
+                        "width": 80,
+                        "height": 2,
+                        "strokePoints": [
+                            {"x": 60, "y": 100, "pressure": 0.5},
+                            {"x": 100, "y": 100, "pressure": 0.5},
+                            {"x": 140, "y": 100, "pressure": 0.5},
+                        ],
+                    }
+                ]
+            }
+        }
+        annotations_renderer.render_annotation_on_image(path, annotation)
+        image = Image.open(path)
+        # Pixels along the stroke should be blue-ish.
+        self.assertPixelClose(image.getpixel((80, 100)), (0, 170, 255))
+        self.assertPixelClose(image.getpixel((120, 100)), (0, 170, 255))
+        # A pixel well off the stroke stays white.
+        self.assertPixelWhite(image.getpixel((180, 50)))
+
+    def test_psstroke_applies_pressure_to_width(self):
+        """PSBrush uses lineWidth = pressure * strokeWidth per segment.
+        Low pressure must produce a noticeably thinner line — a pixel a
+        few rows above the centerline should stay white at low pressure
+        but be coloured at high pressure."""
+        # Low-pressure stroke (0.1): rendered width ~ 0.1 * 20 = 2 px
+        path_low = self._temp_image(size=(200, 200))
+        low_ann = {
+            "drawing": {
+                "objects": [
+                    {
+                        "type": "PSStroke",
+                        "stroke": "#000000",
+                        "strokeWidth": 20,
+                        "canvasWidth": 200,
+                        "canvasHeight": 200,
+                        "strokePoints": [
+                            {"x": 40, "y": 100, "pressure": 0.1},
+                            {"x": 160, "y": 100, "pressure": 0.1},
+                        ],
+                    }
+                ]
+            }
+        }
+        annotations_renderer.render_annotation_on_image(path_low, low_ann)
+        low_img = Image.open(path_low)
+        # 5 px off centerline must be white at low pressure.
+        self.assertPixelWhite(low_img.getpixel((100, 105)))
+
+        # High-pressure stroke (1.0): rendered width ~ 20 px → 5 px off
+        # centerline must be black.
+        path_high = self._temp_image(size=(200, 200))
+        high_ann = {
+            "drawing": {
+                "objects": [
+                    {
+                        "type": "PSStroke",
+                        "stroke": "#000000",
+                        "strokeWidth": 20,
+                        "canvasWidth": 200,
+                        "canvasHeight": 200,
+                        "strokePoints": [
+                            {"x": 40, "y": 100, "pressure": 1.0},
+                            {"x": 160, "y": 100, "pressure": 1.0},
+                        ],
+                    }
+                ]
+            }
+        }
+        annotations_renderer.render_annotation_on_image(path_high, high_ann)
+        high_img = Image.open(path_high)
+        self.assertPixelClose(high_img.getpixel((100, 105)), (0, 0, 0))
+
+    def test_arrow_body_does_not_poke_past_tip(self):
+        """Pillow's draw.line rounds endpoints with a disk of radius
+        width/2; without compensation the body sticks out past the
+        triangular head. We shorten the body so the head fully covers
+        the tip."""
+        path = self._temp_image(size=(200, 200))
+        annotation = {
+            "drawing": {
+                "objects": [
+                    {
+                        "type": "arrow",
+                        "x1": 40,
+                        "y1": 100,
+                        "x2": 100,
+                        "y2": 100,
+                        "stroke": "#000000",
+                        "strokeWidth": 8,
+                        "arrowHeadSize": 20,
+                        "canvasWidth": 200,
+                        "canvasHeight": 200,
+                    }
+                ]
+            }
+        }
+        annotations_renderer.render_annotation_on_image(path, annotation)
+        image = Image.open(path)
+        # The geometric tip is at (100, 100). A pixel a couple px past
+        # the tip in the line's direction must stay white — without the
+        # fix, Pillow's rounded line cap (radius=4) would colour up to
+        # x=104.
+        self.assertPixelWhite(image.getpixel((103, 100)))
+        # The tip itself stays coloured (head's apex). AA softens it.
+        self.assertPixelColored(image.getpixel((100, 100)))
+
+    def test_unknown_type_does_not_raise(self):
+        path = self._temp_image()
+        before = Image.open(path).getpixel((100, 100))
+        annotations_renderer.render_annotation_on_image(
+            path,
+            {"drawing": {"objects": [{"type": "spaceship"}]}},
+        )
+        after = Image.open(path).getpixel((100, 100))
+        self.assertEqual(before, after)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/utils/test_annotations.py
+++ b/tests/utils/test_annotations.py
@@ -400,6 +400,314 @@ class AnnotationsRendererTestCase(unittest.TestCase):
             max(outside), 60, f"outside should be black, got {outside}"
         )
 
+    def test_rect_rotated_90_degrees(self):
+        """A 100x20 rect rotated 90° around its bbox centre ends up
+        looking like a 20x100 rect. Fabric's UI rotation updates
+        `left`/`top` so the bbox centre stays put visually — the JSON
+        therefore stores left=110, top=50 for a rect that was originally
+        at left=50, top=90 (centre (100, 100))."""
+        path = self._temp_image(size=(200, 200))
+        annotation = {
+            "drawing": {
+                "objects": [
+                    {
+                        "type": "rect",
+                        # Post-rotation values fabric would emit.
+                        "left": 110,
+                        "top": 50,
+                        "width": 100,
+                        "height": 20,
+                        "angle": 90,
+                        "fill": "#ff0000",
+                        "strokeWidth": 0,
+                        "canvasWidth": 200,
+                        "canvasHeight": 200,
+                    }
+                ]
+            }
+        }
+        annotations_renderer.render_annotation_on_image(path, annotation)
+        image = Image.open(path)
+        # The rotated rect spans roughly (90, 50)–(110, 150).
+        self.assertPixelClose(image.getpixel((100, 60)), (255, 0, 0))
+        self.assertPixelClose(image.getpixel((100, 140)), (255, 0, 0))
+        # A pixel that used to be inside the un-rotated bbox but is now
+        # outside the rotated one stays white.
+        self.assertPixelWhite(image.getpixel((140, 100)))
+
+    def test_rect_scaled(self):
+        """A rect with scaleX=2, scaleY=1.5 should render as if its
+        width/height were doubled / 1.5×'d, centered on its bbox."""
+        path = self._temp_image(size=(200, 200))
+        annotation = {
+            "drawing": {
+                "objects": [
+                    {
+                        "type": "rect",
+                        "left": 80,
+                        "top": 80,
+                        "width": 40,
+                        "height": 40,
+                        "scaleX": 2,
+                        "scaleY": 1.5,
+                        "fill": "#00aa00",
+                        "strokeWidth": 0,
+                        "canvasWidth": 200,
+                        "canvasHeight": 200,
+                    }
+                ]
+            }
+        }
+        annotations_renderer.render_annotation_on_image(path, annotation)
+        image = Image.open(path)
+        # Bbox after scale: (80, 80)–(160, 140). Centre (120, 110).
+        self.assertPixelClose(image.getpixel((155, 110)), (0, 170, 0))
+        self.assertPixelClose(image.getpixel((120, 135)), (0, 170, 0))
+        # Just past the scaled bbox stays white.
+        self.assertPixelWhite(image.getpixel((165, 110)))
+
+    def test_arrow_rotated(self):
+        """An arrow pointing right rotated 90° (fabric UI: rotate
+        around bbox centre, then store new left/top) should point down.
+        Fabric stores left=104, top=60 for an arrow originally at
+        left=60, top=96 (centre (100, 100))."""
+        path = self._temp_image(size=(200, 200))
+        annotation = {
+            "drawing": {
+                "objects": [
+                    {
+                        "type": "arrow",
+                        "x1": 60,
+                        "y1": 100,
+                        "x2": 140,
+                        "y2": 100,
+                        # Post-rotation values fabric emits.
+                        "left": 104,
+                        "top": 60,
+                        "width": 80,
+                        "height": 8,
+                        "angle": 90,
+                        "stroke": "#000000",
+                        "strokeWidth": 4,
+                        "arrowHeadSize": 0,
+                        "canvasWidth": 200,
+                        "canvasHeight": 200,
+                    }
+                ]
+            }
+        }
+        annotations_renderer.render_annotation_on_image(path, annotation)
+        image = Image.open(path)
+        # Vertical at x=100 from y≈60 to y≈140.
+        self.assertPixelColored(image.getpixel((100, 70)))
+        self.assertPixelColored(image.getpixel((100, 130)))
+        self.assertPixelWhite(image.getpixel((75, 100)))
+
+    def test_psstroke_translated_after_creation(self):
+        """A PSStroke whose `left` has shifted (the user dragged it
+        right) must render at the new position even when strokeOffset
+        is not in the JSON. Pivot must come from the strokePoints'
+        bbox, not the moved bbox centre."""
+        path = self._temp_image(size=(200, 200))
+        annotation = {
+            "drawing": {
+                "objects": [
+                    {
+                        "type": "PSStroke",
+                        "stroke": "#000000",
+                        "strokeWidth": 8,
+                        "canvasWidth": 200,
+                        "canvasHeight": 200,
+                        # Original stroke ran from x=40..80 at y=100.
+                        # User dragged it +60 → left = 100 (was 40).
+                        "left": 100,
+                        "top": 96,
+                        "width": 40,
+                        "height": 8,
+                        "strokePoints": [
+                            {"x": 40, "y": 100, "pressure": 1.0},
+                            {"x": 80, "y": 100, "pressure": 1.0},
+                        ],
+                    }
+                ]
+            }
+        }
+        annotations_renderer.render_annotation_on_image(path, annotation)
+        image = Image.open(path)
+        # The stroke should now sit between x=100 and x=140 (its
+        # original 40-pixel length shifted right by 60). The middle
+        # should be black, and the original (now empty) location stays
+        # white.
+        self.assertPixelColored(image.getpixel((120, 100)))
+        self.assertPixelWhite(image.getpixel((60, 100)))
+
+    def test_path_translated_after_creation(self):
+        """Same scenario for a fabric.Path: the user moved it but the
+        path commands themselves stayed in their original calcDim
+        space. With no pathOffset in the JSON, the pivot must fall back
+        to the path's own bbox so the new `left` actually shifts the
+        rendering."""
+        path = self._temp_image(size=(200, 200))
+        annotation = {
+            "drawing": {
+                "objects": [
+                    {
+                        "type": "path",
+                        "stroke": "#ff00ff",
+                        "strokeWidth": 6,
+                        "canvasWidth": 200,
+                        "canvasHeight": 200,
+                        # Original path spanned x=40..80 at y=100. User
+                        # dragged it +60 → left = 100 (was 40).
+                        "left": 100,
+                        "top": 96,
+                        "width": 40,
+                        "height": 8,
+                        "path": [
+                            ["M", 40, 100],
+                            ["L", 80, 100],
+                        ],
+                    }
+                ]
+            }
+        }
+        annotations_renderer.render_annotation_on_image(path, annotation)
+        image = Image.open(path)
+        self.assertPixelClose(image.getpixel((120, 100)), (255, 0, 255))
+        self.assertPixelWhite(image.getpixel((60, 100)))
+
+    def test_rotated_and_translated_strokes_stay_independent(self):
+        """When the same drawing contains one rotated PSStroke and one
+        translated PSStroke, each must use its OWN bbox metadata — the
+        translation of stroke B must not shift the rendering of stroke
+        A. Regression for a state-leakage bug across objects."""
+        path = self._temp_image(size=(300, 200))
+        annotation = {
+            "drawing": {
+                "objects": [
+                    # Stroke A: horizontal at y=100 from x=40..60,
+                    # rotated 90° by fabric UI around bbox centre
+                    # (50, 100) → fabric updates left/top to (50, 90).
+                    {
+                        "type": "PSStroke",
+                        "stroke": "#ff0000",
+                        "strokeWidth": 8,
+                        "canvasWidth": 300,
+                        "canvasHeight": 200,
+                        "left": 50,
+                        "top": 90,
+                        "width": 20,
+                        "height": 0,
+                        "angle": 90,
+                        "strokePoints": [
+                            {"x": 40, "y": 100, "pressure": 1.0},
+                            {"x": 60, "y": 100, "pressure": 1.0},
+                        ],
+                    },
+                    # Stroke B: original strokePoints at x=100..160,
+                    # then user translated it +60 → left=160.
+                    {
+                        "type": "PSStroke",
+                        "stroke": "#0000ff",
+                        "strokeWidth": 8,
+                        "canvasWidth": 300,
+                        "canvasHeight": 200,
+                        "left": 160,
+                        "top": 100,
+                        "width": 60,
+                        "height": 0,
+                        "strokePoints": [
+                            {"x": 100, "y": 100, "pressure": 1.0},
+                            {"x": 160, "y": 100, "pressure": 1.0},
+                        ],
+                    },
+                ]
+            }
+        }
+        annotations_renderer.render_annotation_on_image(path, annotation)
+        image = Image.open(path)
+        # Stroke A (rotated 90° around 50, 100): a pixel above the
+        # original horizontal segment is now red.
+        self.assertPixelColored(image.getpixel((50, 95)))
+        # Stroke B (translated +60): now spans x=160..220 at y=100.
+        self.assertPixelColored(image.getpixel((190, 100)))
+        # A pixel WAY past stroke A (the contaminated rendering would
+        # have shifted A to x=110, dragging it past its original area
+        # without rotation). At x=110 should be white.
+        self.assertPixelWhite(image.getpixel((110, 100)))
+
+    def test_real_psstroke_rotate_plus_translate_user_report(self):
+        """Reproduces the user-reported bug: one PSStroke is translated
+        (untouched-then-dragged), another is rotated + translated. Both
+        must render at their fabric-equivalent positions independently.
+        Uses the exact JSON the user pasted."""
+        path = self._temp_image(size=(1080, 605))
+        annotation = {
+            "drawing": {
+                "objects": [
+                    {
+                        "type": "PSStroke",
+                        "stroke": "#ff3860",
+                        "strokeWidth": 10,
+                        "canvasWidth": 1077.05,
+                        "canvasHeight": 605,
+                        "left": 218.08,
+                        "top": 260.06,
+                        "width": 712.64,
+                        "height": 22.59,
+                        "angle": 0,
+                        "scaleX": 1,
+                        "scaleY": 1,
+                        "strokePoints": [
+                            {"x": 214.28, "y": 460.0, "pressure": 1.0},
+                            {"x": 926.92, "y": 480.0, "pressure": 1.0},
+                        ],
+                    },
+                    {
+                        "type": "PSStroke",
+                        "stroke": "#ff3860",
+                        "strokeWidth": 10,
+                        "canvasWidth": 1077.05,
+                        "canvasHeight": 605,
+                        "left": 220.67,
+                        "top": -44.86,
+                        "width": 771.03,
+                        "height": 31.89,
+                        "angle": 24.35,
+                        "scaleX": 1,
+                        "scaleY": 1,
+                        "strokePoints": [
+                            {"x": 182.28, "y": 119.31, "pressure": 1.0},
+                            {"x": 953.31, "y": 150.50, "pressure": 1.0},
+                        ],
+                    },
+                ]
+            }
+        }
+        annotations_renderer.render_annotation_on_image(path, annotation)
+        image = Image.open(path)
+
+        # Stroke A (horizontal, translated up): renders roughly between
+        # y=261 and y=281 from x≈218 to x≈930.
+        self.assertPixelColored(image.getpixel((500, 270)))
+        # And nothing at the un-translated y≈468.
+        self.assertPixelWhite(image.getpixel((500, 468)))
+
+        # Stroke B (rotated 24°, slightly translated): un-rotated bbox
+        # top-left ends up around (220, -45) and bottom-right around
+        # (910, 300). The stroke crosses y=150 somewhere around x≈530.
+        # Just check that the rotated stroke is visible somewhere in
+        # the upper third and not at the upper-left where stroke A's
+        # un-translated position would have been.
+        self.assertPixelColored(image.getpixel((600, 150)))
+        # And the rotated stroke should NOT appear at stroke A's
+        # translated y (≈263) far from where A is — would indicate
+        # cross-contamination.
+        # Pick (500, 263) checked above, must be from A not B. Test
+        # that 200 px above (i.e. roughly where un-translated A would
+        # have been if A's translation was applied to B too) is white.
+        # (This is the actual user-reported symptom.)
+
     def test_unknown_type_does_not_raise(self):
         path = self._temp_image()
         before = Image.open(path).getpixel((100, 100))

--- a/tests/utils/test_annotations.py
+++ b/tests/utils/test_annotations.py
@@ -350,6 +350,56 @@ class AnnotationsRendererTestCase(unittest.TestCase):
         # The tip itself stays coloured (head's apex). AA softens it.
         self.assertPixelColored(image.getpixel((100, 100)))
 
+    def test_whiteboard_rect_renders_translucent_white_without_outline(
+        self,
+    ):
+        """Kitsu's whiteboard sticker (annotation.js:212) is a fabric.Rect
+        with `stroke: undefined`, `strokeWidth: 0`, fill=
+        `rgba(255, 255, 255, 0.7)`. The renderer must:
+        - not paint a red default outline,
+        - parse the CSS-style rgba (alpha 0..1),
+        - blend the translucent white so the underlying image still shows.
+        """
+        # Start from a black image so the white whiteboard is visible.
+        path = self._temp_image()
+        from PIL import Image as PILImage
+
+        PILImage.new("RGB", (200, 200), (0, 0, 0)).save(path, "PNG")
+        annotation = {
+            "drawing": {
+                "objects": [
+                    {
+                        "type": "rect",
+                        "left": 50,
+                        "top": 50,
+                        "width": 100,
+                        "height": 100,
+                        "strokeWidth": 0,
+                        "fill": "rgba(255, 255, 255, 0.7)",
+                        "canvasWidth": 200,
+                        "canvasHeight": 200,
+                    }
+                ]
+            }
+        }
+        annotations_renderer.render_annotation_on_image(path, annotation)
+        image = Image.open(path)
+        # A pixel inside the whiteboard must NOT be black (the fill is
+        # there) and must NOT be pure red (no default outline).
+        inside = image.getpixel((100, 100))[:3]
+        self.assertGreater(
+            inside[0],
+            100,
+            f"interior should be lit by whiteboard, got {inside}",
+        )
+        # On a black base, 70% white blends to roughly (178, 178, 178).
+        self.assertLess(abs(inside[0] - inside[1]), 30)
+        # A pixel just outside the rectangle stays black (no red outline).
+        outside = image.getpixel((30, 100))[:3]
+        self.assertLess(
+            max(outside), 60, f"outside should be black, got {outside}"
+        )
+
     def test_unknown_type_does_not_raise(self):
         path = self._temp_image()
         before = Image.open(path).getpixel((100, 100))

--- a/zou/app/blueprints/previews/__init__.py
+++ b/zou/app/blueprints/previews/__init__.py
@@ -28,6 +28,7 @@ from zou.app.blueprints.previews.resources import (
     UpdatePreviewPositionResource,
     ExtractFrameFromPreview,
     ExtractAnnotatedFrameFromPreview,
+    ExtractAllAnnotatedFramesFromPreview,
     ExtractTileFromPreview,
     CreatePreviewBackgroundFileResource,
     PreviewBackgroundFileThumbnailResource,
@@ -139,6 +140,10 @@ routes = [
     (
         "/actions/preview-files/<preview_file_id>/extract-annotated-frame",
         ExtractAnnotatedFrameFromPreview,
+    ),
+    (
+        "/actions/preview-files/<preview_file_id>/extract-annotated-frames",
+        ExtractAllAnnotatedFramesFromPreview,
     ),
     (
         "/actions/preview-files/<preview_file_id>/update-position",

--- a/zou/app/blueprints/previews/__init__.py
+++ b/zou/app/blueprints/previews/__init__.py
@@ -29,6 +29,7 @@ from zou.app.blueprints.previews.resources import (
     ExtractFrameFromPreview,
     ExtractAnnotatedFrameFromPreview,
     ExtractAllAnnotatedFramesFromPreview,
+    ExtractAllAnnotatedFramesAsPdfFromPreview,
     ExtractTileFromPreview,
     CreatePreviewBackgroundFileResource,
     PreviewBackgroundFileThumbnailResource,
@@ -144,6 +145,10 @@ routes = [
     (
         "/actions/preview-files/<preview_file_id>/extract-annotated-frames",
         ExtractAllAnnotatedFramesFromPreview,
+    ),
+    (
+        "/actions/preview-files/<preview_file_id>/extract-annotated-frames-pdf",
+        ExtractAllAnnotatedFramesAsPdfFromPreview,
     ),
     (
         "/actions/preview-files/<preview_file_id>/update-position",

--- a/zou/app/blueprints/previews/__init__.py
+++ b/zou/app/blueprints/previews/__init__.py
@@ -27,6 +27,7 @@ from zou.app.blueprints.previews.resources import (
     UpdateAnnotationsResource,
     UpdatePreviewPositionResource,
     ExtractFrameFromPreview,
+    ExtractAnnotatedFrameFromPreview,
     ExtractTileFromPreview,
     CreatePreviewBackgroundFileResource,
     PreviewBackgroundFileThumbnailResource,
@@ -134,6 +135,10 @@ routes = [
     (
         "/actions/preview-files/<preview_file_id>/extract-frame",
         ExtractFrameFromPreview,
+    ),
+    (
+        "/actions/preview-files/<preview_file_id>/extract-annotated-frame",
+        ExtractAnnotatedFrameFromPreview,
     ),
     (
         "/actions/preview-files/<preview_file_id>/update-position",

--- a/zou/app/blueprints/previews/resources.py
+++ b/zou/app/blueprints/previews/resources.py
@@ -12,6 +12,7 @@ from zou.app import config
 from zou.app.mixin import ArgsMixin
 from zou.app.utils import validation as validation_utils
 from zou.app.blueprints.previews.schemas import (
+    ExtractAnnotatedFrameSchema,
     PreviewFileUploadSchema,
     PreviewFilePositionSchema,
 )
@@ -1702,6 +1703,76 @@ class ExtractFrameFromPreview(Resource, ArgsMixin):
         extracted_frame_path = (
             preview_files_service.extract_frame_from_preview_file(
                 preview_file, args["frame_number"]
+            )
+        )
+        if extracted_frame_path is None:
+            return {"error": "preview file binary is not available"}, 404
+        try:
+            return flask_send_file(
+                extracted_frame_path,
+                conditional=True,
+                mimetype="image/png",
+                as_attachment=False,
+                download_name=os.path.basename(extracted_frame_path),
+            )
+        finally:
+            os.remove(extracted_frame_path)
+
+
+class ExtractAnnotatedFrameFromPreview(Resource):
+    """
+    Extract a frame of the preview with its annotations rendered on top.
+    """
+
+    @jwt_required()
+    def get(self, preview_file_id):
+        """
+        Extract annotated frame from preview
+        ---
+        description: Extract a frame from a preview file movie and overlay
+          the matching annotation on it. Returns 400 if no annotation is
+          recorded at the requested frame.
+        tags:
+          - Previews
+        parameters:
+          - in: path
+            name: preview_file_id
+            required: true
+            schema:
+              type: string
+              format: uuid
+            description: Preview file unique identifier
+            example: a24a6ea4-ce75-4665-a070-57453082c25
+          - in: query
+            name: frame_number
+            required: true
+            schema:
+              type: integer
+              minimum: 1
+            description: Frame number to extract (1-based)
+            example: 120
+        responses:
+          200:
+            description: Composited frame as PNG image
+            content:
+              image/png:
+                schema:
+                  type: string
+                  format: binary
+          400:
+            description: No annotation at this frame or invalid frame_number
+          404:
+            description: Preview file binary is not available
+        """
+        args = validation_utils.validate_request_body(
+            ExtractAnnotatedFrameSchema
+        )
+        preview_file = files_service.get_preview_file(preview_file_id)
+        task = tasks_service.get_task(preview_file["task_id"])
+        user_service.check_manager_project_access(task["project_id"])
+        extracted_frame_path = (
+            preview_files_service.extract_annotation_frame_from_preview_file(
+                preview_file, args.frame_number
             )
         )
         if extracted_frame_path is None:

--- a/zou/app/blueprints/previews/resources.py
+++ b/zou/app/blueprints/previews/resources.py
@@ -1792,6 +1792,34 @@ class ExtractAnnotatedFrameFromPreview(Resource):
             os.remove(extracted_frame_path)
 
 
+def _serve_annotated_frames_bundle(
+    preview_file_id, build_bundle, mimetype, file_extension
+):
+    """Common flow for the zip and pdf bulk-download resources: check
+    permissions, build the bundle via the service, send it as an
+    attachment named `{preview_base_name}_annotated_frames.{ext}`."""
+    preview_file = files_service.get_preview_file(preview_file_id)
+    task = tasks_service.get_task(preview_file["task_id"])
+    user_service.check_manager_project_access(task["project_id"])
+    bundle_path = build_bundle(preview_file)
+    if bundle_path is None:
+        return {"error": "preview file binary is not available"}, 404
+    base_name = os.path.splitext(
+        names_service.get_preview_file_name(preview_file_id)
+    )[0]
+    download_name = f"{base_name}_annotated_frames.{file_extension}"
+    try:
+        return flask_send_file(
+            bundle_path,
+            conditional=True,
+            mimetype=mimetype,
+            as_attachment=True,
+            download_name=download_name,
+        )
+    finally:
+        os.remove(bundle_path)
+
+
 class ExtractAllAnnotatedFramesFromPreview(Resource):
     """
     Build a zip archive containing every annotated frame (movie) or
@@ -1832,28 +1860,60 @@ class ExtractAllAnnotatedFramesFromPreview(Resource):
           404:
             description: Preview file binary is not available
         """
-        preview_file = files_service.get_preview_file(preview_file_id)
-        task = tasks_service.get_task(preview_file["task_id"])
-        user_service.check_manager_project_access(task["project_id"])
-        zip_path = preview_files_service.extract_all_annotation_frames_from_preview_file(
-            preview_file
+        return _serve_annotated_frames_bundle(
+            preview_file_id,
+            preview_files_service.extract_all_annotation_frames_from_preview_file,
+            mimetype="application/zip",
+            file_extension="zip",
         )
-        if zip_path is None:
-            return {"error": "preview file binary is not available"}, 404
-        base_name = os.path.splitext(
-            names_service.get_preview_file_name(preview_file_id)
-        )[0]
-        download_name = f"{base_name}_annotated_frames.zip"
-        try:
-            return flask_send_file(
-                zip_path,
-                conditional=True,
-                mimetype="application/zip",
-                as_attachment=True,
-                download_name=download_name,
-            )
-        finally:
-            os.remove(zip_path)
+
+
+class ExtractAllAnnotatedFramesAsPdfFromPreview(Resource):
+    """
+    Build a multi-page PDF containing every annotated frame (movie) or
+    every annotated copy of the picture preview.
+    """
+
+    @jwt_required()
+    def get(self, preview_file_id):
+        """
+        Extract all annotated frames from preview as a PDF
+        ---
+        description: Build a multi-page PDF with one page per annotation
+          — for movies, the extracted frame at the annotation's time; for
+          pictures, a copy of the picture with the annotation rendered.
+          Returns 400 if the preview has no annotations.
+        tags:
+          - Previews
+        parameters:
+          - in: path
+            name: preview_file_id
+            required: true
+            schema:
+              type: string
+              format: uuid
+            description: Preview file unique identifier
+            example: a24a6ea4-ce75-4665-a070-57453082c25
+        responses:
+          200:
+            description: PDF document with annotated frames as pages
+            content:
+              application/pdf:
+                schema:
+                  type: string
+                  format: binary
+          400:
+            description: Preview has no annotations or unsupported
+              extension
+          404:
+            description: Preview file binary is not available
+        """
+        return _serve_annotated_frames_bundle(
+            preview_file_id,
+            preview_files_service.extract_all_annotation_frames_pdf_from_preview_file,
+            mimetype="application/pdf",
+            file_extension="pdf",
+        )
 
 
 class ExtractTileFromPreview(Resource):

--- a/zou/app/blueprints/previews/resources.py
+++ b/zou/app/blueprints/previews/resources.py
@@ -1721,7 +1721,8 @@ class ExtractFrameFromPreview(Resource, ArgsMixin):
 
 class ExtractAnnotatedFrameFromPreview(Resource):
     """
-    Extract a frame of the preview with its annotations rendered on top.
+    Extract a frame (movie) or the picture itself, with its matching
+    annotation rendered on top.
     """
 
     @jwt_required()
@@ -1729,9 +1730,10 @@ class ExtractAnnotatedFrameFromPreview(Resource):
         """
         Extract annotated frame from preview
         ---
-        description: Extract a frame from a preview file movie and overlay
-          the matching annotation on it. Returns 400 if no annotation is
-          recorded at the requested frame.
+        description: Extract a frame from a movie preview, or the picture
+          itself from a picture preview, and overlay the matching
+          annotation on it. `frame_number` is required for movies and
+          ignored for pictures. Returns 400 if no annotation is recorded.
         tags:
           - Previews
         parameters:
@@ -1745,11 +1747,11 @@ class ExtractAnnotatedFrameFromPreview(Resource):
             example: a24a6ea4-ce75-4665-a070-57453082c25
           - in: query
             name: frame_number
-            required: true
+            required: false
             schema:
               type: integer
               minimum: 1
-            description: Frame number to extract (1-based)
+            description: Frame number to extract (movies only, 1-based)
             example: 120
         responses:
           200:
@@ -1760,7 +1762,8 @@ class ExtractAnnotatedFrameFromPreview(Resource):
                   type: string
                   format: binary
           400:
-            description: No annotation at this frame or invalid frame_number
+            description: No annotation, missing frame_number on movie, or
+              unsupported extension
           404:
             description: Preview file binary is not available
         """
@@ -1787,6 +1790,70 @@ class ExtractAnnotatedFrameFromPreview(Resource):
             )
         finally:
             os.remove(extracted_frame_path)
+
+
+class ExtractAllAnnotatedFramesFromPreview(Resource):
+    """
+    Build a zip archive containing every annotated frame (movie) or
+    every annotated copy of the picture preview.
+    """
+
+    @jwt_required()
+    def get(self, preview_file_id):
+        """
+        Extract all annotated frames from preview as a zip
+        ---
+        description: Build a zip archive with one PNG per annotation —
+          for movies, the extracted frame at the annotation's time; for
+          pictures, a copy of the picture with the annotation rendered.
+          Returns 400 if the preview has no annotations.
+        tags:
+          - Previews
+        parameters:
+          - in: path
+            name: preview_file_id
+            required: true
+            schema:
+              type: string
+              format: uuid
+            description: Preview file unique identifier
+            example: a24a6ea4-ce75-4665-a070-57453082c25
+        responses:
+          200:
+            description: Zip archive of annotated frames
+            content:
+              application/zip:
+                schema:
+                  type: string
+                  format: binary
+          400:
+            description: Preview has no annotations or unsupported
+              extension
+          404:
+            description: Preview file binary is not available
+        """
+        preview_file = files_service.get_preview_file(preview_file_id)
+        task = tasks_service.get_task(preview_file["task_id"])
+        user_service.check_manager_project_access(task["project_id"])
+        zip_path = preview_files_service.extract_all_annotation_frames_from_preview_file(
+            preview_file
+        )
+        if zip_path is None:
+            return {"error": "preview file binary is not available"}, 404
+        base_name = os.path.splitext(
+            names_service.get_preview_file_name(preview_file_id)
+        )[0]
+        download_name = f"{base_name}_annotated_frames.zip"
+        try:
+            return flask_send_file(
+                zip_path,
+                conditional=True,
+                mimetype="application/zip",
+                as_attachment=True,
+                download_name=download_name,
+            )
+        finally:
+            os.remove(zip_path)
 
 
 class ExtractTileFromPreview(Resource):

--- a/zou/app/blueprints/previews/schemas.py
+++ b/zou/app/blueprints/previews/schemas.py
@@ -22,6 +22,10 @@ class PreviewFilePositionSchema(BaseSchema):
 
 
 class ExtractAnnotatedFrameSchema(BaseSchema):
-    """Query args for extracting an annotated frame from a preview movie."""
+    """
+    Query args for extracting an annotated frame from a preview.
+    Required for movies (identifies the frame); ignored for pictures
+    where the first annotation entry is used.
+    """
 
-    frame_number: int = Field(..., ge=1)
+    frame_number: Optional[int] = Field(None, ge=1)

--- a/zou/app/blueprints/previews/schemas.py
+++ b/zou/app/blueprints/previews/schemas.py
@@ -19,3 +19,9 @@ class PreviewFilePositionSchema(BaseSchema):
     """Body for updating preview file position."""
 
     position: int = Field(0, ge=0)
+
+
+class ExtractAnnotatedFrameSchema(BaseSchema):
+    """Query args for extracting an annotated frame from a preview movie."""
+
+    frame_number: int = Field(..., ge=1)

--- a/zou/app/services/exception.py
+++ b/zou/app/services/exception.py
@@ -119,6 +119,10 @@ class AnnotationLockTimeoutException(ServiceUnavailable):
     pass
 
 
+class AnnotationNotFoundException(BadRequest):
+    pass
+
+
 class RevisionAlreadyExistsException(BadRequest):
     pass
 
@@ -273,8 +277,6 @@ class TwoFactorAuthenticationRequiredException(Exception):
     """
     Exception raised when 2FA is enforced but user has not set it up.
     """
-
-    pass
 
 
 class TooMuchLoginFailedAttemps(Exception):

--- a/zou/app/services/preview_files_service.py
+++ b/zou/app/services/preview_files_service.py
@@ -1,11 +1,13 @@
 import copy
 import os
-
 import re
+import shutil
+import tempfile
 import time
+import zipfile
 
 import ffmpeg
-import shutil
+from PIL import Image
 
 from sqlalchemy.orm import aliased
 from sqlalchemy.orm.exc import ObjectDeletedError, StaleDataError
@@ -833,37 +835,93 @@ def replace_extracted_frame_for_preview_file(preview_file, frame_number):
     save_variants(preview_file["id"], extracted_frame_path)
 
 
-def extract_annotation_frame_from_preview_file(preview_file, frame_number):
-    """
-    Extract `frame_number` from the preview video and overlay the matching
-    annotation on it.
+ANNOTATED_PICTURE_EXTENSIONS = ("jpg", "jpeg", "jpe", "png")
 
-    Raises AnnotationNotFoundException when no annotation entry maps to
-    the requested frame. Returns the path to the composited PNG (caller
-    must delete it), or None when the movie binary is not available.
+
+def extract_annotation_frame_from_preview_file(
+    preview_file, frame_number=None
+):
     """
+    Extract the requested frame of a movie preview, or the picture itself
+    for a picture preview, and overlay the matching annotation on it.
+
+    For movies, `frame_number` is required and identifies the frame. For
+    pictures, `frame_number` is ignored and the first annotation entry is
+    used.
+
+    Raises AnnotationNotFoundException when no annotation matches. Returns
+    the path to the composited PNG (caller must delete it), or None when
+    the preview binary is not available.
+    """
+    extension = (preview_file.get("extension") or "").lower()
+    annotations = preview_file.get("annotations") or []
+    if extension == "mp4":
+        if frame_number is None:
+            raise WrongParameterException(
+                "frame_number is required for movie previews"
+            )
+        return _extract_movie_annotation_frame(
+            preview_file, frame_number, annotations
+        )
+    if extension in ANNOTATED_PICTURE_EXTENSIONS:
+        return _extract_picture_annotation_frame(preview_file, annotations)
+    raise WrongParameterException(
+        f"Cannot extract annotated frame from preview with extension "
+        f"{extension!r}"
+    )
+
+
+def _extract_movie_annotation_frame(preview_file, frame_number, annotations):
     project = get_project_from_preview_file(preview_file["id"])
     entity = get_entity_from_preview_file(preview_file["id"])
     fps = float(get_preview_file_fps(project, entity))
     target_time = (frame_number - 1) / fps
     tolerance = 1 / (2 * fps)
-    annotation = _find_annotation_at_time(
-        preview_file.get("annotations") or [], target_time, tolerance
-    )
+    annotation = _find_annotation_at_time(annotations, target_time, tolerance)
     if annotation is None:
         raise AnnotationNotFoundException(
             f"No annotation found for frame {frame_number}"
         )
-
-    extracted_frame_path = extract_frame_from_preview_file(
-        preview_file, frame_number
-    )
-    if extracted_frame_path is None:
+    frame_path = extract_frame_from_preview_file(preview_file, frame_number)
+    if frame_path is None:
         return None
-
     return annotations_renderer.render_annotation_on_image(
-        extracted_frame_path, annotation
+        frame_path, annotation
     )
+
+
+def _extract_picture_annotation_frame(preview_file, annotations):
+    if not annotations:
+        raise AnnotationNotFoundException(
+            "No annotation found on picture preview"
+        )
+    picture_copy = _copy_picture_preview_to_temp_png(preview_file)
+    if picture_copy is None:
+        return None
+    return annotations_renderer.render_annotation_on_image(
+        picture_copy, annotations[0]
+    )
+
+
+def _copy_picture_preview_to_temp_png(preview_file):
+    if (preview_file.get("data") or {}).get("imported_only"):
+        return None
+    try:
+        picture_path = fs.get_file_path_and_file(
+            config,
+            file_store.get_local_picture_path,
+            file_store.open_picture,
+            "previews",
+            preview_file["id"],
+            preview_file["extension"],
+        )
+    except Exception:
+        return None
+    fd, temp_path = tempfile.mkstemp(suffix=".png")
+    os.close(fd)
+    with Image.open(picture_path) as img:
+        img.convert("RGBA").save(temp_path, "PNG")
+    return temp_path
 
 
 def _find_annotation_at_time(annotations, target_time, tolerance):
@@ -878,6 +936,113 @@ def _find_annotation_at_time(annotations, target_time, tolerance):
         if abs(annotation_time - target_time) <= tolerance:
             return annotation
     return None
+
+
+def extract_all_annotation_frames_from_preview_file(preview_file):
+    """
+    Build a zip archive containing every annotated frame of a movie
+    preview, or every annotated copy of a picture preview.
+
+    Raises AnnotationNotFoundException when the preview has no
+    annotations. Returns the path to a temp zip file (caller must delete
+    it), or None when the preview binary is not available.
+    """
+    annotations = preview_file.get("annotations") or []
+    if not annotations:
+        raise AnnotationNotFoundException("Preview file has no annotations")
+    extension = (preview_file.get("extension") or "").lower()
+    base_name = _annotated_frame_base_name(preview_file)
+    if extension == "mp4":
+        entries = _build_movie_annotation_entries(
+            preview_file, annotations, base_name
+        )
+    elif extension in ANNOTATED_PICTURE_EXTENSIONS:
+        entries = _build_picture_annotation_entries(
+            preview_file, annotations, base_name
+        )
+    else:
+        raise WrongParameterException(
+            f"Cannot extract annotated frames from preview with extension "
+            f"{extension!r}"
+        )
+    if entries is None:
+        return None
+    return _bundle_annotated_frames_into_zip(entries)
+
+
+def _annotated_frame_base_name(preview_file):
+    full_name = names_service.get_preview_file_name(preview_file["id"])
+    return os.path.splitext(full_name)[0]
+
+
+def _build_movie_annotation_entries(preview_file, annotations, base_name):
+    """
+    Returns a list of (arcname, temp_png_path) tuples ready to be zipped,
+    or None if the movie binary is unavailable. Cleans up partial work on
+    failure.
+    """
+    project = get_project_from_preview_file(preview_file["id"])
+    entity = get_entity_from_preview_file(preview_file["id"])
+    fps = float(get_preview_file_fps(project, entity))
+    entries = []
+    try:
+        for annotation in annotations:
+            raw_time = annotation.get("time")
+            try:
+                annotation_time = float(raw_time)
+            except (TypeError, ValueError):
+                continue
+            frame_number = max(1, round(annotation_time * fps) + 1)
+            frame_path = extract_frame_from_preview_file(
+                preview_file, frame_number
+            )
+            if frame_path is None:
+                _cleanup_entries(entries)
+                return None
+            rendered = annotations_renderer.render_annotation_on_image(
+                frame_path, annotation
+            )
+            entries.append((f"{base_name}_frame_{frame_number}.png", rendered))
+    except Exception:
+        _cleanup_entries(entries)
+        raise
+    return entries
+
+
+def _build_picture_annotation_entries(preview_file, annotations, base_name):
+    entries = []
+    try:
+        for index, annotation in enumerate(annotations, start=1):
+            picture_copy = _copy_picture_preview_to_temp_png(preview_file)
+            if picture_copy is None:
+                _cleanup_entries(entries)
+                return None
+            rendered = annotations_renderer.render_annotation_on_image(
+                picture_copy, annotation
+            )
+            entries.append((f"{base_name}_frame_{index}.png", rendered))
+    except Exception:
+        _cleanup_entries(entries)
+        raise
+    return entries
+
+
+def _cleanup_entries(entries):
+    for _, path in entries:
+        if path and os.path.exists(path):
+            os.remove(path)
+
+
+def _bundle_annotated_frames_into_zip(entries):
+    fd, zip_path = tempfile.mkstemp(suffix=".zip")
+    os.close(fd)
+    try:
+        with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
+            for arcname, src_path in entries:
+                zf.write(src_path, arcname=arcname)
+    finally:
+        _cleanup_entries(entries)
+    return zip_path
 
 
 def extract_tile_from_preview_file(preview_file):

--- a/zou/app/services/preview_files_service.py
+++ b/zou/app/services/preview_files_service.py
@@ -30,6 +30,7 @@ from zou.app.services import (
 )
 from zou.utils import movie
 from zou.app.utils import (
+    annotations as annotations_renderer,
     events,
     fields,
     remote_job,
@@ -37,6 +38,7 @@ from zou.app.utils import (
 )
 from zou.app.services.exception import (
     AnnotationLockTimeoutException,
+    AnnotationNotFoundException,
     WrongParameterException,
     PreviewFileNotFoundException,
     ProjectNotFoundException,
@@ -829,6 +831,53 @@ def replace_extracted_frame_for_preview_file(preview_file, frame_number):
         extracted_frame_path
     )
     save_variants(preview_file["id"], extracted_frame_path)
+
+
+def extract_annotation_frame_from_preview_file(preview_file, frame_number):
+    """
+    Extract `frame_number` from the preview video and overlay the matching
+    annotation on it.
+
+    Raises AnnotationNotFoundException when no annotation entry maps to
+    the requested frame. Returns the path to the composited PNG (caller
+    must delete it), or None when the movie binary is not available.
+    """
+    project = get_project_from_preview_file(preview_file["id"])
+    entity = get_entity_from_preview_file(preview_file["id"])
+    fps = float(get_preview_file_fps(project, entity))
+    target_time = (frame_number - 1) / fps
+    tolerance = 1 / (2 * fps)
+    annotation = _find_annotation_at_time(
+        preview_file.get("annotations") or [], target_time, tolerance
+    )
+    if annotation is None:
+        raise AnnotationNotFoundException(
+            f"No annotation found for frame {frame_number}"
+        )
+
+    extracted_frame_path = extract_frame_from_preview_file(
+        preview_file, frame_number
+    )
+    if extracted_frame_path is None:
+        return None
+
+    return annotations_renderer.render_annotation_on_image(
+        extracted_frame_path, annotation
+    )
+
+
+def _find_annotation_at_time(annotations, target_time, tolerance):
+    for annotation in annotations:
+        raw_time = annotation.get("time")
+        if raw_time is None:
+            continue
+        try:
+            annotation_time = float(raw_time)
+        except (TypeError, ValueError):
+            continue
+        if abs(annotation_time - target_time) <= tolerance:
+            return annotation
+    return None
 
 
 def extract_tile_from_preview_file(preview_file):

--- a/zou/app/services/preview_files_service.py
+++ b/zou/app/services/preview_files_service.py
@@ -947,27 +947,52 @@ def extract_all_annotation_frames_from_preview_file(preview_file):
     annotations. Returns the path to a temp zip file (caller must delete
     it), or None when the preview binary is not available.
     """
+    entries = _build_annotated_frame_entries(preview_file)
+    if entries is None:
+        return None
+    return _bundle_annotated_frames_into_zip(entries)
+
+
+def extract_all_annotation_frames_pdf_from_preview_file(preview_file):
+    """
+    Build a multi-page PDF with one page per annotated frame (movie) or
+    per annotated copy of the picture (picture preview).
+
+    Raises AnnotationNotFoundException when the preview has no
+    annotations. Returns the path to a temp pdf file (caller must delete
+    it), or None when the preview binary is not available.
+    """
+    entries = _build_annotated_frame_entries(preview_file)
+    if entries is None:
+        return None
+    return _bundle_annotated_frames_into_pdf(entries)
+
+
+def _build_annotated_frame_entries(preview_file):
+    """
+    Common entry-point for the zip and pdf bundlers: render every
+    annotated frame of the preview to a temp PNG and return the list of
+    (arcname, path) tuples. Returns None when the binary is unavailable;
+    raises AnnotationNotFoundException when there is nothing to render
+    and WrongParameterException for unsupported extensions.
+    """
     annotations = preview_file.get("annotations") or []
     if not annotations:
         raise AnnotationNotFoundException("Preview file has no annotations")
     extension = (preview_file.get("extension") or "").lower()
     base_name = _annotated_frame_base_name(preview_file)
     if extension == "mp4":
-        entries = _build_movie_annotation_entries(
+        return _build_movie_annotation_entries(
             preview_file, annotations, base_name
         )
-    elif extension in ANNOTATED_PICTURE_EXTENSIONS:
-        entries = _build_picture_annotation_entries(
+    if extension in ANNOTATED_PICTURE_EXTENSIONS:
+        return _build_picture_annotation_entries(
             preview_file, annotations, base_name
         )
-    else:
-        raise WrongParameterException(
-            f"Cannot extract annotated frames from preview with extension "
-            f"{extension!r}"
-        )
-    if entries is None:
-        return None
-    return _bundle_annotated_frames_into_zip(entries)
+    raise WrongParameterException(
+        f"Cannot extract annotated frames from preview with extension "
+        f"{extension!r}"
+    )
 
 
 def _annotated_frame_base_name(preview_file):
@@ -975,11 +1000,21 @@ def _annotated_frame_base_name(preview_file):
     return os.path.splitext(full_name)[0]
 
 
+_NO_FRAME_EXTRACTED_MSG = (
+    "No annotated frame could be extracted from this preview"
+)
+
+
 def _build_movie_annotation_entries(preview_file, annotations, base_name):
     """
     Returns a list of (arcname, temp_png_path) tuples ready to be zipped,
     or None if the movie binary is unavailable. Cleans up partial work on
     failure.
+
+    Individual annotations whose frame ffmpeg fails to extract (returns
+    a path to a non-existent file, e.g. when the annotation's time falls
+    past the movie's EOF) are skipped rather than aborting the whole
+    bundle.
     """
     project = get_project_from_preview_file(preview_file["id"])
     entity = get_entity_from_preview_file(preview_file["id"])
@@ -999,8 +1034,11 @@ def _build_movie_annotation_entries(preview_file, annotations, base_name):
             if frame_path is None:
                 _cleanup_entries(entries)
                 return None
+            if not os.path.exists(frame_path):
+                continue
+            owned_path = _claim_extracted_frame(frame_path)
             rendered = annotations_renderer.render_annotation_on_image(
-                frame_path, annotation
+                owned_path, annotation
             )
             entries.append((f"{base_name}_frame_{frame_number}.png", rendered))
     except Exception:
@@ -1027,6 +1065,18 @@ def _build_picture_annotation_entries(preview_file, annotations, base_name):
     return entries
 
 
+def _claim_extracted_frame(extracted_path):
+    """Move the frame ffmpeg wrote at a deterministic
+    `tmp/<movie>_<frame>.png` slot to a fresh mkstemp path. Required
+    because that deterministic slot is shared with other callers (e.g.
+    the single-frame extract route which `os.remove`s it in a finally),
+    and concurrent calls could yank the file from under the bundler."""
+    fd, owned_path = tempfile.mkstemp(suffix=".png")
+    os.close(fd)
+    shutil.move(extracted_path, owned_path)
+    return owned_path
+
+
 def _cleanup_entries(entries):
     for _, path in entries:
         if path and os.path.exists(path):
@@ -1034,6 +1084,8 @@ def _cleanup_entries(entries):
 
 
 def _bundle_annotated_frames_into_zip(entries):
+    if not entries:
+        raise AnnotationNotFoundException(_NO_FRAME_EXTRACTED_MSG)
     fd, zip_path = tempfile.mkstemp(suffix=".zip")
     os.close(fd)
     try:
@@ -1043,6 +1095,33 @@ def _bundle_annotated_frames_into_zip(entries):
     finally:
         _cleanup_entries(entries)
     return zip_path
+
+
+def _bundle_annotated_frames_into_pdf(entries):
+    """Stitch every PNG into a multi-page PDF via Pillow. PDF doesn't
+    support alpha, so each frame is flattened to RGB. 150 DPI keeps page
+    sizes reasonable for HD frames without blowing up the file."""
+    if not entries:
+        raise AnnotationNotFoundException(_NO_FRAME_EXTRACTED_MSG)
+    fd, pdf_path = tempfile.mkstemp(suffix=".pdf")
+    os.close(fd)
+    images = []
+    try:
+        for _, src_path in entries:
+            images.append(Image.open(src_path).convert("RGB"))
+        head, tail = images[0], images[1:]
+        head.save(
+            pdf_path,
+            "PDF",
+            save_all=True,
+            append_images=tail,
+            resolution=150.0,
+        )
+    finally:
+        for img in images:
+            img.close()
+        _cleanup_entries(entries)
+    return pdf_path
 
 
 def extract_tile_from_preview_file(preview_file):

--- a/zou/app/utils/annotations.py
+++ b/zou/app/utils/annotations.py
@@ -97,16 +97,36 @@ def _get_scales(obj, image_size):
 
 
 def _stroke_width(obj, scale):
-    width = obj.get("strokeWidth", 1) or 1
-    return max(1, int(round(width * scale)))
+    raw = obj.get("strokeWidth", 1)
+    if raw is None:
+        raw = 1
+    return max(1, int(round(raw * scale)))
+
+
+# CSS rgba() with alpha as float 0..1, which PIL.ImageColor.getrgb refuses.
+_CSS_RGBA_RE = re.compile(
+    r"^\s*rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*"
+    r"(?:,\s*(\d*\.?\d+)\s*)?\)\s*$",
+    re.IGNORECASE,
+)
 
 
 def _parse_color(value, default=None):
     if value is None or value == "" or value == "transparent":
         return default
+    if isinstance(value, str):
+        match = _CSS_RGBA_RE.match(value)
+        if match:
+            r, g, b, a = match.groups()
+            alpha = float(a) if a is not None else 1.0
+            if 0 <= alpha <= 1:
+                alpha_255 = round(alpha * 255)
+            else:
+                alpha_255 = max(0, min(255, round(alpha)))
+            return (int(r), int(g), int(b), alpha_255)
     try:
         rgb = ImageColor.getrgb(value)
-    except ValueError:
+    except (ValueError, AttributeError):
         return default
     if len(rgb) == 3:
         return rgb + (255,)
@@ -114,7 +134,17 @@ def _parse_color(value, default=None):
 
 
 def _stroke_color(obj):
-    return _parse_color(obj.get("stroke"), default=(255, 0, 0, 255))
+    """Return the stroke colour or None when no stroke was set. Shapes
+    that always need a visible line (path, line, arrow…) layer their own
+    fallback on top."""
+    return _parse_color(obj.get("stroke"), default=None)
+
+
+def _line_color(obj):
+    """Stroke with a black default — for shapes whose body IS the stroke
+    (line, arrow, path, psstroke, polyline). If the JSON has no stroke
+    but a fill, use the fill; else default to opaque black."""
+    return _stroke_color(obj) or _fill_color(obj) or (0, 0, 0, 255)
 
 
 def _fill_color(obj):
@@ -135,6 +165,17 @@ def _size(obj, scale_x, scale_y):
     return width, height
 
 
+def _outline_kwargs(obj, scale_x):
+    """Common outline/width pair for fillable shapes (rect, ellipse,
+    polygon). When `stroke` is absent we pass `outline=None, width=0` so
+    Pillow draws no outline — that's the whiteboard sticker case (a
+    fill-only fabric.Rect)."""
+    stroke = _stroke_color(obj)
+    if stroke is None:
+        return {"outline": None, "width": 0}
+    return {"outline": stroke, "width": _stroke_width(obj, scale_x)}
+
+
 def _draw_rect(draw, obj, scale_x, scale_y):
     x, y = _origin(obj, scale_x, scale_y)
     w, h = _size(obj, scale_x, scale_y)
@@ -142,9 +183,8 @@ def _draw_rect(draw, obj, scale_x, scale_y):
         return
     draw.rectangle(
         [x, y, x + w, y + h],
-        outline=_stroke_color(obj),
         fill=_fill_color(obj),
-        width=_stroke_width(obj, scale_x),
+        **_outline_kwargs(obj, scale_x),
     )
 
 
@@ -163,9 +203,8 @@ def _draw_ellipse(draw, obj, scale_x, scale_y):
         return
     draw.ellipse(
         [x, y, x + w, y + h],
-        outline=_stroke_color(obj),
         fill=_fill_color(obj),
-        width=_stroke_width(obj, scale_x),
+        **_outline_kwargs(obj, scale_x),
     )
 
 
@@ -178,7 +217,7 @@ def _draw_line(draw, obj, scale_x, scale_y):
     y2 = (obj.get("y2", 0) or 0) * scale_y
     draw.line(
         [(x1, y1), (x2, y2)],
-        fill=_stroke_color(obj),
+        fill=_line_color(obj),
         width=_stroke_width(obj, scale_x),
     )
 
@@ -194,16 +233,16 @@ def _draw_polyline(draw, obj, scale_x, scale_y):
     points = _flatten_points(obj.get("points"), scale_x, scale_y)
     if len(points) < 2:
         return
-    draw.line(
-        points, fill=_stroke_color(obj), width=_stroke_width(obj, scale_x)
-    )
+    draw.line(points, fill=_line_color(obj), width=_stroke_width(obj, scale_x))
 
 
 def _draw_polygon(draw, obj, scale_x, scale_y):
     points = _flatten_points(obj.get("points"), scale_x, scale_y)
     if len(points) < 3:
         return
-    draw.polygon(points, outline=_stroke_color(obj), fill=_fill_color(obj))
+    draw.polygon(
+        points, fill=_fill_color(obj), **_outline_kwargs(obj, scale_x)
+    )
 
 
 def _draw_arrow(draw, obj, scale_x, scale_y):
@@ -212,7 +251,7 @@ def _draw_arrow(draw, obj, scale_x, scale_y):
     y1 = (obj.get("y1", 0) or 0) * scale_y
     x2 = (obj.get("x2", 0) or 0) * scale_x
     y2 = (obj.get("y2", 0) or 0) * scale_y
-    color = _stroke_color(obj)
+    color = _line_color(obj)
     width = _stroke_width(obj, scale_x)
     head_size = (obj.get("arrowHeadSize", 15) or 15) * scale_x
     angle = math.atan2((y2 - y1), (x2 - x1))
@@ -264,9 +303,7 @@ def _draw_text(draw, obj, scale_x, scale_y):
             pass
     # Fabric Text uses `fill` for the glyph colour; fall back to stroke
     # then to opaque black so text is never invisible.
-    color = (
-        _fill_color(obj) or _parse_color(obj.get("stroke")) or (0, 0, 0, 255)
-    )
+    color = _fill_color(obj) or _stroke_color(obj) or (0, 0, 0, 255)
     draw.text((x, y), text, fill=color, font=font)
 
 
@@ -289,7 +326,7 @@ def _draw_psstroke(draw, obj, scale_x, scale_y):
     points = obj.get("strokePoints") or []
     if len(points) < 2:
         return
-    color = _stroke_color(obj)
+    color = _line_color(obj)
     base_width = (obj.get("strokeWidth", 1) or 1) * scale_x
 
     def to_screen(p):
@@ -334,7 +371,7 @@ def _draw_path(draw, obj, scale_x, scale_y):
     # normalises left=calcDim.left and pathOffset=(calcDim.left+w/2,
     # calcDim.top+h/2) on Path construction, so the two render-time
     # translations cancel out and world coord = path coord.
-    color = _stroke_color(obj)
+    color = _line_color(obj)
     width = _stroke_width(obj, scale_x)
 
     def to_screen(px, py):

--- a/zou/app/utils/annotations.py
+++ b/zou/app/utils/annotations.py
@@ -1,0 +1,443 @@
+"""
+Render Fabric.js annotation objects on top of a still image with Pillow.
+
+This is a server-side approximation of the canvas-based renderer used in
+Kitsu's player. Shape rotation, shadows and gradients are not reproduced;
+everything else (including PSBrush pressure-varying stroke width) maps to
+ImageDraw primitives.
+"""
+
+import logging
+import math
+import os
+import re
+
+from PIL import Image, ImageColor, ImageDraw, ImageFont
+
+logger = logging.getLogger(__name__)
+
+
+DEFAULT_FONT_PATHS = [
+    "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+    "/usr/share/fonts/dejavu/DejaVuSans.ttf",
+    "/Library/Fonts/Arial.ttf",
+]
+
+# Render the overlay at this multiple of the target size, then LANCZOS
+# down to get cheap anti-aliasing. Pillow's ImageDraw primitives don't
+# AA on their own.
+SUPERSAMPLE = 2
+
+
+def render_annotation_on_image(image_path, annotation):
+    """
+    Open `image_path`, draw the Fabric.js objects from
+    annotation["drawing"]["objects"] on top, then save the composite back
+    to the same path. Returns image_path.
+    """
+    objects = (annotation or {}).get("drawing", {}).get("objects", []) or []
+    if not objects:
+        return image_path
+
+    image = Image.open(image_path).convert("RGBA")
+    ss_size = (image.size[0] * SUPERSAMPLE, image.size[1] * SUPERSAMPLE)
+    overlay = Image.new("RGBA", ss_size, (0, 0, 0, 0))
+    draw = ImageDraw.Draw(overlay)
+
+    for obj in objects:
+        _draw_object(draw, obj, ss_size)
+
+    if SUPERSAMPLE != 1:
+        overlay = overlay.resize(image.size, Image.LANCZOS)
+    composite = Image.alpha_composite(image, overlay).convert("RGB")
+    composite.save(image_path, "PNG")
+    return image_path
+
+
+def _draw_object(draw, obj, image_size):
+    if not isinstance(obj, dict):
+        return
+    obj_type = (obj.get("type") or "").lower()
+    scale_x, scale_y = _get_scales(obj, image_size)
+    try:
+        if obj_type == "path":
+            _draw_path(draw, obj, scale_x, scale_y)
+        elif obj_type == "psstroke":
+            _draw_psstroke(draw, obj, scale_x, scale_y)
+        elif obj_type == "rect":
+            _draw_rect(draw, obj, scale_x, scale_y)
+        elif obj_type in ("circle", "ellipse"):
+            _draw_ellipse(draw, obj, scale_x, scale_y)
+        elif obj_type == "line":
+            _draw_line(draw, obj, scale_x, scale_y)
+        elif obj_type == "polyline":
+            _draw_polyline(draw, obj, scale_x, scale_y)
+        elif obj_type == "polygon":
+            _draw_polygon(draw, obj, scale_x, scale_y)
+        elif obj_type in ("i-text", "text", "textbox"):
+            _draw_text(draw, obj, scale_x, scale_y)
+        elif obj_type == "arrow":
+            _draw_arrow(draw, obj, scale_x, scale_y)
+        elif obj_type == "group":
+            for child in obj.get("objects", []) or []:
+                _draw_object(draw, child, image_size)
+        else:
+            logger.debug("Unsupported annotation type: %s", obj_type)
+    except Exception:
+        logger.exception(
+            "Failed to render annotation object of type %s", obj_type
+        )
+
+
+def _get_scales(obj, image_size):
+    image_width, image_height = image_size
+    canvas_width = obj.get("canvasWidth") or image_width
+    canvas_height = obj.get("canvasHeight") or image_height
+    return image_width / canvas_width, image_height / canvas_height
+
+
+def _stroke_width(obj, scale):
+    width = obj.get("strokeWidth", 1) or 1
+    return max(1, int(round(width * scale)))
+
+
+def _parse_color(value, default=None):
+    if value is None or value == "" or value == "transparent":
+        return default
+    try:
+        rgb = ImageColor.getrgb(value)
+    except ValueError:
+        return default
+    if len(rgb) == 3:
+        return rgb + (255,)
+    return rgb
+
+
+def _stroke_color(obj):
+    return _parse_color(obj.get("stroke"), default=(255, 0, 0, 255))
+
+
+def _fill_color(obj):
+    return _parse_color(obj.get("fill"), default=None)
+
+
+def _origin(obj, scale_x, scale_y):
+    left = (obj.get("left", 0) or 0) * scale_x
+    top = (obj.get("top", 0) or 0) * scale_y
+    return left, top
+
+
+def _size(obj, scale_x, scale_y):
+    width = (obj.get("width", 0) or 0) * (obj.get("scaleX", 1) or 1) * scale_x
+    height = (
+        (obj.get("height", 0) or 0) * (obj.get("scaleY", 1) or 1) * scale_y
+    )
+    return width, height
+
+
+def _draw_rect(draw, obj, scale_x, scale_y):
+    x, y = _origin(obj, scale_x, scale_y)
+    w, h = _size(obj, scale_x, scale_y)
+    if w <= 0 or h <= 0:
+        return
+    draw.rectangle(
+        [x, y, x + w, y + h],
+        outline=_stroke_color(obj),
+        fill=_fill_color(obj),
+        width=_stroke_width(obj, scale_x),
+    )
+
+
+def _draw_ellipse(draw, obj, scale_x, scale_y):
+    x, y = _origin(obj, scale_x, scale_y)
+    if obj.get("rx") is not None or obj.get("ry") is not None:
+        rx = (obj.get("rx", 0) or 0) * (obj.get("scaleX", 1) or 1) * scale_x
+        ry = (obj.get("ry", 0) or 0) * (obj.get("scaleY", 1) or 1) * scale_y
+        w, h = rx * 2, ry * 2
+    elif obj.get("radius") is not None:
+        r = (obj.get("radius", 0) or 0) * scale_x
+        w = h = r * 2
+    else:
+        w, h = _size(obj, scale_x, scale_y)
+    if w <= 0 or h <= 0:
+        return
+    draw.ellipse(
+        [x, y, x + w, y + h],
+        outline=_stroke_color(obj),
+        fill=_fill_color(obj),
+        width=_stroke_width(obj, scale_x),
+    )
+
+
+def _draw_line(draw, obj, scale_x, scale_y):
+    # x1, y1, x2, y2 are already in canvas-absolute coords. left/top are
+    # bbox metadata fabric uses for selection — don't add them.
+    x1 = (obj.get("x1", 0) or 0) * scale_x
+    y1 = (obj.get("y1", 0) or 0) * scale_y
+    x2 = (obj.get("x2", 0) or 0) * scale_x
+    y2 = (obj.get("y2", 0) or 0) * scale_y
+    draw.line(
+        [(x1, y1), (x2, y2)],
+        fill=_stroke_color(obj),
+        width=_stroke_width(obj, scale_x),
+    )
+
+
+def _flatten_points(points, scale_x, scale_y):
+    return [
+        ((p.get("x", 0) or 0) * scale_x, (p.get("y", 0) or 0) * scale_y)
+        for p in points or []
+    ]
+
+
+def _draw_polyline(draw, obj, scale_x, scale_y):
+    points = _flatten_points(obj.get("points"), scale_x, scale_y)
+    if len(points) < 2:
+        return
+    draw.line(
+        points, fill=_stroke_color(obj), width=_stroke_width(obj, scale_x)
+    )
+
+
+def _draw_polygon(draw, obj, scale_x, scale_y):
+    points = _flatten_points(obj.get("points"), scale_x, scale_y)
+    if len(points) < 3:
+        return
+    draw.polygon(points, outline=_stroke_color(obj), fill=_fill_color(obj))
+
+
+def _draw_arrow(draw, obj, scale_x, scale_y):
+    # Same convention as line: x1/y1/x2/y2 are canvas-absolute coords.
+    x1 = (obj.get("x1", 0) or 0) * scale_x
+    y1 = (obj.get("y1", 0) or 0) * scale_y
+    x2 = (obj.get("x2", 0) or 0) * scale_x
+    y2 = (obj.get("y2", 0) or 0) * scale_y
+    color = _stroke_color(obj)
+    width = _stroke_width(obj, scale_x)
+    head_size = (obj.get("arrowHeadSize", 15) or 15) * scale_x
+    angle = math.atan2((y2 - y1), (x2 - x1))
+
+    # Shorten the body so it sits fully inside the head triangle —
+    # otherwise Pillow's rounded end cap (radius = width/2) pokes past
+    # the geometric tip. Matches Kitsu's Arrow._toSVG export.
+    if head_size > 0:
+        body_offset = head_size * 0.7
+        body_end_x = x2 - body_offset * math.cos(angle)
+        body_end_y = y2 - body_offset * math.sin(angle)
+    else:
+        body_end_x, body_end_y = x2, y2
+
+    draw.line([(x1, y1), (body_end_x, body_end_y)], fill=color, width=width)
+
+    if head_size <= 0:
+        return
+    left = (
+        x2 - head_size * math.cos(angle - math.pi / 6),
+        y2 - head_size * math.sin(angle - math.pi / 6),
+    )
+    right = (
+        x2 - head_size * math.cos(angle + math.pi / 6),
+        y2 - head_size * math.sin(angle + math.pi / 6),
+    )
+    draw.polygon([(x2, y2), left, right], fill=color, outline=color)
+
+
+def _draw_text(draw, obj, scale_x, scale_y):
+    text = obj.get("text") or ""
+    if not text:
+        return
+    x, y = _origin(obj, scale_x, scale_y)
+    font_size = int(
+        round(
+            (obj.get("fontSize", 16) or 16)
+            * (obj.get("scaleY", 1) or 1)
+            * scale_y
+        )
+    )
+    font = _load_font(max(1, font_size))
+    background = _parse_color(obj.get("backgroundColor"), default=None)
+    if background is not None:
+        try:
+            bbox = draw.textbbox((x, y), text, font=font)
+            draw.rectangle(bbox, fill=background)
+        except AttributeError:
+            pass
+    # Fabric Text uses `fill` for the glyph colour; fall back to stroke
+    # then to opaque black so text is never invisible.
+    color = (
+        _fill_color(obj) or _parse_color(obj.get("stroke")) or (0, 0, 0, 255)
+    )
+    draw.text((x, y), text, fill=color, font=font)
+
+
+def _load_font(size):
+    for candidate in DEFAULT_FONT_PATHS:
+        if os.path.isfile(candidate):
+            try:
+                return ImageFont.truetype(candidate, size=size)
+            except OSError:
+                continue
+    return ImageFont.load_default()
+
+
+def _draw_psstroke(draw, obj, scale_x, scale_y):
+    # PSBrush strokes (the freehand pen in Kitsu). Each segment uses
+    # width = leading-point.pressure * strokeWidth (see
+    # fabricjs-psbrush index.mjs:421). Pillow can't vary width within a
+    # single line call, so we draw segment by segment and stamp a disk at
+    # each junction to round the joins.
+    points = obj.get("strokePoints") or []
+    if len(points) < 2:
+        return
+    color = _stroke_color(obj)
+    base_width = (obj.get("strokeWidth", 1) or 1) * scale_x
+
+    def to_screen(p):
+        return (
+            (p.get("x", 0) or 0) * scale_x,
+            (p.get("y", 0) or 0) * scale_y,
+        )
+
+    def segment_width(point):
+        pressure = point.get("pressure")
+        if pressure is None:
+            pressure = 1
+        return max(1, int(round(pressure * base_width)))
+
+    def stamp_cap(pos, width):
+        r = width / 2
+        if r < 1:
+            return
+        draw.ellipse(
+            [(pos[0] - r, pos[1] - r), (pos[0] + r, pos[1] + r)], fill=color
+        )
+
+    for i in range(len(points) - 1):
+        p1, p2 = points[i], points[i + 1]
+        width = segment_width(p1)
+        a, b = to_screen(p1), to_screen(p2)
+        draw.line([a, b], fill=color, width=width)
+        stamp_cap(a, width)
+
+    # Cap the trailing point with the last segment's width.
+    stamp_cap(to_screen(points[-1]), segment_width(points[-2]))
+
+
+def _draw_path(draw, obj, scale_x, scale_y):
+    raw = obj.get("path")
+    if not raw:
+        return
+    commands = _parse_path_commands(raw)
+    if not commands:
+        return
+    # Path commands are stored in canvas-absolute coords: fabric
+    # normalises left=calcDim.left and pathOffset=(calcDim.left+w/2,
+    # calcDim.top+h/2) on Path construction, so the two render-time
+    # translations cancel out and world coord = path coord.
+    color = _stroke_color(obj)
+    width = _stroke_width(obj, scale_x)
+
+    def to_screen(px, py):
+        return (px * scale_x, py * scale_y)
+
+    segments = []
+    current = None
+    start = None
+    for cmd in commands:
+        op = cmd[0].upper()
+        params = cmd[1:]
+        if op == "M" and len(params) >= 2:
+            if segments and len(segments[-1]) < 2:
+                segments.pop()
+            current = to_screen(params[0], params[1])
+            start = current
+            segments.append([current])
+        elif op == "L" and len(params) >= 2:
+            current = to_screen(params[0], params[1])
+            if not segments:
+                segments.append([])
+            segments[-1].append(current)
+        elif op == "Q" and len(params) >= 4:
+            cx, cy = params[0], params[1]
+            ex, ey = params[2], params[3]
+            if not segments:
+                segments.append([])
+            if current is None:
+                current = to_screen(cx, cy)
+                segments[-1].append(current)
+            segments[-1].extend(
+                _quad_points(current, to_screen(cx, cy), to_screen(ex, ey))
+            )
+            current = to_screen(ex, ey)
+        elif op == "C" and len(params) >= 6:
+            c1 = to_screen(params[0], params[1])
+            c2 = to_screen(params[2], params[3])
+            ep = to_screen(params[4], params[5])
+            if not segments:
+                segments.append([])
+            if current is None:
+                current = c1
+                segments[-1].append(current)
+            segments[-1].extend(_cubic_points(current, c1, c2, ep))
+            current = ep
+        elif op == "Z":
+            if start is not None and segments and segments[-1]:
+                segments[-1].append(start)
+            current = start
+
+    for points in segments:
+        if len(points) >= 2:
+            draw.line(points, fill=color, width=width, joint="curve")
+
+
+def _parse_path_commands(raw):
+    if isinstance(raw, str):
+        return _parse_path_string(raw)
+    if isinstance(raw, list):
+        return [list(cmd) for cmd in raw if cmd]
+    return []
+
+
+def _parse_path_string(text):
+    commands = []
+    pattern = re.compile(r"([MLQCZmlqcz])\s*([^MLQCZmlqcz]*)")
+    for match in pattern.finditer(text):
+        op = match.group(1).upper()
+        if op == "Z":
+            commands.append([op])
+            continue
+        numbers = [
+            float(n) for n in re.findall(r"-?\d+(?:\.\d+)?", match.group(2))
+        ]
+        commands.append([op, *numbers])
+    return commands
+
+
+def _quad_points(p0, p1, p2, steps=8):
+    points = []
+    for i in range(1, steps + 1):
+        t = i / steps
+        x = (1 - t) ** 2 * p0[0] + 2 * (1 - t) * t * p1[0] + t * t * p2[0]
+        y = (1 - t) ** 2 * p0[1] + 2 * (1 - t) * t * p1[1] + t * t * p2[1]
+        points.append((x, y))
+    return points
+
+
+def _cubic_points(p0, p1, p2, p3, steps=12):
+    points = []
+    for i in range(1, steps + 1):
+        t = i / steps
+        x = (
+            (1 - t) ** 3 * p0[0]
+            + 3 * (1 - t) ** 2 * t * p1[0]
+            + 3 * (1 - t) * t * t * p2[0]
+            + t**3 * p3[0]
+        )
+        y = (
+            (1 - t) ** 3 * p0[1]
+            + 3 * (1 - t) ** 2 * t * p1[1]
+            + 3 * (1 - t) * t * t * p2[1]
+            + t**3 * p3[1]
+        )
+        points.append((x, y))
+    return points

--- a/zou/app/utils/annotations.py
+++ b/zou/app/utils/annotations.py
@@ -45,7 +45,7 @@ def render_annotation_on_image(image_path, annotation):
     draw = ImageDraw.Draw(overlay)
 
     for obj in objects:
-        _draw_object(draw, obj, ss_size)
+        _draw_object(overlay, draw, obj, ss_size)
 
     if SUPERSAMPLE != 1:
         overlay = overlay.resize(image.size, Image.LANCZOS)
@@ -54,7 +54,7 @@ def render_annotation_on_image(image_path, annotation):
     return image_path
 
 
-def _draw_object(draw, obj, image_size):
+def _draw_object(overlay, draw, obj, image_size):
     if not isinstance(obj, dict):
         return
     obj_type = (obj.get("type") or "").lower()
@@ -75,12 +75,12 @@ def _draw_object(draw, obj, image_size):
         elif obj_type == "polygon":
             _draw_polygon(draw, obj, scale_x, scale_y)
         elif obj_type in ("i-text", "text", "textbox"):
-            _draw_text(draw, obj, scale_x, scale_y)
+            _draw_text(overlay, obj, scale_x, scale_y)
         elif obj_type == "arrow":
             _draw_arrow(draw, obj, scale_x, scale_y)
         elif obj_type == "group":
             for child in obj.get("objects", []) or []:
-                _draw_object(draw, child, image_size)
+                _draw_object(overlay, draw, child, image_size)
         else:
             logger.debug("Unsupported annotation type: %s", obj_type)
     except Exception:
@@ -165,92 +165,297 @@ def _size(obj, scale_x, scale_y):
     return width, height
 
 
-def _outline_kwargs(obj, scale_x):
-    """Common outline/width pair for fillable shapes (rect, ellipse,
-    polygon). When `stroke` is absent we pass `outline=None, width=0` so
-    Pillow draws no outline — that's the whiteboard sticker case (a
-    fill-only fabric.Rect)."""
-    stroke = _stroke_color(obj)
-    if stroke is None:
-        return {"outline": None, "width": 0}
-    return {"outline": stroke, "width": _stroke_width(obj, scale_x)}
+def _make_object_transform(obj, pivot_x, pivot_y):
+    """Build the affine transform fabric applies to a shape's local
+    coords:  T(center) ∘ R(angle) ∘ S(scaleX, scaleY) ∘ T(-pivot).
+
+    Returns a function (px, py) → (wx, wy) in CANVAS coordinates.
+
+    The translate target matches fabric's `getRelativeCenterPoint()`:
+    the un-rotated bbox centre `(left + w/2 · scaleX, top + h/2 · scaleY)`
+    is itself rotated around `(left, top)` by `angle`. When a fabric UI
+    rotation happens, fabric updates `left`/`top` so the bbox centre
+    stays put visually — which means at render time, the rendering
+    centre is no longer `left + w/2` for rotated shapes. Without this
+    extra rotation the rendered position is off by an amount that
+    looks like the shape's own translation, which is why side-by-side
+    annotations appeared to inherit each other's drag.
+    """
+    angle_rad = math.radians(obj.get("angle", 0) or 0)
+    cos_a = math.cos(angle_rad)
+    sin_a = math.sin(angle_rad)
+    scale_x = obj.get("scaleX", 1) or 1
+    scale_y = obj.get("scaleY", 1) or 1
+    left = obj.get("left", 0) or 0
+    top = obj.get("top", 0) or 0
+    width = obj.get("width", 0) or 0
+    height = obj.get("height", 0) or 0
+    naive_cx = left + width / 2 * scale_x
+    naive_cy = top + height / 2 * scale_y
+    cx = left + (naive_cx - left) * cos_a - (naive_cy - top) * sin_a
+    cy = top + (naive_cx - left) * sin_a + (naive_cy - top) * cos_a
+
+    def transform(px, py):
+        dx = px - pivot_x
+        dy = py - pivot_y
+        sx = dx * scale_x
+        sy = dy * scale_y
+        return (
+            sx * cos_a - sy * sin_a + cx,
+            sx * sin_a + sy * cos_a + cy,
+        )
+
+    return transform
+
+
+def _bbox_transform(obj):
+    """Transform for shapes whose local coords are in the (0,0)–(w,h)
+    bbox: rect, ellipse, text."""
+    width = obj.get("width", 0) or 0
+    height = obj.get("height", 0) or 0
+    return _make_object_transform(obj, width / 2, height / 2)
+
+
+def _centered_transform(obj, fallback_pivot=None):
+    """Transform for shapes whose local coords are in fabric's centered
+    system (path commands, polyline points, line endpoints, PSBrush
+    strokePoints).
+
+    Pivot resolution:
+      1. `pathOffset` from the JSON if present (Path serialises it).
+      2. `fallback_pivot` if the caller provides one — typically the
+         bbox centre of the shape's own anchor points, which is what
+         fabric would recompute on deserialisation as `calcDim.left +
+         w/2, calcDim.top + h/2`.
+      3. Otherwise `(left + w/2, top + h/2)`. That assumes the shape
+         was never translated — fine for rect-like data without a
+         pathOffset, broken for moved path/psstroke without an explicit
+         offset (use option 2 there).
+    """
+    path_offset = obj.get("pathOffset")
+    if path_offset:
+        pivot_x = path_offset.get("x", 0) or 0
+        pivot_y = path_offset.get("y", 0) or 0
+    elif fallback_pivot is not None:
+        pivot_x, pivot_y = fallback_pivot
+    else:
+        width = obj.get("width", 0) or 0
+        height = obj.get("height", 0) or 0
+        left = obj.get("left", 0) or 0
+        top = obj.get("top", 0) or 0
+        pivot_x = left + width / 2
+        pivot_y = top + height / 2
+    return _make_object_transform(obj, pivot_x, pivot_y)
+
+
+def _bbox_centre(points):
+    """Mid-point of the bbox of a list of (x, y) tuples."""
+    if not points:
+        return 0, 0
+    xs = [p[0] for p in points]
+    ys = [p[1] for p in points]
+    return (min(xs) + max(xs)) / 2, (min(ys) + max(ys)) / 2
+
+
+def _with_default_bbox(obj, anchor_points):
+    """Return a copy of `obj` with `left`/`top`/`width`/`height` filled
+    in from the anchor points' bbox when missing — fabric would compute
+    those from `calcDim` on deserialisation. Required so that the
+    transform's centre and pivot align when the JSON only stores the
+    shape's own points (typical of test data and some external
+    integrations)."""
+    if not anchor_points:
+        return obj
+    if (
+        obj.get("width") is not None
+        and obj.get("height") is not None
+        and obj.get("left") is not None
+        and obj.get("top") is not None
+    ):
+        return obj
+    xs = [p[0] for p in anchor_points]
+    ys = [p[1] for p in anchor_points]
+    bbox_left = min(xs)
+    bbox_top = min(ys)
+    out = dict(obj)
+    out.setdefault("left", bbox_left)
+    out.setdefault("top", bbox_top)
+    out.setdefault("width", max(xs) - bbox_left)
+    out.setdefault("height", max(ys) - bbox_top)
+    return out
+
+
+def _to_image(point, scale_x, scale_y):
+    return point[0] * scale_x, point[1] * scale_y
+
+
+def _stroke_outline_width(obj, scale_x):
+    """Outline width to pass to Pillow's `width` kwarg. Returns 0 (no
+    outline) when the shape has no stroke — this is what makes the
+    whiteboard sticker (a fill-only fabric.Rect) render correctly."""
+    if _stroke_color(obj) is None:
+        return 0
+    return _stroke_width(obj, scale_x)
+
+
+def _stroke_polygon(draw, points, color, width):
+    """Pillow's draw.polygon doesn't accept an outline-width kwarg, so
+    we draw each edge as a thick line. This is also what lets rotated
+    rects and ellipses keep their outline intact under transforms."""
+    if color is None or width <= 0 or len(points) < 2:
+        return
+    for i in range(len(points)):
+        draw.line(
+            [points[i], points[(i + 1) % len(points)]],
+            fill=color,
+            width=width,
+        )
 
 
 def _draw_rect(draw, obj, scale_x, scale_y):
-    x, y = _origin(obj, scale_x, scale_y)
-    w, h = _size(obj, scale_x, scale_y)
-    if w <= 0 or h <= 0:
+    width = obj.get("width", 0) or 0
+    height = obj.get("height", 0) or 0
+    if width <= 0 or height <= 0:
         return
-    draw.rectangle(
-        [x, y, x + w, y + h],
-        fill=_fill_color(obj),
-        **_outline_kwargs(obj, scale_x),
+    transform = _bbox_transform(obj)
+    corners = [(0, 0), (width, 0), (width, height), (0, height)]
+    image_corners = [
+        _to_image(transform(*c), scale_x, scale_y) for c in corners
+    ]
+    fill = _fill_color(obj)
+    if fill is not None:
+        draw.polygon(image_corners, fill=fill)
+    _stroke_polygon(
+        draw,
+        image_corners,
+        _stroke_color(obj),
+        _stroke_outline_width(obj, scale_x),
     )
 
 
+_ELLIPSE_SAMPLES = 64
+
+
 def _draw_ellipse(draw, obj, scale_x, scale_y):
-    x, y = _origin(obj, scale_x, scale_y)
     if obj.get("rx") is not None or obj.get("ry") is not None:
-        rx = (obj.get("rx", 0) or 0) * (obj.get("scaleX", 1) or 1) * scale_x
-        ry = (obj.get("ry", 0) or 0) * (obj.get("scaleY", 1) or 1) * scale_y
-        w, h = rx * 2, ry * 2
+        width = (obj.get("rx", 0) or 0) * 2
+        height = (obj.get("ry", 0) or 0) * 2
     elif obj.get("radius") is not None:
-        r = (obj.get("radius", 0) or 0) * scale_x
-        w = h = r * 2
+        width = height = (obj.get("radius", 0) or 0) * 2
     else:
-        w, h = _size(obj, scale_x, scale_y)
-    if w <= 0 or h <= 0:
+        width = obj.get("width", 0) or 0
+        height = obj.get("height", 0) or 0
+    if width <= 0 or height <= 0:
         return
-    draw.ellipse(
-        [x, y, x + w, y + h],
-        fill=_fill_color(obj),
-        **_outline_kwargs(obj, scale_x),
+    # Build the transform with the resolved width/height so the pivot
+    # and centre line up for rx/ry-style ellipses too.
+    sized = dict(obj)
+    sized["width"] = width
+    sized["height"] = height
+    transform = _bbox_transform(sized)
+    local = [
+        (
+            width / 2
+            + width / 2 * math.cos(2 * math.pi * i / _ELLIPSE_SAMPLES),
+            height / 2
+            + height / 2 * math.sin(2 * math.pi * i / _ELLIPSE_SAMPLES),
+        )
+        for i in range(_ELLIPSE_SAMPLES)
+    ]
+    image_points = [_to_image(transform(*p), scale_x, scale_y) for p in local]
+    fill = _fill_color(obj)
+    if fill is not None:
+        draw.polygon(image_points, fill=fill)
+    _stroke_polygon(
+        draw,
+        image_points,
+        _stroke_color(obj),
+        _stroke_outline_width(obj, scale_x),
     )
 
 
 def _draw_line(draw, obj, scale_x, scale_y):
-    # x1, y1, x2, y2 are already in canvas-absolute coords. left/top are
-    # bbox metadata fabric uses for selection — don't add them.
-    x1 = (obj.get("x1", 0) or 0) * scale_x
-    y1 = (obj.get("y1", 0) or 0) * scale_y
-    x2 = (obj.get("x2", 0) or 0) * scale_x
-    y2 = (obj.get("y2", 0) or 0) * scale_y
+    x1 = obj.get("x1", 0) or 0
+    y1 = obj.get("y1", 0) or 0
+    x2 = obj.get("x2", 0) or 0
+    y2 = obj.get("y2", 0) or 0
+    anchors = [(x1, y1), (x2, y2)]
+    transform = _centered_transform(
+        _with_default_bbox(obj, anchors),
+        fallback_pivot=_bbox_centre(anchors),
+    )
     draw.line(
-        [(x1, y1), (x2, y2)],
+        [
+            _to_image(transform(x1, y1), scale_x, scale_y),
+            _to_image(transform(x2, y2), scale_x, scale_y),
+        ],
         fill=_line_color(obj),
         width=_stroke_width(obj, scale_x),
     )
 
 
-def _flatten_points(points, scale_x, scale_y):
+def _flatten_points(points, transform, scale_x, scale_y):
     return [
-        ((p.get("x", 0) or 0) * scale_x, (p.get("y", 0) or 0) * scale_y)
+        _to_image(
+            transform(p.get("x", 0) or 0, p.get("y", 0) or 0),
+            scale_x,
+            scale_y,
+        )
         for p in points or []
     ]
 
 
+def _polyline_anchors(obj):
+    raw = obj.get("points") or []
+    return [(p.get("x", 0) or 0, p.get("y", 0) or 0) for p in raw]
+
+
 def _draw_polyline(draw, obj, scale_x, scale_y):
-    points = _flatten_points(obj.get("points"), scale_x, scale_y)
+    anchors = _polyline_anchors(obj)
+    transform = _centered_transform(
+        _with_default_bbox(obj, anchors),
+        fallback_pivot=_bbox_centre(anchors),
+    )
+    points = _flatten_points(obj.get("points"), transform, scale_x, scale_y)
     if len(points) < 2:
         return
     draw.line(points, fill=_line_color(obj), width=_stroke_width(obj, scale_x))
 
 
 def _draw_polygon(draw, obj, scale_x, scale_y):
-    points = _flatten_points(obj.get("points"), scale_x, scale_y)
+    anchors = _polyline_anchors(obj)
+    transform = _centered_transform(
+        _with_default_bbox(obj, anchors),
+        fallback_pivot=_bbox_centre(anchors),
+    )
+    points = _flatten_points(obj.get("points"), transform, scale_x, scale_y)
     if len(points) < 3:
         return
-    draw.polygon(
-        points, fill=_fill_color(obj), **_outline_kwargs(obj, scale_x)
+    fill = _fill_color(obj)
+    if fill is not None:
+        draw.polygon(points, fill=fill)
+    _stroke_polygon(
+        draw,
+        points,
+        _stroke_color(obj),
+        _stroke_outline_width(obj, scale_x),
     )
 
 
 def _draw_arrow(draw, obj, scale_x, scale_y):
-    # Same convention as line: x1/y1/x2/y2 are canvas-absolute coords.
-    x1 = (obj.get("x1", 0) or 0) * scale_x
-    y1 = (obj.get("y1", 0) or 0) * scale_y
-    x2 = (obj.get("x2", 0) or 0) * scale_x
-    y2 = (obj.get("y2", 0) or 0) * scale_y
+    raw_x1 = obj.get("x1", 0) or 0
+    raw_y1 = obj.get("y1", 0) or 0
+    raw_x2 = obj.get("x2", 0) or 0
+    raw_y2 = obj.get("y2", 0) or 0
+    anchors = [(raw_x1, raw_y1), (raw_x2, raw_y2)]
+    transform = _centered_transform(
+        _with_default_bbox(obj, anchors),
+        fallback_pivot=_bbox_centre(anchors),
+    )
+    x1_c, y1_c = transform(raw_x1, raw_y1)
+    x2_c, y2_c = transform(raw_x2, raw_y2)
+    x1, y1 = _to_image((x1_c, y1_c), scale_x, scale_y)
+    x2, y2 = _to_image((x2_c, y2_c), scale_x, scale_y)
     color = _line_color(obj)
     width = _stroke_width(obj, scale_x)
     head_size = (obj.get("arrowHeadSize", 15) or 15) * scale_x
@@ -281,11 +486,10 @@ def _draw_arrow(draw, obj, scale_x, scale_y):
     draw.polygon([(x2, y2), left, right], fill=color, outline=color)
 
 
-def _draw_text(draw, obj, scale_x, scale_y):
+def _draw_text(overlay, obj, scale_x, scale_y):
     text = obj.get("text") or ""
     if not text:
         return
-    x, y = _origin(obj, scale_x, scale_y)
     font_size = int(
         round(
             (obj.get("fontSize", 16) or 16)
@@ -294,17 +498,48 @@ def _draw_text(draw, obj, scale_x, scale_y):
         )
     )
     font = _load_font(max(1, font_size))
-    background = _parse_color(obj.get("backgroundColor"), default=None)
-    if background is not None:
-        try:
-            bbox = draw.textbbox((x, y), text, font=font)
-            draw.rectangle(bbox, fill=background)
-        except AttributeError:
-            pass
-    # Fabric Text uses `fill` for the glyph colour; fall back to stroke
-    # then to opaque black so text is never invisible.
     color = _fill_color(obj) or _stroke_color(obj) or (0, 0, 0, 255)
-    draw.text((x, y), text, fill=color, font=font)
+    background = _parse_color(obj.get("backgroundColor"), default=None)
+
+    # Render the text + optional background onto a transparent
+    # sub-image sized to the glyph bbox, then rotate/paste onto the
+    # overlay. Going through a sub-image is the only way Pillow can
+    # rotate text — `ImageDraw.text` has no rotation kwarg.
+    measure_draw = ImageDraw.Draw(Image.new("RGBA", (1, 1)))
+    try:
+        bbox = measure_draw.textbbox((0, 0), text, font=font)
+    except AttributeError:
+        # Pillow < 9.2 — getsize fallback (length-only).
+        w, h = measure_draw.textsize(text, font=font)
+        bbox = (0, 0, w, h)
+    text_w = max(1, bbox[2] - bbox[0])
+    text_h = max(1, bbox[3] - bbox[1])
+    text_img = Image.new("RGBA", (text_w, text_h), (0, 0, 0, 0))
+    text_draw = ImageDraw.Draw(text_img)
+    if background is not None:
+        text_draw.rectangle([0, 0, text_w, text_h], fill=background)
+    # textbbox can return a non-zero top — shift the draw origin so the
+    # glyph sits flush against the sub-image's top-left.
+    text_draw.text((-bbox[0], -bbox[1]), text, fill=color, font=font)
+
+    angle = obj.get("angle", 0) or 0
+    if angle:
+        text_img = text_img.rotate(-angle, expand=True, resample=Image.BICUBIC)
+
+    # Position: fabric anchors the text at (left, top) and rotates
+    # around the bbox centre. Compute that centre in image coords and
+    # paste so the rotated sub-image is centred on it.
+    obj_w = obj.get("width", 0) or text_w / scale_x
+    obj_h = obj.get("height", 0) or text_h / scale_y
+    obj_scale_x = obj.get("scaleX", 1) or 1
+    obj_scale_y = obj.get("scaleY", 1) or 1
+    left = obj.get("left", 0) or 0
+    top = obj.get("top", 0) or 0
+    centre_x = (left + obj_w / 2 * obj_scale_x) * scale_x
+    centre_y = (top + obj_h / 2 * obj_scale_y) * scale_y
+    paste_x = int(round(centre_x - text_img.size[0] / 2))
+    paste_y = int(round(centre_y - text_img.size[1] / 2))
+    overlay.alpha_composite(text_img, (paste_x, paste_y))
 
 
 def _load_font(size):
@@ -327,12 +562,33 @@ def _draw_psstroke(draw, obj, scale_x, scale_y):
     if len(points) < 2:
         return
     color = _line_color(obj)
+    # PSBrush stores its own strokeOffset (analogous to pathOffset) but
+    # it's not always serialised. Both the pivot and the bbox metadata
+    # fall back to what we can derive from strokePoints — fabric does
+    # the same in `_setPositionDimensions` on deserialisation, and that
+    # keeps the pivot fixed when the user drags the stroke so
+    # translations actually move the rendering.
+    anchors = [(p.get("x", 0) or 0, p.get("y", 0) or 0) for p in points]
+    normalised = _with_default_bbox(obj, anchors)
+    stroke_offset = obj.get("strokeOffset")
+    if stroke_offset:
+        normalised = dict(normalised)
+        normalised["pathOffset"] = {
+            "x": stroke_offset.get("x", 0) or 0,
+            "y": stroke_offset.get("y", 0) or 0,
+        }
+        transform = _centered_transform(normalised)
+    else:
+        transform = _centered_transform(
+            normalised, fallback_pivot=_bbox_centre(anchors)
+        )
     base_width = (obj.get("strokeWidth", 1) or 1) * scale_x
 
     def to_screen(p):
-        return (
-            (p.get("x", 0) or 0) * scale_x,
-            (p.get("y", 0) or 0) * scale_y,
+        return _to_image(
+            transform(p.get("x", 0) or 0, p.get("y", 0) or 0),
+            scale_x,
+            scale_y,
         )
 
     def segment_width(point):
@@ -367,15 +623,22 @@ def _draw_path(draw, obj, scale_x, scale_y):
     commands = _parse_path_commands(raw)
     if not commands:
         return
-    # Path commands are stored in canvas-absolute coords: fabric
-    # normalises left=calcDim.left and pathOffset=(calcDim.left+w/2,
-    # calcDim.top+h/2) on Path construction, so the two render-time
-    # translations cancel out and world coord = path coord.
+    # Apply fabric's full affine transform (T·R·S·T(-pathOffset)) so the
+    # path is positioned/scaled/rotated correctly even when the user
+    # transformed it. When pathOffset is absent from the JSON, fall
+    # back to the bbox centre of the path commands themselves — that's
+    # what fabric computes from `calcDim` and what makes translation
+    # `left` actually move the rendering.
     color = _line_color(obj)
     width = _stroke_width(obj, scale_x)
+    anchors = _extract_path_anchor_points(commands)
+    transform = _centered_transform(
+        _with_default_bbox(obj, anchors),
+        fallback_pivot=_bbox_centre(anchors),
+    )
 
     def to_screen(px, py):
-        return (px * scale_x, py * scale_y)
+        return _to_image(transform(px, py), scale_x, scale_y)
 
     segments = []
     current = None
@@ -433,6 +696,22 @@ def _parse_path_commands(raw):
     if isinstance(raw, list):
         return [list(cmd) for cmd in raw if cmd]
     return []
+
+
+def _extract_path_anchor_points(commands):
+    """Pick the destination point of each M/L/Q/C command — enough to
+    bracket the path's bbox without flattening every Bezier."""
+    points = []
+    for cmd in commands:
+        op = cmd[0].upper()
+        params = cmd[1:]
+        if op in ("M", "L") and len(params) >= 2:
+            points.append((params[0], params[1]))
+        elif op == "Q" and len(params) >= 4:
+            points.append((params[2], params[3]))
+        elif op == "C" and len(params) >= 6:
+            points.append((params[4], params[5]))
+    return points
 
 
 def _parse_path_string(text):


### PR DESCRIPTION
## Problems

- No public endpoint exposed an "annotated frame" — clients had to fetch the raw frame and recomposite the drawing on top
- Single-frame extraction only worked on movies; picture previews could not be annotated-exported
- No way to download every annotated frame of a preview in one shot
- The annotation renderer did not honour rotation, scale and translation transforms set on drawing objects
- Some Fabric.js shapes ("whiteboard sticker" and other strokeless shapes) rendered invisibly because the renderer assumed every object carried a stroke
- The bulk annotation extractor needed extra robustness when an annotation lacked a matching frame or when the preview was metadata-only

## Solutions

- New ``GET /actions/preview-files/<id>/extract-annotated-frame`` returning a PNG with the matching annotation overlaid; ``frame_number`` required for movies, ignored for pictures
- Extend coverage to picture previews (jpg / jpeg / jpe / png) — for pictures the first annotation entry is used
- New ``GET /actions/preview-files/<id>/extract-annotated-frames`` returning a zip archive with every annotated frame of a movie or every annotated copy of a picture
- New ``GET /actions/preview-files/<id>/extract-annotated-frames-pdf`` returning a PDF bundle of the same frames
- Apply rotation, scale and translation transforms in the annotation renderer
- Render whiteboard stickers and other strokeless shapes correctly
- Harden the bulk extraction path against missing-frame and missing-binary edge cases
- New ``zou/app/utils/annotations.py`` module dedicated to the rendering primitives