### PR TITLE
[crud] Return 4xx instead of 500 on malformed criterions and member-insert races

### DIFF
--- a/tests/edits/test_edit_routes.py
+++ b/tests/edits/test_edit_routes.py
@@ -21,3 +21,13 @@ class EditRoutesTestCase(BaseEditTestCase):
     def test_get_edit_versions(self):
         result = self.get(f"/data/edits/{self.edit_id}/versions")
         self.assertIsInstance(result, list)
+
+    def test_get_edits_with_tasks(self):
+        result = self.get("/data/edits/with-tasks")
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["name"], "Edit")
+
+    def test_get_edits_with_tasks_wrong_id_format(self):
+        self.get("/data/edits/with-tasks?project_id=not-a-uuid", 400)
+        self.get("/data/edits/with-tasks?episode_id=not-a-uuid", 400)
+        self.get("/data/edits/with-tasks?id=not-a-uuid", 400)

--- a/tests/services/test_projects_service.py
+++ b/tests/services/test_projects_service.py
@@ -99,6 +99,27 @@ class ProjectServiceTestCase(ApiDBTestCase):
         project = projects_service.get_project(self.project.id, relations=True)
         self.assertEqual(project["team"], [str(self.person.id)])
 
+    def test_add_team_member_swallows_concurrent_insert(self):
+        from unittest import mock
+        from sqlalchemy.exc import IntegrityError
+
+        self.generate_fixture_person()
+        project_id = str(self.project.id)
+        person_id = str(self.person.id)
+
+        # Simulate the TOCTOU race: a concurrent request inserted the same
+        # link first, so our own INSERT raises a UniqueViolation at save.
+        # add_team_member must treat it as a no-op instead of bubbling up a
+        # 500, and still return the up-to-date project.
+        with mock.patch.object(
+            projects_service,
+            "_save_project",
+            side_effect=IntegrityError("duplicate key", {}, Exception()),
+        ):
+            project = projects_service.add_team_member(project_id, person_id)
+
+        self.assertEqual(project["id"], project_id)
+
     def test_remove_team_member(self):
         self.generate_fixture_person()
         projects_service.add_team_member(self.project.id, self.person.id)

--- a/tests/utils/test_query.py
+++ b/tests/utils/test_query.py
@@ -1,0 +1,42 @@
+import unittest
+
+from zou.app.utils.query import check_criterion_id_format
+from zou.app.services.exception import WrongParameterException
+
+
+class CheckCriterionIdFormatTestCase(unittest.TestCase):
+    valid_id = "a24a6ea4-ce75-4665-a070-57453082c25e"
+
+    def test_valid_ids_pass(self):
+        criterions = {
+            "id": self.valid_id,
+            "project_id": self.valid_id,
+            "episode_id": self.valid_id,
+        }
+        self.assertIsNone(check_criterion_id_format(criterions))
+
+    def test_missing_ids_pass(self):
+        self.assertIsNone(check_criterion_id_format({"name": "foo"}))
+
+    def test_invalid_id_raises(self):
+        for field in ("id", "project_id", "episode_id"):
+            with self.assertRaises(WrongParameterException):
+                check_criterion_id_format({field: "not-a-uuid"})
+
+    def test_episode_id_sentinels_pass(self):
+        for sentinel in ("all", "main"):
+            self.assertIsNone(
+                check_criterion_id_format({"episode_id": sentinel})
+            )
+
+    def test_sentinels_not_allowed_for_other_fields(self):
+        for field in ("id", "project_id"):
+            with self.assertRaises(WrongParameterException):
+                check_criterion_id_format({field: "all"})
+
+    def test_only_listed_fields_are_checked(self):
+        self.assertIsNone(
+            check_criterion_id_format(
+                {"episode_id": "not-a-uuid"}, ["id", "project_id"]
+            )
+        )

--- a/zou/app/blueprints/assets/resources.py
+++ b/zou/app/blueprints/assets/resources.py
@@ -1,5 +1,5 @@
 from flask import request
-from flask_restful import Resource, inputs
+from flask_restful import Resource
 from flask_jwt_extended import jwt_required
 
 from zou.app.utils import permissions, query, validation
@@ -291,6 +291,7 @@ class AssetsAndTasksResource(Resource, ArgsMixin):
                         description: Array of related tasks
         """
         criterions = query.get_query_criterions_from_request(request)
+        query.check_criterion_id_format(criterions)
         check_criterion_access(criterions)
         if permissions.has_vendor_permissions():
             criterions["assigned_to"] = persons_service.get_current_user()[

--- a/zou/app/blueprints/concepts/resources.py
+++ b/zou/app/blueprints/concepts/resources.py
@@ -494,6 +494,7 @@ class ConceptsAndTasksResource(Resource):
                         example: "2023-01-01T12:30:00Z"
         """
         criterions = query.get_query_criterions_from_request(request)
