### PR TITLE
[projects] Add single-preview-per-revision project option

### DIFF
--- a/tests/tasks/test_preview_revision.py
+++ b/tests/tasks/test_preview_revision.py
@@ -171,3 +171,53 @@ class PreviewRevisionTestCase(ApiDBTestCase):
         tasks_service.check_revision_is_unique_for_task(
             str(self.task.id), revision=1
         )
+
+    def enable_single_preview(self):
+        """
+        Turn on the single-preview-per-revision option on the project.
+        """
+        from zou.app.services import projects_service
+
+        projects_service.update_project(
+            str(self.project.id),
+            {"is_single_preview_per_revision": True},
+        )
+
+    def test_extra_preview_rejected_when_single_preview_enabled(self):
+        """
+        With the flag on, adding a second preview to a revision fails (400).
+        """
+        self.enable_single_preview()
+        comment = self.create_comment()
+        preview1 = self.add_preview(comment["id"], revision=1)
+        self.assertEqual(preview1["position"], 1)
+
+        path = (
+            f"/actions/tasks/{self.task_id}/comments/{comment['id']}"
+            f"/preview-files/{preview1['id']}"
+        )
+        response = self.post(path, {}, code=400)
+        self.assertIn("preview", response.get("message", "").lower())
+
+    def test_new_revision_allowed_when_single_preview_enabled(self):
+        """
+        With the flag on, a fresh revision (position 1) is still allowed.
+        """
+        self.enable_single_preview()
+        comment1 = self.create_comment()
+        preview1 = self.add_preview(comment1["id"], revision=1)
+        self.assertEqual(preview1["position"], 1)
+
+        comment2 = self.create_comment()
+        preview2 = self.add_preview(comment2["id"], revision=2)
+        self.assertEqual(preview2["position"], 1)
+        self.assertEqual(preview2["revision"], 2)
+
+    def test_extra_preview_allowed_when_flag_off(self):
+        """
+        Regression: with the flag off, extra previews still work.
+        """
+        comment = self.create_comment()
+        preview1 = self.add_preview(comment["id"], revision=1)
+        preview2 = self.add_extra_preview(comment["id"], preview1["id"])
+        self.assertEqual(preview2["position"], 2)

--- a/zou/app/models/project.py
+++ b/zou/app/models/project.py
@@ -173,6 +173,7 @@ class Project(db.Model, BaseMixin, SerializerMixin):
     homepage = db.Column(db.String(80), default="assets")
     is_publish_default_for_artists = db.Column(db.Boolean(), default=False)
     is_bot_collaboration_enabled = db.Column(db.Boolean(), default=False)
+    is_single_preview_per_revision = db.Column(db.Boolean(), default=False)
     hd_bitrate_compression = db.Column(db.Integer, default=28)
     ld_bitrate_compression = db.Column(db.Integer, default=6)
 

--- a/zou/app/models/project_template.py
+++ b/zou/app/models/project_template.py
@@ -136,6 +136,7 @@ class ProjectTemplate(db.Model, BaseMixin, SerializerMixin):
     is_preview_download_allowed = db.Column(db.Boolean(), default=False)
     is_set_preview_automated = db.Column(db.Boolean(), default=False)
     is_publish_default_for_artists = db.Column(db.Boolean(), default=False)
+    is_single_preview_per_revision = db.Column(db.Boolean(), default=False)
     homepage = db.Column(db.String(80), default="assets")
     hd_bitrate_compression = db.Column(db.Integer, default=28)
     ld_bitrate_compression = db.Column(db.Integer, default=6)

--- a/zou/app/services/exception.py
+++ b/zou/app/services/exception.py
@@ -127,6 +127,10 @@ class RevisionAlreadyExistsException(BadRequest):
     pass
 
 
+class TooManyPreviewFilesException(BadRequest):
+    pass
+
+
 class CommentNotFoundException(NotFound):
     pass
 

--- a/zou/app/services/tasks_service.py
+++ b/zou/app/services/tasks_service.py
@@ -45,6 +45,7 @@ from zou.app.services.exception import (
     EpisodeNotFoundException,
     PersonNotFoundException,
     RevisionAlreadyExistsException,
+    TooManyPreviewFilesException,
     TaskNotFoundException,
     TaskStatusNotFoundException,
     TaskTypeNotFoundException,
@@ -1822,6 +1823,13 @@ def add_preview_file_to_comment(comment_id, person_id, task_id, revision=0):
         if len(comment.previews) == 0:
             check_revision_is_unique_for_task(task_id, revision)
         position = get_next_position(task_id, revision)
+    if position > 1:
+        project = projects_service.get_project(project_id)
+        if project.get("is_single_preview_per_revision"):
+            raise TooManyPreviewFilesException(
+                "Only one preview file is allowed per revision for this "
+                "project."
+            )
     preview_file = files_service.create_preview_file_raw(
         str(uuid.uuid4())[:13], revision, task_id, person_id, position=position
     )

--- a/zou/migrations/versions/a7d4e2f9c1b8_add_single_preview_per_revision.py
+++ b/zou/migrations/versions/a7d4e2f9c1b8_add_single_preview_per_revision.py
@@ -1,0 +1,34 @@
+"""Add is_single_preview_per_revision to project and project_template
+
+Revision ID: a7d4e2f9c1b8
+Revises: b3f1a9c2d7e4
+Create Date: 2026-06-02 10:00:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "a7d4e2f9c1b8"
+down_revision = "b3f1a9c2d7e4"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    for table in ("project", "project_template"):
+        with op.batch_alter_table(table, schema=None) as batch_op:
+            batch_op.add_column(
+                sa.Column(
+                    "is_single_preview_per_revision",
+                    sa.Boolean(),
+                    nullable=True,
+                    server_default=sa.text("false"),
+                )
+            )
+
+
+def downgrade():
+    for table in ("project", "project_template"):
+        with op.batch_alter_table(table, schema=None) as batch_op:
+            batch_op.drop_column("is_single_preview_per_revision")


### PR DESCRIPTION
**Problem**
- Some productions need to enforce a single preview file per revision, but Zou always allows extra previews (position > 1) to be added to a revision.

**Solution**
- Add an `is_single_preview_per_revision` boolean to `Project` and `ProjectTemplate` (migration adds it to both tables, nullable with default false).
- Reject adding an extra preview file to a revision with HTTP 400 (`TooManyPreviewFilesException`) when the option is enabled, enforced at the single choke point `add_preview_file_to_comment`.