### PR TITLE
[security] Fix critical auth, IDOR and XSS vulnerabilities

### DIFF
--- a/zou/app/__init__.py
+++ b/zou/app/__init__.py
@@ -116,6 +116,17 @@ def shutdown_session(exception=None):
         db.session.remove()
 
 
+@app.after_request
+def set_security_headers(response):
+    """
+    Add baseline security headers to every response. nosniff stops the
+    browser from MIME-sniffing a response into an executable type, e.g.
+    rendering an uploaded file served as octet-stream as HTML.
+    """
+    response.headers.setdefault("X-Content-Type-Options", "nosniff")
+    return response
+
+
 @app.errorhandler(404)
 def page_not_found(error):
     return jsonify(error=True, message=str(error)), 404

--- a/zou/app/blueprints/breakdown/resources.py
+++ b/zou/app/blueprints/breakdown/resources.py
@@ -79,6 +79,9 @@ class CastingResource(Resource):
         user_service.check_project_access(project_id)
         if permissions.has_vendor_permissions():
             raise permissions.PermissionDenied
+        entity = entities_service.get_entity(entity_id)
+        if entity["project_id"] != project_id:
+            raise permissions.PermissionDenied
         return breakdown_service.get_casting(entity_id)
 
     @jwt_required()
@@ -166,6 +169,9 @@ class CastingResource(Resource):
                 "message": "Request body must be a JSON array",
             }, 400
         user_service.check_manager_project_access(project_id)
+        entity = entities_service.get_entity(entity_id)
+        if entity["project_id"] != project_id:
+            raise permissions.PermissionDenied
         return breakdown_service.update_casting(entity_id, casting)
 
 
@@ -424,7 +430,9 @@ class SequenceCastingResource(Resource):
         user_service.check_project_access(project_id)
         if permissions.has_vendor_permissions():
             raise permissions.PermissionDenied
-        shots_service.get_sequence(sequence_id)
+        sequence = shots_service.get_sequence(sequence_id)
+        if sequence["project_id"] != project_id:
+            raise permissions.PermissionDenied
         return breakdown_service.get_sequence_casting(sequence_id)
 
 
