### PR TITLE
[docs] Split local env commands into CLAUDE.local.md.example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,6 @@ data.ms
 .venv
 additions
 previews-test
+
+# Local-only Claude Code instructions
+CLAUDE.local.md

--- a/CLAUDE.local.md.example
+++ b/CLAUDE.local.md.example
@@ -1,0 +1,31 @@
+# Zou - Local Environment Guidelines
+
+Local-only instructions: environment activation, test execution, migration commands. Copy this file to `CLAUDE.local.md` and adapt to your setup.
+
+## Quick Reference
+
+```bash
+# Activate env
+source ~/.virtualenvs/zou/bin/activate
+
+# Run tests (requires PostgreSQL on localhost:5432)
+DB_DATABASE=zoudb-test py.test tests/path/to/test_file.py -v
+
+# Run full test suite
+DB_DATABASE=zoudb-test py.test tests/ -v
+
+# Generate a migration
+zou migrate-db --message "Add column X to table Y"
+
+# Apply migrations
+zou upgrade-db
+```
+
+## Running tests
+
+```bash
+source ~/.virtualenvs/zou/bin/activate
+DB_DATABASE=zoudb-test py.test tests/services/test_my_service.py -v
+```
+
+Requires PostgreSQL running locally on port 5432. The test DB is created/dropped automatically by `conftest.py`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,23 +5,11 @@ Zou is the REST API backend for **Kitsu**, a production management tool for anim
 ## Quick Reference
 
 ```bash
-# Activate env
-source ~/.virtualenvs/zou/bin/activate
-
-# Run tests (requires PostgreSQL on localhost:5432)
-DB_DATABASE=zoudb-test py.test tests/path/to/test_file.py -v
-
-# Run full test suite
-DB_DATABASE=zoudb-test py.test tests/ -v
-
 # Lint / format
 pre-commit run --all-files
 
 # Generate a migration
 zou migrate-db --message "Add column X to table Y"
-
-# Apply migrations
-zou upgrade-db
 ```
 
 ## Architecture
@@ -245,14 +233,7 @@ Format: `<table_name>:<action>` — e.g., `task:new`, `comment:delete`, `person:
 
 ## Testing
 
-### Running tests
-
-```bash
-source ~/.virtualenvs/zou/bin/activate
-DB_DATABASE=zoudb-test py.test tests/services/test_my_service.py -v
-```
-
-Requires PostgreSQL running locally on port 5432. The test DB is created/dropped automatically by `conftest.py`.
+See `CLAUDE.local.md` for how to run tests locally. The test DB schema is created/dropped automatically by `conftest.py`.
 
 ### Test base class
 
@@ -326,7 +307,6 @@ class MyServiceTestCase(ApiDBTestCase):
 ```
 
 ## Migrations
-
 ```bash
 # Generate
 zou migrate-db --message "Add column X to table Y"
@@ -336,9 +316,10 @@ zou upgrade-db
 
 # Rollback one step
 zou downgrade-db --revision "-1"
-```
 
 Migrations live in `zou/migrations/versions/`. Each file has `upgrade()` and `downgrade()` functions. Use `UUIDType(binary=False)` for UUID columns.
+
+See `CLAUDE.local.md` for `zou migrate-db` / `zou upgrade-db` / `zou downgrade-db` invocations.
 
 ## Key Environment Variables
 

--- a/README.rst
+++ b/README.rst
@@ -53,6 +53,17 @@ committing:
     pip install pre-commit
     pre-commit install
 
+If you use Claude Code (or another AI assistant that reads ``CLAUDE.md``),
+copy ``CLAUDE.local.md.example`` to ``CLAUDE.local.md`` and adapt it to your
+local environment (virtualenv path, test database name, etc.). The
+``CLAUDE.local.md`` file is gitignored and holds your local-only commands
+(test execution, migrations), while ``CLAUDE.md`` only documents code
+conventions shared by the whole team.
+
+.. code:: bash
+
+    cp CLAUDE.local.md.example CLAUDE.local.md
+
 Instructions for setting up a development environment are available in
 `the documentation <https://zou.cg-wire.com/development/>`__
 


### PR DESCRIPTION
Problem
  - CLAUDE.md mixed shared code conventions with developer-specific commands (virtualenv path, test DB name, zou CLI invocations), forcing every contributor to share the same
  local setup.
  - New contributors using Claude Code had no separation between team-wide guidelines and their personal environment.

Solution
  - Add CLAUDE.local.md.example containing the per-developer commands (venv activation, DB_DATABASE=zoudb-test py.test ..., zou migrate-db/upgrade-db/downgrade-db).
  - Trim CLAUDE.md to keep only code-related content (architecture, conventions, patterns); replace removed sections with pointers to CLAUDE.local.md. Keep pre-commit run
  --all-files, env-vars table, and cheatsheet runtime commands untouched.
  - Gitignore CLAUDE.local.md and document the cp CLAUDE.local.md.example CLAUDE.local.md setup step in README.rst.