### PR TITLE
[previews] Add a command to normalize annotation times

### DIFF
--- a/tests/services/test_preview_files_service.py
+++ b/tests/services/test_preview_files_service.py
@@ -232,6 +232,121 @@ class PlaylistTestCase(ApiDBTestCase):
             persisted_preview_file["annotations"],
         )
 
+    def test_normalize_annotation_times_merges_same_frame_entries(self):
+        annotations = [
+            {
+                "time": 0.6,
+                "frame": 16,
+                "drawing": {"objects": [{"id": "new-1"}]},
+            },
+            {
+                "time": 0.616,
+                "frame": "017",
+                "drawing": {"objects": [{"id": "old-1"}, {"id": "old-2"}]},
+            },
+        ]
+        result, changed = preview_files_service.normalize_annotation_times(
+            annotations, 25
+        )
+        self.assertTrue(changed)
+        self.assertEqual(1, len(result))
+        self.assertEqual(0.6, result[0]["time"])
+        self.assertEqual(
+            ["new-1", "old-1", "old-2"],
+            [o["id"] for o in result[0]["drawing"]["objects"]],
+        )
+
+    def test_normalize_annotation_times_snaps_string_times(self):
+        annotations = [
+            {"time": "2", "drawing": {"objects": [{"id": "obj-1"}]}}
+        ]
+        result, changed = preview_files_service.normalize_annotation_times(
+            annotations, 25
+        )
+        self.assertTrue(changed)
+        self.assertEqual(2.0, result[0]["time"])
+
+    def test_normalize_annotation_times_keeps_distinct_frames(self):
+        annotations = [
+            {"time": 0.6, "drawing": {"objects": [{"id": "a"}]}},
+            {"time": 0.88, "drawing": {"objects": [{"id": "b"}]}},
+        ]
+        result, changed = preview_files_service.normalize_annotation_times(
+            annotations, 25
+        )
+        self.assertFalse(changed)
+        self.assertEqual(2, len(result))
+
+    def test_normalize_annotation_times_deduplicates_objects_by_id(self):
+        annotations = [
+            {"time": 0.6, "drawing": {"objects": [{"id": "a"}]}},
+            {
+                "time": 0.616,
+                "drawing": {"objects": [{"id": "a"}, {"id": "b"}]},
+            },
+        ]
+        result, _ = preview_files_service.normalize_annotation_times(
+            annotations, 25
+        )
+        self.assertEqual(
+            ["a", "b"], [o["id"] for o in result[0]["drawing"]["objects"]]
+        )
+
+    def test_normalize_annotation_times_keeps_unparseable_entries(self):
+        annotations = [{"time": "abc", "drawing": {"objects": [{"id": "a"}]}}]
+        result, changed = preview_files_service.normalize_annotation_times(
+            annotations, 25
+        )
+        self.assertFalse(changed)
+        self.assertEqual(annotations, result)
+
+    def test_normalize_annotation_times_does_not_mutate_input(self):
+        annotations = [
+            {"time": 0.6, "drawing": {"objects": [{"id": "a"}]}},
+            {"time": 0.616, "drawing": {"objects": [{"id": "b"}]}},
+        ]
+        preview_files_service.normalize_annotation_times(annotations, 25)
+        self.assertEqual(0.616, annotations[1]["time"])
+        self.assertEqual(1, len(annotations[0]["drawing"]["objects"]))
+
+    def test_normalize_preview_file_annotation_times(self):
+        preview_file = self.generate_fixture_preview_file()
+        preview_file.update(
+            {
+                "annotations": [
+                    {
+                        "time": 0.6,
+                        "drawing": {"objects": [{"id": "new-1"}]},
+                    },
+                    {
+                        "time": 0.616,
+                        "drawing": {"objects": [{"id": "old-1"}]},
+                    },
+                ]
+            }
+        )
+        changed = (
+            preview_files_service.normalize_preview_file_annotation_times(
+                preview_file
+            )
+        )
+        self.assertTrue(changed)
+        persisted = files_service.get_preview_file(str(preview_file.id))
+        self.assertEqual(1, len(persisted["annotations"]))
+        self.assertEqual(
+            ["new-1", "old-1"],
+            [
+                o["id"]
+                for o in persisted["annotations"][0]["drawing"]["objects"]
+            ],
+        )
+        changed = (
+            preview_files_service.normalize_preview_file_annotation_times(
+                preview_file
+            )
+        )
+        self.assertFalse(changed)
+
     def test_update_annotations_aborts_when_lock_unavailable(self):
         """
         When the Redis lock can't be acquired (Redis down or wait

--- a/zou/app/services/preview_files_service.py
+++ b/zou/app/services/preview_files_service.py
@@ -1,4 +1,5 @@
 import copy
+import math
 import os
 import re
 import shutil
@@ -722,6 +723,101 @@ def _clear_empty_annotations(annotations):
         for annotation in annotations
         if len(annotation.get("drawing", {}).get("objects", [])) > 0
     ]
+
+
+def _round_time_to_frame(time_value, fps):
+    """
+    Snap a playback time onto the frame grid the Kitsu player uses:
+    the frame duration is 1 / fps rounded to 4 decimals, and rounding is
+    half-up to mirror the JavaScript Math.round used client-side.
+    """
+    precision_factor = 10000
+    frame_duration = (
+        math.floor(1 / fps * precision_factor + 0.5) / precision_factor
+    )
+    frame_number = math.floor(time_value / frame_duration + 0.5)
+    return (
+        math.floor(frame_number * frame_duration * precision_factor + 0.5)
+        / precision_factor
+    )
+
+
+def normalize_annotation_times(annotations, fps):
+    """
+    Collapse annotation entries that land on the same frame into one and
+    snap every entry time onto the frame grid.
+
+    Older Kitsu versions stored unrounded times (sometimes as strings)
+    while current ones snap them to the frame grid, so the same logical
+    frame can exist several times in a preview file's annotation list.
+    The player only displays the first entry matching a frame, which makes
+    the other entries' drawings invisible, and grid-timed deletions or
+    updates never match the legacy entries.
+
+    Objects are deduplicated by id and the input list is not mutated.
+    Returns a (annotations, changed) tuple; entries with unparseable times
+    are kept untouched.
+    """
+    result = []
+    by_frame_time = {}
+    changed = False
+    for annotation in annotations or []:
+        try:
+            time_value = max(float(annotation.get("time") or 0), 0.0)
+        except (TypeError, ValueError):
+            result.append(copy.deepcopy(annotation))
+            continue
+        frame_time = _round_time_to_frame(time_value, fps)
+        existing = by_frame_time.get(frame_time)
+        objects = (annotation.get("drawing") or {}).get("objects", [])
+        if existing is None:
+            entry = copy.deepcopy(annotation)
+            if entry.get("time") != frame_time:
+                changed = True
+            entry["time"] = frame_time
+            entry["drawing"] = {
+                **(entry.get("drawing") or {}),
+                "objects": (entry.get("drawing") or {}).get("objects", []),
+            }
+            by_frame_time[frame_time] = entry
+            result.append(entry)
+        else:
+            changed = True
+            seen_ids = {
+                existing_object.get("id")
+                for existing_object in existing["drawing"]["objects"]
+            }
+            existing["drawing"]["objects"].extend(
+                copy.deepcopy(new_object)
+                for new_object in objects
+                if new_object.get("id") not in seen_ids
+            )
+    return result, changed
+
+
+def normalize_preview_file_annotation_times(preview_file):
+    """
+    Normalize a preview file's annotation times in place (see
+    normalize_annotation_times). Returns True when the stored annotations
+    were modified.
+    """
+    if not preview_file.annotations:
+        return False
+    task = Task.get(preview_file.task_id)
+    project = Project.get(task.project_id).serialize()
+    entity = Entity.get(task.entity_id)
+    fps = float(
+        get_preview_file_fps(
+            project, entity.serialize() if entity is not None else None
+        )
+    )
+    annotations, changed = normalize_annotation_times(
+        preview_file.annotations, fps
+    )
+    if changed:
+        preview_file.update({"annotations": annotations})
+        files_service.clear_preview_file_cache(str(preview_file.id))
+    return changed
 
 
 def get_running_preview_files(cursor_preview_file_id=None, limit=None):

--- a/zou/app/utils/commands.py
+++ b/zou/app/utils/commands.py
@@ -26,8 +26,10 @@ from zou.app.services import (
     sync_service,
     tasks_service,
 )
+from zou.app.models.entity import Entity
 from zou.app.models.person import Person
 from zou.app.models.preview_file import PreviewFile
+from zou.app.models.project import Project
 from zou.app.models.task import Task
 from zou.app.models.plugin import Plugin
 from sqlalchemy.sql.expression import not_
@@ -1119,6 +1121,63 @@ def renormalize_movie_preview_files(
                             f"Could not mark {preview_file_id} as broken: {mark_err}"
                         )
                     continue
+
+
+def normalize_annotation_times(project_id=None, dry_run=False):
+    """
+    Merge preview file annotation entries that land on the same frame and
+    snap their times onto the frame grid used by the Kitsu player. Older
+    Kitsu versions stored unrounded times, leaving duplicated entries whose
+    drawings the player cannot display.
+    """
+    with app.app_context():
+        query = PreviewFile.query.filter(
+            PreviewFile.annotations.isnot(None)
+        ).order_by(PreviewFile.created_at.asc())
+        if project_id is not None:
+            query = query.join(Task).filter(Task.project_id == project_id)
+        changed_count = 0
+        scanned_count = 0
+        for preview_file in query:
+            if not preview_file.annotations:
+                continue
+            scanned_count += 1
+            preview_file_id = str(preview_file.id)
+            try:
+                if dry_run:
+                    task = Task.get(preview_file.task_id)
+                    project = Project.get(task.project_id).serialize()
+                    entity = Entity.get(task.entity_id)
+                    fps = float(
+                        preview_files_service.get_preview_file_fps(
+                            project,
+                            entity.serialize() if entity is not None else None,
+                        )
+                    )
+                    _, changed = (
+                        preview_files_service.normalize_annotation_times(
+                            preview_file.annotations, fps
+                        )
+                    )
+                else:
+                    changed = preview_files_service.normalize_preview_file_annotation_times(
+                        preview_file
+                    )
+                if changed:
+                    changed_count += 1
+                    print(
+                        f"Preview file {preview_file_id} "
+                        f"{'needs normalization' if dry_run else 'normalized'}."
+                    )
+            except Exception as e:
+                print(
+                    f"Normalization of preview file {preview_file_id} "
+                    f"failed: {e}"
+                )
+        print(
+            f"{changed_count}/{scanned_count} annotated preview files "
+            f"{'need normalization' if dry_run else 'normalized'}."
+        )
 
 
 def list_plugins(output_format, verbose, filter_field, filter_value):

--- a/zou/cli.py
+++ b/zou/cli.py
@@ -1075,6 +1075,26 @@ def renormalize_movie_preview_files(
 
 @cli.command()
 @click.option(
+    "--project-id",
+    required=False,
+    default=None,
+    show_default=True,
+)
+@click.option("--dry-run", is_flag=True, default=False, show_default=True)
+def normalize_annotation_times(project_id, dry_run):
+    """
+    Merge preview file annotation entries duplicated on the same frame and
+    snap their times onto the player's frame grid. Older Kitsu versions
+    stored unrounded annotation times, leaving entries the player cannot
+    display.
+    """
+    from zou.app.utils import commands
+
+    commands.normalize_annotation_times(project_id=project_id, dry_run=dry_run)
+
+
+@cli.command()
+@click.option(
     "--path",
     required=True,
     help="Plugin path: local directory, zip file, or git repository URL",


### PR DESCRIPTION
**Problem**
- Older Kitsu versions stored unrounded annotation times (sometimes as strings), while current ones snap them to the frame grid, so the same logical frame can exist several times in a preview file's annotation list.
- The player only displays the first entry matching a frame, making the other entries' drawings invisible, and grid-timed deletions or updates never match the legacy entries.

**Solution**
- Add `normalize_annotation_times()` to merge same-frame entries (objects deduplicated by id) and snap times onto the player's frame grid, mirroring the client-side rounding.
- Add a `zou normalize-annotation-times` CLI command (per-project filter, `--dry-run`) to clean existing preview files.