### PR TITLE
fix(previews): block normalize dispatch when source movie missing loc…

### DIFF
--- a/tests/files/test_preview_files.py
+++ b/tests/files/test_preview_files.py
@@ -1,4 +1,11 @@
+import os
+import tempfile
+from unittest.mock import patch
+
 from tests.base import ApiDBTestCase
+
+from zou.app.blueprints.previews.resources import BaseNewPreviewFilePicture
+from zou.app.services.exception import WrongParameterException
 
 
 class PreviewFilesTestCase(ApiDBTestCase):
@@ -22,3 +29,48 @@ class PreviewFilesTestCase(ApiDBTestCase):
         self.assertEqual(len(preview_files), 2)
         self.assertEqual(preview_files[0]["id"], preview_file_processing["id"])
         self.assertEqual(preview_files[1]["id"], preview_file_broken["id"])
+
+
+class _StubPreviewHandler(BaseNewPreviewFilePicture):
+    def get_no_job(self):
+        return False
+
+
+class SaveMoviePreviewValidationTestCase(ApiDBTestCase):
+    def setUp(self):
+        super().setUp()
+        self.handler = _StubPreviewHandler()
+
+    def test_raises_when_uploaded_movie_path_missing(self):
+        missing_path = "/tmp/zou-test-missing-uploaded-movie.mp4"
+        if os.path.exists(missing_path):
+            os.remove(missing_path)
+        with patch(
+            "zou.app.blueprints.previews.resources.movie.save_file",
+            return_value=missing_path,
+        ):
+            self.assertRaises(
+                WrongParameterException,
+                self.handler.save_movie_preview,
+                "preview-id",
+                None,
+            )
+
+    def test_raises_when_uploaded_movie_path_empty(self):
+        with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as tmp:
+            empty_path = tmp.name
+        try:
+            self.assertEqual(os.path.getsize(empty_path), 0)
+            with patch(
+                "zou.app.blueprints.previews.resources.movie.save_file",
+                return_value=empty_path,
+            ):
+                self.assertRaises(
+                    WrongParameterException,
+                    self.handler.save_movie_preview,
+                    "preview-id",
+                    None,
+                )
+        finally:
+            if os.path.exists(empty_path):
+                os.remove(empty_path)

--- a/tests/misc/test_commands.py
+++ b/tests/misc/test_commands.py
@@ -1,12 +1,16 @@
 import datetime
+import io
+from contextlib import redirect_stdout
+from unittest.mock import patch
 
 from click.testing import CliRunner
 
 from tests.base import ApiDBTestCase
 
 from zou.app.models.person import Person
+from zou.app.services import preview_files_service
+from zou.app.stores import auth_tokens_store, file_store
 from zou.app.utils import commands
-from zou.app.stores import auth_tokens_store
 from zou.app.models.entity_type import EntityType
 from zou.app.models.task_type import TaskType
 from zou.cli import cli
@@ -105,3 +109,57 @@ class DisableTwoFactorAuthenticationCommandTestCase(ApiDBTestCase):
         )
         self.assertEqual(result.exit_code, 1)
         self.assertIn("can't be disabled", result.output)
+
+
+class RenormalizeMoviePreviewFilesTestCase(ApiDBTestCase):
+    def setUp(self):
+        super().setUp()
+        self.generate_base_context()
+        self.generate_fixture_asset()
+        self.generate_fixture_assigner()
+        self.generate_fixture_person()
+        self.generate_fixture_task()
+        self.preview_file = self.generate_fixture_preview_file(status="broken")
+        self.preview_file_id = str(self.preview_file.id)
+
+    def _run_renormalize(self):
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            commands.renormalize_movie_preview_files(
+                preview_file_id=self.preview_file_id,
+                all_broken=True,
+            )
+        return buf.getvalue()
+
+    def test_skips_when_source_missing_in_storage(self):
+        with patch.object(
+            file_store, "exists_movie", return_value=False
+        ), patch.object(
+            preview_files_service, "prepare_and_store_movie"
+        ) as mock_prepare:
+            output = self._run_renormalize()
+
+        self.assertIn("Source movie missing in storage", output)
+        mock_prepare.assert_not_called()
+
+    def test_skips_when_local_copy_missing(self):
+        missing_path = "/tmp/zou-test-source-does-not-exist.mp4"
+        with patch.object(
+            file_store, "exists_movie", return_value=True
+        ), patch.object(
+            file_store,
+            "get_local_movie_path",
+            return_value=missing_path,
+        ), patch(
+            "zou.app.utils.commands.shutil.copyfile"
+        ), patch(
+            "zou.app.utils.commands.config.FS_BACKEND", "local"
+        ), patch(
+            "zou.app.utils.commands.config.ENABLE_JOB_QUEUE", False
+        ), patch.object(
+            preview_files_service, "prepare_and_store_movie"
+        ) as mock_prepare:
+            output = self._run_renormalize()
+
+        self.assertIn("Local copy of source movie is missing or", output)
+        mock_prepare.assert_not_called()

