### PR TITLE
Fixes on People and Shared Playlist

### DIFF
--- a/tests/export/test_persons_to_csv.py
+++ b/tests/export/test_persons_to_csv.py
@@ -1,5 +1,6 @@
 from tests.base import ApiDBTestCase
 
+from zou.app.models.person import Person
 from zou.app.models.studio import Studio
 
 
@@ -24,10 +25,26 @@ class PersonsCsvExportTestCase(ApiDBTestCase):
         )
 
     def test_export(self):
+        # Two extra fixtures pin the export ordering in the same assertion:
+        # - "Aaron Zzz" would land last under a last_name-primary sort, so
+        #   its first position proves the sort is first-name primary.
+        # - "bob" (lower-case) would land after "John" under a case-sensitive
+        #   byte-order sort (a-z > A-Z); interleaving it between "Aaron" and
+        #   "John" proves the sort is case-insensitive.
+        Person.create(
+            first_name="Aaron", last_name="Zzz", email="aaron.zzz@gmail.com"
+        )
+        Person.create(
+            first_name="bob", last_name="Aaa", email="bob.aaa@gmail.com"
+        )
         csv_persons = self.get_raw("/export/csv/persons.csv")
         expected_result = (
             "First Name;Last Name;Email;Phone;Role;Departments;Studio;"
             "Country;Contract Type;Position;Seniority;Daily Salary;Active\r\n"
+            "Aaron;Zzz;aaron.zzz@gmail.com;;user;;;;open-ended;artist;mid;0;"
+            "yes\r\n"
+            "bob;Aaa;bob.aaa@gmail.com;;user;;;;open-ended;artist;mid;0;"
+            "yes\r\n"
             "John;Did;john.did@gmail.com;;admin;;;;open-ended;artist;mid;0;"
             "yes\r\n"
             "John;Doe;john.doe@gmail.com;;user;Animation,Modeling;"

--- a/tests/persons/test_person_routes.py
+++ b/tests/persons/test_person_routes.py
@@ -1,6 +1,8 @@
 from tests.base import ApiDBTestCase
 
 from zou.app.models.day_off import DayOff
+from zou.app.models.person import Person
+from zou.app.utils import auth
 
 
 class PersonRoutesTestCase(ApiDBTestCase):
@@ -159,6 +161,38 @@ class PersonRoutesTestCase(ApiDBTestCase):
             200,
         )
         self.assertTrue(result.get("success"))
+
+    def test_change_password_for_new_admin(self):
+        new_admin = Person.create(
+            first_name="New",
+            last_name="Admin",
+            role="admin",
+            email="new.admin@gmail.com",
+        )
+        result = self.post(
+            f"/actions/persons/{new_admin.id}/change-password",
+            {"password": "newpassword123", "password_2": "newpassword123"},
+            200,
+        )
+        self.assertTrue(result.get("success"))
+
+    def test_change_password_for_existing_admin_is_blocked(self):
+        other_admin = Person.create(
+            first_name="Other",
+            last_name="Admin",
+            role="admin",
+            email="other.admin@gmail.com",
+            password=auth.encrypt_password("existingpassword"),
+        )
+        result = self.post(
+            f"/actions/persons/{other_admin.id}/change-password",
+            {"password": "newpassword123", "password_2": "newpassword123"},
+            400,
+        )
+        self.assertEqual(
+            result.get("message"),
+            "An admin can't change another admin's password.",
+        )
 
     def test_clear_avatar(self):
         self.delete(f"/actions/persons/{self.person_id}/clear-avatar")

--- a/tests/shared/test_playlist_sharing.py
+++ b/tests/shared/test_playlist_sharing.py
@@ -796,3 +796,200 @@ class PlaylistSharingTestCase(ApiDBTestCase):
             f"/preview-files/{other_revision.id}/download"
         )
         self.assertEqual(response.status_code, 403)