+        query.check_criterion_id_format(criterions, ["id", "project_id"])
         user_service.check_project_access(criterions.get("project_id", None))
         if (
             permissions.has_vendor_permissions()

--- a/zou/app/blueprints/edits/resources.py
+++ b/zou/app/blueprints/edits/resources.py
@@ -740,6 +740,7 @@ class EditsAndTasksResource(Resource):
                         example: "2023-01-01T12:30:00Z"
         """
         criterions = query.get_query_criterions_from_request(request)
+        query.check_criterion_id_format(criterions)
         user_service.check_project_access(criterions.get("project_id", None))
         if permissions.has_vendor_permissions():
             criterions["assigned_to"] = persons_service.get_current_user()[

--- a/zou/app/blueprints/export/csv/assets.py
+++ b/zou/app/blueprints/export/csv/assets.py
@@ -46,6 +46,7 @@ class AssetsCsvExport(Resource):
         self.check_permissions(project["id"])
 
         criterions = query.get_query_criterions_from_request(request)
+        query.check_criterion_id_format(criterions, ["id", "episode_id"])
         criterions["project_id"] = project["id"]
 
         self.task_type_map = tasks_service.get_task_type_map()

--- a/zou/app/blueprints/export/csv/shots.py
+++ b/zou/app/blueprints/export/csv/shots.py
@@ -46,6 +46,7 @@ class ShotsCsvExport(Resource):
         self.check_permissions(project["id"])
 
         criterions = query.get_query_criterions_from_request(request)
+        query.check_criterion_id_format(criterions, ["id", "episode_id"])
         criterions["project_id"] = project["id"]
 
         self.task_status_map = tasks_service.get_task_status_map()

--- a/zou/app/blueprints/shots/resources.py
+++ b/zou/app/blueprints/shots/resources.py
@@ -1041,6 +1041,7 @@ class ShotsAndTasksResource(Resource):
                                   example: SH010 Animation
         """
         criterions = query.get_query_criterions_from_request(request)
+        query.check_criterion_id_format(criterions)
         user_service.check_project_access(criterions.get("project_id", None))
         if permissions.has_vendor_permissions():
             criterions["assigned_to"] = persons_service.get_current_user()[
@@ -1104,6 +1105,9 @@ class SceneAndTasksResource(Resource):
                                   example: Layout
         """
         criterions = query.get_query_criterions_from_request(request)
+        query.check_criterion_id_format(
+            criterions, ["project_id", "episode_id"]
+        )
         user_service.check_project_access(criterions.get("project_id", None))
         if permissions.has_vendor_permissions():
             raise permissions.PermissionDenied
@@ -1163,6 +1167,9 @@ class SequenceAndTasksResource(Resource):
                                   example: SQ010 Editing
         """
         criterions = query.get_query_criterions_from_request(request)
+        query.check_criterion_id_format(
+            criterions, ["project_id", "episode_id"]
+        )
         user_service.check_project_access(criterions.get("project_id", None))
         if permissions.has_vendor_permissions():
             raise permissions.PermissionDenied
@@ -1222,6 +1229,9 @@ class EpisodeAndTasksResource(Resource):
                                   example: EP01 Layout
         """
         criterions = query.get_query_criterions_from_request(request)
+        query.check_criterion_id_format(
+            criterions, ["project_id", "episode_id"]
+        )
         user_service.check_project_access(criterions.get("project_id", None))
         if permissions.has_vendor_permissions():
             raise permissions.PermissionDenied

--- a/zou/app/services/projects_service.py
+++ b/zou/app/services/projects_service.py
@@ -560,7 +560,14 @@ def _add_to_list_attr(project_id, model_class, model_id, list_attr):
         )
     if str(model.id) not in [str(m.id) for m in getattr(project, list_attr)]:
         getattr(project, list_attr).append(model)
-        return _save_project(project)
+        try:
+            return _save_project(project)
+        except IntegrityError:
+            # A concurrent request already added the same link. The check
+            # above is not atomic, so treat the duplicate as a no-op and
+            # return the up-to-date project. The failed transaction has
+            # already been rolled back by Model.save().
+            return get_project_raw(project_id).serialize()
     else:
         return project.serialize()
 

--- a/zou/app/utils/query.py
+++ b/zou/app/utils/query.py
@@ -23,6 +23,33 @@ def get_query_criterions_from_request(request):
     return criterions
 
 
+# Some criterions accept sentinel values that are not UUIDs (e.g. "all" or
+# "main" for episode_id) and must therefore bypass UUID validation.
+EPISODE_ID_SENTINELS = ["all", "main"]
+
+
+def check_criterion_id_format(
+    criterions, id_fields=("id", "project_id", "episode_id")
+):
+    """
+    Ensure the id criterions extracted from a request hold a valid UUID before
+    they are injected into a custom SQL query. Resources that build queries by
+    hand (the various "*-and-tasks" endpoints) bypass the casting done in
+    apply_criterions_to_db_query, so an invalid UUID would otherwise reach the
+    database and raise a StatementError (HTTP 500) instead of a 400.
+    """
+    for id_field in id_fields:
+        value = criterions.get(id_field)
+        if value is None:
+            continue
+        if id_field == "episode_id" and value in EPISODE_ID_SENTINELS:
+            continue
+        if not fields.is_valid_id(value):
+            raise WrongParameterException(
+                f"Invalid UUID format for {id_field}: {value}"
+            )
+
+
 def apply_criterions_to_db_query(model, db_query, criterions):
     """
     Apply criterions given in HTTP request to the sqlachemy db query object.


### PR DESCRIPTION
## Problems

- The "*-and-tasks" endpoints and the shots/assets CSV exports inject id/project_id/episode_id criterions straight into UUID columns, so a malformed UUID raised a StatementError (HTTP 500) instead of a 400.
- Adding a member to a project list (team, asset types, task types...) was not atomic, so two concurrent requests adding the same link triggered an IntegrityError 500.

## Solutions

- Add query.check_criterion_id_format() and call it at each affected resource to reject malformed id criterions with a 400, tolerating the "all"/"main" sentinels for episode_id.
- Catch the IntegrityError in _add_to_list_attr() and return the up-to-date project, treating the duplicate insert as a no-op.