### PR TITLE
[shots] Allow vendors to load sequences and episodes with tasks

### DIFF
--- a/tests/shots/test_episodes.py
+++ b/tests/shots/test_episodes.py
@@ -152,12 +152,18 @@ class EpisodeTestCase(ApiDBTestCase):
         self._setup_vendor()
         self.get(f"data/episodes/{self.episode_id}/tasks", 403)
 
-    def test_get_episodes_with_tasks_vendor_blocked(self):
+    def test_get_episodes_with_tasks_vendor(self):
         self._setup_vendor()
-        self.get(
-            f"data/episodes/with-tasks?project_id={self.project_id}",
-            403,
-        )
+        path = f"data/episodes/with-tasks?project_id={self.project_id}"
+        # Without an assigned shot, the vendor gets no episode (but no 403).
+        self.assertEqual(len(self.get(path)), 0)
+        # Assigning a descendant shot task surfaces its episode.
+        tasks_service.assign_task(self.shot_task.id, self.user_vendor["id"])
+        episodes = self.get(path)
+        self.assertEqual(len(episodes), 1)
+        self.assertEqual(episodes[0]["id"], self.episode_id)
+        # Episode-level tasks stay hidden unless directly assigned.
+        self.assertEqual(episodes[0]["tasks"], [])
 
     def test_force_delete_episode(self):
         self.get(f"data/episodes/{self.episode_id}")

--- a/tests/shots/test_sequences.py
+++ b/tests/shots/test_sequences.py
@@ -1,6 +1,6 @@
 from tests.base import ApiDBTestCase
 
-from zou.app.services import projects_service, tasks_service
+from zou.app.services import entities_service, projects_service, tasks_service
 
 
 class SequenceTestCase(ApiDBTestCase):
@@ -131,12 +131,37 @@ class SequenceTestCase(ApiDBTestCase):
         self._setup_vendor()
         self.get(f"data/sequences/{self.sequence_id}/tasks", 403)
 
-    def test_get_sequences_with_tasks_vendor_blocked(self):
+    def test_get_sequences_with_tasks_vendor(self):
         self._setup_vendor()
-        self.get(
-            f"data/sequences/with-tasks?project_id={self.project_id}",
-            403,
+        path = f"data/sequences/with-tasks?project_id={self.project_id}"
+        # Without an assigned shot, the vendor gets no sequence (but no 403).
+        self.assertEqual(len(self.get(path)), 0)
+        # Assigning a shot task surfaces its parent sequence.
+        tasks_service.assign_task(self.shot_task.id, self.user_vendor["id"])
+        sequences = self.get(path)
+        self.assertEqual(len(sequences), 1)
+        self.assertEqual(sequences[0]["id"], self.sequence_id)
+        # Sequence-level tasks stay hidden unless directly assigned.
+        self.assertEqual(sequences[0]["tasks"], [])
+
+    def test_get_sequences_with_tasks_vendor_task_filter(self):
+        self._setup_vendor()
+        tasks_service.assign_task(self.shot_task.id, self.user_vendor["id"])
+        # A task on the very sequence holding the assigned shot, not yet
+        # assigned to the vendor.
+        sequence = entities_service.get_entity(self.shot.parent_id)
+        sequence_task = tasks_service.create_task(
+            self.task_type_animation.serialize(), sequence
         )
+        path = f"data/sequences/with-tasks?project_id={self.project_id}"
+        # The sequence is visible but its task stays hidden.
+        sequences = self.get(path)
+        self.assertEqual(len(sequences), 1)
+        self.assertEqual(sequences[0]["tasks"], [])
+        # Once assigned to the vendor, the sequence task shows up.
+        tasks_service.assign_task(sequence_task["id"], self.user_vendor["id"])
+        sequences = self.get(path)
+        self.assertEqual(len(sequences[0]["tasks"]), 1)
 
     def test_force_delete_sequence(self):
         self.get(f"data/sequences/{self.sequence_id}")

--- a/zou/app/blueprints/shots/resources.py
+++ b/zou/app/blueprints/shots/resources.py
@@ -1171,9 +1171,24 @@ class SequenceAndTasksResource(Resource):
             criterions, ["project_id", "episode_id"]
         )
         user_service.check_project_access(criterions.get("project_id", None))
-        if permissions.has_vendor_permissions():
-            raise permissions.PermissionDenied
         criterions["entity_type_id"] = shots_service.get_sequence_type()["id"]
+        if permissions.has_vendor_permissions():
+            # Vendors only see sequences holding a shot with a task assigned
+            # to them, and only their own tasks on those sequences.
+            if criterions.get("episode_id"):
+                sequences = shots_service.get_sequences_for_episode(
+                    criterions["episode_id"], only_assigned=True
+                )
+            else:
+                sequences = shots_service.get_sequences_for_project(
+                    criterions["project_id"], only_assigned=True
+                )
+            criterions["entity_ids"] = [
+                sequence["id"] for sequence in sequences
+            ]
+            criterions["assigned_to"] = persons_service.get_current_user()[
+                "id"
+            ]
         return entities_service.get_entities_and_tasks(criterions)
 
 
@@ -1233,9 +1248,17 @@ class EpisodeAndTasksResource(Resource):
             criterions, ["project_id", "episode_id"]
         )
         user_service.check_project_access(criterions.get("project_id", None))
-        if permissions.has_vendor_permissions():
-            raise permissions.PermissionDenied
         criterions["entity_type_id"] = shots_service.get_episode_type()["id"]
+        if permissions.has_vendor_permissions():
+            # Vendors only see episodes holding a shot with a task assigned
+            # to them, and only their own tasks on those episodes.
+            episodes = shots_service.get_episodes_for_project(
+                criterions["project_id"], only_assigned=True
+            )
+            criterions["entity_ids"] = [episode["id"] for episode in episodes]
+            criterions["assigned_to"] = persons_service.get_current_user()[
+                "id"
+            ]
         return entities_service.get_entities_and_tasks(criterions)
 
 

--- a/zou/app/services/entities_service.py
+++ b/zou/app/services/entities_service.py
@@ -294,6 +294,9 @@ def get_entities_and_tasks(criterions=None):
     if "episode_id" in criterions:
         query = query.filter(Entity.parent_id == criterions["episode_id"])
 
+    if "entity_ids" in criterions:
+        query = query.filter(Entity.id.in_(criterions["entity_ids"]))
+
     for (
         entity,
         task_id,
@@ -368,7 +371,16 @@ def get_entities_and_tasks(criterions=None):
             if person_id:
                 task_map[task_id]["assignees"].append(str(person_id))
 
-    return list(entity_map.values())
+    entities = list(entity_map.values())
+    assigned_to = criterions.get("assigned_to")
+    if assigned_to is not None:
+        for entity in entities:
+            entity["tasks"] = [
+                task
+                for task in entity["tasks"]
+                if assigned_to in task["assignees"]
+            ]
+    return entities
 
 
 def get_entity_tasks(entity):


### PR DESCRIPTION
**Problem**
- Vendor users got a 403 on the Kitsu shots page: it loads `/data/sequences/with-tasks` before shots, and that endpoint (plus `/data/episodes/with-tasks`) rejected every vendor outright.
- Assets worked fine, making the breakage shots-only.

**Solution**
- `SequenceAndTasksResource` / `EpisodeAndTasksResource` no longer 403 for vendors; they return the sequences/episodes that hold a shot with a task assigned to the vendor, reusing the existing `only_assigned` helpers.
- `get_entities_and_tasks` gains `entity_ids` (restrict returned entities) and `assigned_to` (show only the vendor's own tasks on those entities).

Fix cgwire/kitsu#2053