### PR TITLE
Manager task-dates, shared-playlist 403 fix, password reset link

### DIFF
--- a/tests/persons/test_person_routes.py
+++ b/tests/persons/test_person_routes.py
@@ -1,7 +1,10 @@
+import urllib.parse
+
 from tests.base import ApiDBTestCase
 
 from zou.app.models.day_off import DayOff
 from zou.app.models.person import Person
+from zou.app.stores import auth_tokens_store
 from zou.app.utils import auth
 
 
@@ -187,6 +190,78 @@ class PersonRoutesTestCase(ApiDBTestCase):
         result = self.post(
             f"/actions/persons/{other_admin.id}/change-password",
             {"password": "newpassword123", "password_2": "newpassword123"},
+            400,
+        )
+        self.assertEqual(
+            result.get("message"),
+            "An admin can't change another admin's password.",
+        )
+
+    def test_get_reset_password_link(self):
+        email = self.person.email
+        result = self.post(
+            f"/actions/persons/{self.person_id}/reset-password-link",
+            {},
+            200,
+        )
+        reset_link = result["reset_password_link"]
+        self.assertIn("/reset-change-password?", reset_link)
+
+        query = urllib.parse.urlparse(reset_link).query
+        params = dict(urllib.parse.parse_qsl(query))
+        self.assertEqual(params["email"], email)
+        # The link carries the very token stored for the reset flow, so it
+        # can be used to set a new password just like the emailed link.
+        self.assertEqual(
+            params["token"], auth_tokens_store.get(f"reset-token-{email}")
+        )
+        new_password = "newpassword123"
+        self.put(
+            "auth/reset-password",
+            {
+                "email": email,
+                "token": params["token"],
+                "password": new_password,
+                "password2": new_password,
+            },
+            200,
+        )
+        self.post(
+            "auth/login", {"email": email, "password": new_password}, 200
+        )
+
+    def test_get_reset_password_link_is_reused(self):
+        path = f"/actions/persons/{self.person_id}/reset-password-link"
+        first = self.post(path, {}, 200)["reset_password_link"]
+        second = self.post(path, {}, 200)["reset_password_link"]
+        # A pending token is reused so a previously shared link stays valid.
+        self.assertEqual(first, second)
+
+    def test_get_reset_password_link_for_new_admin(self):
+        new_admin = Person.create(
+            first_name="New",
+            last_name="Admin",
+            role="admin",
+            email="new.admin@gmail.com",
+        )
+        result = self.post(
+            f"/actions/persons/{new_admin.id}/reset-password-link",
+            {},
+            200,
+        )
+        self.assertIn("reset_password_link", result)
+
+    def test_get_reset_password_link_for_existing_admin_is_blocked(self):
+        other_admin = Person.create(
+            first_name="Other",
+            last_name="Admin",
+            role="admin",
+            email="other.admin@gmail.com",
+            password=auth.encrypt_password("existingpassword"),
+        )
+        result = self.post(
+            f"/actions/persons/{other_admin.id}/reset-password-link",
+            {},
             400,
         )
         self.assertEqual(

--- a/tests/shared/test_playlist_sharing.py
+++ b/tests/shared/test_playlist_sharing.py
@@ -993,3 +993,184 @@ class PlaylistSharingTestCase(ApiDBTestCase):
             f"/pictures/originals/preview-files/{preview_file.id}.gif"
         )
         self.assertEqual(response.status_code, 404)
