### PR TITLE
perf: lazy-import heavy native libs to reduce per-worker memory

### DIFF
--- a/zou/app/blueprints/source/otio.py
+++ b/zou/app/blueprints/source/otio.py
@@ -1,6 +1,5 @@
 import os
 import pathlib
-import opentimelineio as otio
 import re
 
 from string import Template
@@ -162,6 +161,8 @@ class OTIOBaseResource(Resource, ArgsMixin):
     ):
         result = {"updated_shots": [], "created_shots": []}
         try:
+            import opentimelineio as otio
+
             kwargs = {}
             extension = pathlib.Path(file_path).suffix
             if extension == ".edl":

--- a/zou/app/services/auth_service.py
+++ b/zou/app/services/auth_service.py
@@ -7,11 +7,6 @@ from datetime import timedelta
 from flask import request, session, current_app
 from babel.dates import format_datetime
 
-from ldap3 import Server, Connection, ALL, NTLM, SIMPLE
-from ldap3.core.exceptions import (
-    LDAPSocketOpenError,
-    LDAPInvalidCredentialsResult,
-)
 
 from zou.app.services import persons_service, templates_service
 from zou.app.models.person import Person
@@ -164,6 +159,12 @@ def ldap_auth_strategy(person, password, app):
     (only if fallback is activated (via LDAP_FALLBACK flag) in configuration)
     """
     if person["is_generated_from_ldap"]:
+        from ldap3 import Server, Connection, ALL, NTLM, SIMPLE
+        from ldap3.core.exceptions import (
+            LDAPSocketOpenError,
+            LDAPInvalidCredentialsResult,
+        )
+
         try:
             SSL = app.config["LDAP_SSL"]
             if app.config["LDAP_IS_AD_SIMPLE"]:

--- a/zou/app/utils/chats.py
+++ b/zou/app/utils/chats.py
@@ -1,10 +1,3 @@
-from slack import WebClient as SlackClient
-from matterhook import Webhook
-from discord import (
-    Client as DiscordClient,
-    Intents as DiscordIntents,
-    Embed as DiscordEmbed,
-)
 from zou.app import config
 import asyncio
 import logging
@@ -24,6 +17,8 @@ def send_to_slack(token, userid, message):
     if token:
         if userid:
             try:
+                from slack import WebClient as SlackClient
+
                 client = SlackClient(token=token)
                 blocks = [
                     {
@@ -53,6 +48,8 @@ def send_to_mattermost(webhook, userid, message):
     if webhook:
         if userid:
             try:
+                from matterhook import Webhook
+
                 arg = webhook.split("/")
                 server = f"{arg[0]}{arg[1]}//{arg[2]}"
                 hook = arg[4]
@@ -82,6 +79,12 @@ def send_to_mattermost(webhook, userid, message):
 
 
 def send_to_discord(token, userid, message):
+    from discord import (
+        Client as DiscordClient,
+        Intents as DiscordIntents,
+        Embed as DiscordEmbed,
+    )
+
     async def send_to_discord_async(token, userid, message):
         intents = DiscordIntents.default()
         intents.members = True

--- a/zou/app/utils/thumbnail.py
+++ b/zou/app/utils/thumbnail.py
@@ -1,8 +1,6 @@
 import os
 import shutil
 import math
-import cv2
-import numpy
 
 from pathlib import Path
 
@@ -218,6 +216,9 @@ def turn_hdr_into_thumbnail(original_path, size=BIG_RECTANGLE_SIZE):
     """
     Turn an HDR file into a thumbnail.
     """
+    import cv2
+    import numpy
+
     file_target_path = Path(original_path).with_suffix(".png")
     hdr = cv2.imread(original_path, flags=cv2.IMREAD_ANYDEPTH)
     # Simply clamp values to a 0-1 range for tone-mapping

--- a/zou/utils/movie.py
+++ b/zou/utils/movie.py
@@ -8,7 +8,6 @@ import subprocess
 import tempfile
 
 import ffmpeg
-import opentimelineio as otio
 
 logger = logging.getLogger(__name__)
 loghandler = logging.StreamHandler()
@@ -75,6 +74,8 @@ def extract_frame_from_movie(movie_path, frame_number, movie_fps):
     Extract a frame from the movie given at movie path. It
     takes a picture at the specified time of the movie.
     """
+    import opentimelineio as otio
+
     file_source_name = os.path.basename(movie_path)
     file_target_name = f"{file_source_name[:-4]}_{frame_number}.png"
     file_target_path = os.path.join(tempfile.gettempdir(), file_target_name)


### PR DESCRIPTION
**Problem**
  - Each gunicorn worker imports cv2, numpy, opentimelineio, discord, slack, matterhook, and ldap3 at module load time, regardless of whether those features are used
  - Without preload_app, every worker independently re-loads all native extensions, consuming ~330 MB RSS each with no page sharing between workers

**Solution**
  - Move import cv2 / import numpy inside turn_hdr_into_thumbnail() (only function that uses them)
  - Move import opentimelineio as otio inside extract_frame_from_movie() and OTIOBaseResource.run_import()
  - Move slack, matterhook, discord imports inside their respective send_to_* functions in chats.py
  - Move ldap3 imports inside ldap_auth_strategy() in auth_service.py