@@ -967,4 +975,8 @@ class ProjectEntityLinkResource(Resource):
             description: Entity link successfully deleted
         """
         user_service.check_manager_project_access(project_id)
+        link = entities_service.get_entity_link(entity_link_id)
+        entity = entities_service.get_entity(link["entity_in_id"])
+        if entity["project_id"] != project_id:
+            raise permissions.PermissionDenied
         return entities_service.remove_entity_link(entity_link_id)

--- a/zou/app/blueprints/comments/resources.py
+++ b/zou/app/blueprints/comments/resources.py
@@ -90,7 +90,10 @@ class DownloadAttachmentResource(Resource):
                 file_path,
                 conditional=True,
                 mimetype=attachment_file["mimetype"],
-                as_attachment=False,
+                # Force download: the mimetype comes verbatim from the
+                # uploader, so serving inline would let an attacker run
+                # HTML/SVG in Kitsu's origin (stored XSS).
+                as_attachment=True,
                 download_name=attachment_file["name"],
                 max_age=config.CLIENT_CACHE_MAX_AGE,
                 last_modified=date_helpers.get_datetime_from_string(

--- a/zou/app/blueprints/crud/person.py
+++ b/zou/app/blueprints/crud/person.py
@@ -16,6 +16,7 @@ from zou.app.services import (
     persons_service,
 )
 from zou.app.utils import permissions, auth, date_helpers
+from zou.app.utils.fields import serialize_value
 
 from zou.app.blueprints.crud.base import BaseModelsResource, BaseModelResource
 
@@ -251,10 +252,16 @@ class PersonsResource(BaseModelsResource):
 
         if permissions.has_admin_permissions():
             if self.get_bool_parameter("with_pass_hash"):
-                return [
-                    person.serialize(relations=relations)
-                    for person in query.all()
-                ]
+                # Only the password hash is re-added (needed for Kitsu ->
+                # Kitsu migration). Never expose the 2FA secrets
+                # (totp/email OTP/recovery codes/FIDO) that the full
+                # serialize() would otherwise leak.
+                persons = []
+                for person in query.all():
+                    person_dict = person.serialize_safe(relations=relations)
+                    person_dict["password"] = serialize_value(person.password)
+                    persons.append(person_dict)
+                return persons
             else:
                 return [
                     person.serialize_safe(relations=relations)

--- a/zou/app/config.py
+++ b/zou/app/config.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import datetime
 import tempfile
 
@@ -13,6 +14,16 @@ DEBUG_PORT = int(os.getenv("DEBUG_PORT", 5000))
 APP_NAME = "Zou"
 APP_SYSTEM_ERROR_SUBJECT_LINE = f"{APP_NAME} system error"
 SECRET_KEY = os.getenv("SECRET_KEY", "mysecretkey")
+# The default key is public: since JWT signing falls back to SECRET_KEY, an
+# unconfigured production deployment lets anyone forge admin tokens. Refuse to
+# boot with the default outside DEBUG. Test runs (pytest) are exempt so the
+# suite keeps working without setting the variable.
+if SECRET_KEY == "mysecretkey" and not DEBUG and "pytest" not in sys.modules:
+    raise RuntimeError(
+        "SECRET_KEY is set to the insecure default 'mysecretkey'. Set the "
+        "SECRET_KEY environment variable to a strong, unique value before "
+        "starting Zou in production."
+    )
 
 AUTH_STRATEGY = os.getenv("AUTH_STRATEGY", "auth_local_classic")
 BCRYPT_LOG_ROUNDS = int(os.getenv("BCRYPT_LOG_ROUNDS", 12))

--- a/zou/app/config.py
+++ b/zou/app/config.py
@@ -91,6 +91,7 @@ PREVIEW_FOLDER = os.getenv(
     os.getenv("THUMBNAIL_FOLDER", os.path.join(os.getcwd(), "previews")),
 )
 PREVIEW_SAVE_SOURCE_FILE = envtobool("PREVIEW_SAVE_SOURCE_FILE", False)
+MAX_IMAGE_PIXELS = int(os.getenv("MAX_IMAGE_PIXELS", 20000 * 20000))
 TMP_DIR = os.getenv("TMP_DIR", os.path.join(tempfile.gettempdir(), "zou"))
 
 EVENT_STREAM_HOST = os.getenv("EVENT_STREAM_HOST", "localhost")

--- a/zou/app/services/entities_service.py
+++ b/zou/app/services/entities_service.py
@@ -397,6 +397,17 @@ def get_entity_tasks(entity):
     return get_tasks(entity["id"])
 
 
+def get_entity_link(link_id):
+    """
+    Return the entity link matching given id, as a dict. Raises an exception
+    if nothing is found.
+    """
+    link = EntityLink.get_by(id=link_id)
+    if link is None:
+        raise EntityLinkNotFoundException
+    return link.serialize()
+
+
 def remove_entity_link(link_id):
     try:
         link = EntityLink.get_by(id=link_id)

--- a/zou/app/services/playlist_sharing_service.py
+++ b/zou/app/services/playlist_sharing_service.py
@@ -443,7 +443,10 @@ def download_shared_attachment(token, attachment_id, file_name):
         file_path,
         conditional=True,
         mimetype=attachment["mimetype"],
-        as_attachment=False,
+        # Force download: this path is unauthenticated (share link) and the
+        # mimetype is attacker-controlled, so inline serving would allow a
+        # stored XSS in Kitsu's origin.
+        as_attachment=True,
         download_name=attachment["name"],
     )
 

--- a/zou/app/utils/thumbnail.py
+++ b/zou/app/utils/thumbnail.py
@@ -6,11 +6,12 @@ from pathlib import Path
 
 from PIL import Image, ImageFile
 
+from zou.app import config
 from zou.app.utils import fs
 
 ImageFile.LOAD_TRUNCATED_IMAGES = True
 
-Image.MAX_IMAGE_PIXELS = 20000 * 20000
+Image.MAX_IMAGE_PIXELS = config.MAX_IMAGE_PIXELS
 RECTANGLE_SIZE = 150, 100
 SQUARE_SIZE = 100, 100
 PREVIEW_SIZE = 1200, 0


### PR DESCRIPTION
**Problem**
- The default SECRET_KEY is public, so an unconfigured deployment lets anyone forge admin JWTs.
- `GET /data/persons?with_pass_hash=true` returns every account's 2FA secrets (TOTP/email OTP/recovery codes/FIDO), not just the password hash.
- Comment and shared-playlist attachments are served inline with a caller-controlled mimetype, enabling stored XSS (the shared path is unauthenticated).
- Breakdown casting and entity-link endpoints check the URL project but act on an object from any project (cross-tenant IDOR).
- A tiny image declaring huge dimensions decodes to gigabytes on the web worker (decompression-bomb DoS).

**Solution**
- Refuse to boot outside DEBUG when SECRET_KEY is the default (pytest exempt).
- Serialize persons from `serialize_safe()` and re-add only the password hash.
- Force `as_attachment=True` on both attachment paths and add a global `X-Content-Type-Options: nosniff` header.
- Verify each breakdown object belongs to the URL project before acting.
- Make Pillow's `MAX_IMAGE_PIXELS` configurable (default unchanged).