### PR TITLE
Skip bot email validation on update

### DIFF
--- a/tests/models/test_person.py
+++ b/tests/models/test_person.py
@@ -157,6 +157,23 @@ class PersonTestCase(ApiDBTestCase):
         person = self.post("data/persons", data)
         self.assertIsNotNone(person["id"])
 
+    def test_update_bot_can_keep_email_shared_with_person(self):
+        data = {
+            "first_name": "Bot",
+            "last_name": "Bot",
+            "email": "ema.doe@gmail.com",
+            "is_bot": True,
+        }
+        bot = self.post("data/persons", data)
+
+        self.put(
+            f"data/persons/{bot['id']}",
+            {"first_name": "Renamed Bot", "email": bot["email"]},
+        )
+        bot_again = self.get(f"data/persons/{bot['id']}")
+        self.assertEqual(bot_again["first_name"], "Renamed Bot")
+        self.assertEqual(bot_again["email"], "ema.doe@gmail.com")
+
     def test_update_person(self):
         person = self.get_first("data/persons")
         data = {

--- a/zou/app/blueprints/crud/person.py
+++ b/zou/app/blueprints/crud/person.py
@@ -630,13 +630,16 @@ class PersonResource(BaseModelResource, ArgsMixin):
             except auth.EmailNotValidException as e:
                 raise WrongParameterException(str(e))
 
-            existing = Person.query.filter(
-                Person.email == data["email"],
-                Person.id != instance_id,
-                Person.is_bot.isnot(True),
-            ).first()
-            if existing is not None:
-                raise WrongParameterException("Email already in use.")
+            person = Person.get(instance_id)
+            is_bot = data.get("is_bot", person.is_bot)
+            if not is_bot:
+                existing = Person.query.filter(
+                    Person.email == data["email"],
+                    Person.id != instance_id,
+                    Person.is_bot.isnot(True),
+                ).first()
+                if existing is not None:
+                    raise WrongParameterException("Email already in use.")
 
         return data
 


### PR DESCRIPTION
# Problem

Bot user updates fail with `Email already in use` when the bot shares an email with a regular user. Making impossible to update any bot field after creation.

## Reproduction

1. Create a bot using the same email as an existing user (Default behavior from Kitsu)
2. Edit only the bot name
3. Save

Before: update fails with `Email already in use`.
After: bot update succeeds, matching bot creation behavior.

## Solution

Ignore email check when updating a bot