+
+    def test_membership_same_entity_in_several_shots(self):
+        """
+        A playlist may list the same entity several times, each shot
+        positioned on a different task type and a different revision (e.g.
+        one task pinned to revision 2 and another to revision 1). Every
+        positioned preview must pass the shared-playlist membership check,
+        not only the last shot's. Before the fix the check collapsed the
+        shots into a single entity -> preview_file_id mapping (regression
+        from 54ec061ce): only the last shot's preview, and any preview
+        sharing its revision number, was served — so the revision 2 preview
+        returned 403 while the revision 1 one (matching the last shot)
+        worked.
+
+        The two shots are pinned to *different* revisions on purpose: with
+        equal revisions the old code let the non-last preview through by
+        coincidence and the regression would slip past this test.
+        """
+        from zou.app.models.playlist import Playlist as PlaylistModel
+        from zou.app.models.preview_file import PreviewFile
+        from zou.app.models.task import Task
+        from zou.app.services import playlist_sharing_service
+
+        # Two task types positioned on the SAME asset, on different revisions.
+        first_task = self.task
+        second_task = Task.create(
+            name="Second",
+            project_id=self.project.id,
+            task_type_id=self.task_type_modeling.id,
+            task_status_id=self.task_status.id,
+            entity_id=self.asset.id,
+            assigner_id=self.assigner.id,
+        )
+        first_preview = PreviewFile.create(
+            name="first.png",
+            revision=2,
+            extension="png",
+            task_id=first_task.id,
+            person_id=self.person.id,
+        )
+        second_preview = PreviewFile.create(
+            name="second.png",
+            revision=1,
+            extension="png",
+            task_id=second_task.id,
+            person_id=self.person.id,
+        )
+        PlaylistModel.get(self.playlist["id"]).update(
+            {
+                "shots": [
+                    {
+                        "entity_id": str(self.asset.id),
+                        "preview_file_id": str(first_preview.id),
+                    },
+                    {
+                        "entity_id": str(self.asset.id),
+                        "preview_file_id": str(second_preview.id),
+                    },
+                ]
+            }
+        )
+        link = playlist_sharing_service.create_share_link(
+            self.playlist["id"], self.person.id
+        )
+        token = link["token"]
+
+        # Both positioned previews belong to the shared playlist. The first
+        # shot's preview (revision 2) used to be overwritten in the entity
+        # map by the last shot (revision 1) and 403'd.
+        self.assertTrue(
+            playlist_sharing_service.is_preview_file_in_shared_playlist(
+                token, str(first_preview.id)
+            )
+        )
+        self.assertTrue(
+            playlist_sharing_service.is_preview_file_in_shared_playlist(
+                token, str(second_preview.id)
+            )
+        )
+
+        # A sibling position of a positioned revision is still accepted
+        # (same task, same revision, different position).
+        sibling = PreviewFile.create(
+            name="first-pos2.png",
+            revision=first_preview.revision,
+            position=first_preview.position + 1,
+            extension="png",
+            task_id=first_task.id,
+            person_id=self.person.id,
+        )
+        self.assertTrue(
+            playlist_sharing_service.is_preview_file_in_shared_playlist(
+                token, str(sibling.id)
+            )
+        )
+
+        # A different revision of a positioned task stays rejected.
+        other_revision = PreviewFile.create(
+            name="first-rev2.png",
+            revision=first_preview.revision + 1,
+            extension="png",
+            task_id=first_task.id,
+            person_id=self.person.id,
+        )
+        self.assertFalse(
+            playlist_sharing_service.is_preview_file_in_shared_playlist(
+                token, str(other_revision.id)
+            )
+        )
+
+        # A preview on a DIFFERENT positioned task that merely shares another
+        # positioned preview's revision NUMBER stays rejected: membership is
+        # decided on (task_id, revision), not on the revision number alone.
+        # This is the case the (task_id) guard exists for; without it the
+        # revision-only comparison would wrongly accept it.
+        cross_task_collision = PreviewFile.create(
+            name="second-rev2.png",
+            revision=first_preview.revision,  # 2: same number as first_preview
+            extension="png",
+            task_id=second_task.id,  # but a different (also positioned) task
+            person_id=self.person.id,
+        )
+        self.assertFalse(
+            playlist_sharing_service.is_preview_file_in_shared_playlist(
+                token, str(cross_task_collision.id)
+            )
+        )
+
+    def test_membership_skips_dangling_positioned_preview(self):
+        """
+        A playlist shot keeps its preview_file_id even after that preview is
+        deleted (deletion does not scrub playlist.shots). The membership
+        check must skip such a dangling positioned id and answer cleanly,
+        instead of raising PreviewFileNotFoundException and turning a
+        legitimate response into a 404.
+        """
+        from zou.app.models.playlist import Playlist as PlaylistModel
+        from zou.app.models.preview_file import PreviewFile
+        from zou.app.services import playlist_sharing_service
+
+        positioned = PreviewFile.create(
+            name="positioned.png",
+            revision=1,
+            extension="png",
+            task_id=self.task.id,
+            person_id=self.person.id,
+        )
+        # Another, non-positioned preview of the same entity, on a different
+        # revision, so it is not a member.
+        other = PreviewFile.create(
+            name="other.png",
+            revision=2,
+            extension="png",
+            task_id=self.task.id,
+            person_id=self.person.id,
+        )
+        PlaylistModel.get(self.playlist["id"]).update(
+            {
+                "shots": [
+                    {
+                        "entity_id": str(self.asset.id),
+                        "preview_file_id": str(positioned.id),
+                    }
+                ]
+            }
+        )
+        link = playlist_sharing_service.create_share_link(
+            self.playlist["id"], self.person.id
+        )
+        token = link["token"]
+
+        # Delete the positioned preview, leaving a dangling id in the shot.
+        PreviewFile.get(positioned.id).delete()
+
+        # The loop dereferences the dangling positioned id; it must be skipped
+        # rather than raising, so the check returns False cleanly.
+        self.assertFalse(
+            playlist_sharing_service.is_preview_file_in_shared_playlist(
+                token, str(other.id)
+            )
+        )