+
+    # --- Shared original picture by extension (gif, svg, jpg, ...) ---
+
+    def _attach_gif_preview_to_playlist(self):
+        """
+        Create an animated-GIF still preview with real bytes on disk and
+        wire it into the playlist's shots, the way an uploaded GIF is
+        stored (under the ``previews`` prefix, extension ``gif``).
+        """
+        import tempfile
+
+        from zou.app.models.playlist import Playlist as PlaylistModel
+        from zou.app.models.preview_file import PreviewFile
+        from zou.app.stores import file_store
+
+        preview_file = PreviewFile.create(
+            name="loop.gif",
+            revision=1,
+            extension="gif",
+            task_id=self.task.id,
+            person_id=self.person.id,
+        )
+        payload = b"GIF89a-fake-animated-payload"
+        with tempfile.NamedTemporaryFile(suffix=".gif", delete=False) as tmp:
+            tmp.write(payload)
+            tmp_path = tmp.name
+        file_store.add_file("previews", str(preview_file.id), tmp_path)
+        self.addCleanup(
+            file_store.remove_file, "previews", str(preview_file.id)
+        )
+
+        PlaylistModel.get(self.playlist["id"]).update(
+            {
+                "shots": [
+                    {
+                        "id": str(self.asset.id),
+                        "preview_file_id": str(preview_file.id),
+                        "preview_file_task_id": str(self.task.id),
+                    }
+                ]
+            }
+        )
+        return preview_file, payload
+
+    def test_shared_original_gif(self):
+        """
+        A GIF still preview in a shared playlist must be served through
+        the originals picture path. The ``.png``-only shared route did
+        not match ``.gif`` (or any non-PNG extension), so animated GIFs
+        404'd through a share link.
+        """
+        preview_file, payload = self._attach_gif_preview_to_playlist()
+        link = self.post(
+            f"/data/playlists/{self.playlist['id']}/share",
+            {},
+            201,
+        )
+        self.log_out()
+        response = self.app.get(
+            f"/shared/playlists/{link['token']}"
+            f"/pictures/originals/preview-files/{preview_file.id}.gif"
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data, payload)
+
+    def test_shared_original_gif_not_in_playlist(self):
+        """
+        A GIF preview that the shared playlist does not expose cannot be
+        fetched through its share link, even with a valid token.
+        """
+        from zou.app.models.preview_file import PreviewFile
+
+        foreign = PreviewFile.create(
+            name="foreign.gif",
+            revision=1,
+            extension="gif",
+            task_id=self.task.id,
+            person_id=self.person.id,
+        )
+        link = self.post(
+            f"/data/playlists/{self.playlist['id']}/share",
+            {},
+            201,
+        )
+        self.log_out()
+        response = self.app.get(
+            f"/shared/playlists/{link['token']}"
+            f"/pictures/originals/preview-files/{foreign.id}.gif"
+        )
+        self.assertEqual(response.status_code, 403)
+
+    def test_shared_original_extension_not_allowed(self):
+        """
+        Disallowed extensions are rejected with a 400, mirroring the
+        authenticated generic originals route.
+        """
+        preview_file, _ = self._attach_gif_preview_to_playlist()
+        link = self.post(
+            f"/data/playlists/{self.playlist['id']}/share",
+            {},
+            201,
+        )
+        self.log_out()
+        response = self.app.get(
+            f"/shared/playlists/{link['token']}"
+            f"/pictures/originals/preview-files/{preview_file.id}.exe"
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_shared_original_png_still_served(self):
+        """
+        Regression guard: the static ``.png`` originals route must keep
+        winning over the new generic ``.<extension>`` route, and a PNG
+        original (stored under the ``original`` picture prefix) is served.
+        """
+        import tempfile
+
+        from zou.app.models.playlist import Playlist as PlaylistModel
+        from zou.app.models.preview_file import PreviewFile
+        from zou.app.stores import file_store
+
+        preview_file = PreviewFile.create(
+            name="still.png",
+            revision=1,
+            extension="png",
+            task_id=self.task.id,
+            person_id=self.person.id,
+        )
+        payload = b"\x89PNG\r\n\x1a\n-fake-original-png"
+        with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp:
+            tmp.write(payload)
+            tmp_path = tmp.name
+        file_store.add_picture("original", str(preview_file.id), tmp_path)
+        self.addCleanup(
+            file_store.remove_picture, "original", str(preview_file.id)
+        )
+        PlaylistModel.get(self.playlist["id"]).update(
+            {
+                "shots": [
+                    {
+                        "id": str(self.asset.id),
+                        "preview_file_id": str(preview_file.id),
+                        "preview_file_task_id": str(self.task.id),
+                    }
+                ]
+            }
+        )
+        link = self.post(
+            f"/data/playlists/{self.playlist['id']}/share",
+            {},
+            201,
+        )
+        self.log_out()
+        response = self.app.get(
+            f"/shared/playlists/{link['token']}"
+            f"/pictures/originals/preview-files/{preview_file.id}.png"
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data, payload)
+
+    def test_shared_original_missing_file(self):
+        """
+        A preview that is part of the shared playlist but whose original
+        file is absent from storage yields a 404, not a 500.
+        """
+        from zou.app.models.playlist import Playlist as PlaylistModel
+        from zou.app.models.preview_file import PreviewFile
+
+        preview_file = PreviewFile.create(
+            name="gone.gif",
+            revision=1,
+            extension="gif",
+            task_id=self.task.id,
+            person_id=self.person.id,
+        )
+        PlaylistModel.get(self.playlist["id"]).update(
+            {
+                "shots": [
+                    {
+                        "id": str(self.asset.id),
+                        "preview_file_id": str(preview_file.id),
+                        "preview_file_task_id": str(self.task.id),
+                    }
+                ]
+            }
+        )
+        link = self.post(
+            f"/data/playlists/{self.playlist['id']}/share",
+            {},
+            201,
+        )
+        self.log_out()
+        response = self.app.get(
+            f"/shared/playlists/{link['token']}"
+            f"/pictures/originals/preview-files/{preview_file.id}.gif"
+        )
+        self.assertEqual(response.status_code, 404)

--- a/zou/app/blueprints/export/csv/persons.py
+++ b/zou/app/blueprints/export/csv/persons.py
@@ -1,5 +1,6 @@
 from zou.app.blueprints.export.csv.base import BaseCsvExport
 from flask_jwt_extended import jwt_required
+from sqlalchemy import func
 from sqlalchemy.orm import selectinload
 
 from zou.app.models.person import Person
@@ -57,7 +58,10 @@ class PersonsCsvExport(BaseCsvExport):
         return (
             Person.query.options(selectinload(Person.departments))
             .filter(Person.is_bot.isnot(True), Person.is_guest.isnot(True))
-            .order_by(Person.last_name, Person.first_name)
+            .order_by(
+                func.lower(Person.first_name),
+                func.lower(Person.last_name),
+            )
         )
 
     def get_studio_name(self, studio_id):

--- a/zou/app/blueprints/persons/resources.py
+++ b/zou/app/blueprints/persons/resources.py
@@ -1650,9 +1650,10 @@ class ChangePasswordForPersonResource(Resource, ArgsMixin):
         Change person password
         ---
         description: Allow admin to change password for given user.
-          An admin can't change other admins password. The new password requires
-          a confirmation to ensure that the admin didn't make a mistake by
-          typing the new password.
+          An admin can't change another admin's existing password, but can
+          set the initial password of a newly created admin. The new password
+          requires a confirmation to ensure that the admin didn't make a
+          mistake by typing the new password.
         tags:
           - Persons
         parameters:
@@ -1719,11 +1720,17 @@ class ChangePasswordForPersonResource(Resource, ArgsMixin):
         current_user = persons_service.get_current_user()
         try:
             person = persons_service.get_person(person_id)
-            if person["id"] != current_user["id"] and (
-                person["email"] in config.PROTECTED_ACCOUNTS
-                or person["role"] == "admin"
-            ):
-                raise PersonInProtectedAccounts()
+            if person["id"] != current_user["id"]:
+                if person["email"] in config.PROTECTED_ACCOUNTS:
+                    raise PersonInProtectedAccounts(
+                        "This user is in protected accounts."
+                    )
+                elif person["role"] == "admin":
+                    person_raw = persons_service.get_person_raw(person_id)
+                    if person_raw.password is not None:
+                        raise PersonInProtectedAccounts(
+                            "An admin can't change another admin's password."
+                        )
             auth.validate_password(password, password_2)
             password = auth.encrypt_password(password)
             persons_service.update_password(person["email"], password)
@@ -1754,11 +1761,11 @@ class ChangePasswordForPersonResource(Resource, ArgsMixin):
             return {"error": True, "message": "Password is too short."}, 400
         except UnactiveUserException:
             return {"error": True, "message": "User is unactive."}, 400
-        except PersonInProtectedAccounts:
+        except PersonInProtectedAccounts as exception:
             return (
                 {
                     "error": True,
-                    "message": "This user is in protected accounts.",
+                    "message": exception.description,
                 },
                 400,
             )

--- a/zou/app/blueprints/shared/__init__.py
+++ b/zou/app/blueprints/shared/__init__.py
@@ -15,6 +15,7 @@ from zou.app.blueprints.shared.resources import (
     SharedPlaylistPreviewFileMovieResource,
     SharedPlaylistPreviewFileThumbnailResource,
     SharedPlaylistPreviewFileOriginalResource,
+    SharedPlaylistPreviewFileExtensionResource,
     SharedPlaylistPreviewFileTileResource,
     SharedPlaylistPreviewFileDownloadResource,
     SharedPlaylistContextResource,
@@ -73,6 +74,11 @@ routes = [
         "/shared/playlists/<token>/pictures/originals/"
         "preview-files/<preview_file_id>.png",
         SharedPlaylistPreviewFileOriginalResource,
+    ),
+    (
+        "/shared/playlists/<token>/pictures/originals/"
+        "preview-files/<preview_file_id>.<extension>",
+        SharedPlaylistPreviewFileExtensionResource,
     ),
     (
         "/shared/playlists/<token>/movies/tiles/"

--- a/zou/app/blueprints/shared/resources.py
+++ b/zou/app/blueprints/shared/resources.py
@@ -3,6 +3,8 @@ from flask_fs.errors import FileNotFound
 from flask_restful import Resource
 
 from zou.app.blueprints.previews.resources import (
+    ALLOWED_FILE_EXTENSION,
+    ALLOWED_PICTURE_EXTENSION,
     send_movie_file,
     send_picture_file,
     send_standard_file,
@@ -25,7 +27,10 @@ from zou.app.services import (
     preview_files_service,
     tasks_service,
 )
-from zou.app.services.exception import PreviewFileNotFoundException
+from zou.app.services.exception import (
+    PreviewFileNotFoundException,
+    WrongParameterException,
+)
 from zou.app.utils import permissions, validation
 
 
@@ -762,6 +767,84 @@ class SharedPlaylistPreviewFileOriginalResource(Resource):
             raise permissions.PermissionDenied
         try:
             return send_picture_file("original", preview_file_id)
+        except FileNotFound:
+            raise PreviewFileNotFoundException
+
+
+class SharedPlaylistPreviewFileExtensionResource(Resource):
+    @require_valid_playlist_share_link()
+    def get(self, token, preview_file_id, extension):
+        """
+        Get shared original picture preview for any extension
+        ---
+        description: Serve the original still preview for an arbitrary
+          extension (gif, svg, jpg, pdf, ...), authorized by the share token.
+          Mirrors the authenticated
+          ``/pictures/originals/preview-files/<id>.<extension>`` route, which
+          the ``.png``-only shared route did not cover, so animated GIFs and
+          other non-PNG originals 404'd through a share link.
+        tags:
+          - Playlists
+        parameters:
+          - in: path
+            name: token
+            required: true
+            schema:
+              type: string
+            description: Share link token
+          - in: path
+            name: preview_file_id
+            required: true
+            schema:
+              type: string
+              format: uuid
+            description: Preview file unique identifier
+          - in: path
+            name: extension
+            required: true
+            schema:
+              type: string
+            description: File extension
+        responses:
+          200:
+            description: Original picture file
+            content:
+              application/octet-stream:
+                schema:
+                  type: string
+                  format: binary
+          400:
+            description: Extension not allowed
+          403:
+            description: Preview file is not part of this shared playlist
+          404:
+            description: Original file missing
+            content:
+              application/json:
+                schema:
+                  type: object
+                  properties:
+                    error:
+                      type: string
+        """
+        if not playlist_sharing_service.is_preview_file_in_shared_playlist(
+            token, preview_file_id
+        ):
+            raise permissions.PermissionDenied
+        extension = extension.lower()
+        if extension not in ALLOWED_PICTURE_EXTENSION | ALLOWED_FILE_EXTENSION:
+            raise WrongParameterException(
+                f"Extension not allowed: {extension}"
+            )
+        try:
+            if extension == "png":
+                return send_picture_file("original", preview_file_id)
+            elif extension == "pdf":
+                return send_standard_file(
+                    preview_file_id, extension, "application/pdf"
+                )
+            else:
+                return send_standard_file(preview_file_id, extension)
         except FileNotFound:
             raise PreviewFileNotFoundException
 


### PR DESCRIPTION
**Problem**
- The people CSV export is sorted by last name, then first name, and case-sensitively, which does not match the interface order.
- Admins cannot set the initial password of a newly created admin from the People page, and the returned error message is misleading.
- Non-PNG original previews (GIF, JPG, SVG, PDF, …) return a 404 when opened through a shared playlist link.

**Solution**
- Sort the persons CSV export by first name, then last name, case-insensitively, to match the interface.
- Allow setting a new admin's initial password while still blocking resets of an existing admin's password, with a clear dedicated message.
- Serve original previews of any allowed format through shared playlist links, mirroring the authenticated previews route.
