### PR TITLE
Add country field and support more fields in person CSV import/export

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -684,6 +684,7 @@ class ApiDBTestCase(ApiTestCase):
         last_name="Doe",
         desktop_login="john.doe",
         email="john.doe@gmail.com",
+        country=None,
     ):
         self.person = Person.get_by(email=email)
         if self.person is None:
@@ -693,6 +694,7 @@ class ApiDBTestCase(ApiTestCase):
                 desktop_login=desktop_login,
                 email=email,
                 password=_CACHED_PASSWORD_HASH,
+                country=country,
             )
         return self.person
 

--- a/tests/export/test_persons_to_csv.py
+++ b/tests/export/test_persons_to_csv.py
@@ -1,15 +1,36 @@
 from tests.base import ApiDBTestCase
 
+from zou.app.models.studio import Studio
+
 
 class PersonsCsvExportTestCase(ApiDBTestCase):
     def setUp(self):
         super(PersonsCsvExportTestCase, self).setUp()
 
-        self.generate_fixture_person()
+        # Creates departments "Modeling" and "Animation".
+        self.generate_fixture_department()
+        studio = Studio.create(name="Test Studio", color="#000000")
+        self.person = self.generate_fixture_person(country="fr")
+        self.person.update(
+            {
+                "position": "lead",
+                "seniority": "senior",
+                "daily_salary": 300,
+                "studio_id": studio.id,
+            }
+        )
+        self.person.set_departments(
+            [self.department.id, self.department_animation.id]
+        )
 
     def test_export(self):
         csv_persons = self.get_raw("/export/csv/persons.csv")
-        expected_result = """Last Name;First Name;Email;Phone;Role;Contract Type;Active\r
-Did;John;john.did@gmail.com;;admin;open-ended;yes\r
-Doe;John;john.doe@gmail.com;;user;open-ended;yes\r\n"""
+        expected_result = (
+            "First Name;Last Name;Email;Phone;Role;Departments;Studio;"
+            "Country;Contract Type;Position;Seniority;Daily Salary;Active\r\n"
+            "John;Did;john.did@gmail.com;;admin;;;;open-ended;artist;mid;0;"
+            "yes\r\n"
+            "John;Doe;john.doe@gmail.com;;user;Animation,Modeling;"
+            "Test Studio;FR;open-ended;lead;senior;300;yes\r\n"
+        )
         self.assertEqual(csv_persons, expected_result)

--- a/tests/fixtures/csv/persons.csv
+++ b/tests/fixtures/csv/persons.csv
@@ -1,3 +1,3 @@
-First Name,Last Name,Email,Phone
-John,Doe,john.doe@gmail.com,+33 6 08 08 08 08
-Ema,Doe,ema.doe@gmail.com, +33 6 08 08 08 09
+"First Name";"Last Name";"Email";"Phone";"Role";"Departments";"Studio";"Country";"Contract Type";"Position";"Seniority";"Daily Salary";"Active"
+"John";"Doe";"john.doe@gmail.com";"+33 6 08 08 08 08";"Artist";"Animation,Modeling";"Test Studio";"fr";"Open-ended";"Lead";"Senior";"320";"yes"
+"Ema";"Doe";"ema.doe@gmail.com";"+33 6 08 08 08 09";"supervisor";"Animation";"Test Studio";"US";"freelance";"artist";"junior";"450";"no"

--- a/tests/models/test_person.py
+++ b/tests/models/test_person.py
@@ -146,6 +146,103 @@ class PersonTestCase(ApiDBTestCase):
         self.assertEqual(data["first_name"], person_again["first_name"])
         self.put_404(f"data/persons/{fields.gen_uuid()}", data)
 
