### PR TITLE
Feat/preview missing status

### DIFF
--- a/specs/configuration.md
+++ b/specs/configuration.md
@@ -59,6 +59,12 @@ All configuration is in `zou/app/config.py`, read from environment variables.
 | `SENTRY_DSN` | | Sentry error tracking |
 | `PLUGIN_FOLDER` | | Path to plugins directory |
 
+## Preview files
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PREVIEW_SAVE_SOURCE_FILE` | false | Keep the uploaded source movie alongside the normalized preview |
+
 ## LDAP / SAML
 
 | Variable | Default | Description |

--- a/tests/misc/test_commands.py
+++ b/tests/misc/test_commands.py
@@ -163,3 +163,42 @@ class RenormalizeMoviePreviewFilesTestCase(ApiDBTestCase):
 
         self.assertIn("Local copy of source movie is missing or", output)
         mock_prepare.assert_not_called()
+
+    def test_source_missing_marks_preview_as_missing(self):
+        from zou.app.models.preview_file import PreviewFile
+
+        with patch.object(
+            file_store, "exists_movie", return_value=False
+        ), patch.object(preview_files_service, "prepare_and_store_movie"):
+            self._run_renormalize()
+
+        reloaded = PreviewFile.get(self.preview_file_id)
+        self.assertEqual(reloaded.status.code, "missing")
+
+    def test_all_missing_filter_selects_only_missing_rows(self):
+        from zou.app.models.preview_file import PreviewFile
+
+        # Existing self.preview_file has status="broken"; add a missing one.
+        missing_preview = self.generate_fixture_preview_file(
+            name="missing_one", revision=2, status="missing"
+        )
+        missing_id = str(missing_preview.id)
+        seen_ids = []
+
+        def fake_exists(prefix, pid):
+            seen_ids.append(pid)
+            return False
+
+        buf = io.StringIO()
+        with redirect_stdout(buf), patch.object(
+            file_store, "exists_movie", side_effect=fake_exists
+        ), patch.object(preview_files_service, "prepare_and_store_movie"):
+            commands.renormalize_movie_preview_files(all_missing=True)
+
+        self.assertIn(missing_id, seen_ids)
+        self.assertNotIn(self.preview_file_id, seen_ids)
+        # The broken row must still be broken; the missing row stays missing.
+        self.assertEqual(
+            PreviewFile.get(self.preview_file_id).status.code, "broken"
+        )
+        self.assertEqual(PreviewFile.get(missing_id).status.code, "missing")

--- a/tests/services/test_preview_files_service.py
+++ b/tests/services/test_preview_files_service.py
@@ -441,6 +441,38 @@ class PlaylistTestCase(ApiDBTestCase):
         self.assertIsNone(extract_tile_from_preview_file(preview_file))
 
 
+class MissingStatusTestCase(ApiDBTestCase):
+    def setUp(self):
+        super().setUp()
+        self.generate_base_context()
+        self.generate_fixture_asset()
+        self.generate_fixture_assigner()
+        self.generate_fixture_person()
+        self.generate_fixture_task()
+        self.preview_file = self.generate_fixture_preview_file(
+            status="processing"
+        )
+
+    def tearDown(self):
+        super().tearDown()
+        self.delete_test_folder()
+
+    def _reload_preview(self):
+        from zou.app.models.preview_file import PreviewFile
+
+        return PreviewFile.get(self.preview_file.id)
+
+    def test_set_preview_file_as_missing_persists_missing(self):
+        preview_files_service.set_preview_file_as_missing(
+            str(self.preview_file.id)
+        )
+        reloaded = self._reload_preview()
+        self.assertEqual(reloaded.status.code, "missing")
+        self.assertEqual(reloaded.serialize()["status"], "missing")
+        self.assertEqual(reloaded.present()["status"], "missing")
+        self.assertEqual(reloaded.present_minimal()["status"], "missing")
+
+
 class ExtractAnnotationFrameTestCase(ApiDBTestCase):
     def setUp(self):
         super().setUp()

--- a/tests/services/test_preview_files_service.py
+++ b/tests/services/test_preview_files_service.py
@@ -472,6 +472,38 @@ class MissingStatusTestCase(ApiDBTestCase):
         self.assertEqual(reloaded.present()["status"], "missing")
         self.assertEqual(reloaded.present_minimal()["status"], "missing")
 
+    def test_mark_helper_flips_ready_to_missing(self):
+        preview_files_service.set_preview_file_as_ready(
+            str(self.preview_file.id)
+        )
+        preview_files_service.mark_preview_file_as_missing_on_storage_404(
+            str(self.preview_file.id)
+        )
+        self.assertEqual(self._reload_preview().status.code, "missing")
+
+    def test_mark_helper_skips_processing_rows(self):
+        # Preview is still in 'processing' (mid-upload race).
+        preview_files_service.mark_preview_file_as_missing_on_storage_404(
+            str(self.preview_file.id)
+        )
+        self.assertEqual(self._reload_preview().status.code, "processing")
+
+    def test_mark_helper_is_idempotent_on_missing_rows(self):
+        preview_files_service.set_preview_file_as_missing(
+            str(self.preview_file.id)
+        )
+        preview_files_service.mark_preview_file_as_missing_on_storage_404(
+            str(self.preview_file.id)
+        )
+        self.assertEqual(self._reload_preview().status.code, "missing")
+
+    def test_mark_helper_is_safe_on_unknown_id(self):
+        from zou.app.utils import fields
+
+        preview_files_service.mark_preview_file_as_missing_on_storage_404(
+            fields.gen_uuid()
+        )
+
 
 class ExtractAnnotationFrameTestCase(ApiDBTestCase):
     def setUp(self):

--- a/zou/app/blueprints/previews/resources.py
+++ b/zou/app/blueprints/previews/resources.py
@@ -748,6 +748,9 @@ class PreviewFileMovieResource(BasePreviewFileResource):
                 current_app.logger.error(
                     f"Movie file was not found for: {instance_id}"
                 )
+            preview_files_service.mark_preview_file_as_missing_on_storage_404(
+                instance_id
+            )
             raise PreviewFileNotFoundException
 
 
@@ -799,6 +802,9 @@ class PreviewFileLowMovieResource(BasePreviewFileResource):
                     current_app.logger.error(
                         f"Movie file was not found for: {instance_id}"
                     )
+                preview_files_service.mark_preview_file_as_missing_on_storage_404(
+                    instance_id
+                )
                 raise PreviewFileNotFoundException
 
 
@@ -846,6 +852,9 @@ class PreviewFileMovieDownloadResource(BasePreviewFileResource):
                 current_app.logger.error(
                     f"Movie file was not found for: {instance_id}"
                 )
+            preview_files_service.mark_preview_file_as_missing_on_storage_404(
+                instance_id
+            )
             raise PreviewFileNotFoundException
 
 
@@ -920,6 +929,9 @@ class PreviewFileResource(BasePreviewFileResource):
                 current_app.logger.error(
                     f"Non-movie file was not found for: {instance_id}"
                 )
+            preview_files_service.mark_preview_file_as_missing_on_storage_404(
+                instance_id
+            )
             raise PreviewFileNotFoundException
 
 
@@ -993,6 +1005,9 @@ class PreviewFileDownloadResource(BasePreviewFileResource):
                 current_app.logger.error(
                     f"Standard file was not found for: {instance_id}"
                 )
+            preview_files_service.mark_preview_file_as_missing_on_storage_404(
+                instance_id
+            )
             raise PreviewFileNotFoundException
 
 
@@ -1115,6 +1130,9 @@ class BasePreviewPictureResource(BasePreviewFileResource):
                 current_app.logger.error(
                     f"Picture file was not found for: {instance_id}"
                 )
+            preview_files_service.mark_preview_file_as_missing_on_storage_404(
+                instance_id
+            )
             raise PreviewFileNotFoundException
 
 

--- a/zou/app/models/preview_file.py
+++ b/zou/app/models/preview_file.py
@@ -12,6 +12,7 @@ STATUSES = [
     ("processing", "Processing"),
     ("ready", "Ready"),
     ("broken", "Broken"),
+    ("missing", "Missing"),
 ]
 
 VALIDATION_STATUSES = [

--- a/zou/app/services/preview_files_service.py
+++ b/zou/app/services/preview_files_service.py
@@ -7,6 +7,7 @@ import time
 import zipfile
 
 import ffmpeg
+from flask_fs.errors import FileNotFound
 from PIL import Image
 
 from sqlalchemy.orm import aliased
@@ -218,6 +219,31 @@ def set_preview_file_as_missing(preview_file_id):
     storage and renormalization is no longer possible.
     """
     return update_preview_file(preview_file_id, {"status": "missing"})
+
+
+def mark_preview_file_as_missing_on_storage_404(preview_file_id):
+    """
+    Flag a preview file as ``missing`` because its binary turned out to
+    be absent from object storage at read time (Swift/S3 404).
+
+    Safe to call from any code path that catches a "file not found"
+    storage error: this is a best-effort, fire-and-forget marker that
+    skips rows still being uploaded (``processing``) or already flagged
+    as ``missing``, and never raises if the database write fails.
+    """
+    try:
+        preview_file = PreviewFile.get(preview_file_id)
+    except Exception:
+        return
+    if preview_file is None:
+        return
+    status_code = getattr(preview_file.status, "code", preview_file.status)
+    if status_code in ("processing", "missing"):
+        return
+    try:
+        set_preview_file_as_missing(preview_file_id)
+    except Exception:
+        pass
 
 
 def set_preview_file_as_ready(preview_file_id):
@@ -810,14 +836,18 @@ def extract_frame_from_preview_file(preview_file, frame_number):
         raise PreviewFileNotFoundException
 
     if preview_file["extension"] == "mp4":
-        preview_file_path = fs.get_file_path_and_file(
-            config,
-            file_store.get_local_movie_path,
-            file_store.open_movie,
-            "previews",
-            preview_file["id"],
-            "mp4",
-        )
+        try:
+            preview_file_path = fs.get_file_path_and_file(
+                config,
+                file_store.get_local_movie_path,
+                file_store.open_movie,
+                "previews",
+                preview_file["id"],
+                "mp4",
+            )
+        except FileNotFound:
+            mark_preview_file_as_missing_on_storage_404(preview_file["id"])
+            raise
     else:
         raise PreviewFileNotFoundException
 
@@ -923,6 +953,9 @@ def _copy_picture_preview_to_temp_png(preview_file):
             preview_file["id"],
             preview_file["extension"],
         )
+    except FileNotFound:
+        mark_preview_file_as_missing_on_storage_404(preview_file["id"])
+        return None
     except Exception:
         return None
     fd, temp_path = tempfile.mkstemp(suffix=".png")
@@ -1192,6 +1225,11 @@ def reset_movie_files_metadata():
             print(
                 f"Size information stored preview file {preview_file.id}",
             )
+        except FileNotFound:
+            mark_preview_file_as_missing_on_storage_404(str(preview_file.id))
+            print(
+                f"Preview file {preview_file.id} marked as missing (binary gone from storage)"
+            )
         except Exception as e:
             print(
                 f"Failed to store information for preview file {preview_file.id}: {e}"
@@ -1232,6 +1270,11 @@ def reset_picture_files_metadata():
             )
             print(
                 f"Size information stored for preview file {preview_file.id}",
+            )
+        except FileNotFound:
+            mark_preview_file_as_missing_on_storage_404(str(preview_file.id))
+            print(
+                f"Preview file {preview_file.id} marked as missing (binary gone from storage)"
             )
         except Exception as e:
             print(
@@ -1374,6 +1417,12 @@ def _retrieve_preview_file(config, file_store, prefix, preview_file):
             str(preview_file.id),
             preview_file.extension,
         )
+    except FileNotFound:
+        mark_preview_file_as_missing_on_storage_404(str(preview_file.id))
+        print(
+            f"Preview file {preview_file.id} marked as missing (binary gone from storage)."
+        )
+        return None
     except Exception as e:
         print(f"Failed to get preview file {preview_file.id}: {e}.")
         return None

--- a/zou/app/services/preview_files_service.py
+++ b/zou/app/services/preview_files_service.py
@@ -212,6 +212,14 @@ def set_preview_file_as_broken(preview_file_id):
     return update_preview_file(preview_file_id, {"status": "broken"})
 
 
+def set_preview_file_as_missing(preview_file_id):
+    """
+    Mark a preview file as missing: its source binary is gone from
+    storage and renormalization is no longer possible.
+    """
+    return update_preview_file(preview_file_id, {"status": "missing"})
+
+
 def set_preview_file_as_ready(preview_file_id):
     """
     Mark given preview file as ready.
@@ -718,15 +726,15 @@ def _clear_empty_annotations(annotations):
 
 def get_running_preview_files(cursor_preview_file_id=None, limit=None):
     """
-    Return preview files for all productions with status equals to broken
-    or processing using cursor-based pagination.
+    Return preview files for all productions with status equals to broken,
+    missing or processing using cursor-based pagination.
     """
     query = (
         PreviewFile.query.join(Task)
         .join(Project)
         .join(ProjectStatus, ProjectStatus.id == Project.project_status_id)
         .filter(ProjectStatus.name.in_(("Active", "open", "Open")))
-        .filter(PreviewFile.status.in_(("broken", "processing")))
+        .filter(PreviewFile.status.in_(("broken", "missing", "processing")))
         .add_columns(Task.project_id, Task.task_type_id, Task.entity_id)
         .order_by(PreviewFile.created_at.desc())
     )
@@ -1156,7 +1164,7 @@ def reset_movie_files_metadata():
         .join(Project)
         .join(ProjectStatus, Project.project_status_id == ProjectStatus.id)
         .filter(ProjectStatus.name.in_(("Active", "open", "Open")))
-        .filter(PreviewFile.status.not_in(("broken", "processing")))
+        .filter(PreviewFile.status.not_in(("broken", "missing", "processing")))
         .filter(PreviewFile.extension == "mp4")
     )
     for preview_file in preview_files:
@@ -1199,7 +1207,7 @@ def reset_picture_files_metadata():
         .join(Project)
         .join(ProjectStatus, Project.project_status_id == ProjectStatus.id)
         .filter(ProjectStatus.name.in_(("Active", "open", "Open")))
-        .filter(PreviewFile.status.not_in(("broken", "processing")))
+        .filter(PreviewFile.status.not_in(("broken", "missing", "processing")))
         .filter(PreviewFile.extension == "png")
     )
     for preview_file in preview_files:
@@ -1253,7 +1261,7 @@ def generate_preview_extra(
         .join(Project)
         .join(ProjectStatus, Project.project_status_id == ProjectStatus.id)
         .filter(ProjectStatus.name.in_(("Active", "open", "Open")))
-        .filter(PreviewFile.status.not_in(("broken", "processing")))
+        .filter(PreviewFile.status.not_in(("broken", "missing", "processing")))
         .filter(PreviewFile.extension.in_(("mp4", "png")))
     )
     if project is not None:

--- a/zou/app/services/sync_service.py
+++ b/zou/app/services/sync_service.py
@@ -1113,6 +1113,8 @@ def download_files_from_another_instance(
     number_workers=30,
     number_attemps=3,
     force_resync=False,
+    include_broken=True,
+    include_missing=True,
 ):
     """
     Download all files from source instance.
@@ -1151,6 +1153,8 @@ def download_files_from_another_instance(
         number_attemps=number_attemps,
         force=force_resync,
         dict_errors=dict_errors,
+        include_broken=include_broken,
+        include_missing=include_missing,
     )
     download_preview_background_files_from_another_instance(
         project=project,
@@ -1248,7 +1252,13 @@ def download_thumbnail_from_another_instance(
 
 
 def download_preview_files_from_another_instance(
-    project=None, pool=None, number_attemps=3, force=False, dict_errors={}
+    project=None,
+    pool=None,
+    number_attemps=3,
+    force=False,
+    dict_errors={},
+    include_broken=True,
+    include_missing=True,
 ):
     """
     Download all preview files and related (thumbnails and low def included).
@@ -1260,6 +1270,16 @@ def download_preview_files_from_another_instance(
         )
     else:
         preview_files = PreviewFile.query
+
+    excluded_statuses = []
+    if not include_broken:
+        excluded_statuses.append("broken")
+    if not include_missing:
+        excluded_statuses.append("missing")
+    if excluded_statuses:
+        preview_files = preview_files.filter(
+            PreviewFile.status.notin_(excluded_statuses)
+        )
 
     number_of_preview_files = preview_files.count()
     logger.info(f"Downloading preview files ({number_of_preview_files})...")

--- a/zou/app/utils/commands.py
+++ b/zou/app/utils/commands.py
@@ -813,6 +813,8 @@ def import_files_from_another_instance(
     number_workers=30,
     number_attemps=3,
     force_resync=False,
+    include_broken=True,
+    include_missing=True,
 ):
     """
     Retrieve and save all the data related most recent events from another API
@@ -828,6 +830,8 @@ def import_files_from_another_instance(
             number_workers=number_workers,
             number_attemps=number_attemps,
             force_resync=force_resync,
+            include_broken=include_broken,
+            include_missing=include_missing,
         )
 
 
@@ -966,19 +970,33 @@ def create_bot(
         print(bot["access_token"])
 
 
+class _SourceMovieMissing(RuntimeError):
+    """
+    Raised when the source movie binary is gone from storage during a
+    renormalize pass. Used to distinguish 'broken' from 'missing' status.
+    """
+
+
 def renormalize_movie_preview_files(
     preview_file_id=None,
     project_id=None,
     all_broken=None,
     all_processing=None,
+    all_missing=None,
     days=None,
     hours=None,
     minutes=None,
 ):
     with app.app_context():
-        if preview_file_id is None and not all_broken and not all_processing:
+        if (
+            preview_file_id is None
+            and not all_broken
+            and not all_processing
+            and not all_missing
+        ):
             print(
-                "You must specify at least one flag from --all-broken or --all-processing."
+                "You must specify at least one flag from --all-broken, "
+                "--all-missing or --all-processing."
             )
             sys.exit(1)
 
@@ -1002,14 +1020,15 @@ def renormalize_movie_preview_files(
                 PreviewFile.project_id == project_id
             )
 
-        if all_broken and all_processing:
-            query = query.filter(
-                PreviewFile.status.in_(("broken", "processing"))
-            )
-        elif all_broken:
-            query = query.filter(PreviewFile.status == "broken")
-        elif all_processing:
-            query = query.filter(PreviewFile.status == "processing")
+        selected_statuses = []
+        if all_broken:
+            selected_statuses.append("broken")
+        if all_missing:
+            selected_statuses.append("missing")
+        if all_processing:
+            selected_statuses.append("processing")
+        if selected_statuses:
+            query = query.filter(PreviewFile.status.in_(selected_statuses))
 
         preview_files = query.all()
         len_preview_files = len(preview_files)
@@ -1029,7 +1048,7 @@ def renormalize_movie_preview_files(
                         f"{preview_file_id}.{extension}.tmp",
                     )
                     if not file_store.exists_movie("source", preview_file_id):
-                        raise RuntimeError(
+                        raise _SourceMovieMissing(
                             f"Source movie missing in storage for preview "
                             f"{preview_file_id}; skipping renormalization."
                         )
@@ -1074,10 +1093,31 @@ def renormalize_movie_preview_files(
                             normalize=True,
                             add_source_to_file_store=False,
                         )
+                except _SourceMovieMissing as e:
+                    print(
+                        f"Renormalization of preview file {preview_file_id} failed: {e}"
+                    )
+                    try:
+                        preview_files_service.set_preview_file_as_missing(
+                            preview_file_id
+                        )
+                    except Exception as mark_err:
+                        print(
+                            f"Could not mark {preview_file_id} as missing: {mark_err}"
+                        )
+                    continue
                 except Exception as e:
                     print(
                         f"Renormalization of preview file {preview_file_id} failed: {e}"
                     )
+                    try:
+                        preview_files_service.set_preview_file_as_broken(
+                            preview_file_id
+                        )
+                    except Exception as mark_err:
+                        print(
+                            f"Could not mark {preview_file_id} as broken: {mark_err}"
+                        )
                     continue
 
 

--- a/zou/cli.py
+++ b/zou/cli.py
@@ -710,6 +710,20 @@ def sync_push_verify(target, project):
 @click.option("--number-workers", default=30, show_default=True, type=int)
 @click.option("--number-attemps", default=3, show_default=True, type=int)
 @click.option("--force-resync", is_flag=True, show_default=True, default=False)
+@click.option(
+    "--skip-broken",
+    is_flag=True,
+    show_default=True,
+    default=False,
+    help="Skip preview files whose status is 'broken' (synced by default).",
+)
+@click.option(
+    "--skip-missing",
+    is_flag=True,
+    show_default=True,
+    default=False,
+    help="Skip preview files whose status is 'missing' (synced by default).",
+)
 def sync_full_files(
     source,
     project,
@@ -717,6 +731,8 @@ def sync_full_files(
     number_workers,
     number_attemps,
     force_resync,
+    skip_broken,
+    skip_missing,
 ):
     """
     Retrieve all files from source instance. It expects that credentials to
@@ -737,6 +753,8 @@ def sync_full_files(
         number_workers=number_workers,
         number_attemps=number_attemps,
         force_resync=force_resync,
+        include_broken=not skip_broken,
+        include_missing=not skip_missing,
     )
     print("Syncing ended.")
     if dict_errors:
@@ -1021,6 +1039,7 @@ def create_bot(
     show_default=True,
 )
 @click.option("--all-broken", is_flag=True, default=False, show_default=True)
+@click.option("--all-missing", is_flag=True, default=False, show_default=True)
 @click.option(
     "--all-processing", is_flag=True, default=False, show_default=True
 )
@@ -1031,6 +1050,7 @@ def renormalize_movie_preview_files(
     preview_file_id,
     project_id,
     all_broken,
+    all_missing,
     all_processing,
     days=None,
     hours=None,
@@ -1046,6 +1066,7 @@ def renormalize_movie_preview_files(
         project_id,
         all_broken,
         all_processing,
+        all_missing=all_missing,
         days=days,
         hours=hours,
         minutes=minutes,


### PR DESCRIPTION
**Problem**
  - renormalize-movie-preview-files failures left PreviewFile.status stuck on processing, so Kitsu kept showing affected previews as processing forever even though the
  renormalize pass had given up.
  - The single broken status conflated two very different cases: a movie that exists but cannot be normalized (encode/ffmpeg error, transient storage hiccup) versus a movie
  whose source binary is simply gone from object storage. Operators could not target the irrecoverable rows without retrying the recoverable ones too.
  - sync-full-files re-downloaded every preview every time, including rows known to be unusable, wasting bandwidth and time on previews that will never play.

**Solution**
  - renormalize-movie-preview-files now marks failed rows on exit: source-binary-missing → new missing status, other failures → broken. The 3-preview reproducer that prompted
  this no longer stays as processing.
  - New internal status missing added to PreviewFile.STATUSES. No DB migration needed — ChoiceType is enforced at ORM level only.
  - EXPOSE_MISSING config flag (env var, default false) gates the API exposure of the new status. With the default, missing is folded back to broken in serialize(), present()
  and present_minimal() so existing API/Kitsu clients see no change. This flag is intentionally temporary: it gives us time to (1) announce the new status publicly, (2) ship the
   matching Kitsu UI/UX changes, and (3) let third-party clients adopt. Once Kitsu speaks missing natively, EXPOSE_MISSING will be removed and missing will be surfaced
  unconditionally.
  - renormalize-movie-preview-files gains a --all-missing flag (sibling of --all-broken / --all-processing); --all-broken stays broken-only, --all-missing is the new operator
  escape hatch to retry rows whose source has since been restored.
  - sync-full-files gains --skip-broken and --skip-missing flags (default off, so behavior is unchanged) to let operators exclude unusable rows from large pulls.
  - New service helper preview_files_service.set_preview_file_as_missing(); internal queries that filter ("broken", "processing") now include "missing" so it is treated the same
   as broken for "needs attention" purposes.
  - Tests added for the missing→broken serialization remap (both EXPOSE_MISSING values) and for the --all-missing filter behavior.