### PR TITLE
[previews] Fix upload error messages, frame extraction and eraser rendering

### DIFF
--- a/tests/tasks/test_preview_processing_failure.py
+++ b/tests/tasks/test_preview_processing_failure.py
@@ -1,0 +1,69 @@
+import os
+
+from unittest import mock
+
+from tests.base import ApiDBTestCase
+
+
+class PreviewProcessingFailureTestCase(ApiDBTestCase):
+    """
+    A server-side movie processing failure (ffmpeg, storage...) must be
+    reported as a 500 with the underlying reason, not as a 400 mislabelled
+    as a normalization problem.
+    """
+
+    def setUp(self):
+        super(PreviewProcessingFailureTestCase, self).setUp()
+
+        self.generate_fixture_project_status()
+        self.generate_fixture_project()
+        self.generate_fixture_asset_type()
+        self.generate_fixture_asset()
+        self.generate_fixture_department()
+        self.generate_fixture_task_type()
+        self.generate_fixture_task_status()
+        self.generate_fixture_task_status_wip()
+        self.generate_fixture_person()
+        self.generate_fixture_assigner()
+        self.generate_fixture_task()
+
+        self.task_id = str(self.task.id)
+        self.wip_status_id = str(self.task_status_wip.id)
+
+    def add_movie_preview(self):
+        """
+        Create a comment, attach a preview slot and return the movie path.
+        """
+        path = f"/actions/tasks/{self.task_id}/comment/"
+        comment = self.post(
+            path,
+            {"task_status_id": self.wip_status_id, "comment": "c"},
+        )
+        path = (
+            f"/actions/tasks/{self.task_id}"
+            f"/comments/{comment['id']}/add-preview"
+        )
+        preview_file = self.post(path, {})
+        movie_path = self.get_fixture_file_path(
+            os.path.join("videos", "test_preview_tiles.mp4")
+        )
+        return preview_file["id"], movie_path
+
+    @mock.patch(
+        "zou.app.services.preview_files_service.prepare_and_store_movie"
+    )
+    def test_processing_failure_returns_500_with_reason(self, mocked):
+        mocked.side_effect = Exception("ffmpeg exploded")
+        preview_file_id, movie_path = self.add_movie_preview()
+
+        response = self.upload_file(
+            f"/pictures/preview-files/{preview_file_id}?normalize=false",
+            movie_path,
+            code=500,
+        )
+        message = response.get("message", "")
+        self.assertIn("processing failed", message)
+        self.assertIn("normalization disabled", message)
+        self.assertEqual(
+            response.get("data", {}).get("reason"), "ffmpeg exploded"
+        )

--- a/tests/tasks/test_preview_revision.py
+++ b/tests/tasks/test_preview_revision.py
@@ -70,7 +70,12 @@ class PreviewRevisionTestCase(ApiDBTestCase):
         comment2 = self.create_comment()
         path = f"/actions/tasks/{self.task_id}/comments/{comment2['id']}/add-preview"
         response = self.post(path, {"revision": 1}, code=400)
