### PR TITLE
[shots] Derive nb_frames from the frame range on CSV import

### DIFF
--- a/tests/source/csv/test_import_shots.py
+++ b/tests/source/csv/test_import_shots.py
@@ -57,6 +57,11 @@ class ImportCsvShotsTestCase(ApiDBTestCase):
         shot = shots[0]
         self.assertEqual(shot["data"].get("contractor", None), "contractor 1")
 
+        # nb_frames is derived from the imported frame range (all fixture
+        # rows cover 100-frame ranges).
+        for shot in shots:
+            self.assertEqual(shot["nb_frames"], 101)
+
         self.assertEqual(
             set(str(task.entity_id) for task in tasks),
             set(shot["id"] for shot in shots),

--- a/zou/app/blueprints/source/csv/shots.py
+++ b/zou/app/blueprints/source/csv/shots.py
@@ -265,6 +265,19 @@ class ShotsCsvImportResource(BaseCsvProjectImportResource):
         if frame_out is not None:
             shot_new_values["data"]["frame_out"] = frame_out
 
+        # Keep the frame count consistent with an imported frame range when
+        # the CSV doesn't provide it explicitly.
+        if "nb_frames" not in shot_new_values:
+            try:
+                frame_in_value = int(shot_new_values["data"]["frame_in"])
+                frame_out_value = int(shot_new_values["data"]["frame_out"])
+                if frame_out_value > frame_in_value:
+                    shot_new_values["nb_frames"] = (
+                        frame_out_value - frame_in_value + 1
+                    )
+            except (KeyError, TypeError, ValueError):
+                pass
+
         fps = row.get("FPS", None)
         if fps is not None:
             shot_new_values["data"]["fps"] = fps


### PR DESCRIPTION
## Problems

- Importing a shots CSV with Frame In / Frame Out left `nb_frames` untouched, so the Frames column stayed stale unless provided explicitly (cgwire/kitsu#1383, CSV path)

## Solutions

- Derive `nb_frames` from the imported frame range when the CSV doesn't provide it, with test coverage on the shots import