### PR TITLE
[tasks] Block task type deletion with clean 400 when still linked

### DIFF
--- a/tests/models/test_task_type.py
+++ b/tests/models/test_task_type.py
@@ -1,5 +1,6 @@
 from tests.base import ApiDBTestCase
 from zou.app.models.task_type import TaskType
+from zou.app.models.project import ProjectTaskTypeLink
 
 from zou.app.utils import fields
 
@@ -50,3 +51,29 @@ class TaskTypeTestCase(ApiDBTestCase):
         task_types = self.get("data/task-types")
         self.assertEqual(len(task_types), 2)
         self.delete_404(f"data/task-types/{fields.gen_uuid()}")
+
+    def test_delete_task_type_linked_to_project(self):
+        self.generate_fixture_project()
+        task_type = TaskType.create(
+            name="Linked",
+            short_name="lnk",
+            color="#FFFFFF",
+            for_entity="Asset",
+            department_id=self.department_id,
+        )
+        ProjectTaskTypeLink.create(
+            project_id=self.project.id, task_type_id=task_type.id
+        )
+        task_type_id = str(task_type.id)
+        # Without force, the link refuses the delete with a clean 400.
+        self.delete(f"data/task-types/{task_type_id}", 400)
+        self.assertIsNotNone(TaskType.get(task_type_id))
+        # With force, the link is purged first so the deletion succeeds.
+        self.delete(f"data/task-types/{task_type_id}?force=true")
+        self.assertIsNone(TaskType.get(task_type_id))
+        self.assertEqual(
+            ProjectTaskTypeLink.query.filter_by(
+                task_type_id=task_type_id
+            ).count(),
+            0,
+        )

--- a/zou/app/blueprints/crud/task_type.py
+++ b/zou/app/blueprints/crud/task_type.py
@@ -2,6 +2,7 @@ from flask_jwt_extended import jwt_required
 
 from zou.app.models.task_type import TaskType
 from zou.app.models.schedule_item import ScheduleItem
+from zou.app.models.project import ProjectTaskTypeLink
 from zou.app.services.exception import WrongParameterException
 from zou.app.services import tasks_service
 
@@ -320,11 +321,31 @@ class TaskTypeResource(BaseModelResource):
 
     def pre_delete(self, instance_dict):
         """
-        Delete related ScheduleItems before deleting the TaskType.
-        This runs AFTER check_delete_permissions, preventing foreign key
-        constraint violations while maintaining security.
+        Refuse the delete with a clean 400 when the task type still has
+        scheduled items or is attached to projects, unless ``force`` is
+        set. With force, those rows are purged first so the deletion is
+        not blocked by their foreign keys.
         """
-        ScheduleItem.query.filter_by(task_type_id=instance_dict["id"]).delete()
+        task_type_id = instance_dict["id"]
+        if self.get_force():
+            ScheduleItem.query.filter_by(task_type_id=task_type_id).delete()
+            ProjectTaskTypeLink.query.filter_by(
+                task_type_id=task_type_id
+            ).delete()
+            return instance_dict
+
+        blockers = []
+        if ScheduleItem.query.filter_by(task_type_id=task_type_id).count():
+            blockers.append("schedule items")
+        if ProjectTaskTypeLink.query.filter_by(
+            task_type_id=task_type_id
+        ).count():
+            blockers.append("projects")
+        if blockers:
+            raise WrongParameterException(
+                f"Task type is attached to {' and '.join(blockers)}. "
+                "Re-issue the request with force=true to detach."
+            )
         return instance_dict
 
     def update_data(self, data, instance_id):


### PR DESCRIPTION
**Problem**
- Deleting a task type still attached to projects or scheduled items hit a foreign-key IntegrityError, returning an opaque 500.
- The previous `pre_delete` only purged ScheduleItems and ignored ProjectTaskTypeLink rows entirely.

**Solution**
- Without `force`, refuse the delete with a 400 listing the blockers (schedule items and/or projects).
- With `force=true`, purge ScheduleItem and ProjectTaskTypeLink rows before removing the task type.