### PR TITLE
[previews] Letterbox anamorphic sources without distortion

### DIFF
--- a/tests/tiles/test_route_tiles.py
+++ b/tests/tiles/test_route_tiles.py
@@ -60,4 +60,8 @@ class RouteTileTestCase(ApiDBTestCase):
         self.download_file(path, result_file_path)
 
         result_image = Image.open(result_file_path)
-        self.assertEqual(result_image.size, (1912, 600))
+        # The fixture is anamorphic (2.39 display in a 16:9 raster). Movie
+        # normalization now letterboxes it into the 16:9 project canvas
+        # (default 1920x1080), so the tile follows the 16:9 display ratio
+        # (8 * ceil(16/9 * 100) = 1424) instead of the source's 2.39 ratio.
+        self.assertEqual(result_image.size, (1424, 600))

--- a/tests/utils/test_movie.py
+++ b/tests/utils/test_movie.py
@@ -126,6 +126,34 @@ class MovieTestCase(unittest.TestCase):
         self.assertGreater(center_r, 150)
         self.assertLess(center_g + center_b, 120)
 
+    def test_normalize_anamorphic_letterbox(self):
+        # An anamorphic source (non-square pixels, 2.39 display inside a
+        # 16:9 raster) must be de-anamorphed and letterboxed into the 16:9
+        # project canvas, not squished to fill it. The tile-size route test
+        # cannot catch this distortion, so assert on the pixels here.
+        source = "./tests/fixtures/videos/test_preview_tiles.mp4"
+        video = str(Path(self.tmpdir) / "test_anamorphic.mp4")
+        shutil.copyfile(source, video)
+
+        normalized, _, _ = movie.normalize_movie(video, 5, 1920, 1080)
+        self.assertEqual(movie.get_movie_size(normalized), (1920, 1080))
+
+        frame = str(Path(self.tmpdir) / "test_anamorphic_frame.png")
+        ffmpeg.input(normalized).output(
+            frame, vframes=1
+        ).overwrite_output().run(quiet=True)
+        image = Image.open(frame).convert("L")
+        width, height = image.size
+
+        # Top band is a black letterbox bar...
+        top = image.crop((0, 0, width, 80)).tobytes()
+        self.assertLess(sum(top) / len(top), 10)
+        # ...while the center keeps the undistorted content.
+        mid = image.crop(
+            (0, height // 2 - 40, width, height // 2 + 40)
+        ).tobytes()
+        self.assertGreater(sum(mid) / len(mid), 30)
+
     def test_concat_demuxer_testing(self):
         test_name = "test_concate_demuxer"
         self.concat_testing(movie.concat_demuxer, test_name)

--- a/zou/utils/movie.py
+++ b/zou/utils/movie.py
@@ -229,6 +229,12 @@ def normalize_encoding(
         movflags="+faststart",
         x264opts=f"keyint={keyframes}:scenecut=0",
         vf=(
+            # De-anamorph first so anamorphic sources (non-square pixels)
+            # are fit by their *display* size, not their raster size; a
+            # no-op for the common square-pixel case (sar == 1). Then fit
+            # inside the target canvas preserving the ratio and pad with
+            # black bars instead of stretching.
+            "scale=trunc(iw*sar/2)*2:ih,"
             f"scale={width}:{height}:"
             "force_original_aspect_ratio=decrease:force_divisible_by=2,"
             f"pad={width}:{height}:(ow-iw)/2:(oh-ih)/2,"


### PR DESCRIPTION
## Problems

- Anamorphic uploads (non-square pixels) were squished to fill the project canvas instead of being letterboxed: normalization sized the output from the source raster and forced square pixels, discarding the display aspect ratio.

## Solutions

- De-anamorph the source before fit+pad so the display ratio is preserved and padded with black bars; no-op for square-pixel sources.
- Add a pixel-level anamorphic normalization test and update the tile route expectation to the 16:9 canvas the source is now conformed to.