### PR TITLE
[auth] Harden OIDC SSO (PKCE, email_verified, userinfo fallback)

### DIFF
--- a/specs/configuration.md
+++ b/specs/configuration.md
@@ -93,6 +93,7 @@ a matching Kitsu account is found by email (or created on first login).
 | `OIDC_EMAIL_CLAIM` | `email` | Claim used as the account email |
 | `OIDC_GIVEN_NAME_CLAIM` | `given_name` | Claim used for the first name |
 | `OIDC_FAMILY_NAME_CLAIM` | `family_name` | Claim used for the last name |
+| `OIDC_REQUIRE_EMAIL_VERIFIED` | true | When true, the provider must assert `email_verified == true`; logins with an absent or false claim are rejected. Set to false only for providers that do not emit the claim and whose emails are otherwise trusted. |
 | `OIDC_SKIP_2FA` | false | When true, OIDC sessions skip Kitsu's 2FA setup gate (trust the IdP for MFA). When false, `ENFORCE_2FA` applies as usual. |
 
 The redirect URI to register with the provider is

--- a/tests/auth/test_oidc.py
+++ b/tests/auth/test_oidc.py
@@ -45,15 +45,22 @@ class OIDCClaimMappingTestCase(ApiDBTestCase):
         )
 
     def test_map_claims_omits_missing_fields(self):
-        self.assertEqual(oidc.map_claims({"given_name": "Jane"}), {
-            "first_name": "Jane"
-        })
+        self.assertEqual(
+            oidc.map_claims({"given_name": "Jane"}), {"first_name": "Jane"}
+        )
         self.assertEqual(oidc.map_claims({}), {})
 
-    def test_is_email_verified(self):
-        self.assertTrue(oidc.is_email_verified({}))
-        self.assertTrue(oidc.is_email_verified({"email_verified": True}))
-        self.assertFalse(oidc.is_email_verified({"email_verified": False}))
+    def test_is_email_verified_strict(self):
+        with mock.patch.object(config, "OIDC_REQUIRE_EMAIL_VERIFIED", True):
+            self.assertFalse(oidc.is_email_verified({}))
+            self.assertTrue(oidc.is_email_verified({"email_verified": True}))
+            self.assertFalse(oidc.is_email_verified({"email_verified": False}))
+
+    def test_is_email_verified_permissive(self):
+        with mock.patch.object(config, "OIDC_REQUIRE_EMAIL_VERIFIED", False):
+            self.assertTrue(oidc.is_email_verified({}))
+            self.assertTrue(oidc.is_email_verified({"email_verified": True}))
+            self.assertFalse(oidc.is_email_verified({"email_verified": False}))
 
 
 class OIDCCallbackTestCase(ApiDBTestCase):
@@ -64,14 +71,17 @@ class OIDCCallbackTestCase(ApiDBTestCase):
         self._oidc_enabled = config.OIDC_ENABLED
         self._enforce_2fa = config.ENFORCE_2FA
         self._skip_2fa = config.OIDC_SKIP_2FA
+        self._require_email_verified = config.OIDC_REQUIRE_EMAIL_VERIFIED
         config.OIDC_ENABLED = True
         config.ENFORCE_2FA = False
         config.OIDC_SKIP_2FA = False
+        config.OIDC_REQUIRE_EMAIL_VERIFIED = True
 
     def tearDown(self):
         config.OIDC_ENABLED = self._oidc_enabled
         config.ENFORCE_2FA = self._enforce_2fa
         config.OIDC_SKIP_2FA = self._skip_2fa
+        config.OIDC_REQUIRE_EMAIL_VERIFIED = self._require_email_verified
         super().tearDown()
 
     def mock_client(self, claims):