+    def test_person_country_round_trip(self):
+        data = {
+            "first_name": "Country",
+            "last_name": "Tester",
+            "email": "country.tester@gmail.com",
+            "country": "fr",  # lower-case input is normalized to "FR"
+        }
+        person = self.post("data/persons", data)
+        self.assertEqual(person["country"], "FR")
+
+        person_again = self.get(f"data/persons/{person['id']}")
+        self.assertEqual(person_again["country"], "FR")
+        person_with_relations = self.get(
+            f"data/persons/{person['id']}?relations=true"
+        )
+        self.assertEqual(person_with_relations["country"], "FR")
+        listed = next(
+            p for p in self.get("data/persons") if p["id"] == person["id"]
+        )
+        self.assertEqual(listed["country"], "FR")
+
+        self.put(f"data/persons/{person['id']}", {"country": "us"})
+        person_again = self.get(f"data/persons/{person['id']}")
+        self.assertEqual(person_again["country"], "US")
+
+        self.put(f"data/persons/{person['id']}", {"country": None})
+        person_again = self.get(f"data/persons/{person['id']}")
+        self.assertIsNone(person_again["country"])
+
+        self.put(f"data/persons/{person['id']}", {"country": ""})
+        person_again = self.get(f"data/persons/{person['id']}")
+        self.assertIsNone(person_again["country"])
+
+    def test_create_person_without_country(self):
+        data = {
+            "first_name": "NoCountry",
+            "last_name": "Doe",
+            "email": "no.country@gmail.com",
+        }
+        person = self.post("data/persons", data)
+        self.assertIsNone(person["country"])
+
+    def test_create_person_with_invalid_country(self):
+        data = {
+            "first_name": "Bad",
+            "last_name": "Country",
+            "email": "bad.country@gmail.com",
+            "country": "France",
+        }
+        self.post("data/persons", data, 400)
+
+    def test_update_person_with_invalid_country(self):
+        person = self.get_first("data/persons")
+        self.put(f"data/persons/{person['id']}", {"country": "xyz"}, 400)
+        self.put(f"data/persons/{person['id']}", {"country": "f1"}, 400)
+
+    def test_update_person_country_is_normalized(self):
+        person = self.get_first("data/persons")
+        self.put(f"data/persons/{person['id']}", {"country": " fr "})
+        person_again = self.get(f"data/persons/{person['id']}")
+        self.assertEqual(person_again["country"], "FR")
+
+    def test_update_person_with_non_ascii_country(self):
+        person = self.get_first("data/persons")
+        # Two non-ASCII letters must be rejected (isascii guard).
+        self.put(f"data/persons/{person['id']}", {"country": "éé"}, 400)
+
+    def test_update_person_with_non_string_country(self):
+        # A non-string body (int, or a single-element list as produced by a
+        # SAML assertion) must yield a clean 400, not a 500.
+        person = self.get_first("data/persons")
+        self.put(f"data/persons/{person['id']}", {"country": 123}, 400)
+        self.put(f"data/persons/{person['id']}", {"country": ["FR"]}, 400)
+
+    def test_country_validator_never_raises_on_direct_write(self):
+        # Direct writes (SSO sign-in, imports, scripts) bypass the API guard,
+        # so the model validator must silently discard bad input instead of
+        # raising.
+        person = Person.get_by(email="ema.doe@gmail.com")
+        person.update({"country": ["FR"]})
+        self.assertIsNone(person.country)
+        person.update({"country": 123})
+        self.assertIsNone(person.country)
+        person.update({"country": "FRA"})
+        self.assertIsNone(person.country)
+        person.update({"country": " us "})
+        self.assertEqual(person.country, "US")
+
+    def test_country_not_exposed_in_present_minimal(self):
+        # The minimal representation is served to non-managers (including
+        # external client/vendor roles), so it must not leak the country.
+        person = Person.get_by(email="ema.doe@gmail.com")
+        person.update({"country": "FR"})
+        self.assertNotIn("country", person.present_minimal())
+        safe = person.serialize_safe()
+        self.assertEqual(safe["country"], "FR")
+
     def test_update_person_with_duplicate_email(self):
         persons = sorted(self.get("data/persons"), key=itemgetter("email"))
         target = persons[0]

--- a/tests/models/test_person.py
+++ b/tests/models/test_person.py
@@ -1,11 +1,32 @@
 # -*- coding: UTF-8 -*-
+import unittest
+
 from tests.base import ApiDBTestCase
 from zou.app.models.department import Department
-from zou.app.models.person import Person
+from zou.app.models.person import Person, normalize_country
 
 from zou.app.utils import fields
 
 from operator import itemgetter
+
+
+class NormalizeCountryTestCase(unittest.TestCase):
+    """
+    Unit coverage for normalize_country, the single source of truth shared
+    by the model validator, the API guard and the CSV import.
+    """
+
+    def test_valid_codes_are_trimmed_and_uppercased(self):
+        for value, expected in [("fr", "FR"), ("FR", "FR"), (" us ", "US")]:
+            self.assertEqual(normalize_country(value), (True, expected))
+
+    def test_empty_values_mean_no_country(self):
+        for value in [None, "", "   "]:
+            self.assertEqual(normalize_country(value), (True, None))
+
+    def test_malformed_values_are_rejected(self):
+        for value in ["France", "FRA", "f", "f1", "éé", 123, ["FR"], 1.5]:
+            self.assertEqual(normalize_country(value), (False, None))
 
 
 class PersonTestCase(ApiDBTestCase):
@@ -171,6 +192,11 @@ class PersonTestCase(ApiDBTestCase):
         person_again = self.get(f"data/persons/{person['id']}")
         self.assertEqual(person_again["country"], "US")
 
+        # Whitespace is trimmed and the value upper-cased on update.
+        self.put(f"data/persons/{person['id']}", {"country": " fr "})
+        person_again = self.get(f"data/persons/{person['id']}")
+        self.assertEqual(person_again["country"], "FR")
+
         self.put(f"data/persons/{person['id']}", {"country": None})
         person_again = self.get(f"data/persons/{person['id']}")
         self.assertIsNone(person_again["country"])
@@ -198,27 +224,12 @@ class PersonTestCase(ApiDBTestCase):
         self.post("data/persons", data, 400)
 
     def test_update_person_with_invalid_country(self):
+        # The PUT guard rejects every malformed category with a clean 400
+        # (never a 500), including non-ASCII and non-string bodies such as an
+        # int or a single-element list from a SAML assertion.
         person = self.get_first("data/persons")
-        self.put(f"data/persons/{person['id']}", {"country": "xyz"}, 400)
-        self.put(f"data/persons/{person['id']}", {"country": "f1"}, 400)
-
-    def test_update_person_country_is_normalized(self):
-        person = self.get_first("data/persons")
-        self.put(f"data/persons/{person['id']}", {"country": " fr "})
-        person_again = self.get(f"data/persons/{person['id']}")
-        self.assertEqual(person_again["country"], "FR")
-
-    def test_update_person_with_non_ascii_country(self):
-        person = self.get_first("data/persons")
-        # Two non-ASCII letters must be rejected (isascii guard).
-        self.put(f"data/persons/{person['id']}", {"country": "éé"}, 400)
-
-    def test_update_person_with_non_string_country(self):
-        # A non-string body (int, or a single-element list as produced by a
-        # SAML assertion) must yield a clean 400, not a 500.
-        person = self.get_first("data/persons")
-        self.put(f"data/persons/{person['id']}", {"country": 123}, 400)
-        self.put(f"data/persons/{person['id']}", {"country": ["FR"]}, 400)
+        for value in ["France", "f1", "éé", 123, ["FR"]]:
+            self.put(f"data/persons/{person['id']}", {"country": value}, 400)
 
     def test_country_validator_never_raises_on_direct_write(self):
         # Direct writes (SSO sign-in, imports, scripts) bypass the API guard,

