### PR TITLE
[projects] Clean up production schedule versions on project deletion

### DIFF
--- a/tests/services/test_deletion_service.py
+++ b/tests/services/test_deletion_service.py
@@ -3,15 +3,17 @@ from tests.base import ApiDBTestCase
 from zou.app.models.comment import Comment
 from zou.app.models.task import Task
 from zou.app.models.notification import Notification
-from zou.app.models.news import News
 from zou.app.models.preview_file import PreviewFile
 from zou.app.models.event import ApiEvent
 from zou.app.models.login_log import LoginLog
+from zou.app.models.production_schedule_version import (
+    ProductionScheduleVersion,
+    ProductionScheduleVersionTaskLink,
+)
+from zou.app.models.project import Project
 
 from zou.app.services import (
-    comments_service,
     deletion_service,
-    tasks_service,
 )
 from zou.app.services.exception import (
     CommentNotFoundException,
@@ -126,3 +128,29 @@ class DeletionServiceTestCase(ApiDBTestCase):
             str(self.asset.id)
         )
         self.assertEqual(result, [])
+
+    def test_remove_project_with_production_schedule_version(self):
+        # Regression: deleting a project that had a production schedule
+        # version failed on the FK constraint because the version (and its
+        # task links + self-reference) were never cleaned up.
+        project_id = str(self.project.id)
+        version = ProductionScheduleVersion.create(
+            name="v1", project_id=self.project.id
+        )
+        derived = ProductionScheduleVersion.create(
+            name="v2",
+            project_id=self.project.id,
+            production_schedule_from=version.id,
+        )
+        ProductionScheduleVersionTaskLink.create(
+            production_schedule_version_id=version.id,
+            task_id=self.task.id,
+        )
+        version_id = str(version.id)
+        derived_id = str(derived.id)
+
+        deletion_service.remove_project(project_id)
+
+        self.assertIsNone(Project.get(project_id))
+        self.assertIsNone(ProductionScheduleVersion.get(version_id))
+        self.assertIsNone(ProductionScheduleVersion.get(derived_id))

--- a/zou/app/services/deletion_service.py
+++ b/zou/app/services/deletion_service.py
@@ -24,6 +24,10 @@ from zou.app.models.person import Person
 from zou.app.models.playlist import Playlist
 from zou.app.models.preview_background_file import PreviewBackgroundFile
 from zou.app.models.preview_file import PreviewFile
+from zou.app.models.production_schedule_version import (
+    ProductionScheduleVersion,
+    ProductionScheduleVersionTaskLink,
+)
 from zou.app.models.project import Project
 from zou.app.models.schedule_item import ScheduleItem
 from zou.app.models.search_filter import SearchFilter
@@ -433,6 +437,7 @@ def remove_project(project_id):
     MetadataDescriptor.delete_all_by(project_id=project_id)
     Milestone.delete_all_by(project_id=project_id)
     ScheduleItem.delete_all_by(project_id=project_id)
+    remove_production_schedule_versions_for_project(project_id)
     SearchFilterGroup.delete_all_by(project_id=project_id)
     SearchFilter.delete_all_by(project_id=project_id)
     News.query.filter(
@@ -442,6 +447,37 @@ def remove_project(project_id):
     project.delete()
     events.emit("project:delete", {"project_id": project.id})
     return project_id
+
+
+def remove_production_schedule_versions_for_project(project_id):
+    """
+    Delete production schedule versions of a project together with their
+    task links. Done explicitly because the project FK on
+    production_schedule_version is not guaranteed to cascade on every
+    deployed database, and the table self-references through
+    ``production_schedule_from``.
+    """
+    version_ids = [
+        str(row[0])
+        for row in ProductionScheduleVersion.query.with_entities(
+            ProductionScheduleVersion.id
+        )
+        .filter_by(project_id=project_id)
+        .all()
+    ]
+    if not version_ids:
+        return
+
+    # Break self-references so the rows can be deleted in any order.
+    ProductionScheduleVersion.query.filter(
+        ProductionScheduleVersion.production_schedule_from.in_(version_ids)
+    ).update({"production_schedule_from": None}, synchronize_session=False)
+    ProductionScheduleVersionTaskLink.query.filter(
+        ProductionScheduleVersionTaskLink.production_schedule_version_id.in_(
+            version_ids
+        )
+    ).delete(synchronize_session=False)
+    ProductionScheduleVersion.delete_all_by(project_id=project_id)
 
 
 def remove_person(person_id, force=True):


### PR DESCRIPTION
## Problems

- Deleting a project that has a production schedule version fails with a ForeignKeyViolation — remove_project tore down schedule items, milestones and metadata descriptors but never the production_schedule_version rows
- The project FK on production_schedule_version declares ondelete=CASCADE in the model, but the constraint on already-deployed databases doesn't have it, so the delete is rejected

## Solutions

- remove_project now removes the project's production schedule versions explicitly: null out the self-referential production_schedule_from links, delete the task links, then delete the versions
- Works regardless of whether the database FK constraint cascades