--- a/zou/app/blueprints/previews/resources.py
+++ b/zou/app/blueprints/previews/resources.py
@@ -258,6 +258,14 @@ class BaseNewPreviewFilePicture:
         uploaded_movie_path = movie.save_file(
             tmp_folder, preview_file_id, uploaded_file
         )
+        if (
+            not os.path.exists(uploaded_movie_path)
+            or os.path.getsize(uploaded_movie_path) == 0
+        ):
+            raise WrongParameterException(
+                "Uploaded movie could not be written to temporary storage "
+                "or is empty; aborting before dispatching normalization."
+            )
         save_source_file = config.PREVIEW_SAVE_SOURCE_FILE
         if normalize and config.ENABLE_JOB_QUEUE and not no_job:
             queue_store.job_queue.enqueue(

--- a/zou/app/utils/commands.py
+++ b/zou/app/utils/commands.py
@@ -1022,23 +1022,34 @@ def renormalize_movie_preview_files(
                         config.TMP_DIR,
                         f"{preview_file_id}.{extension}.tmp",
                     )
-                    try:
-                        if config.FS_BACKEND == "local":
-                            shutil.copyfile(
-                                file_store.get_local_movie_path(
-                                    "source", preview_file_id
-                                ),
-                                uploaded_movie_path,
-                            )
-                        else:
-                            sync_service.download_file(
-                                uploaded_movie_path,
-                                "source",
-                                file_store.open_movie,
-                                str(preview_file_id),
-                            )
-                    except Exception:
-                        pass
+                    if not file_store.exists_movie("source", preview_file_id):
+                        raise RuntimeError(
+                            f"Source movie missing in storage for preview "
+                            f"{preview_file_id}; skipping renormalization."
+                        )
+                    if config.FS_BACKEND == "local":
+                        shutil.copyfile(
+                            file_store.get_local_movie_path(
+                                "source", preview_file_id
+                            ),
+                            uploaded_movie_path,
+                        )
+                    else:
+                        sync_service.download_file(
+                            uploaded_movie_path,
+                            "source",
+                            file_store.open_movie,
+                            str(preview_file_id),
+                        )
+                    if (
+                        not os.path.exists(uploaded_movie_path)
+                        or os.path.getsize(uploaded_movie_path) == 0
+                    ):
+                        raise RuntimeError(
+                            f"Local copy of source movie is missing or "
+                            f"empty at {uploaded_movie_path}; skipping "
+                            f"renormalization of {preview_file_id}."
+                        )
                     if config.ENABLE_JOB_QUEUE:
                         queue_store.job_queue.enqueue(
                             preview_files_service.prepare_and_store_movie,


### PR DESCRIPTION
Problem
  - renormalize_movie_preview_files swallowed all download/copy errors with except Exception: pass, then dispatched normalization jobs against a missing or empty source movie.
  - New preview uploads also dispatched normalization without verifying the temporary movie was written, producing jobs that fail later with confusing errors.

  Solution
  - In commands.renormalize_movie_preview_files, check file_store.exists_movie("source", preview_file_id) before copy/download, drop the silent try/except, and raise
  RuntimeError when the local copy is missing or zero-byte so normalization is skipped with a clear message.
  - In BaseNewPreviewFilePicture (previews resource), raise WrongParameterException when uploaded_movie_path is absent or empty, aborting before the normalize job is enqueued.