--- a/tests/source/csv/test_import_persons.py
+++ b/tests/source/csv/test_import_persons.py
@@ -1,24 +1,213 @@
 import os
+import tempfile
 
 from tests.base import ApiDBTestCase
 
 from zou.app.models.person import Person
+from zou.app.models.studio import Studio
 
 
 class ImportCsvPersonsTestCase(ApiDBTestCase):
+
+    columns = [
+        "First Name",
+        "Last Name",
+        "Email",
+        "Phone",
+        "Role",
+        "Departments",
+        "Studio",
+        "Country",
+        "Contract Type",
+        "Position",
+        "Seniority",
+        "Daily Salary",
+        "Active",
+    ]
+
     def setUp(self):
         super(ImportCsvPersonsTestCase, self).setUp()
-
-    def tearDown(self):
-        super(ImportCsvPersonsTestCase, self).tearDown()
+        # Creates departments "Modeling" and "Animation".
+        self.generate_fixture_department()
+        Studio.create(name="Test Studio", color="#000000")
 
     def test_import_persons(self):
-        path = "/import/csv/persons"
-
-        file_path_fixture = self.get_fixture_file_path(
-            os.path.join("csv", "persons.csv")
+        self.upload_file(
+            "/import/csv/persons",
+            self.get_fixture_file_path(os.path.join("csv", "persons.csv")),
         )
-        self.upload_file(path, file_path_fixture)
 
         persons = Person.query.all()
         self.assertEqual(len(persons), 3)
+
+        # First row mixes human labels (Artist / Lead / Senior / Open-ended)
+        # and a comma-separated department cell in a ";"-delimited file.
+        john = Person.get_by(email="john.doe@gmail.com")
+        self.assertEqual(john.role.code, "user")
+        self.assertEqual(john.position.code, "lead")
+        self.assertEqual(john.seniority.code, "senior")
+        self.assertEqual(john.contract_type.code, "open-ended")
+        self.assertEqual(john.country, "FR")
+        self.assertEqual(john.daily_salary, 320)
+        self.assertTrue(john.active)
+        self.assertEqual(
+            sorted(department.name for department in john.departments),
+            ["Animation", "Modeling"],
+        )
+        self.assertEqual(Studio.get(john.studio_id).name, "Test Studio")
+
+        # Second row uses stored codes (supervisor / artist / junior /
+        # freelance) instead of labels.
+        ema = Person.get_by(email="ema.doe@gmail.com")
+        self.assertEqual(ema.role.code, "supervisor")
+        self.assertEqual(ema.position.code, "artist")
+        self.assertEqual(ema.seniority.code, "junior")
+        self.assertEqual(ema.contract_type.code, "freelance")
+        self.assertEqual(ema.country, "US")
+        self.assertEqual(ema.daily_salary, 450)
+        self.assertFalse(ema.active)
+        self.assertEqual(
+            [department.name for department in ema.departments], ["Animation"]
+        )
+
+    def test_import_persons_update_replaces_departments(self):
+        self.upload_file(
+            "/import/csv/persons",
+            self.get_fixture_file_path(os.path.join("csv", "persons.csv")),
+        )
+        self._upload_csv(
+            self._csv(
+                **{
+                    "First Name": "John",
+                    "Last Name": "Doe",
+                    "Email": "john.doe@gmail.com",
+                    "Departments": "Animation",
+                }
+            ),
+            update=True,
+        )
+        john = Person.get_by(email="john.doe@gmail.com")
+        self.assertEqual(
+            [department.name for department in john.departments], ["Animation"]
+        )
+
+    def test_import_persons_update_replaces_scalar_fields(self):
+        # The update branch (person.update(data)) must persist the new scalar
+        # fields on an existing person, not just departments.
+        self.upload_file(
+            "/import/csv/persons",
+            self.get_fixture_file_path(os.path.join("csv", "persons.csv")),
+        )
+        Studio.create(name="Other Studio", color="#FFFFFF")
+        self._upload_csv(
+            self._csv(
+                **{
+                    "First Name": "John",
+                    "Last Name": "Doe",
+                    "Email": "john.doe@gmail.com",
+                    "Country": "us",
+                    "Position": "artist",
+                    "Seniority": "junior",
+                    "Daily Salary": "500",
+                    "Studio": "Other Studio",
+                }
+            ),
+            update=True,
+        )
+        john = Person.get_by(email="john.doe@gmail.com")
+        self.assertEqual(john.country, "US")
+        self.assertEqual(john.position.code, "artist")
+        self.assertEqual(john.seniority.code, "junior")
+        self.assertEqual(john.daily_salary, 500)
+        self.assertEqual(Studio.get(john.studio_id).name, "Other Studio")
+
+    def test_import_persons_existing_without_update_is_noop(self):
+        # Re-importing an existing email without ?update=true leaves the
+        # person untouched (scalar fields and departments) and still
+        # returns 201.
+        self.upload_file(
+            "/import/csv/persons",
+            self.get_fixture_file_path(os.path.join("csv", "persons.csv")),
+        )
+        self._upload_csv(
+            self._csv(
+                **{
+                    "First Name": "John",
+                    "Last Name": "Doe",
+                    "Email": "john.doe@gmail.com",
+                    "Country": "us",
+                    "Position": "artist",
+                    "Departments": "Animation",
+                }
+            )
+        )
+        john = Person.get_by(email="john.doe@gmail.com")
+        self.assertEqual(john.country, "FR")
+        self.assertEqual(john.position.code, "lead")
+        self.assertEqual(
+            sorted(department.name for department in john.departments),
+            ["Animation", "Modeling"],
+        )
+
+    def test_import_persons_invalid_country(self):
+        self._upload_csv(self._csv(Country="France"), code=400)
+
+    def test_import_persons_invalid_position(self):
+        self._upload_csv(self._csv(Position="Boss"), code=400)
+
+    def test_import_persons_invalid_daily_salary(self):
+        self._upload_csv(self._csv(**{"Daily Salary": "lots"}), code=400)
+
+    def test_import_persons_unknown_studio(self):
+        self._upload_csv(self._csv(Studio="Ghost Studio"), code=400)
+        self.assertIsNone(Person.get_by(email="test.user@gmail.com"))
+
+    def test_import_persons_unknown_department(self):
+        # Departments are resolved before the person is written, so a bad
+        # name fails the row without leaving an orphan person behind.
+        self._upload_csv(self._csv(Departments="Ghost"), code=400)
+        self.assertIsNone(Person.get_by(email="test.user@gmail.com"))
+
+    def test_import_persons_studio_and_department_are_case_sensitive(self):
+        # Studio "Test Studio" and department "Animation" exist; names are
+        # matched exactly, so a casing mismatch fails the row (400) without
+        # leaving an orphan person behind.
+        self._upload_csv(self._csv(Studio="test studio"), code=400)
+        self.assertIsNone(Person.get_by(email="test.user@gmail.com"))
+        self._upload_csv(self._csv(Departments="animation"), code=400)
+        self.assertIsNone(Person.get_by(email="test.user@gmail.com"))
+
+        # The exact names resolve as expected.
+        self._upload_csv(
+            self._csv(Studio="Test Studio", Departments="Animation")
+        )
+        person = Person.get_by(email="test.user@gmail.com")
+        self.assertEqual(Studio.get(person.studio_id).name, "Test Studio")
+        self.assertEqual(
+            [department.name for department in person.departments],
+            ["Animation"],
+        )
+
+    def _csv(self, **overrides):
+        values = {column: "" for column in self.columns}
+        values["First Name"] = "Test"
+        values["Last Name"] = "User"
+        values["Email"] = "test.user@gmail.com"
+        values.update(overrides)
+        header = ";".join(f'"{column}"' for column in self.columns)
+        row = ";".join(f'"{values[column]}"' for column in self.columns)
+        return f"{header}\n{row}\n"
+
+    def _upload_csv(self, content, code=201, update=False):
+        path = "/import/csv/persons"
+        if update:
+            path = f"{path}?update=true"
+        descriptor, file_path = tempfile.mkstemp(suffix=".csv")
+        try:
+            with os.fdopen(
+                descriptor, "w", encoding="utf-8", newline=""
+            ) as csv_file:
+                csv_file.write(content)
+            return self.upload_file(path, file_path, code)
+        finally:
+            os.remove(file_path)

--- a/zou/app/blueprints/auth/resources.py
+++ b/zou/app/blueprints/auth/resources.py
@@ -1464,7 +1464,8 @@ class SAMLSSOResource(Resource, ArgsMixin):
         person_info = {
             k: (
                 " ".join(v)
-                if isinstance(v, list) and k in ["first_name", "last_name"]
+                if isinstance(v, list)
+                and k in ["first_name", "last_name", "country"]
                 else v
             )
             for k, v in authn_response.ava.items()
@@ -1475,8 +1476,15 @@ class SAMLSSOResource(Resource, ArgsMixin):
                 "phone",
                 "departments",
                 "studio_id",
+                "country",
             ]
         }
