### PR TITLE
[emails] Wrap outgoing message lines to comply with RFC 5322

### DIFF
--- a/tests/utils/test_emails.py
+++ b/tests/utils/test_emails.py
@@ -1,0 +1,61 @@
+from tests.base import ApiDBTestCase
+
+from zou.app import app
+from zou.app.utils import emails
+
+# RFC 5322 section 2.1.1: hard limit of 998 characters per line
+# (excluding the trailing CRLF).
+RFC_5322_MAX_LINE_LENGTH = 998
+
+
+class EmailsLineLengthTestCase(ApiDBTestCase):
+    def _get_message_bytes(self, subject, html, body=None):
+        """
+        Build a Flask-Mail Message exactly like ``send_email`` does and
+        return its serialized bytes (what would be sent over SMTP).
+        """
+        from flask_mail import Message
+
+        if body is None:
+            body = emails.strip_html_tags(html)
+        with app.app_context():
+            message = Message(
+                sender="Kitsu Bot <bot@example.com>",
+                body=body,
+                html=html,
+                subject=subject,
+                recipients=["recipient@example.com"],
+            )
+            return message.as_bytes()
+
+    def _assert_lines_within_rfc5322(self, raw_bytes):
+        for index, line in enumerate(raw_bytes.split(b"\r\n")):
+            self.assertLessEqual(
+                len(line),
+                RFC_5322_MAX_LINE_LENGTH,
+                f"Line {index} exceeds RFC 5322 limit "
+                f"({len(line)} > {RFC_5322_MAX_LINE_LENGTH}): "
+                f"{line[:120]!r}...",
+            )
+
+    def test_long_html_line_is_wrapped(self):
+        long_url = "https://example.com/" + ("a" * 2000)
+        html = f'<p>Click here: <a href="{long_url}">link</a></p>'
+        raw = self._get_message_bytes("Subject", html)
+        self._assert_lines_within_rfc5322(raw)
+
+    def test_long_plain_body_is_wrapped(self):
+        body = "word " * 500
+        html = "<p>short</p>"
+        raw = self._get_message_bytes("Subject", html, body=body)
+        self._assert_lines_within_rfc5322(raw)
+
+    def test_html_without_line_breaks_is_wrapped(self):
+        html = "<p>" + ("x" * 3000) + "</p>"
+        raw = self._get_message_bytes("Subject", html)
+        self._assert_lines_within_rfc5322(raw)
+
+    def test_unicode_html_is_wrapped(self):
+        html = "<p>" + ("é" * 2000) + "</p>"
+        raw = self._get_message_bytes("Sujet avec accents é", html)
+        self._assert_lines_within_rfc5322(raw)

--- a/zou/app/utils/emails.py
+++ b/zou/app/utils/emails.py
@@ -1,10 +1,23 @@
 import re
 import traceback
+from email import charset as email_charset
 from io import StringIO
 from html.parser import HTMLParser
 from flask_mail import Message
 
 from zou.app import mail, app
+
+# Force quoted-printable encoding for utf-8 message bodies so that the
+# Python email module wraps lines at 76 chars. Without this, long HTML
+# lines (e.g. inline styles, long URLs) can exceed RFC 5322's 998-char
+# hard limit and SMTP servers reject the message with
+# "Maximum line length exceeded (see RFC 5322)".
+email_charset.add_charset(
+    "utf-8",
+    email_charset.QP,
+    email_charset.QP,
+    "utf-8",
+)
 
 
 def send_email(subject, html, recipient_email, body=None, locale=None):


### PR DESCRIPTION
**Problem**
  - Outgoing emails occasionally rejected by SMTP servers with Maximum line length exceeded (see RFC 5322).
  - Python's email.mime.text.MIMEText with the default utf-8 charset does not wrap long lines in HTML or plain bodies (observed >4000 chars on a single line for a 3000-char
  <p>), exceeding the RFC 5322 hard limit of 998 chars.

**Solution**
  - Register quoted-printable as the body encoding for utf-8 in zou/app/utils/emails.py at module import. The email module now wraps every body line at 76 chars for both
  text/plain and text/html parts of every outgoing message, well under the 998-char limit.
  - Add tests/utils/test_emails.py covering long HTML lines, long plain bodies, single-block HTML without breaks, and unicode subject/body — each asserts every line of
  Message.as_bytes() stays within the RFC 5322 limit.