### PR TITLE
[previews] Letterbox normalized movies; fix stale comment reply cache

### DIFF
--- a/tests/utils/test_movie.py
+++ b/tests/utils/test_movie.py
@@ -97,6 +97,35 @@ class MovieTestCase(unittest.TestCase):
         self.assertEqual(width / 2, width_norm)
         self.assertEqual(height / 2, height_norm)
 
+    def test_normalize_letterbox(self):
+        # A 4:3 source normalized into a 16:9 canvas must be letterboxed
+        # (pillarboxed here), not stretched: exact canvas dimensions, black
+        # side bars, undistorted content in the center.
+        source = str(Path(self.tmpdir) / "test_letterbox_source.m4v")
+        ffmpeg.input("color=c=red:s=320x240:d=1", f="lavfi").output(
+            source, r=5, vcodec="libx264", pix_fmt="yuv420p"
+        ).overwrite_output().run(quiet=True)
+
+        normalized, _, _ = movie.normalize_movie(source, 5, 320, 180)
+
+        width_norm, height_norm = movie.get_movie_size(normalized)
+        self.assertEqual(width_norm, 320)
+        self.assertEqual(height_norm, 180)
+
+        frame = str(Path(self.tmpdir) / "test_letterbox_frame.png")
+        ffmpeg.input(normalized).output(
+            frame, vframes=1
+        ).overwrite_output().run(quiet=True)
+        image = Image.open(frame).convert("RGB")
+
+        # Side bars (4:3 into 16:9 -> 40px pillars) are black...
+        left_r, left_g, left_b = image.getpixel((5, 90))
+        self.assertLess(left_r + left_g + left_b, 30)
+        # ...and the center keeps the undistorted red content.
+        center_r, center_g, center_b = image.getpixel((160, 90))
+        self.assertGreater(center_r, 150)
+        self.assertLess(center_g + center_b, 120)
+
     def test_concat_demuxer_testing(self):
         test_name = "test_concate_demuxer"
         self.concat_testing(movie.concat_demuxer, test_name)

--- a/zou/app/services/comments_service.py
+++ b/zou/app/services/comments_service.py
@@ -700,6 +700,7 @@ def delete_reply(comment_id, reply_id):
         reply for reply in comment.replies if reply["id"] != reply_id
     ]
     comment.save()
+    tasks_service.clear_comment_cache(comment_id)
     Notification.delete_all_by(reply_id=reply_id)
     events.emit(
         "comment:delete-reply",

--- a/zou/utils/movie.py
+++ b/zou/utils/movie.py
@@ -228,7 +228,12 @@ def normalize_encoding(
         vcodec="libx264",
         movflags="+faststart",
         x264opts=f"keyint={keyframes}:scenecut=0",
-        s=f"{width}x{height}",
+        vf=(
+            f"scale={width}:{height}:"
+            "force_original_aspect_ratio=decrease:force_divisible_by=2,"
+            f"pad={width}:{height}:(ow-iw)/2:(oh-ih)/2,"
+            "setsar=1"
+        ),
     )
     try:
         logger.info(f"ffmpeg {' '.join(stream.get_args())}")


### PR DESCRIPTION
## Problems

- Movie normalization forced uploads to the project resolution with ffmpeg's `-s`, stretching any clip whose aspect ratio differed from the project's.
- delete_reply() saved the comment without invalidating the memoized get_comment (120s TTL), so GET /data/comments/<id> kept serving a deleted reply for up to two minutes.

## Solutions

- Preserve the source ratio with a scale+pad filter so non-matching uploads are letterboxed with black bars instead of distorted; covers both the high and low def variants.
- Clear the comment cache in delete_reply(), mirroring what reply_comment() already does on the write path.