--- a/tests/tasks/test_task_routes.py
+++ b/tests/tasks/test_task_routes.py
@@ -1,6 +1,13 @@
 from tests.base import ApiDBTestCase
 
-from zou.app.services import concepts_service, tasks_service
+from zou.app.models.person import Person
+from zou.app.models.task import Task
+from zou.app.services import (
+    concepts_service,
+    projects_service,
+    tasks_service,
+)
+from zou.app.utils import fields
 
 
 class TaskRoutesTestCase(ApiDBTestCase):
@@ -31,8 +38,164 @@ class TaskRoutesTestCase(ApiDBTestCase):
         self.assertIsInstance(result, list)
 
     def test_get_persons_task_dates(self):
+        # Admin gets the studio-wide view.
         result = self.get("/data/persons/task-dates")
         self.assertIsInstance(result, list)
+        person_ids = [entry["person_id"] for entry in result]
+        self.assertIn(str(self.person.id), person_ids)
+
+    def test_get_persons_task_dates_as_manager(self):
+        # A manager who is a team member of the project sees its persons.
+        self.generate_fixture_user_manager()
+        projects_service.add_team_member(
+            self.project_id, self.user_manager["id"]
+        )
+        self.log_in_manager()
+        result = self.get("/data/persons/task-dates")
+        person_ids = [entry["person_id"] for entry in result]
+        self.assertIn(str(self.person.id), person_ids)
+
+    def test_get_persons_task_dates_manager_scoped_to_own_projects(self):
+        # A manager who belongs to no project sees no one (the default view is
+        # scoped to the caller's projects, not studio-wide).
+        self.generate_fixture_user_manager()
+        self.log_in_manager()
+        result = self.get("/data/persons/task-dates")
+        self.assertEqual(result, [])
+
+    def test_get_persons_task_dates_manager_own_project_id(self):
+        self.generate_fixture_user_manager()
+        projects_service.add_team_member(
+            self.project_id, self.user_manager["id"]
+        )
+        self.log_in_manager()
+        result = self.get(
+            f"/data/persons/task-dates?project_id={self.project_id}"
+        )
+        person_ids = [entry["person_id"] for entry in result]
+        self.assertIn(str(self.person.id), person_ids)
+
+    def test_get_persons_task_dates_manager_foreign_project_id(self):
+        # A manager cannot reach a project they are not a team member of.
+        self.generate_fixture_user_manager()
+        projects_service.add_team_member(
+            self.project_id, self.user_manager["id"]
+        )
+        self.generate_fixture_project_standard()
+        self.log_in_manager()
+        self.get(
+            f"/data/persons/task-dates?project_id={self.project_standard.id}",
+            403,
+        )
+
+    def test_get_persons_task_dates_admin_project_id(self):
+        # Admin can scope the studio-wide view to a single project.
+        result = self.get(
+            f"/data/persons/task-dates?project_id={self.project_id}"
+        )
+        person_ids = [entry["person_id"] for entry in result]
+        self.assertIn(str(self.person.id), person_ids)
+
+    def test_get_persons_task_dates_manager_excludes_foreign_persons(self):
+        # A manager only sees persons from their own projects, never a person
+        # whose tasks live solely in a project they are not a member of.
+        person_id = str(self.person.id)
+        self.generate_fixture_user_manager()
+        projects_service.add_team_member(
+            self.project_id, self.user_manager["id"]
+        )
+        self.generate_fixture_asset_standard()
+        foreign_person = Person.create(
+            first_name="Foreign",
+            last_name="Artist",
+            email="foreign.artist@gmail.com",
+        )
+        Task.create(
+            name="Foreign task",
+            project_id=self.project_standard.id,
+            task_type_id=self.task_type.id,
+            task_status_id=self.task_status.id,
+            entity_id=self.asset_standard.id,
+            assignees=[foreign_person],
+            assigner_id=self.assigner.id,
+            start_date=fields.get_date_object("2017-02-20"),
+            due_date=fields.get_date_object("2017-02-28"),
+        )
+        self.log_in_manager()
+        result = self.get("/data/persons/task-dates")
+        person_ids = [entry["person_id"] for entry in result]
+        self.assertIn(person_id, person_ids)
+        self.assertNotIn(str(foreign_person.id), person_ids)
+
+    def test_get_persons_task_dates_empty_project_id(self):
+        # An empty `?project_id=` filter is treated as absent, not as an
+        # invalid UUID (regression: 500 for admins, 404 for managers).
+        result = self.get("/data/persons/task-dates?project_id=")
+        person_ids = [entry["person_id"] for entry in result]
+        self.assertIn(str(self.person.id), person_ids)
+
+        self.generate_fixture_user_manager()
+        projects_service.add_team_member(
+            self.project_id, self.user_manager["id"]
+        )
+        self.log_in_manager()
+        result = self.get("/data/persons/task-dates?project_id=")
+        person_ids = [entry["person_id"] for entry in result]
+        self.assertIn(str(self.person.id), person_ids)
+
+    def test_get_persons_task_dates_invalid_project_id(self):
+        # A non-empty, non-UUID `project_id` is rejected with a 400 (before the
+        # role branch), instead of reaching the query as an invalid UUID (which
+        # used to 500 for admins and 404 for managers).
+        self.get("/data/persons/task-dates?project_id=not-a-uuid", 400)
+        # Whitespace-only is normalised away like an empty filter, not a 400.
+        result = self.get("/data/persons/task-dates?project_id=%20")
+        person_ids = [entry["person_id"] for entry in result]
+        self.assertIn(str(self.person.id), person_ids)
+
+    def test_get_persons_task_dates_manager_closed_project_id(self):
+        # A manager who is a team member of a CLOSED project can still pull its
+        # persons when scoping explicitly to it: an access-checked project_id is
+        # honoured directly, not intersected with the open-project list (which
+        # would drop the closed project and return an empty result).
+        self.generate_fixture_user_manager()
+        self.generate_fixture_project_closed()
+        projects_service.add_team_member(
+            str(self.project_closed.id), self.user_manager["id"]
+        )
+        closed_person = Person.create(
+            first_name="Closed",
+            last_name="Artist",
+            email="closed.artist@gmail.com",
+        )
+        Task.create(
+            name="Closed task",
+            project_id=self.project_closed.id,
+            task_type_id=self.task_type.id,
+            task_status_id=self.task_status.id,
+            entity_id=self.asset.id,
+            assignees=[closed_person],
+            assigner_id=self.assigner.id,
+            start_date=fields.get_date_object("2017-02-20"),
+            due_date=fields.get_date_object("2017-02-28"),
+        )
+        self.log_in_manager()
+        result = self.get(
+            f"/data/persons/task-dates?project_id={self.project_closed.id}"
+        )
+        person_ids = [entry["person_id"] for entry in result]
+        self.assertIn(str(closed_person.id), person_ids)
+
+    def test_get_persons_task_dates_supervisor_unauthorized(self):
+        # The gate is manager-or-above: a supervisor is rejected.
+        self.generate_fixture_user_supervisor()
+        self.log_in_supervisor()
+        self.get("/data/persons/task-dates", 403)
+
+    def test_get_persons_task_dates_unauthorized(self):
+        self.generate_fixture_user_vendor()
+        self.log_in_vendor()
+        self.get("/data/persons/task-dates", 403)
 
     def test_assign_person_to_tasks(self):
         result = self.put(

--- a/zou/app/blueprints/auth/resources.py
+++ b/zou/app/blueprints/auth/resources.py
@@ -1,6 +1,5 @@
 import hmac
 import secrets
-import urllib.parse
 
 from flask import request, jsonify, current_app, redirect, make_response
 from flask_restful import Resource
@@ -781,12 +780,7 @@ class ResetPasswordResource(Resource, ArgsMixin):
 
         token = auth_service.generate_reset_token()
         auth_tokens_store.add(f"reset-token-{body.email}", token, ttl=3600 * 2)
-        params = {"email": body.email, "token": token}
-        query = urllib.parse.urlencode(params)
-        reset_url = (
-            f"{config.DOMAIN_PROTOCOL}://{config.DOMAIN_NAME}"
-            f"/reset-change-password?{query}"
-        )
+        reset_url = persons_service.build_password_reset_url(body.email, token)
         locale = user.get("locale") or getattr(
             config, "DEFAULT_LOCALE", "en_US"
         )

--- a/zou/app/blueprints/persons/__init__.py
+++ b/zou/app/blueprints/persons/__init__.py
@@ -7,6 +7,7 @@ from zou.app.blueprints.persons.resources import (
     DayOffForMonthResource,
     DesktopLoginsResource,
     InvitePersonResource,
+    ResetPasswordLinkResource,
     PersonMonthQuotaShotsResource,
     PersonWeekQuotaShotsResource,
     PersonDayQuotaShotsResource,
@@ -95,6 +96,10 @@ routes = [
         PersonDayOffResource,
     ),
     ("/actions/persons/<person_id>/invite", InvitePersonResource),
+    (
+        "/actions/persons/<person_id>/reset-password-link",
+        ResetPasswordLinkResource,
+    ),
     ("/actions/persons/<person_id>/departments/add", AddToDepartmentResource),
     (
         "/actions/persons/<person_id>/departments/<department_id>",

--- a/zou/app/blueprints/persons/resources.py
+++ b/zou/app/blueprints/persons/resources.py
@@ -5,7 +5,6 @@ from flask import abort, request, current_app
 from flask_restful import Resource
 from flask_jwt_extended import jwt_required
 
-from zou.app import config
 from zou.app.mixin import ArgsMixin
 from zou.app.services import (
     persons_service,
@@ -1302,6 +1301,61 @@ class InvitePersonResource(Resource):
         return {"success": True, "message": "Email sent"}
 
 
+class ResetPasswordLinkResource(Resource):
+
+    @jwt_required()
+    def post(self, person_id):
+        """
+        Get a password reset link
+        ---
+        description: Return the password reset link for the given person. It is
+          the same link as the one embedded in the password recovery email, so
+          an admin can share it manually (for instance when email delivery is
+          not configured). An already pending reset token is reused so a link
+          shared earlier stays valid; a new one is generated otherwise.
+        tags:
+          - Persons
+        parameters:
+          - in: path
+            name: person_id
+            required: true
+            schema:
+              type: string
+              format: uuid
+            description: Person unique identifier
+            example: a24a6ea4-ce75-4665-a070-57453082c25
+        responses:
+          200:
+            description: Password reset link generated
+            content:
+              application/json:
+                schema:
+                  type: object
+                  properties:
+                    reset_password_link:
+                      type: string
+                      description: Link to follow to choose a new password
+          400:
+            description: User is a protected account or another admin who
+              already has a password
+        """
+        user_service.check_person_is_not_bot(person_id)
+        permissions.check_admin_permissions()
+        current_user = persons_service.get_current_user()
+        try:
+            person = persons_service.check_password_change_allowed(person_id)
+            reset_password_link = (
+                persons_service.get_or_create_password_reset_link(person_id)
+            )
+            current_app.logger.info(
+                f"User {current_user['email']} generated a password reset "
+                f"link for {person['email']}"
+            )
+            return {"reset_password_link": reset_password_link}
+        except PersonInProtectedAccounts as exception:
+            return {"error": True, "message": exception.description}, 400
+
+
 class DayOffForMonthResource(Resource, ArgsMixin):
 
     @jwt_required()
@@ -1719,18 +1773,7 @@ class ChangePasswordForPersonResource(Resource, ArgsMixin):
         password, password_2 = body.password, body.password_2
         current_user = persons_service.get_current_user()
         try:
-            person = persons_service.get_person(person_id)
-            if person["id"] != current_user["id"]:
-                if person["email"] in config.PROTECTED_ACCOUNTS:
-                    raise PersonInProtectedAccounts(
-                        "This user is in protected accounts."
-                    )
-                elif person["role"] == "admin":
-                    person_raw = persons_service.get_person_raw(person_id)
-                    if person_raw.password is not None:
-                        raise PersonInProtectedAccounts(
-                            "An admin can't change another admin's password."
-                        )
+            person = persons_service.check_password_change_allowed(person_id)
             auth.validate_password(password, password_2)
             password = auth.encrypt_password(password)
             persons_service.update_password(person["email"], password)

--- a/zou/app/blueprints/tasks/resources.py
+++ b/zou/app/blueprints/tasks/resources.py
@@ -29,7 +29,14 @@ from zou.app.services import (
     user_service,
     concepts_service,
 )
-from zou.app.utils import events, query, permissions, date_helpers, validation
+from zou.app.utils import (
+    events,
+    query,
+    permissions,
+    date_helpers,
+    validation,
+    fields,
+)
 from zou.app.mixin import ArgsMixin
 from zou.app.blueprints.tasks.schemas import (
     CommentPreviewSchema,
@@ -2672,7 +2679,6 @@ class SetTaskMainPreviewResource(Resource):
 class PersonsTasksDatesResource(Resource, ArgsMixin):
 
     @jwt_required()
-    @permissions.require_admin
     def get(self):
         """
         Get persons tasks dates
@@ -2681,7 +2687,8 @@ class PersonsTasksDatesResource(Resource, ArgsMixin):
         - Tasks
         description: For each active person, return the first start date of all
           tasks assigned to them and the last end date. Useful for schedule
-          planning.
+          planning. Admins get the studio-wide view; managers are restricted to
+          the projects of their own teams.
         parameters:
           - in: query
             name: project_id
@@ -2706,19 +2713,34 @@ class PersonsTasksDatesResource(Resource, ArgsMixin):
                           type: string
                           format: uuid
                           example: a24a6ea4-ce75-4665-a070-57453082c25
-                        first_start_date:
+                        min_date:
                           type: string
-                          format: date
-                          example: "2024-01-15"
-                        last_end_date:
+                          description: First task start date for this person
+                            within the requested scope
+                          example: "2024-01-15 00:00:00"
+                        max_date:
                           type: string
-                          format: date
-                          example: "2024-03-21"
+                          description: Last task due date for this person
+                            within the requested scope
+                          example: "2024-03-21 00:00:00"
         """
-        permissions.check_admin_permissions()
-        args = self.get_args([("project_id", None, False, str)])
+        # Normalise the `project_id` filter once, before branching on the
+        # caller's role. An empty or whitespace-only `?project_id=` is treated
+        # as an absent filter; any other non-UUID value is rejected with a 400
+        # rather than reaching the query as an invalid UUID (which used to 500
+        # for admins and 404 for managers).
+        project_id = (self.get_project_id() or "").strip() or None
+        if project_id is not None and not fields.is_valid_id(project_id):
+            raise WrongParameterException("Invalid project_id.")
+        project_ids = None
+        if not permissions.has_admin_permissions():
+            permissions.check_manager_permissions()
+            if project_id is not None:
+                user_service.check_manager_project_access(project_id)
+            else:
+                project_ids = user_service.get_open_project_ids()
         return tasks_service.get_persons_tasks_dates(
-            project_id=args["project_id"]
+            project_id=project_id, project_ids=project_ids
         )
 
 

--- a/zou/app/services/persons_service.py
+++ b/zou/app/services/persons_service.py
@@ -584,6 +584,62 @@ def is_admin(person):
     return person["role"] == "admin"
 
 
+def build_password_reset_url(email, token, token_type=None):
+    """
+    Build the URL a user can follow to choose a new password. It matches the
+    link embedded in the password recovery and invitation emails.
+    """
+    params = {"email": email, "token": token}
+    if token_type is not None:
+        params["type"] = token_type
+    query = urllib.parse.urlencode(params)
+    return (
+        f"{config.DOMAIN_PROTOCOL}://{config.DOMAIN_NAME}"
+        f"/reset-change-password?{query}"
+    )
+
+
+def check_password_change_allowed(person_id):
+    """
+    Ensure the current user is allowed to set the password of the given
+    person. The current user can always act on his own account, but cannot
+    set the password of a protected account nor the one of another admin who
+    already has a password. Returns the person on success, raises
+    PersonInProtectedAccounts otherwise.
+    """
+    current_user = get_current_user()
+    person = get_person(person_id)
+    if person["id"] != current_user["id"]:
+        if person["email"] in config.PROTECTED_ACCOUNTS:
+            raise PersonInProtectedAccounts(
+                "This user is in protected accounts."
+            )
+        elif person["role"] == "admin":
+            person_raw = get_person_raw(person_id)
+            if person_raw.password is not None:
+                raise PersonInProtectedAccounts(
+                    "An admin can't change another admin's password."
+                )
+    return person
+
+
+def get_or_create_password_reset_link(person_id):
+    """
+    Return the password reset link for the given person. If a reset token is
+    already stored for that person (for instance from a recovery email or a
+    previous call), it is reused so that a link shared earlier stays valid.
+    Otherwise a new token is generated and stored. It is the same link as the
+    one embedded in the password recovery email.
+    """
+    person = get_person(person_id)
+    key = f"reset-token-{person['email']}"
+    token = auth_tokens_store.get(key)
+    if not token:
+        token = auth_service.generate_reset_token()
+        auth_tokens_store.add(key, token, ttl=3600 * 2)
+    return build_password_reset_url(person["email"], token)
+
+
 def invite_person(person_id):
     """
     Send an invitation email to given person (a mail telling him/her how to
@@ -595,11 +651,8 @@ def invite_person(person_id):
     auth_tokens_store.add(
         f"reset-token-{person['email']}", token, ttl=3600 * 24 * 7
     )
-    params = {"email": person["email"], "token": token, "type": "new"}
-    query = urllib.parse.urlencode(params)
-    reset_url = (
-        f"{config.DOMAIN_PROTOCOL}://{config.DOMAIN_NAME}"
-        f"/reset-change-password?{query}"
+    reset_url = build_password_reset_url(
+        person["email"], token, token_type="new"
     )
 
     locale = person.get("locale") or getattr(config, "DEFAULT_LOCALE", "en_US")

--- a/zou/app/services/playlist_sharing_service.py
+++ b/zou/app/services/playlist_sharing_service.py
@@ -22,6 +22,7 @@ from zou.app.services import (
 from zou.app.services.exception import (
     PlaylistShareLinkNotFoundException,
     PlaylistNotFoundException,
+    PreviewFileNotFoundException,
 )
 from zou.app.utils import auth as auth_utils, fields
 
@@ -156,6 +157,14 @@ def is_preview_file_in_shared_playlist(token, preview_file_id):
     preview_file_id stored on a shot, or another preview file that
     shares its (task, revision) with the positioned one — a single
     revision may carry several previews (different positions).
+
+    The same entity may be listed several times in a playlist, each shot
+    positioned on a different task type / preview file (e.g. reviewing the
+    texturing, posing and expression previews of a single asset). We
+    therefore gather *every* preview positioned for the requested entity
+    instead of collapsing the shots into one entity -> preview_file_id
+    mapping, which kept only the last shot and 403'd the previews
+    positioned on the others.
     """
     share_link = validate_share_token(token)
     playlist = Playlist.get(share_link["playlist_id"])
@@ -163,21 +172,37 @@ def is_preview_file_in_shared_playlist(token, preview_file_id):
         return False
     preview_file = files_service.get_preview_file(preview_file_id)
     task = tasks_service.get_task(preview_file["task_id"])
-    entity_id_map = {
-        str(shot.get("entity_id") or shot.get("id")): shot.get(
-            "preview_file_id"
-        )
-        for shot in playlist.shots
-    }
+    entity_id = str(task["entity_id"])
 
-    main_preview_file_id = entity_id_map.get(str(task["entity_id"]))
-    if main_preview_file_id is None:
+    positioned_ids = {
+        str(shot["preview_file_id"])
+        for shot in playlist.shots
+        if str(shot.get("entity_id") or shot.get("id")) == entity_id
+        and shot.get("preview_file_id")
+    }
+    if not positioned_ids:
         return False
-    if main_preview_file_id == preview_file_id:
+    if str(preview_file_id) in positioned_ids:
         return True
 
-    main_preview_file = files_service.get_preview_file(main_preview_file_id)
-    return main_preview_file["revision"] == preview_file["revision"]
+    # Accept the other positions of a positioned revision: a single revision
+    # may carry several preview files (same task, same revision, different
+    # position). A different revision — or the same revision number on another
+    # task type of the entity — stays rejected.
+    for positioned_id in positioned_ids:
+        try:
+            main_preview_file = files_service.get_preview_file(positioned_id)
+        except PreviewFileNotFoundException:
+            # A deleted preview can stay referenced in playlist.shots
+            # (deletion does not scrub the shots column). Skip the dangling
+            # id instead of letting it mask a valid sibling/revision match.
+            continue
+        if (
+            str(main_preview_file["task_id"]) == str(preview_file["task_id"])
+            and main_preview_file["revision"] == preview_file["revision"]
+        ):
+            return True
+    return False
 
 
 class GuestCommentForbidden(Exception):

--- a/zou/app/services/tasks_service.py
+++ b/zou/app/services/tasks_service.py
@@ -2052,12 +2052,34 @@ def reset_task_data(task_id):
     return task.serialize(relations=True)
 
 
-def get_persons_tasks_dates(project_id=None):
+def get_persons_tasks_dates(project_id=None, project_ids=None):
     """
     For schedule usages, for each active person, it returns the first start
     date of all tasks of assigned to this person and the last end date.
+
+    Scoping (project_id takes precedence over project_ids):
+    - project_id, when set, scopes the lookup to that single project and
+      nothing else. It is honoured directly -- including closed projects --
+      instead of being intersected with the open-project list, otherwise a
+      closed but legitimately accessible project would yield an empty result.
+      The caller is responsible for checking access to it.
+    - project_ids restricts the lookup to a set of projects. Only None (not an
+      empty list) triggers the studio-wide fallback below. An empty list is
+      honoured as-is and matches no project, which is how a manager with no
+      project gets an empty result -- the guard must stay an `is None` identity
+      test and never become `if not project_ids:`, otherwise such a manager
+      would leak the studio-wide view.
     """
-    project_ids = projects_service.open_project_ids()
+    if project_id is not None:
+        # An explicit, access-checked project scopes the lookup directly. This
+        # short-circuits the open-project fallback so a closed project the
+        # caller may legitimately see is not filtered out to an empty result.
+        project_ids = [project_id]
+    elif project_ids is None:
+        # Studio-wide fallback. Note this is the project-scoped helper, not
+        # user_service.get_open_project_ids() which is limited to the current
+        # user's projects.
+        project_ids = projects_service.open_project_ids()
     query = (
         Task.query.with_entities(
             Person.id, func.min(Task.start_date), func.max(Task.due_date)
@@ -2067,9 +2089,6 @@ def get_persons_tasks_dates(project_id=None):
         .group_by(Person.id)
         .join(Task.assignees)
     )
-
-    if project_id is not None:
-        query = query.filter(Task.project_id == project_id)
 
     return [
         {


### PR DESCRIPTION
**Problem**
- `/data/persons/task-dates` was admin-only, so managers could not retrieve schedule data for their own projects.
- A shared playlist that lists the same entity several times (one entity positioned on several task types / revisions) returned 403 for every preview except the last shot's, since the membership check collapsed the shots into a single entity -> preview_file_id mapping.
- There was no way for an admin to obtain a person's password reset link when email delivery is not configured.

**Solution**
- Open `/data/persons/task-dates` to managers, scoped to the projects of their own teams (admins keep the studio-wide view), and normalize an empty `?project_id=` so it is treated as absent instead of an invalid UUID.
- In the shared-playlist membership check, gather every preview positioned for the requested entity and accept a preview matching a positioned one on (task, revision); skip dangling positioned previews still referenced after deletion.
- Add admin-only `POST /actions/persons/<person_id>/reset-password-link` returning the recovery link (reusing a pending token, 2h TTL otherwise), guarded like the admin change-password action; centralize reset-link construction in `build_password_reset_url`.