-        self.assertIn("already exists", response.get("message", ""))
+        message = response.get("message", "")
+        self.assertIn("already exists", message)
+        # The message must tell the user how to resolve the conflict and
+        # must not be mislabelled as a normalization problem.
+        self.assertIn("auto-increment", message)
+        self.assertNotIn("ormaliz", message)
 
     def test_extra_preview_same_revision_allowed(self):
         """

--- a/tests/utils/test_annotations.py
+++ b/tests/utils/test_annotations.py
@@ -734,6 +734,290 @@ class AnnotationsRendererTestCase(unittest.TestCase):
         # have been if A's translation was applied to B too) is white.
         # (This is the actual user-reported symptom.)
 
+    def test_eraser_punches_hole_in_filled_rect(self):
+        """
+        A filled red rect with a horizontal eraser path through the
+        middle should keep the top and bottom bands red and clear a
+        transparent band in the centre.
+
+        Path geometry: the eraser group is layout=fixed at origin
+        (0, 0) with the parent's local dimensions (100x100). A path
+        child with left=-30, top=-20, width=60, height=40 puts its
+        bbox-top-left at (-30, -20) in eraser-centered coords. The
+        path commands draw a horizontal line at y=20 in path-local
+        coords → spans (-30, 0) to (30, 0) in eraser-centered →
+        (70, 100) to (130, 100) in canvas, stroked 40px → covers
+        the band y≈80..120, x≈70..130 of the rect.
+        """
+        path = self._temp_image(size=(200, 200))
+        annotation = {
+            "drawing": {
+                "objects": [
+                    {
+                        "type": "rect",
+                        "left": 50,
+                        "top": 50,
+                        "width": 100,
+                        "height": 100,
+                        "fill": "#ff0000",
+                        "canvasWidth": 200,
+                        "canvasHeight": 200,
+                        "eraser": {
+                            "type": "eraser",
+                            "width": 100,
+                            "height": 100,
+                            "objects": [
+                                {
+                                    "type": "path",
+                                    "left": -30,
+                                    "top": -20,
+                                    "width": 60,
+                                    "height": 40,
+                                    "scaleX": 1,
+                                    "scaleY": 1,
+                                    "angle": 0,
+                                    "stroke": "#000",
+                                    "strokeWidth": 40,
+                                    "pathOffset": {"x": 30, "y": 20},
+                                    "path": [
+                                        ["M", 0, 20],
+                                        ["L", 60, 20],
+                                    ],
+                                }
+                            ],
+                        },
+                    }
+                ]
+            }
+        }
+        annotations_renderer.render_annotation_on_image(path, annotation)
+        image = Image.open(path)
+        # Top of the rect stays red.
+        self.assertPixelClose(image.getpixel((100, 60)), (255, 0, 0))
+        # Bottom of the rect stays red.
+        self.assertPixelClose(image.getpixel((100, 140)), (255, 0, 0))
+        # Centre of the rect is erased → background shows through (white).
+        self.assertPixelWhite(image.getpixel((100, 100)))
+
+    def test_eraser_follows_rotated_parent(self):
+        """
+        Eraser paths are stored in the parent's local centered frame:
+        rotating the parent rotates the erased band with it. A 90°
+        rotation of the rect above should turn the horizontal erased
+        band into a vertical erased band.
+        """
+        path = self._temp_image(size=(200, 200))
+        annotation = {
+            "drawing": {
+                "objects": [
+                    {
+                        "type": "rect",
+                        # 90° rotation around the original bbox centre
+                        # leaves the centre at (100, 100); fabric stores
+                        # the post-rotation left/top so that the rotated
+                        # bbox lines up with the centre.
+                        "left": 150,
+                        "top": 50,
+                        "width": 100,
+                        "height": 100,
+                        "angle": 90,
+                        "fill": "#ff0000",
+                        "canvasWidth": 200,
+                        "canvasHeight": 200,
+                        "eraser": {
+                            "type": "eraser",
+                            "width": 100,
+                            "height": 100,
+                            "objects": [
+                                {
+                                    "type": "path",
+                                    "left": -30,
+                                    "top": -20,
+                                    "width": 60,
+                                    "height": 40,
+                                    "scaleX": 1,
+                                    "scaleY": 1,
+                                    "angle": 0,
+                                    "stroke": "#000",
+                                    "strokeWidth": 40,
+                                    "pathOffset": {"x": 30, "y": 20},
+                                    "path": [
+                                        ["M", 0, 20],
+                                        ["L", 60, 20],
+                                    ],
+                                }
+                            ],
+                        },
+                    }
+                ]
+            }
+        }
+        annotations_renderer.render_annotation_on_image(path, annotation)
+        image = Image.open(path)
+        # After 90° rotation the erased band runs vertically through the
+        # centre. Top of the band is now erased…
+        self.assertPixelWhite(image.getpixel((100, 80)))
+        # …bottom too.
+        self.assertPixelWhite(image.getpixel((100, 120)))
+        # …and the left/right of the rect (now top/bottom in the rotated
+        # frame) stay red.
+        self.assertPixelClose(image.getpixel((75, 100)), (255, 0, 0))
+        self.assertPixelClose(image.getpixel((125, 100)), (255, 0, 0))
+
+    def test_eraser_on_one_object_does_not_affect_siblings(self):
+        """
+        Two filled rects side by side. Only the left one carries an
+        eraser; the right one must stay fully red.
+        """
+        path = self._temp_image(size=(300, 200))
+        eraser_payload = {
+            "type": "eraser",
+            "width": 80,
+            "height": 80,
+            "objects": [
+                {
+                    "type": "path",
+                    "left": -30,
+                    "top": -15,
+                    "width": 60,
+                    "height": 30,
+                    "scaleX": 1,
+                    "scaleY": 1,
+                    "angle": 0,
+                    "stroke": "#000",
+                    "strokeWidth": 30,
+                    "pathOffset": {"x": 30, "y": 15},
+                    "path": [["M", 0, 15], ["L", 60, 15]],
+                }
+            ],
+        }
+        annotation = {
+            "drawing": {
+                "objects": [
+                    {
+                        "type": "rect",
+                        "left": 40,
+                        "top": 60,
+                        "width": 80,
+                        "height": 80,
+                        "fill": "#ff0000",
+                        "canvasWidth": 300,
+                        "canvasHeight": 200,
+                        "eraser": eraser_payload,
+                    },
+                    {
+                        "type": "rect",
+                        "left": 180,
+                        "top": 60,
+                        "width": 80,
+                        "height": 80,
+                        "fill": "#ff0000",
+                        "canvasWidth": 300,
+                        "canvasHeight": 200,
+                    },
+                ]
+            }
+        }
+        annotations_renderer.render_annotation_on_image(path, annotation)
+        image = Image.open(path)
+        # Left rect centre is erased.
+        self.assertPixelWhite(image.getpixel((80, 100)))
+        # Right rect centre is intact.
+        self.assertPixelClose(image.getpixel((220, 100)), (255, 0, 0))
+
+    def test_eraser_on_psstroke_clears_segment(self):
+        """
+        A freehand stroke crossing the centre of the canvas with an
+        eraser path clipping its middle should keep its ends and lose
+        its centre.
+        """
+        path = self._temp_image(size=(200, 200))
+        annotation = {
+            "drawing": {
+                "objects": [
+                    {
+                        "type": "PSStroke",
+                        "stroke": "#0000ff",
+                        "strokeWidth": 10,
+                        "canvasWidth": 200,
+                        "canvasHeight": 200,
+                        "left": 30,
+                        "top": 95,
+                        "width": 140,
+                        "height": 10,
+                        "strokePoints": [
+                            {"x": 30, "y": 100, "pressure": 1.0},
+                            {"x": 170, "y": 100, "pressure": 1.0},
+                        ],
+                        "eraser": {
+                            "type": "eraser",
+                            "width": 140,
+                            "height": 10,
+                            "objects": [
+                                {
+                                    "type": "path",
+                                    "left": -25,
+                                    "top": -10,
+                                    "width": 50,
+                                    "height": 20,
+                                    "scaleX": 1,
+                                    "scaleY": 1,
+                                    "angle": 0,
+                                    "stroke": "#000",
+                                    "strokeWidth": 30,
+                                    "pathOffset": {"x": 25, "y": 10},
+                                    "path": [
+                                        ["M", 0, 10],
+                                        ["L", 50, 10],
+                                    ],
+                                }
+                            ],
+                        },
+                    }
+                ]
+            }
+        }
+        annotations_renderer.render_annotation_on_image(path, annotation)
+        image = Image.open(path)
+        # Left end of the stroke is still blue.
+        self.assertPixelClose(image.getpixel((40, 100)), (0, 0, 255))
+        # Right end is still blue.
+        self.assertPixelClose(image.getpixel((160, 100)), (0, 0, 255))
+        # Middle of the stroke has been erased.
+        self.assertPixelWhite(image.getpixel((100, 100)))
+
+    def test_empty_eraser_leaves_object_intact(self):
+        """
+        An object with an eraser carrying no paths should render
+        normally (no false-positive erasing of the whole shape).
+        """
+        path = self._temp_image(size=(200, 200))
+        annotation = {
+            "drawing": {
+                "objects": [
+                    {
+                        "type": "rect",
+                        "left": 50,
+                        "top": 50,
+                        "width": 100,
+                        "height": 100,
+                        "fill": "#ff0000",
+                        "canvasWidth": 200,
+                        "canvasHeight": 200,
+                        "eraser": {
+                            "type": "eraser",
+                            "width": 100,
+                            "height": 100,
+                            "objects": [],
+                        },
+                    }
+                ]
+            }
+        }
+        annotations_renderer.render_annotation_on_image(path, annotation)
+        image = Image.open(path)
+        self.assertPixelClose(image.getpixel((100, 100)), (255, 0, 0))
+
     def test_unknown_type_does_not_raise(self):
         path = self._temp_image()
         before = Image.open(path).getpixel((100, 100))

--- a/zou/app/__init__.py
+++ b/zou/app/__init__.py
@@ -32,6 +32,7 @@ from zou.app.indexer import indexing
 from zou.app.services.exception import (
     ModelWithRelationsDeletionException,
     PersonNotFoundException,
+    PreviewProcessingFailedException,
     TwoFactorAuthenticationRequiredException,
     WrongIdFormatException,
     WrongParameterException,
@@ -130,6 +131,11 @@ def id_parameter_format_error(error):
 @app.errorhandler(WrongParameterException)
 def wrong_parameter(error):
     return jsonify(error=True, message=str(error), data=error.dict), 400
+
+
+@app.errorhandler(PreviewProcessingFailedException)
+def preview_processing_failed(error):
+    return jsonify(error=True, message=str(error), data=error.dict), 500
 
 
 @app.errorhandler(ExpiredSignatureError)

--- a/zou/app/blueprints/previews/resources.py
+++ b/zou/app/blueprints/previews/resources.py
@@ -44,6 +44,7 @@ from zou.app.services.exception import (
     PreviewBackgroundFileNotFoundException,
     PreviewFileNotFoundException,
     PreviewFileReuploadNotAllowedException,
+    PreviewProcessingFailedException,
     WrongParameterException,
 )
 
@@ -353,17 +354,39 @@ class BaseNewPreviewFilePicture:
             )
             tasks_service.update_preview_file_info(preview_file)
         elif extension in ALLOWED_MOVIE_EXTENSION:
+            normalize = self.get_bool_parameter("normalize", "true")
             try:
-                normalize = self.get_bool_parameter("normalize", "true")
                 self.save_movie_preview(instance_id, uploaded_file, normalize)
-            except Exception as e:
-                current_app.logger.error(e, exc_info=1)
-                current_app.logger.error("Normalization failed.")
+            except WrongParameterException:
+                # Invalid upload (e.g. empty or corrupted transfer): the file
+                # itself is the problem, so keep the original 400 message.
                 deletion_service.remove_preview_file_by_id(
                     instance_id, force=True
                 )
                 if abort_on_failed:
-                    raise WrongParameterException("Normalization failed.")
+                    raise
+                return None
+            except Exception as e:
+                # Genuine server-side processing failure (ffmpeg, storage,
+                # normalization...): this is not the client's fault. Report it
+                # as a 500 and keep the underlying error so it can be
+                # diagnosed.
+                current_app.logger.error(e, exc_info=1)
+                if normalize:
+                    message = "Movie preview normalization failed."
+                else:
+                    message = (
+                        "Movie preview processing failed "
+                        "(normalization disabled)."
+                    )
+                current_app.logger.error(message)
+                deletion_service.remove_preview_file_by_id(
+                    instance_id, force=True
+                )
+                if abort_on_failed:
+                    raise PreviewProcessingFailedException(
+                        message, dict={"reason": str(e)}
+                    )
                 return None
             preview_file = preview_files_service.update_preview_file(
                 instance_id,
@@ -445,7 +468,9 @@ class CreatePreviewFilePictureResource(
                       description: File size in bytes
                       example: 1024000
           400:
-            description: Wrong file format or normalization failed
+            description: Wrong file format or invalid upload
+          500:
+            description: Movie preview processing failed (server-side)
         """
         self.is_allowed(instance_id)
 