+        # Align the country with its stored canonical form so an unchanged
+        # value does not re-trigger an update on every login.
+        if isinstance(person_info.get("country"), str):
+            person_info["country"] = (
+                person_info["country"].strip().upper() or None
+            )
         try:
             user = persons_service.get_person_by_email(email)
             for k, v in person_info.items():

--- a/zou/app/blueprints/auth/resources.py
+++ b/zou/app/blueprints/auth/resources.py
@@ -40,6 +40,7 @@ from zou.app.blueprints.auth.schemas import (
     FidoUnregisterSchema,
 )
 from zou.app.utils.email_i18n import get_email_translation
+from zou.app.models.person import normalize_country
 from zou.app.services import (
     persons_service,
     auth_service,
@@ -1480,11 +1481,16 @@ class SAMLSSOResource(Resource, ArgsMixin):
             ]
         }
         # Align the country with its stored canonical form so an unchanged
-        # value does not re-trigger an update on every login.
-        if isinstance(person_info.get("country"), str):
-            person_info["country"] = (
-                person_info["country"].strip().upper() or None
-            )
+        # value does not re-trigger an update on every login. An empty value
+        # clears the stored country (the IdP is authoritative), but a
+        # malformed value is dropped so a transient bad assertion neither
+        # wipes a previously stored valid code nor breaks the SSO sign-in.
+        if "country" in person_info:
+            is_valid, normalized = normalize_country(person_info["country"])
+            if is_valid:
+                person_info["country"] = normalized
+            else:
+                del person_info["country"]
         try:
             user = persons_service.get_person_by_email(email)
             for k, v in person_info.items():

