### PR TITLE
[previews] Allow revision 0 and add per-project revision padding

### DIFF
--- a/tests/projects/test_route_revision_padding.py
+++ b/tests/projects/test_route_revision_padding.py
@@ -1,0 +1,24 @@
+from tests.base import ApiDBTestCase
+
+
+class ProjectRevisionPaddingTestCase(ApiDBTestCase):
+    """
+    Test the revision_padding project setting (display-only padding for
+    revision numbers, default 0 = no padding).
+    """
+
+    def setUp(self):
+        super(ProjectRevisionPaddingTestCase, self).setUp()
+
+        self.generate_fixture_project_status()
+        self.generate_fixture_project()
+        self.project_id = str(self.project.id)
+
+    def test_revision_padding_defaults_to_zero(self):
+        project = self.get(f"data/projects/{self.project_id}")
+        self.assertEqual(project["revision_padding"], 0)
+
+    def test_revision_padding_is_updatable(self):
+        self.put(f"data/projects/{self.project_id}", {"revision_padding": 3})
+        project = self.get(f"data/projects/{self.project_id}")
+        self.assertEqual(project["revision_padding"], 3)

--- a/tests/tasks/test_preview_revision.py
+++ b/tests/tasks/test_preview_revision.py
@@ -218,6 +218,32 @@ class PreviewRevisionTestCase(ApiDBTestCase):
         self.assertEqual(preview2["position"], 1)
         self.assertEqual(preview2["revision"], 2)
 
+    def test_preview_with_revision_zero_is_stored(self):
+        """
+        An explicit revision=0 is a valid value and must be stored as 0,
+        not treated as the auto-increment sentinel.
+        """
+        comment = self.create_comment()
+        path = (
+            f"/actions/tasks/{self.task_id}/comments/{comment['id']}"
+            f"/add-preview"
+        )
+        preview = self.post(path, {"revision": 0})
+        self.assertEqual(preview["revision"], 0)
+
+    def test_preview_without_revision_auto_increments(self):
+        """
+        Omitting revision keeps the auto-increment behaviour: the first
+        preview gets revision 1, the next one 2.
+        """
+        comment1 = self.create_comment()
+        preview1 = self.add_preview(comment1["id"])
+        self.assertEqual(preview1["revision"], 1)
+
+        comment2 = self.create_comment()
+        preview2 = self.add_preview(comment2["id"])
+        self.assertEqual(preview2["revision"], 2)
+
     def test_extra_preview_allowed_when_flag_off(self):
         """
         Regression: with the flag off, extra previews still work.

--- a/zou/app/blueprints/tasks/schemas.py
+++ b/zou/app/blueprints/tasks/schemas.py
@@ -15,7 +15,7 @@ class CommentPreviewSchema(BaseSchema):
     Body for adding a preview to a comment.
     """
 
-    revision: int = Field(0, ge=0)
+    revision: Optional[int] = Field(None, ge=0)
 
 
 class ToReviewSchema(BaseSchema):

--- a/zou/app/models/project.py
+++ b/zou/app/models/project.py
@@ -174,6 +174,7 @@ class Project(db.Model, BaseMixin, SerializerMixin):
     is_publish_default_for_artists = db.Column(db.Boolean(), default=False)
     is_bot_collaboration_enabled = db.Column(db.Boolean(), default=False)
     is_single_preview_per_revision = db.Column(db.Boolean(), default=False)
+    revision_padding = db.Column(db.Integer, default=0, nullable=False)
     hd_bitrate_compression = db.Column(db.Integer, default=28)
     ld_bitrate_compression = db.Column(db.Integer, default=6)
 

--- a/zou/app/models/project_template.py
+++ b/zou/app/models/project_template.py
@@ -137,6 +137,7 @@ class ProjectTemplate(db.Model, BaseMixin, SerializerMixin):
     is_set_preview_automated = db.Column(db.Boolean(), default=False)
     is_publish_default_for_artists = db.Column(db.Boolean(), default=False)
     is_single_preview_per_revision = db.Column(db.Boolean(), default=False)
+    revision_padding = db.Column(db.Integer, default=0, nullable=False)
     homepage = db.Column(db.String(80), default="assets")
     hd_bitrate_compression = db.Column(db.Integer, default=28)
     ld_bitrate_compression = db.Column(db.Integer, default=6)

--- a/zou/app/services/tasks_service.py
+++ b/zou/app/services/tasks_service.py
@@ -1806,19 +1806,21 @@ def check_revision_is_unique_for_task(
         )
 
 
-def add_preview_file_to_comment(comment_id, person_id, task_id, revision=0):
+def add_preview_file_to_comment(comment_id, person_id, task_id, revision=None):
     """
     Add a preview to comment preview list. Auto set the revision field
     (add 1 if it's a new preview, keep the preview revision in other cases).
+    A revision of None means "auto-pick the next revision"; an explicit 0
+    is a valid, stored revision.
     """
     comment = get_comment_raw(comment_id)
     news = News.get_by(comment_id=comment_id)
     task = Task.get(comment.object_id)
     project_id = str(task.project_id)
     position = 1
-    if revision == 0 and len(comment.previews) == 0:
+    if revision is None and len(comment.previews) == 0:
         revision = get_next_preview_revision(task_id)
-    elif revision == 0:
+    elif revision is None:
         revision = comment.previews[0].revision
         position = get_next_position(task_id, revision)
     else:

--- a/zou/migrations/versions/c5e8b2a4f1d3_add_revision_padding.py
+++ b/zou/migrations/versions/c5e8b2a4f1d3_add_revision_padding.py
@@ -1,0 +1,34 @@
+"""Add revision_padding to project and project_template
+
+Revision ID: c5e8b2a4f1d3
+Revises: a7d4e2f9c1b8
+Create Date: 2026-06-05 10:00:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "c5e8b2a4f1d3"
+down_revision = "a7d4e2f9c1b8"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    for table in ("project", "project_template"):
+        with op.batch_alter_table(table, schema=None) as batch_op:
+            batch_op.add_column(
+                sa.Column(
+                    "revision_padding",
+                    sa.Integer(),
+                    nullable=False,
+                    server_default=sa.text("0"),
+                )
+            )
+
+
+def downgrade():
+    for table in ("project", "project_template"):
+        with op.batch_alter_table(table, schema=None) as batch_op:
+            batch_op.drop_column("revision_padding")


### PR DESCRIPTION
**Problem**
- Revision 0 can't be stored on previews: 0 doubles as the "auto-pick next revision" sentinel, forcing studios that need a `v000` nomenclature to offset their pipeline.
- No per-project setting controls the displayed width of revision numbers.

**Solution**
- Migrate the add-preview auto-increment sentinel from 0 to None, so an explicit `revision=0` is stored as-is while omitting revision still auto-increments.
- Add a `revision_padding` column (default 0) on `project` and `project_template`, with migration.