--- a/zou/app/services/exception.py
+++ b/zou/app/services/exception.py
@@ -309,6 +309,18 @@ class WrongParameterException(Exception):
         self.dict = dict
 
 
+class PreviewProcessingFailedException(Exception):
+    """
+    Raised when a preview file could not be processed server-side
+    (e.g. ffmpeg normalization or file storage failure). This is an
+    internal failure, not a client error.
+    """
+
+    def __init__(self, message, dict=None):
+        super().__init__(message)
+        self.dict = dict
+
+
 class WrongIdFormatException(Exception):
     pass
 

--- a/zou/app/services/tasks_service.py
+++ b/zou/app/services/tasks_service.py
@@ -1800,7 +1800,9 @@ def check_revision_is_unique_for_task(
     existing = query.first()
     if existing is not None:
         raise RevisionAlreadyExistsException(
-            f"Revision {revision} already exists for this task."
+            f"Revision {revision} already exists for this task. "
+            "Choose a different revision number, or omit it to let the "
+            "revision auto-increment."
         )
 
 

--- a/zou/app/utils/annotations.py
+++ b/zou/app/utils/annotations.py
@@ -12,7 +12,7 @@ import math
 import os
 import re
 
-from PIL import Image, ImageColor, ImageDraw, ImageFont
+from PIL import Image, ImageChops, ImageColor, ImageDraw, ImageFont
 
 logger = logging.getLogger(__name__)
 
@@ -42,10 +42,9 @@ def render_annotation_on_image(image_path, annotation):
     image = Image.open(image_path).convert("RGBA")
     ss_size = (image.size[0] * SUPERSAMPLE, image.size[1] * SUPERSAMPLE)
     overlay = Image.new("RGBA", ss_size, (0, 0, 0, 0))
-    draw = ImageDraw.Draw(overlay)
 
     for obj in objects:
-        _draw_object(overlay, draw, obj, ss_size)
+        _draw_object(overlay, obj, ss_size)
 
     if SUPERSAMPLE != 1:
         overlay = overlay.resize(image.size, Image.LANCZOS)
@@ -54,11 +53,26 @@ def render_annotation_on_image(image_path, annotation):
     return image_path
 
 
-def _draw_object(overlay, draw, obj, image_size):
+def _draw_object(overlay, obj, image_size):
     if not isinstance(obj, dict):
         return
+    if isinstance(obj.get("eraser"), dict):
+        # The eraser punches holes via destination-out compositing, which
+        # Pillow primitives can't do in-place. Render the shape onto its
+        # own transparent layer, subtract the eraser mask from that layer's
+        # alpha channel, then composite the result back onto the overlay.
+        layer = Image.new("RGBA", overlay.size, (0, 0, 0, 0))
+        _dispatch_shape(layer, obj, image_size)
+        _apply_eraser(layer, obj, image_size)
+        overlay.alpha_composite(layer)
+    else:
+        _dispatch_shape(overlay, obj, image_size)
+
+
+def _dispatch_shape(target, obj, image_size):
     obj_type = (obj.get("type") or "").lower()
     scale_x, scale_y = _get_scales(obj, image_size)
+    draw = ImageDraw.Draw(target)
     try:
         if obj_type == "path":
             _draw_path(draw, obj, scale_x, scale_y)
@@ -75,18 +89,102 @@ def _draw_object(overlay, draw, obj, image_size):
         elif obj_type == "polygon":
             _draw_polygon(draw, obj, scale_x, scale_y)
         elif obj_type in ("i-text", "text", "textbox"):
-            _draw_text(overlay, obj, scale_x, scale_y)
+            _draw_text(target, obj, scale_x, scale_y)
         elif obj_type == "arrow":
             _draw_arrow(draw, obj, scale_x, scale_y)
         elif obj_type == "group":
             for child in obj.get("objects", []) or []:
-                _draw_object(overlay, draw, child, image_size)
+                _draw_object(target, child, image_size)
         else:
             logger.debug("Unsupported annotation type: %s", obj_type)
     except Exception:
         logger.exception(
             "Failed to render annotation object of type %s", obj_type
         )
+
+
+def _apply_eraser(layer, parent_obj, image_size):
+    """
+    Subtract the eraser mask from `layer`'s alpha channel.
+
+    The eraser is a fabric Group of paths in the PARENT's local centered
+    coordinate frame (eraser group sits at origin (0, 0) with the parent's
+    untransformed dimensions, with default `originX/Y='center'`). Each
+    child path is positioned within that frame via its own
+    `left/top/scaleX/scaleY/angle`. Path commands run from the path-local
+    frame → parent-centered frame → canvas frame → image frame.
+
+    Pillow has no destination-out compositing, so we stamp the eraser
+    paths onto an L-mode mask (255 = erased) and subtract that mask from
+    the layer's alpha. Anti-aliasing comes from the renderer's overall
+    supersample + LANCZOS downsample.
+    """
+    eraser = parent_obj.get("eraser")
+    if not isinstance(eraser, dict):
+        return
+    children = eraser.get("objects") or []
+    if not children:
+        return
+
+    scale_x, scale_y = _get_scales(parent_obj, image_size)
+    parent_centered = _make_object_transform(parent_obj, 0, 0)
+    parent_scale_x = parent_obj.get("scaleX", 1) or 1
+
+    mask = Image.new("L", layer.size, 0)
+    mask_draw = ImageDraw.Draw(mask)
+
+    for child in children:
+        if not isinstance(child, dict):
+            continue
+        if (child.get("type") or "").lower() != "path":
+            continue
+        _draw_eraser_path_on_mask(
+            mask_draw,
+            child,
+            parent_centered,
+            parent_scale_x,
+            scale_x,
+            scale_y,
+        )
+
+    if mask.getbbox() is None:
+        return
+
+    _, _, _, alpha = layer.split()
+    layer.putalpha(ImageChops.subtract(alpha, mask))
+
+
+def _draw_eraser_path_on_mask(
+    mask_draw, child, parent_centered, parent_scale_x, scale_x, scale_y
+):
+    raw = child.get("path")
+    if not raw:
+        return
+    commands = _parse_path_commands(raw)
+    if not commands:
+        return
+    anchors = _extract_path_anchor_points(commands)
+    # Child path local → eraser-centered (= parent-centered) coords.
+    child_transform = _centered_transform(
+        _with_default_bbox(child, anchors),
+        fallback_pivot=_bbox_centre(anchors),
+    )
+
+    def to_image(px, py):
+        ex, ey = child_transform(px, py)
+        cx_out, cy_out = parent_centered(ex, ey)
+        return cx_out * scale_x, cy_out * scale_y
+
+    # Eraser stroke width sits in the parent's local frame: it scales
+    # with the parent's transform (scaleX) before reaching canvas, then
+    # again with the canvas → image factor.
+    raw_width = child.get("strokeWidth", 1) or 1
+    pillow_width = max(1, int(round(raw_width * parent_scale_x * scale_x)))
+
+    segments = _path_to_segments(commands, to_image)
+    for points in segments:
+        if len(points) >= 2:
+            mask_draw.line(points, fill=255, width=pillow_width, joint="curve")
 
 
 def _get_scales(obj, image_size):
@@ -658,6 +756,19 @@ def _draw_path(draw, obj, scale_x, scale_y):
     def to_screen(px, py):
         return _to_image(transform(px, py), scale_x, scale_y)
 
+    segments = _path_to_segments(commands, to_screen)
+    for points in segments:
+        if len(points) >= 2:
+            draw.line(points, fill=color, width=width, joint="curve")
+
+
+def _path_to_segments(commands, to_point):
+    """
+    Flatten an SVG-like command list (M/L/Q/C/Z) into polyline
+    segments expressed via `to_point(px, py)` for every anchor and
+    sampled curve point. Shared by the path renderer and the eraser
+    mask renderer.
+    """
     segments = []
     current = None
     start = None
@@ -667,11 +778,11 @@ def _draw_path(draw, obj, scale_x, scale_y):
         if op == "M" and len(params) >= 2:
             if segments and len(segments[-1]) < 2:
                 segments.pop()
-            current = to_screen(params[0], params[1])
+            current = to_point(params[0], params[1])
             start = current
             segments.append([current])
         elif op == "L" and len(params) >= 2:
-            current = to_screen(params[0], params[1])
+            current = to_point(params[0], params[1])
             if not segments:
                 segments.append([])
             segments[-1].append(current)
@@ -681,16 +792,16 @@ def _draw_path(draw, obj, scale_x, scale_y):
             if not segments:
                 segments.append([])
             if current is None:
-                current = to_screen(cx, cy)
+                current = to_point(cx, cy)
                 segments[-1].append(current)
             segments[-1].extend(
-                _quad_points(current, to_screen(cx, cy), to_screen(ex, ey))
+                _quad_points(current, to_point(cx, cy), to_point(ex, ey))
             )
-            current = to_screen(ex, ey)
+            current = to_point(ex, ey)
         elif op == "C" and len(params) >= 6:
-            c1 = to_screen(params[0], params[1])
-            c2 = to_screen(params[2], params[3])
-            ep = to_screen(params[4], params[5])
+            c1 = to_point(params[0], params[1])
+            c2 = to_point(params[2], params[3])
+            ep = to_point(params[4], params[5])
             if not segments:
                 segments.append([])
             if current is None:
@@ -702,10 +813,7 @@ def _draw_path(draw, obj, scale_x, scale_y):
             if start is not None and segments and segments[-1]:
                 segments[-1].append(start)
             current = start
-
-    for points in segments:
-        if len(points) >= 2:
-            draw.line(points, fill=color, width=width, joint="curve")
+    return segments
 
 
 def _parse_path_commands(raw):

--- a/zou/utils/movie.py
+++ b/zou/utils/movie.py
@@ -55,8 +55,11 @@ def generate_thumbnail(movie_path):
     file_target_path = os.path.join(tempfile.gettempdir(), file_target_name)
 
     try:
+        # `update=1` lets the image2 muxer write a single PNG to a
+        # plain (non-pattern) filename on ffmpeg ≥ 6, which otherwise
+        # refuses the path and skips the write.
         ffmpeg.input(movie_path, ss="00:00:00").output(
-            file_target_path, vframes=1
+            file_target_path, vframes=1, update=1
         ).overwrite_output().run(quiet=True)
     except ffmpeg._run.Error as e:
         log_ffmpeg_error(e, "an error occured during generate_thumbnail")
@@ -81,8 +84,13 @@ def extract_frame_from_movie(movie_path, frame_number, movie_fps):
     ).to_time_string()
 
     try:
+        # ffmpeg ≥ 6 rejects non-pattern filenames in the image2 muxer
+        # unless `-update 1` is set. Without it the muxer logs "filename
+        # does not contain an image sequence pattern" and the frame is
+        # not always written. `update=1` keeps the single-PNG path
+        # explicit and works on older ffmpeg too.
         ffmpeg.input(movie_path, ss=frame_time).output(
-            file_target_path, vframes=1
+            file_target_path, vframes=1, update=1
         ).overwrite_output().run(quiet=False)
     except ffmpeg._run.Error as e:
         log_ffmpeg_error(e, "extracting_frame")


### PR DESCRIPTION
## Problems

- Preview upload failures were misleading: a revision conflict returned a bare 400, and movie processing failures were always labelled "Normalization failed" even when normalization was disabled
- Single-PNG-frame extraction produced inconsistent output because ffmpeg was not told it was overwriting an existing frame
- The eraser annotation field was not handled by the renderer, so erased strokes were not applied

## Solutions

- Make the revision-conflict message actionable, and report genuine server-side movie processing failures as 500 with the cause in `data.reason` (400 kept only for bad uploads)
- Pass `update=1` to ffmpeg when writing a single PNG frame
- Handle the eraser annotation field in the renderer