--- a/zou/app/blueprints/crud/person.py
+++ b/zou/app/blueprints/crud/person.py
@@ -28,6 +28,28 @@ from zou.app.services.exception import (
 from zou.app import config
 
 
+def check_country(data):
+    """
+    Ensure the country, when provided, is an ISO 3166-1 alpha-2 code (two
+    letters). Empty values are treated as "no country" and accepted. The
+    stored value is normalized to uppercase by the Person model.
+    """
+    country = data.get("country")
+    if country is None:
+        return
+    if not isinstance(country, str):
+        raise WrongParameterException(
+            "Invalid country code, expected an ISO 3166-1 alpha-2 code."
+        )
+    country = country.strip()
+    if country != "" and (
+        len(country) != 2 or not country.isascii() or not country.isalpha()
+    ):
+        raise WrongParameterException(
+            "Invalid country code, expected an ISO 3166-1 alpha-2 code."
+        )
+
+
 class PersonsResource(BaseModelsResource):
     def __init__(self):
         BaseModelsResource.__init__(self, Person)
@@ -169,6 +191,10 @@ class PersonsResource(BaseModelsResource):
                     type: boolean
                     default: false
                     example: false
+                  country:
+                    type: string
+                    description: ISO 3166-1 alpha-2 country code (nullable)
+                    example: FR
         responses:
             201:
               description: Person created successfully
@@ -203,6 +229,10 @@ class PersonsResource(BaseModelsResource):
                       two_factor_authentication:
                         type: string
                         example: none
+                      country:
+                        type: string
+                        description: ISO 3166-1 alpha-2 country code (nullable)
+                        example: FR
                       access_token:
                         type: string
                         example: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9
@@ -270,6 +300,7 @@ class PersonsResource(BaseModelsResource):
             contract_type for contract_type, _ in CONTRACT_TYPES
         ]:
             raise WrongParameterException("Invalid contract_type")
+        check_country(data)
         if "two_factor_authentication" in data and data[
             "two_factor_authentication"
         ] not in [
@@ -404,6 +435,10 @@ class PersonResource(BaseModelResource, ArgsMixin):
                           type: string
                           format: uuid
                         example: []
+                      country:
+                        type: string
+                        description: ISO 3166-1 alpha-2 country code (nullable)
+                        example: FR
                       created_at:
                         type: string
                         format: date-time
@@ -478,6 +513,10 @@ class PersonResource(BaseModelResource, ArgsMixin):
                     format: date
                     example: "2025-12-31"
                     description: Person or admin only
+                  country:
+                    type: string
+                    description: ISO 3166-1 alpha-2 country code (nullable)
+                    example: FR
         responses:
             200:
               description: Person updated successfully
@@ -518,6 +557,10 @@ class PersonResource(BaseModelResource, ArgsMixin):
                           type: string
                           format: uuid
                         example: []
+                      country:
+                        type: string
+                        description: ISO 3166-1 alpha-2 country code (nullable)
+                        example: FR
                       access_token:
                         type: string
                         example: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9
@@ -564,6 +607,7 @@ class PersonResource(BaseModelResource, ArgsMixin):
             contract_type for contract_type, _ in CONTRACT_TYPES
         ]:
             raise WrongParameterException("Invalid contract_type")
