### PR TITLE
Fix preview access for assigned vendors

### DIFF
--- a/tests/playlists/test_playlist_routes.py
+++ b/tests/playlists/test_playlist_routes.py
@@ -1,7 +1,7 @@
 from tests.base import ApiDBTestCase
 
 from zou.app.models.playlist import Playlist
-from zou.app.services import projects_service
+from zou.app.services import projects_service, tasks_service
 
 
 class PlaylistRoutesTestCase(ApiDBTestCase):
@@ -52,6 +52,27 @@ class PlaylistRoutesTestCase(ApiDBTestCase):
             f"/data/playlists/entities/{self.shot.id}/preview-files"
         )
         self.assertIsInstance(result, dict)
+
+    def test_get_entity_preview_files_vendor_assigned(self):
+        self.generate_fixture_user_vendor()
+        self.log_in_vendor()
+        path = f"/data/playlists/entities/{self.shot.id}/preview-files"
+        self.get(path, 403)
+        projects_service.add_team_member(
+            self.project.id, self.user_vendor["id"]
+        )
+        tasks_service.assign_task(self.shot_task.id, self.user_vendor["id"])
+        result = self.get(path)
+        self.assertIsInstance(result, dict)
+
+    def test_get_entity_preview_files_vendor_not_assigned(self):
+        self.generate_fixture_user_vendor()
+        projects_service.add_team_member(
+            self.project.id, self.user_vendor["id"]
+        )
+        self.log_in_vendor()
+        path = f"/data/playlists/entities/{self.shot.id}/preview-files"
+        self.get(path, 403)
 
     def test_get_project_build_jobs(self):
         result = self.get(f"/data/projects/{self.project_id}/build-jobs")

--- a/tests/playlists/test_playlist_routes.py
+++ b/tests/playlists/test_playlist_routes.py
@@ -86,6 +86,29 @@ class PlaylistRoutesTestCase(ApiDBTestCase):
         )
         self.assertIsInstance(result, list)
 
+    def test_create_temp_playlist_vendor_assigned(self):
+        self.generate_fixture_user_vendor()
+        self.log_in_vendor()
+        path = f"/data/projects/{self.project_id}/playlists/temp"
+        data = {"task_ids": [str(self.shot_task.id)]}
+        self.post(path, data, 403)
+        projects_service.add_team_member(
+            self.project.id, self.user_vendor["id"]
+        )
+        tasks_service.assign_task(self.shot_task.id, self.user_vendor["id"])
+        result = self.post(path, data, 200)
+        self.assertIsInstance(result, list)
+
+    def test_create_temp_playlist_vendor_not_assigned(self):
+        self.generate_fixture_user_vendor()
+        projects_service.add_team_member(
+            self.project.id, self.user_vendor["id"]
+        )
+        self.log_in_vendor()
+        path = f"/data/projects/{self.project_id}/playlists/temp"
+        data = {"task_ids": [str(self.shot_task.id)]}
+        self.post(path, data, 403)
+
     def test_add_entity_to_playlist(self):
         self.generate_fixture_playlist("Add Entity Playlist")
         playlists = self.get(f"/data/projects/{self.project_id}/playlists")

--- a/zou/app/blueprints/playlists/resources.py
+++ b/zou/app/blueprints/playlists/resources.py
@@ -300,9 +300,9 @@ class EntityPreviewsResource(Resource):
                           description: Preview file name
                           example: "preview_v001.png"
         """
-        user_service.block_access_to_vendor()
         entity = entities_service.get_entity(entity_id)
         user_service.check_project_access(entity["project_id"])
+        user_service.check_entity_access(entity_id)
         return playlists_service.get_preview_files_for_entity(entity_id)
 
 

--- a/zou/app/blueprints/playlists/resources.py
+++ b/zou/app/blueprints/playlists/resources.py
@@ -880,10 +880,11 @@ class TempPlaylistResource(Resource, ArgsMixin):
           400:
             description: Invalid task IDs
         """
-        user_service.block_access_to_vendor()
         user_service.check_project_access(project_id)
         body = validation.validate_request_body(TempPlaylistCreateSchema)
         task_ids = [str(t) for t in body.task_ids]
+        for task_id in task_ids:
+            user_service.check_task_access(task_id)
         sort = self.get_bool_parameter("sort")
         return (
             playlists_service.generate_temp_playlist(task_ids, sort=sort) or []


### PR DESCRIPTION
**Problem**
- d0a5689 (v1.0.16) added a blanket block_access_to_vendor() on two preview endpoints
- Vendors lost preview/comment access on their assigned tasks (#1093)
- Vendors could no longer build temp playlists for their tasks

**Solution**
- Replace the blanket block: assigned vendors allowed, non-assigned stay blocked
- Entity preview-files: use check_entity_access, matching the shot/edit/concept endpoints
- Temp playlist: check_task_access on each task, so vendors only get their assigned ones
