### PR TITLE
Fix asset matching in task type CSV import

### DIFF
--- a/tests/source/csv/test_import_task_type_estimations.py
+++ b/tests/source/csv/test_import_task_type_estimations.py
@@ -1,0 +1,41 @@
+import os
+import tempfile
+
+from tests.base import ApiDBTestCase
+
+from zou.app.models.task import Task
+
+
+class ImportCsvTaskTypeEstimationsTestCase(ApiDBTestCase):
+    def setUp(self):
+        super(ImportCsvTaskTypeEstimationsTestCase, self).setUp()
+
+        self.generate_fixture_project_status()
+        self.generate_fixture_project()
+        self.generate_fixture_department()
+        self.generate_fixture_task_type()
+        self.generate_fixture_person()
+        self.generate_fixture_assigner()
+
+    def write_csv(self, content):
+        """
+        Write CSV content to a temporary file and return its path.
+        """
+        descriptor, file_path = tempfile.mkstemp(suffix=".csv")
+        with os.fdopen(descriptor, "w", newline="", encoding="utf-8") as f:
+            f.write(content)
+        return file_path
+
+    def test_import_matches_asset_entity(self):
+        # For assets, a row is matched on its asset type ("Props") as Parent
+        # and its asset name ("Tree") as Entity.
+        self.generate_fixture_task()
+        path = (
+            f"/import/csv/projects/{self.project.id}"
+            f"/task-types/{self.task_type.id}/estimations"
+        )
+        content = "Parent,Entity,Start date\nProps,Tree,2024-01-05\n"
+        self.upload_file(path, self.write_csv(content))
+
+        task = Task.get(self.task.id)
+        self.assertEqual(task.start_date.strftime("%Y-%m-%d"), "2024-01-05")

--- a/zou/app/blueprints/source/csv/task_type_estimations.py
+++ b/zou/app/blueprints/source/csv/task_type_estimations.py
@@ -106,7 +106,10 @@ class TaskTypeEstimationsCsvImportResource(BaseCsvProjectImportResource):
                 criterions_assets["source_id"] = episode_id
             assets = assets_service.get_assets(criterions_assets)
             for asset in assets:
-                key = f'asset_types_map[asset["entity_type_id"]]{slugify(asset["name"])}'
+                key = (
+                    f"{asset_types_map[asset['entity_type_id']]}"
+                    f"{slugify(asset['name'])}"
+                )
                 self.assets_map[key] = asset["id"]
         elif task_type["for_entity"] == "Shot":
             sequences_map = {}
@@ -137,7 +140,9 @@ class TaskTypeEstimationsCsvImportResource(BaseCsvProjectImportResource):
         elif task_type["for_entity"] == "Shot" and self.shots_map.get(key):
             entity_id = self.shots_map[key]
         else:
-            raise RowException(f"Entity {key} not found")
+            raise RowException(
+                f"Entity '{row['Entity']}' with parent '{row['Parent']}' not found"
+            )
 
         new_data = {}
 


### PR DESCRIPTION
**Problem**
- During task type estimations CSV import, the asset lookup key was built from literal text instead of the asset-type slug, so no asset row ever matched (regression from the %-to-f-string conversion in bf7d4fef8).

**Solution**
- Rebuild the asset key by interpolating the asset-type slug and the asset name, restoring the original matching behavior.
- Report the raw CSV `Parent`/`Entity` values in the "not found" error instead of the internal slugified key, so the user can fix their file.