+        check_country(data)
         if "two_factor_authentication" in data and data[
             "two_factor_authentication"
         ] not in [

--- a/zou/app/blueprints/crud/person.py
+++ b/zou/app/blueprints/crud/person.py
@@ -8,6 +8,7 @@ from zou.app.models.person import (
     ROLE_TYPES,
     CONTRACT_TYPES,
     TWO_FACTOR_AUTHENTICATION_TYPES,
+    normalize_country,
 )
 from zou.app.services import (
     deletion_service,
@@ -30,21 +31,12 @@ from zou.app import config
 
 def check_country(data):
     """
-    Ensure the country, when provided, is an ISO 3166-1 alpha-2 code (two
-    letters). Empty values are treated as "no country" and accepted. The
-    stored value is normalized to uppercase by the Person model.
+    Reject an invalid country code with a clean 400. Empty or missing values
+    are treated as "no country" and accepted. The stored value is normalized
+    to uppercase by the Person model.
     """
-    country = data.get("country")
-    if country is None:
-        return
-    if not isinstance(country, str):
-        raise WrongParameterException(
-            "Invalid country code, expected an ISO 3166-1 alpha-2 code."
-        )
-    country = country.strip()
-    if country != "" and (
-        len(country) != 2 or not country.isascii() or not country.isalpha()
-    ):
+    is_valid, _ = normalize_country(data.get("country"))
+    if not is_valid:
         raise WrongParameterException(
             "Invalid country code, expected an ISO 3166-1 alpha-2 code."
         )

--- a/zou/app/blueprints/export/csv/persons.py
+++ b/zou/app/blueprints/export/csv/persons.py
@@ -1,13 +1,16 @@
 from zou.app.blueprints.export.csv.base import BaseCsvExport
 from flask_jwt_extended import jwt_required
+from sqlalchemy.orm import selectinload
 
 from zou.app.models.person import Person
+from zou.app.models.studio import Studio
 
 
 class PersonsCsvExport(BaseCsvExport):
     def __init__(self):
         BaseCsvExport.__init__(self)
         self.file_name = "people_export"
+        self.studio_cache = {}
 
     @jwt_required()
     def get(self):
@@ -16,9 +19,10 @@ class PersonsCsvExport(BaseCsvExport):
         ---
         tags:
           - Export
-        description: Export persons as CSV file. Includes person information
-          with last name, first name, email, phone, role, contract type,
-          and active status. Excludes bot accounts.
+        description: Export persons as CSV file. Includes first name, last
+          name, email, phone, role, departments, studio, country, contract
+          type, position, seniority, daily salary and active status.
+          Excludes bot accounts.
         produces:
           - text/csv
         responses:
@@ -28,36 +32,55 @@ class PersonsCsvExport(BaseCsvExport):
                 text/csv:
                   schema:
                     type: string
-                  example: "Last Name,First Name,Email,Phone,Role,Contract Type,Active\nDoe,John,john.doe@example.com,+1234567890,user,freelance,yes"
+                  example: "First Name;Last Name;Email;Phone;Role;Departments;Studio;Country;Contract Type;Position;Seniority;Daily Salary;Active\nJohn;Doe;john.doe@example.com;+1234567890;user;Animation;Paris;FR;freelance;artist;mid;320;yes"
         """
         return super().get()
 
     def build_headers(self):
         return [
-            "Last Name",
             "First Name",
+            "Last Name",
             "Email",
             "Phone",
             "Role",
+            "Departments",
+            "Studio",
+            "Country",
             "Contract Type",
+            "Position",
+            "Seniority",
+            "Daily Salary",
             "Active",
         ]
 
     def build_query(self):
-        return Person.query.filter(
-            Person.is_bot.isnot(True), Person.is_guest.isnot(True)
-        ).order_by(Person.last_name, Person.first_name)
+        return (
+            Person.query.options(selectinload(Person.departments))
+            .filter(Person.is_bot.isnot(True), Person.is_guest.isnot(True))
+            .order_by(Person.last_name, Person.first_name)
+        )
+
+    def get_studio_name(self, studio_id):
+        if studio_id is None:
+            return ""
+        if studio_id not in self.studio_cache:
+            self.studio_cache[studio_id] = Studio.get(studio_id)
+        studio = self.studio_cache[studio_id]
+        return studio.name if studio is not None else ""
 
     def build_row(self, person):
-        active = "yes"
-        if not person.active:
-            active = "no"
         return [
-            person.last_name,
             person.first_name,
+            person.last_name,
             person.email,
             person.phone,
             person.role.code,
+            ",".join(sorted(d.name for d in person.departments)),
+            self.get_studio_name(person.studio_id),
+            person.country or "",
             person.contract_type.code,
-            active,
+            person.position.code if person.position else "",
+            person.seniority.code if person.seniority else "",
+            person.daily_salary if person.daily_salary is not None else "",
+            "yes" if person.active else "no",
         ]

--- a/zou/app/blueprints/source/csv/persons.py
+++ b/zou/app/blueprints/source/csv/persons.py
@@ -1,6 +1,18 @@
-from zou.app.blueprints.source.csv.base import BaseCsvImportResource
+from zou.app.blueprints.source.csv.base import (
+    BaseCsvImportResource,
+    RowException,
+)
 
-from zou.app.models.person import Person, ROLE_TYPES, CONTRACT_TYPES
+from zou.app.models.person import (
+    Person,
+    ROLE_TYPES,
+    CONTRACT_TYPES,
+    POSITION_TYPES,
+    SENIORITY_TYPES,
+    normalize_country,
+)
+from zou.app.models.department import Department
+from zou.app.models.studio import Studio
 from zou.app.services import index_service
 from zou.app.utils import permissions
 
@@ -15,8 +27,9 @@ class PersonsCsvImportResource(BaseCsvImportResource):
         tags:
           - Import
         description: Import persons from a CSV file. Creates or updates
-          persons based on CSV rows. Supports role, contract type, and
-          active status updates.
+          persons based on CSV rows. Supports first/last name, email, phone,
+          role, departments, studio, country, contract type, position,
+          seniority, daily salary and active status.
         consumes:
           - multipart/form-data
         parameters:
@@ -60,6 +73,35 @@ class PersonsCsvImportResource(BaseCsvImportResource):
                         phone:
                           type: string
                           example: +1234567890
+                        role:
+                          type: string
+                          example: user
+                        departments:
+                          type: array
+                          items:
+                            type: string
+                            format: uuid
+                          example: []
+                        studio_id:
+                          type: string
+                          format: uuid
+                          example: null
+                        country:
+                          type: string
+                          description: ISO 3166-1 alpha-2 country code (nullable)
+                          example: FR
+                        contract_type:
+                          type: string
+                          example: open-ended
+                        position:
+                          type: string
+                          example: lead
+                        seniority:
+                          type: string
+                          example: senior
+                        daily_salary:
+                          type: integer
+                          example: 320
                         active:
                           type: boolean
                           example: true
@@ -76,6 +118,14 @@ class PersonsCsvImportResource(BaseCsvImportResource):
         self.contract_types_map = {
             contract[1]: contract[0] for contract in CONTRACT_TYPES
         }
+        self.position_types_map = {
+            position[1]: position[0] for position in POSITION_TYPES
+        }
+        self.seniority_types_map = {
+            seniority[1]: seniority[0] for seniority in SENIORITY_TYPES
+        }
+        self.studio_cache = {}
+        self.department_cache = {}
 
     def import_row(self, row):
         first_name = row["First Name"]
@@ -84,32 +134,106 @@ class PersonsCsvImportResource(BaseCsvImportResource):
         phone = row.get("Phone", None)
         role = row.get("Role", None)
         contract_type = row.get("Contract Type", None)
+        position = row.get("Position", None)
+        seniority = row.get("Seniority", None)
+        country = row.get("Country", None)
+        daily_salary = row.get("Daily Salary", None)
+        studio_name = row.get("Studio", None)
+        departments_value = row.get("Departments", None)
         active = row.get("Active", None)
 
         data = {"first_name": first_name, "last_name": last_name}
         if role:
-            if role in self.role_types_map.keys():
-                role = self.role_types_map[role]
-            elif role not in self.role_types_map.values():
-                raise ValueError(f"Role: {role}")
-            data["role"] = role
+            data["role"] = self.map_choice("Role", role, self.role_types_map)
         if contract_type:
-            if contract_type in self.contract_types_map.keys():
-                contract_type = self.contract_types_map[contract_type]
-            elif contract_type not in self.contract_types_map.values():
-                raise ValueError(f"Contract Type: {contract_type}")
-            data["contract_type"] = contract_type
+            data["contract_type"] = self.map_choice(
+                "Contract Type", contract_type, self.contract_types_map
+            )
+        if position:
+            data["position"] = self.map_choice(
+                "Position", position, self.position_types_map
+            )
+        if seniority:
+            data["seniority"] = self.map_choice(
+                "Seniority", seniority, self.seniority_types_map
+            )
+        # Share the Person model rule (ISO 3166-1 alpha-2) but fail the row
+        # instead of silently storing None like the model validator.
+        is_valid_country, normalized_country = normalize_country(country)
+        if not is_valid_country:
+            raise ValueError(f"Country: {country}")
+        if normalized_country:
+            data["country"] = normalized_country
+        if daily_salary:
+            try:
+                data["daily_salary"] = int(daily_salary)
+            except ValueError:
+                raise ValueError(f"Daily Salary: {daily_salary}")
+        if studio_name:
+            studio = self.add_to_cache_if_absent(
+                self.studio_cache,
+                lambda name: Studio.get_by(name=name),
+                studio_name,
+            )
+            if studio is None:
+                raise RowException(f"Studio not found: {studio_name}")
+            data["studio_id"] = studio.id
         if phone:
             data["phone"] = phone
         if active:
             data["active"] = strtobool(active)
 
+        # Resolve departments before any write so an unknown name fails the
+        # row without leaving an orphan person behind.
+        department_ids = None
+        if departments_value:
+            department_ids = self.resolve_departments(departments_value)
+
         person = Person.get_by(email=email, is_bot=False)
-        if person is None:
+        created = person is None
+        if created:
             data["email"] = email
             data["password"] = None
             person = Person.create(**data)
         elif self.is_update:
             person.update(data)
+
+        if (created or self.is_update) and department_ids is not None:
+            person.set_departments(department_ids)
+
         index_service.index_person(person)
         return person.serialize_safe()
+
+    def map_choice(self, label, value, choice_map):
+        """
+        Accept either a human label ("Lead") or a stored code ("lead") for a
+        ChoiceType column and return the code. Raise ValueError (400) on an
+        unknown value, like the other typed columns.
+        """
+        if value in choice_map:
+            return choice_map[value]
+        if value not in choice_map.values():
+            raise ValueError(f"{label}: {value}")
+        return value
+
+    def resolve_departments(self, departments_value):
+        """
+        Turn a comma-separated list of department names into a list of UUIDs,
+        raising RowException (400) on any unknown name. Names are matched
+        exactly (case-sensitive), like the other typed columns.
+        """
+        department_ids = []
+        for name in [
+            name.strip()
+            for name in departments_value.split(",")
+            if name.strip()
+        ]:
+            department = self.add_to_cache_if_absent(
+                self.department_cache,
+                lambda name: Department.get_by(name=name),
+                name,
+            )
+            if department is None:
+                raise RowException(f"Department not found: {name}")
+            department_ids.append(department.id)
+        return department_ids

--- a/zou/app/models/person.py
+++ b/zou/app/models/person.py
@@ -1,3 +1,5 @@
+import logging
+
 from sqlalchemy_utils import (
     UUIDType,
     EmailType,
@@ -7,6 +9,7 @@ from sqlalchemy_utils import (
 )
 from sqlalchemy import Index
 from sqlalchemy.ext.hybrid import hybrid_property
+from sqlalchemy.orm import validates
 from sqlalchemy.dialects.postgresql import JSONB
 
 from pytz import timezone as pytz_timezone
@@ -17,6 +20,8 @@ from zou.app.models.department import Department
 from zou.app.models.base import BaseMixin
 from zou.app import db
 from zou.app.stores import config_store
+
+logger = logging.getLogger(__name__)
 
 TWO_FACTOR_AUTHENTICATION_TYPES = [
     ("totp", "TOTP"),
@@ -88,6 +93,7 @@ class Person(db.Model, BaseMixin, SerializerMixin):
     last_name = db.Column(db.String(80), nullable=False)
     email = db.Column(EmailType)
     phone = db.Column(db.String(30))
+    country = db.Column(db.String(2))
     contract_type = db.Column(
         ChoiceType(CONTRACT_TYPES), default="open-ended", nullable=False
     )
@@ -164,6 +170,36 @@ class Person(db.Model, BaseMixin, SerializerMixin):
 
     def __repr__(self):
         return f"<Person {self.full_name}>"
+
+    @validates("country")
+    def validate_country(self, key, value):
+        """
+        Normalize ISO 3166-1 alpha-2 country codes to their canonical
+        uppercase form. Empty or malformed values (not two ASCII letters)
+        are stored as None. API requests are rejected upstream with a clean
+        400 error; this is the last-resort guard for direct writes (SSO
+        sign-in, imports, scripts) that never raises, even on non-string
+        input (e.g. a single-element list from a SAML assertion).
+        """
+        if value is None:
+            return None
+        if not isinstance(value, str):
+            logger.warning(
+                f"Discarded non-string country value for person: {value!r}"
+            )
+            return None
+        normalized = value.strip().upper()
+        if (
+            len(normalized) == 2
+            and normalized.isascii()
+            and normalized.isalpha()
+        ):
+            return normalized
+        if normalized != "":
+            logger.warning(
+                f"Discarded invalid country code for person: {value!r}"
+            )
+        return None
 
     @hybrid_property
     def full_name(self):

--- a/zou/app/models/person.py
+++ b/zou/app/models/person.py
@@ -60,6 +60,33 @@ SENIORITY_TYPES = [
 ]
 
 
+def normalize_country(value):
+    """
+    Normalize an ISO 3166-1 alpha-2 country code to its canonical uppercase
+    form. Returns an ``(is_valid, normalized)`` tuple:
+
+      - ``(True, "FR")`` for a valid two-letter code (any casing/whitespace);
+      - ``(True, None)`` for an empty or ``None`` value (i.e. "no country");
+      - ``(False, None)`` for a malformed value (wrong length, non-ASCII,
+        non-alphabetic, or non-string input such as a SAML single-element
+        list).
+
+    Single source of truth shared by the API guard (raises 400 on invalid),
+    the CSV import (fails the row on invalid) and the model validator
+    (silently discards invalid).
+    """
+    if value is None:
+        return True, None
+    if not isinstance(value, str):
+        return False, None
+    normalized = value.strip().upper()
+    if normalized == "":
+        return True, None
+    if len(normalized) == 2 and normalized.isascii() and normalized.isalpha():
+        return True, normalized
+    return False, None
+
+
 class DepartmentLink(db.Model):
     __tablename__ = "department_link"
     person_id = db.Column(
@@ -175,31 +202,18 @@ class Person(db.Model, BaseMixin, SerializerMixin):
     def validate_country(self, key, value):
         """
         Normalize ISO 3166-1 alpha-2 country codes to their canonical
-        uppercase form. Empty or malformed values (not two ASCII letters)
-        are stored as None. API requests are rejected upstream with a clean
-        400 error; this is the last-resort guard for direct writes (SSO
-        sign-in, imports, scripts) that never raises, even on non-string
-        input (e.g. a single-element list from a SAML assertion).
+        uppercase form. Empty or malformed values are stored as None. API
+        requests and CSV imports are rejected upstream with a clean error;
+        this is the last-resort guard for direct writes (SSO sign-in,
+        scripts) that never raises, even on non-string input (e.g. a
+        single-element list from a SAML assertion).
         """
-        if value is None:
-            return None
-        if not isinstance(value, str):
+        is_valid, normalized = normalize_country(value)
+        if not is_valid:
             logger.warning(
-                f"Discarded non-string country value for person: {value!r}"
+                f"Discarded invalid country value for person: {value!r}"
             )
-            return None
-        normalized = value.strip().upper()
-        if (
-            len(normalized) == 2
-            and normalized.isascii()
-            and normalized.isalpha()
-        ):
-            return normalized
-        if normalized != "":
-            logger.warning(
-                f"Discarded invalid country code for person: {value!r}"
-            )
-        return None
+        return normalized
 
     @hybrid_property
     def full_name(self):

--- a/zou/app/services/persons_service.py
+++ b/zou/app/services/persons_service.py
@@ -340,6 +340,7 @@ def create_person(
     is_bot=False,
     expiration_date=None,
     studio_id=None,
+    country=None,
     active=True,
     serialize=True,
 ):
@@ -382,6 +383,7 @@ def create_person(
         is_bot=is_bot,
         expiration_date=expiration_date,
         studio_id=studio_id,
+        country=country,
         active=active,
     )
     if is_bot:

--- a/zou/migrations/versions/b1f3c7d29e84_add_country_to_person.py
+++ b/zou/migrations/versions/b1f3c7d29e84_add_country_to_person.py
@@ -1,0 +1,28 @@
+"""add country to person
+
+Revision ID: b1f3c7d29e84
+Revises: a7d4e2f9c1b8
+Create Date: 2026-06-01 10:00:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "b1f3c7d29e84"
+down_revision = "a7d4e2f9c1b8"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("person", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column("country", sa.String(length=2), nullable=True)
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("person", schema=None) as batch_op:
+        batch_op.drop_column("country")


### PR DESCRIPTION
**Problem**
- Person has no country, which the carbon-footprint plugin needs to estimate travel emissions.
- CSV person import/export only covers name, email, phone, role and contract type, so studios cannot bulk-manage country, position, seniority, daily salary, studio and departments.
- ISO 3166-1 country validation would otherwise be duplicated across the model, the API, the CSV import and the SAML SSO path.

**Solution**
- Add a nullable ISO 3166-1 alpha-2 `country` column on Person, validated and uppercased, settable via POST/PUT and SAML SSO, and kept out of the minimal (non-manager) payload.
- Import/export country, position, seniority, daily salary, studio and departments; typed columns accept either the human label or the stored code, studio/department names match exactly (case-sensitive), and invalid values fail the row with a 400.
- Factor the validation into a single `normalize_country` helper shared by the model validator (silently discards), the API guard (400) and the CSV import (fails the row).
- On SAML SSO, normalize the country to its canonical form so an unchanged value no longer re-triggers an update on every login; an empty value clears it while a malformed assertion is ignored rather than wiping a stored code or breaking sign-in.
- Add a migration for the nullable `country` column.
