### PR TITLE
Fix 404 on temp playlist when a task belongs to an edit

### DIFF
--- a/tests/services/test_playlists_service.py
+++ b/tests/services/test_playlists_service.py
@@ -113,6 +113,23 @@ class PlaylistsServiceTestCase(ApiDBTestCase):
         self.assertEqual(str(self.shot.id), shots[0]["id"])
         self.assertEqual(len(shots[0]["preview_files"][task_type_id]), 2)
 
+    def test_generate_temp_playlist_with_edit_task(self):
+        self.generate_fixture_edit_task()
+        entities = playlists_service.generate_temp_playlist(
+            [self.edit_task.id]
+        )
+        self.assertEqual(len(entities), 1)
+        self.assertEqual(str(self.edit.id), entities[0]["id"])
+        self.assertEqual(entities[0]["parent_name"], "")
+
+        self.generate_fixture_edit("Edit E01", parent_id=self.episode.id)
+        edit_task = self.generate_fixture_edit_task("Edit E01 task")
+        entities = playlists_service.generate_temp_playlist([edit_task.id])
+        self.assertEqual(len(entities), 1)
+        self.assertEqual(str(self.edit.id), entities[0]["id"])
+        self.assertEqual(entities[0]["episode_name"], self.episode.name)
+        self.assertEqual(entities[0]["parent_name"], self.episode.name)
+
     def test_generate_playlisted_entity_from_task(self):
         self.generate_fixture_preview_files()
         task_id = self.task.id

--- a/zou/app/services/playlists_service.py
+++ b/zou/app/services/playlists_service.py
@@ -35,6 +35,7 @@ from zou.app.stores.redis_lock import with_playlist_lock
 from zou.app.services import (
     assets_service,
     base_service,
+    edits_service,
     entities_service,
     files_service,
     preview_files_service,
@@ -1094,6 +1095,8 @@ def generate_playlisted_entity_from_task(task_id, task_type_links):
         playlisted_entity = get_base_sequence_for_playlist(entity, task_id)
     elif shots_service.is_episode(entity):
         playlisted_entity = get_base_episode_for_playlist(entity, task_id)
+    elif edits_service.is_edit(entity):
+        playlisted_entity = get_base_edit_for_playlist(entity, task_id)
     else:
         playlisted_entity = get_base_asset_for_playlist(entity, task_id)
 
@@ -1188,6 +1191,36 @@ def get_base_shot_for_playlist(entity, task_id):
         "sequence_name": sequence["name"],
         "parent_name": sequence["name"],
     }
+    return playlisted_entity
+
+
+def get_base_edit_for_playlist(entity, task_id):
+    edit = edits_service.get_edit(entity["id"])
+    episode = None
+    try:
+        episode = shots_service.get_episode(edit["parent_id"])
+    except Exception as e:
+        logger.debug(
+            f"No episode for edit parent_id={edit.get('parent_id')}: {e}"
+        )
+    if episode is not None:
+        playlisted_entity = {
+            "id": edit["id"],
+            "name": edit["name"],
+            "preview_file_task_id": task_id,
+            "episode_id": episode["id"],
+            "episode_name": episode["name"],
+            "parent_name": episode["name"],
+        }
+    else:
+        playlisted_entity = {
+            "id": edit["id"],
+            "name": edit["name"],
+            "preview_file_task_id": task_id,
+            "episode_id": "",
+            "episode_name": "",
+            "parent_name": "",
+        }
     return playlisted_entity
 
 


### PR DESCRIPTION
**Problem**
- `POST /data/projects/<project_id>/playlists/temp` returns a 404 for the whole request when one of the tasks belongs to an edit: the entity falls through to the asset branch of `generate_playlisted_entity_from_task` and `assets_service.get_asset()` raises `AssetNotFoundException`

**Solution**
- Add an edit branch with a dedicated `get_base_edit_for_playlist()` that resolves the parent episode when the edit has one, and returns empty parent fields otherwise
