### PR TITLE
[sync] Add silent flag to skip event emission during sync-push

### DIFF
--- a/tests/source/test_import_kitsu.py
+++ b/tests/source/test_import_kitsu.py
@@ -172,8 +172,10 @@ class ImportKitsuRoutesTestCase(ApiDBTestCase):
         self._post_kitsu("/import/kitsu/news", payload)
 
     def test_import_preview_files_flags_imported_only(self):
-        """Imported previews are flagged so frame/tile extraction skips them
-        — the push only sends metadata, not the binary."""
+        """
+        Imported previews are flagged so frame/tile extraction skips them
+        — the push only sends metadata, not the binary.
+        """
         new_id = str(fields.gen_uuid())
         payload = [
             {
@@ -288,3 +290,33 @@ class ImportKitsuRoutesTestCase(ApiDBTestCase):
         response = self._post_kitsu("/import/kitsu/milestones", payload)
         self.assertEqual(response, [])
         self.assertIsNone(Milestone.get(new_id))
+
+    def test_silent_flag_skips_event_emission(self):
+        """
+        ``?silent=true`` is what sync-push uses to dodge the per-row
+        events.emit storm: no api_event row is written and no Redis
+        publish happens. The Milestone itself still gets created.
+        """
+        from zou.app.models.event import ApiEvent
+
+        new_id = str(fields.gen_uuid())
+        payload = [
+            {
+                "id": new_id,
+                "project_id": self.project_id,
+                "task_type_id": str(self.task_type.id),
+                "name": "Silent milestone",
+                "date": "2026-06-01",
+            }
+        ]
+        events_before = ApiEvent.query.count()
+        self._post_kitsu("/import/kitsu/milestones?silent=true", payload)
+        self.assertIsNotNone(Milestone.get(new_id))
+        self.assertEqual(ApiEvent.query.count(), events_before)
+
+        # And the noisy default still does emit.
+        noisy_id = str(fields.gen_uuid())
+        payload[0]["id"] = noisy_id
+        payload[0]["name"] = "Noisy milestone"
+        self._post_kitsu("/import/kitsu/milestones", payload)
+        self.assertGreater(ApiEvent.query.count(), events_before)

--- a/zou/app/blueprints/source/kitsu.py
+++ b/zou/app/blueprints/source/kitsu.py
@@ -122,15 +122,23 @@ class BaseImportKitsuResource(Resource, ArgsMixin):
         if not isinstance(kitsu_entries, list):
             raise WrongParameterException("A list of entities is expected.")
 
+        # Bulk imports (sync-push) pass ?silent=true to skip per-row
+        # event emission: each emit persists an api_event row and triggers
+        # a Redis PUBLISH, which adds up to thousands of writes on a
+        # project-wide import. Connected UIs miss the live updates but
+        # the target instance stays responsive.
+        silent = request.args.get("silent", "").lower() in ("1", "true", "yes")
+
         instances = []
         for entry in kitsu_entries:
             if self.check_access(entry):
                 try:
                     instance, is_updated = self.model.create_from_import(entry)
-                    if is_updated:
-                        self.emit_event("update", entry)
-                    else:
-                        self.emit_event("new", entry)
+                    if not silent:
+                        if is_updated:
+                            self.emit_event("update", entry)
+                        else:
+                            self.emit_event("new", entry)
                 except IntegrityError as exc:
                     raise WrongParameterException(exc.orig)
                 instances.append(instance)
@@ -580,9 +588,11 @@ class ImportKitsuEntityLinksResource(BaseImportKitsuResource):
 
 
 class _ProjectScopedImportResource(BaseImportKitsuResource):
-    """Import resource whose entries carry a ``project_id`` directly.
+    """
+    Import resource whose entries carry a ``project_id`` directly.
 
     Admin-only by inheritance (BaseImportKitsuResource.check_access).
+
     """
 
     event_name = ""
@@ -601,9 +611,11 @@ class _ProjectScopedImportResource(BaseImportKitsuResource):
 
 
 class _TaskScopedImportResource(BaseImportKitsuResource):
-    """Import resource whose entries derive their project via ``task_id``.
+    """
+    Import resource whose entries derive their project via ``task_id``.
 
     Admin-only by inheritance (BaseImportKitsuResource.check_access).
+
     """
 
     event_name = ""
@@ -709,7 +721,9 @@ class ImportKitsuMilestonesResource(_ProjectScopedImportResource):
 
 
 class ImportKitsuBuildJobsResource(BaseImportKitsuResource):
-    """Admin-only by inheritance."""
+    """
+    Admin-only by inheritance.
+    """
 
     def __init__(self):
         BaseImportKitsuResource.__init__(self, BuildJob)
@@ -727,7 +741,9 @@ class ImportKitsuBuildJobsResource(BaseImportKitsuResource):
 
 
 class ImportKitsuAttachmentFilesResource(BaseImportKitsuResource):
-    """Admin-only by inheritance."""
+    """
+    Admin-only by inheritance.
+    """
 
     def __init__(self):
         BaseImportKitsuResource.__init__(self, AttachmentFile)

--- a/zou/app/services/sync_service.py
+++ b/zou/app/services/sync_service.py
@@ -332,6 +332,7 @@ def push_project_data(
     project_name,
     batch_size=200,
     throttle=0.0,
+    silent=True,
 ):
     """
     Push a single project's data to a target zou instance via the
@@ -343,6 +344,11 @@ def push_project_data(
     ``throttle`` is a pause (in seconds) between every batch POST. Useful
     to spare the target instance under load — set to 0.5 or 1.0 if the
     default rate causes timeouts or saturates request workers.
+
+    ``silent`` (default True) appends ``?silent=true`` to every POST so
+    the target skips per-row ``events.emit`` — no api_event rows written
+    and no Redis broadcast per imported entry. Bulk migration is not
+    something connected UIs need a live event storm for.
     """
     gazu.set_host(target)
     gazu.log_in(login, password)
@@ -357,6 +363,7 @@ def push_project_data(
         "/import/kitsu/projects",
         [project.serialize(relations=True)],
         batch_size,
+        silent=silent,
     )
 
     _push_query(
@@ -364,6 +371,7 @@ def push_project_data(
         MetadataDescriptor.query.filter_by(project_id=project_id),
         batch_size=batch_size,
         throttle=throttle,
+        silent=silent,
         relations=True,
     )
     _push_query(
@@ -371,6 +379,7 @@ def push_project_data(
         Milestone.query.filter_by(project_id=project_id),
         batch_size=batch_size,
         throttle=throttle,
+        silent=silent,
     )
 
     # Entities in hierarchy order so FKs (parent_id) resolve as we go.
@@ -391,6 +400,7 @@ def push_project_data(
             ),
             batch_size=batch_size,
             throttle=throttle,
+            silent=silent,
             label=f"/import/kitsu/entities ({entity_type_name})",
         )
 
@@ -399,6 +409,7 @@ def push_project_data(
         ScheduleItem.query.filter_by(project_id=project_id),
         batch_size=batch_size,
         throttle=throttle,
+        silent=silent,
     )
     _push_query(
         "/import/kitsu/entity-links",
@@ -407,6 +418,7 @@ def push_project_data(
         ).filter(Entity.project_id == project_id),
         batch_size=batch_size,
         throttle=throttle,
+        silent=silent,
     )
 
     _push_query(
@@ -414,24 +426,28 @@ def push_project_data(
         Task.query.filter_by(project_id=project_id),
         batch_size=batch_size,
         throttle=throttle,
+        silent=silent,
     )
     _push_query(
         "/import/kitsu/subscriptions",
         Subscription.query.join(Task).filter(Task.project_id == project_id),
         batch_size=batch_size,
         throttle=throttle,
+        silent=silent,
     )
     _push_query(
         "/import/kitsu/notifications",
         Notification.query.join(Task).filter(Task.project_id == project_id),
         batch_size=batch_size,
         throttle=throttle,
+        silent=silent,
     )
     _push_query(
         "/import/kitsu/time-spents",
         TimeSpent.query.join(Task).filter(Task.project_id == project_id),
         batch_size=batch_size,
         throttle=throttle,
+        silent=silent,
     )
 
     _push_query(
@@ -441,6 +457,7 @@ def push_project_data(
         ),
         batch_size=batch_size,
         throttle=throttle,
+        silent=silent,
         relations=True,
     )
     _push_query(
@@ -448,6 +465,7 @@ def push_project_data(
         PreviewFile.query.join(Task).filter(Task.project_id == project_id),
         batch_size=batch_size,
         throttle=throttle,
+        silent=silent,
         # source_file_id -> OutputFile.id, and OutputFile is out of scope
         # for sync-push (see the verify "NOT SYNCED" rows). Strip it so the
         # FK doesn't blow up the whole batch on the target side.
@@ -461,12 +479,14 @@ def push_project_data(
         .filter(Task.project_id == project_id),
         batch_size=batch_size,
         throttle=throttle,
+        silent=silent,
     )
     _push_query(
         "/import/kitsu/news",
         News.query.join(Task).filter(Task.project_id == project_id),
         batch_size=batch_size,
         throttle=throttle,
+        silent=silent,
     )
 
     _push_query(
@@ -474,6 +494,7 @@ def push_project_data(
         Playlist.query.filter_by(project_id=project_id),
         batch_size=batch_size,
         throttle=throttle,
+        silent=silent,
         relations=True,
     )
     _push_query(
@@ -483,6 +504,7 @@ def push_project_data(
         ),
         batch_size=batch_size,
         throttle=throttle,
+        silent=silent,
     )
 
     logger.info(f"Push of {project.name} complete.")
@@ -496,6 +518,7 @@ def _push_query(
     label=None,
     strip_fields=None,
     throttle=0.0,
+    silent=True,
 ):
     """
     Page through a query (offset+limit) and POST one batch at a time.
@@ -508,6 +531,7 @@ def _push_query(
     which yield_per refuses to combine with.
     """
     display = label or path
+    post_path = f"{path}?silent=true" if silent else path
     total_expected = query.count()
     if total_expected == 0:
         logger.info(f"  {display}: nothing to push")
@@ -531,7 +555,7 @@ def _push_query(
                     item.pop(field, None)
             items.append(item)
         try:
-            gazu.client.post(path, items)
+            gazu.client.post(post_path, items)
         except Exception:
             logger.error(
                 f"  {display}: batch at offset {offset} failed", exc_info=1
@@ -556,16 +580,19 @@ def _push_query(
         logger.info(f"  {display}: pushed {total} rows")
 
 
-def _push_batch(path, payload, batch_size=200, label=None):
-    """One-shot POST helper for the small pre-built lists (e.g. the
-    project itself). For query-driven pushes, use _push_query."""
+def _push_batch(path, payload, batch_size=200, label=None, silent=True):
+    """
+    One-shot POST helper for the small pre-built lists (e.g. the
+    project itself). For query-driven pushes, use _push_query.
+    """
     display = label or path
+    post_path = f"{path}?silent=true" if silent else path
     total = len(payload)
     failed = 0
     for offset in range(0, total, batch_size):
         chunk = payload[offset : offset + batch_size]
         try:
-            gazu.client.post(path, chunk)
+            gazu.client.post(post_path, chunk)
         except Exception:
             logger.error(f"  {display}: batch {offset} failed", exc_info=1)
             failed += len(chunk)
@@ -1810,10 +1837,12 @@ def _safe(fn):
 
 
 def _src_count(path):
-    """Return a callable counting rows on the source instance for a path.
+    """
+    Return a callable counting rows on the source instance for a path.
 
     Handles list-returning routes (e.g. /projects/X/assets) and paginated
     routes (which return {"data": ..., "total": N, "nb_pages": M}).
+
     """
 
     def fetch():
@@ -1865,7 +1894,9 @@ def _tgt_entity_type(project_id, type_name):
 
 
 def _tgt_asset(project_id):
-    """Assets are entities whose type is not one of the structural types."""
+    """
+    Assets are entities whose type is not one of the structural types.
+    """
     structural = ["Episode", "Sequence", "Shot", "Concept", "Edit", "Scene"]
 
     def count():
@@ -1884,7 +1915,9 @@ def _tgt_asset(project_id):
 
 
 def _tgt_entity_link(project_id):
-    """Entity links whose source entity lives in the project."""
+    """
+    Entity links whose source entity lives in the project.
+    """
 
     def count():
         return (
@@ -1897,7 +1930,9 @@ def _tgt_entity_link(project_id):
 
 
 def _tgt_comment(project_id):
-    """Comments attached to tasks of the project (matches the source route)."""
+    """
+    Comments attached to tasks of the project (matches the source route).
+    """
 
     def count():
         return (
@@ -1968,7 +2003,9 @@ def _tgt_subscription(project_id):
 
 
 def _tgt_notification(project_id):
-    """Notifications attached to tasks of the project."""
+    """
+    Notifications attached to tasks of the project.
+    """
 
     def count():
         return (
@@ -1981,7 +2018,9 @@ def _tgt_notification(project_id):
 
 
 def _tgt_news(project_id):
-    """News tied to tasks of the project."""
+    """
+    News tied to tasks of the project.
+    """
 
     def count():
         return (
@@ -2029,7 +2068,9 @@ def _tgt_asset_instance(project_id):
 
 
 def _tgt_chat(project_id):
-    """Chats attached to entities of the project."""
+    """
+    Chats attached to entities of the project.
+    """
 
     def count():
         return (

--- a/zou/app/utils/commands.py
+++ b/zou/app/utils/commands.py
@@ -61,7 +61,9 @@ def clear_all_auth_tokens():
 
 
 def _init_asset_types_for_domain(domain):
-    """Initialize asset types according to domain (2d, 3d, vfx, games)."""
+    """
+    Initialize asset types according to domain (2d, 3d, vfx, games).
+    """
     if domain == "2d":
         for name in ("Character", "Prop", "Background", "FX"):
             assets_service.get_or_create_asset_type(name)
@@ -78,7 +80,9 @@ def _init_asset_types_for_domain(domain):
 
 
 def _init_task_types_for_domain(domain):
-    """Initialize departments and task types according to domain."""
+    """
+    Initialize departments and task types according to domain.
+    """
     if domain == "2d":
         concept = tasks_service.get_or_create_department("Concept", "#8D6E63")
         layout = tasks_service.get_or_create_department("Layout", "#7CB342")
@@ -721,6 +725,7 @@ def push_project_to_target(
     project_name,
     batch_size=200,
     throttle=0.0,
+    silent=True,
 ):
     """
     Push the project named ``project_name`` from the local instance to
@@ -734,6 +739,7 @@ def push_project_to_target(
             project_name,
             batch_size=batch_size,
             throttle=throttle,
+            silent=silent,
         )
 
 

--- a/zou/cli.py
+++ b/zou/cli.py
@@ -28,11 +28,13 @@ def _get_db_uri():
 
 
 def _get_alembic_config():
-    """Build an Alembic config that talks directly to the DB.
+    """
+    Build an Alembic config that talks directly to the DB.
 
     Bypasses Flask/Flask-SQLAlchemy/Flask-Migrate entirely — only needs
     Alembic + the DB driver.  env.py detects the absence of a Flask app
     context and reads the URL from the Alembic config instead.
+
     """
     from alembic.config import Config
 
@@ -46,9 +48,11 @@ def _get_alembic_config():
 
 
 def _get_alembic_config_legacy():
-    """Alembic config that includes both current and legacy migrations.
+    """
+    Alembic config that includes both current and legacy migrations.
 
     Used as fallback when an instance is on a pre-squash revision.
+
     """
     from alembic.config import Config
 
@@ -647,7 +651,17 @@ def sync_verify(source, project):
     type=float,
     help="Seconds to sleep between batch POSTs (e.g. 0.5).",
 )
-def sync_push(target, project, batch_size, throttle):
+@click.option(
+    "--broadcast",
+    is_flag=True,
+    default=False,
+    help=(
+        "Let the target emit events for every imported row "
+        "(api_event + Redis publish). Off by default — bulk imports "
+        "don't need a live event storm on the target."
+    ),
+)
+def sync_push(target, project, batch_size, throttle, broadcast):
     """
     Push a project from the current instance to a target zou instance via
     /import/kitsu/* routes. Reference data (persons, departments, task
@@ -666,6 +680,7 @@ def sync_push(target, project, batch_size, throttle):
         project,
         batch_size=batch_size,
         throttle=throttle,
+        silent=not broadcast,
     )
 
 


### PR DESCRIPTION
**Problem**
- A project-wide ``sync-push`` fires one ``events.emit`` per imported row — each one persists an ``api_event`` row and triggers a Redis publish
- On a project with tens of thousands of comments / preview-files that adds thousands of extra writes on the target and floods connected UIs with a storm of websocket events

**Solution**
- ``/import/kitsu/*`` routes now accept ``?silent=true`` — when present the per-row ``emit_event`` call is skipped
- ``sync_service.push_project_data`` and ``zou sync-push`` default to ``silent=True`` so bulk migrations are quiet
- New ``--broadcast`` CLI flag re-enables the old behaviour for callers who want the live events
- Regression test covers both the silent path (no ``api_event`` row created) and the noisy default