@@ -99,6 +109,7 @@ class OIDCCallbackTestCase(ApiDBTestCase):
         response = self.call_callback(
             {
                 "email": email,
+                "email_verified": True,
                 "given_name": "New",
                 "family_name": "Comer",
             }
@@ -115,6 +126,7 @@ class OIDCCallbackTestCase(ApiDBTestCase):
         response = self.call_callback(
             {
                 "email": existing["email"],
+                "email_verified": True,
                 "given_name": "Updated",
                 "family_name": "Name",
             }
@@ -125,7 +137,9 @@ class OIDCCallbackTestCase(ApiDBTestCase):
         self.assertEqual(person["first_name"], "Updated")
 
     def test_missing_email_returns_400(self):
-        response = self.call_callback({"given_name": "No", "family_name": "Mail"})
+        response = self.call_callback(
+            {"given_name": "No", "family_name": "Mail"}
+        )
         self.assertEqual(response.status_code, 400)
 
     def test_unverified_email_rejected(self):
@@ -138,6 +152,41 @@ class OIDCCallbackTestCase(ApiDBTestCase):
             persons_service.get_person_by_email,
             "spoof@example.com",
         )
+
+    def test_absent_email_verified_rejected_when_strict(self):
+        response = self.call_callback(
+            {
+                "email": "noclaim@example.com",
+                "given_name": "No",
+                "family_name": "Claim",
+            }
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertRaises(
+            Exception,
+            persons_service.get_person_by_email,
+            "noclaim@example.com",
+        )
+
+    def test_absent_email_verified_accepted_when_permissive(self):
+        config.OIDC_REQUIRE_EMAIL_VERIFIED = False
+        response = self.call_callback(
+            {
+                "email": "permissive@example.com",
+                "given_name": "Per",
+                "family_name": "Missive",
+            }
+        )
+        self.assertEqual(response.status_code, 302)
+        person = persons_service.get_person_by_email("permissive@example.com")
+        self.assertEqual(person["first_name"], "Per")
+
+    def test_token_exchange_failure_returns_400(self):
+        client = mock.Mock()
+        client.authorize_access_token.side_effect = Exception("boom")
+        with mock.patch.object(oidc, "get_oidc_client", return_value=client):
+            response = self.app.get("auth/oidc/callback")
+        self.assertEqual(response.status_code, 400)
 
     def _capture_claims(self, claims):
         """Run the callback capturing the additional_claims passed to the JWT."""
@@ -154,6 +203,7 @@ class OIDCCallbackTestCase(ApiDBTestCase):
         additional_claims = self._capture_claims(
             {
                 "email": "needs2fa@example.com",
+                "email_verified": True,
                 "given_name": "Needs",
                 "family_name": "Tfa",
             }
@@ -166,6 +216,7 @@ class OIDCCallbackTestCase(ApiDBTestCase):
         additional_claims = self._capture_claims(
             {
                 "email": "skip2fa@example.com",
+                "email_verified": True,
                 "given_name": "Skip",
                 "family_name": "Tfa",
             }

--- a/zou/app/blueprints/auth/resources.py
+++ b/zou/app/blueprints/auth/resources.py
@@ -1644,6 +1644,19 @@ class OIDCCallbackResource(Resource, ArgsMixin):
         if not oidc.is_email_verified(claims):
             return {"error": "Email address is not verified."}, 400
 
+        # Some providers (notably Azure AD/Entra ID) omit name claims from the
+        # ID token and only expose them on the userinfo endpoint. Fetch it as a
+        # best-effort fallback when the token carried no usable name claims; a
+        # failure here must not block an otherwise valid login.
+        if not oidc.map_claims(claims):
+            try:
+                userinfo = oidc.get_oidc_client().userinfo(token=token)
+                claims = {**userinfo, **claims}
+            except Exception:
+                current_app.logger.exception(
+                    "OIDC userinfo fetch failed; proceeding without it."
+                )
+
         person_info = oidc.map_claims(claims)
 
         try:

--- a/zou/app/blueprints/auth/resources.py
+++ b/zou/app/blueprints/auth/resources.py
@@ -1631,7 +1631,11 @@ class OIDCCallbackResource(Resource, ArgsMixin):
         if not config.OIDC_ENABLED:
             return {"error": "OIDC is not enabled."}, 400
 
-        token = oidc.get_oidc_client().authorize_access_token()
+        try:
+            token = oidc.get_oidc_client().authorize_access_token()
+        except Exception:
+            current_app.logger.exception("OIDC token exchange failed.")
+            return {"error": "OIDC authentication failed."}, 400
         claims = token.get("userinfo") or {}
 
         email = oidc.get_email_from_claims(claims)

--- a/zou/app/config.py
+++ b/zou/app/config.py
@@ -163,6 +163,7 @@ OIDC_SCOPES = os.getenv("OIDC_SCOPES", "openid email profile")
 OIDC_EMAIL_CLAIM = os.getenv("OIDC_EMAIL_CLAIM", "email")
 OIDC_GIVEN_NAME_CLAIM = os.getenv("OIDC_GIVEN_NAME_CLAIM", "given_name")
 OIDC_FAMILY_NAME_CLAIM = os.getenv("OIDC_FAMILY_NAME_CLAIM", "family_name")
+OIDC_REQUIRE_EMAIL_VERIFIED = envtobool("OIDC_REQUIRE_EMAIL_VERIFIED", True)
 OIDC_SKIP_2FA = envtobool("OIDC_SKIP_2FA", False)
 
 LOGS_MODE = os.getenv("LOGS_MODE", "default")

--- a/zou/app/utils/oidc.py
+++ b/zou/app/utils/oidc.py
@@ -16,7 +16,10 @@ def oidc_client_for(app):
         server_metadata_url=config.OIDC_DISCOVERY_URL,
         client_id=config.OIDC_CLIENT_ID,
         client_secret=config.OIDC_CLIENT_SECRET,
-        client_kwargs={"scope": config.OIDC_SCOPES},
+        client_kwargs={
+            "scope": config.OIDC_SCOPES,
+            "code_challenge_method": "S256",
+        },
     )
     return oauth
 
@@ -39,12 +42,21 @@ def get_email_from_claims(claims):
 
 def is_email_verified(claims):
     """
-    Return whether the email can be trusted. We only reject when the
-    provider explicitly states the email is not verified; an absent
-    ``email_verified`` claim is treated as verified to stay compatible with
-    providers that do not emit it.
+    Return whether the email can be trusted.
+
+    With ``OIDC_REQUIRE_EMAIL_VERIFIED`` enabled (the default), the provider
+    must explicitly assert ``email_verified == true``; an absent claim is
+    rejected. This guards against account takeover when linking/provisioning
+    by email against a provider that allows unverified addresses.
+
+    With the flag disabled, we only reject when the provider explicitly
+    states the email is not verified, treating an absent claim as verified to
+    stay compatible with providers that do not emit it.
     """
-    return claims.get("email_verified", True) is not False
+    verified = claims.get("email_verified")
+    if config.OIDC_REQUIRE_EMAIL_VERIFIED:
+        return verified is True
+    return verified is not False
 
 
 def map_claims(claims):


### PR DESCRIPTION
**Problem**
- OIDC login advertised PKCE but only requested scopes, so the exchange ran without PKCE protection
- Linking/provisioning trusted an absent `email_verified` claim, allowing account takeover via providers that permit unverified emails
- Token-exchange failures in the callback surfaced as bare 500s
- Names were left empty for providers (notably Azure AD) that omit them from the ID token

**Solution**
- Enable PKCE (`code_challenge_method=S256`)
- Add `OIDC_REQUIRE_EMAIL_VERIFIED` (default true): require an explicit verified claim before linking/provisioning; flag off restores the permissive behaviour
- Catch callback token-exchange failures and return 400 instead of 500
- Best-effort fall back to the userinfo endpoint for names when the ID token lacks them