### PR TITLE
[qa] Audit follow-up: security, correctness and cleanup fixes

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,7 +4,7 @@ We release Zou versions through Github Actions on Pypi. Every time a new version
 follow this process:
 
 1. Rebase on the main branch.
-2. Up the version number located the `zou/__version__` file.
+2. Bump the `__version__` variable in `zou/__init__.py`.
 3. Push changes to `main` branch.
 4. Tag the commit and push the changes to Github.
 5. Github Actions will build the package from the sources and publish the package on Pypi

--- a/specs/services.md
+++ b/specs/services.md
@@ -71,11 +71,11 @@ def update_person(person_id, data):
 ## Event emission pattern
 
 ```python
-from zou.app.services import events_service
+from zou.app.utils import events
 
 def create_task(data):
     task = Task.create(**data)
-    events_service.emit(
+    events.emit(
         "task:new",
         {"task_id": str(task.id)},
         project_id=str(task.project_id),

--- a/tests/auth/test_auth_route.py
+++ b/tests/auth/test_auth_route.py
@@ -245,8 +245,11 @@ class AuthTestCase(ApiDBTestCase):
     def test_reset_password(self):
         email = self.user["email"]
         self.assertIsNotAuthenticated({}, code=422)
+        # Unknown and known emails must return the same response so the
+        # endpoint cannot be used to enumerate accounts.
         data = {"email": "fake_email@test.com"}
-        self.post("auth/reset-password", data, 400)
+        response = self.post("auth/reset-password", data, 200)
+        self.assertTrue(response["success"])
         data = {"email": email}
         response = self.post("auth/reset-password", data, 200)
         self.assertTrue(response["success"])

--- a/tests/auth/test_auth_route.py
+++ b/tests/auth/test_auth_route.py
@@ -465,6 +465,37 @@ class Enforce2FATestCase(ApiDBTestCase):
         response = self.app.get("data/persons", headers=new_headers)
         self.assertEqual(response.status_code, 200)
 
+    def test_disable_totp_with_recovery_code(self):
+        """
+        Disabling TOTP with a recovery code succeeds. Regression: the
+        unsafe current-user path exposes recovery codes as raw bytes, which
+        used to crash when removing the consumed code.
+        """
+        tokens = self.post("auth/login", self.credentials, 200)
+        headers = self.get_auth_headers(tokens)
+        headers["Content-type"] = "application/json"
+
+        response = self.app.put("auth/totp", headers=headers)
+        otp_secret = json.loads(response.data.decode("utf-8"))["otp_secret"]
+        totp = pyotp.TOTP(otp_secret)
+        response = self.app.post(
+            "auth/totp",
+            data=json.dumps({"totp": totp.now()}),
+            headers=headers,
+        )
+        self.assertEqual(response.status_code, 200)
+        recovery_codes = json.loads(response.data.decode("utf-8"))[
+            "otp_recovery_codes"
+        ]
+        persons_service.clear_person_cache()
+
+        response = self.app.delete(
+            "auth/totp",
+            data=json.dumps({"recovery_code": recovery_codes[0]}),
+            headers=headers,
+        )
+        self.assertEqual(response.status_code, 200)
+
     def test_exempt_user_gets_unrestricted_tokens(self):
         """
         Users in TWO_FA_EXEMPT_USERS get unrestricted tokens.

--- a/tests/services/test_deletion_service.py
+++ b/tests/services/test_deletion_service.py
@@ -17,6 +17,7 @@ from zou.app.services import (
 )
 from zou.app.services.exception import (
     CommentNotFoundException,
+    PreviewBackgroundFileNotFoundException,
     PreviewFileNotFoundException,
 )
 
@@ -46,6 +47,12 @@ class DeletionServiceTestCase(ApiDBTestCase):
     def test_remove_comment_not_found(self):
         with self.assertRaises(CommentNotFoundException):
             deletion_service.remove_comment(
+                "00000000-0000-0000-0000-000000000000"
+            )
+
+    def test_remove_preview_background_file_not_found(self):
+        with self.assertRaises(PreviewBackgroundFileNotFoundException):
+            deletion_service.remove_preview_background_file_by_id(
                 "00000000-0000-0000-0000-000000000000"
             )
 

--- a/tests/thumbnails/test_route_thumbnail.py
+++ b/tests/thumbnails/test_route_thumbnail.py
@@ -68,6 +68,13 @@ class RouteThumbnailTestCase(ApiDBTestCase):
 
         self.assertEqual(result_image.size, thumbnail.BIG_SQUARE_SIZE)
 
+    def test_add_thumbnail_without_file_keeps_has_avatar_false(self):
+        path = f"/pictures/thumbnails/persons/{self.person_id}"
+        response = self.app.post(path, headers=self.base_headers)
+        self.assertEqual(response.status_code, 400)
+        person = self.get(f"data/persons/{self.person_id}")
+        self.assertFalse(person["has_avatar"])
+
     def test_add_preview(self):
         path = f"/pictures/preview-files/{self.preview_file_id}"
 

--- a/zou/app/blueprints/auth/resources.py
+++ b/zou/app/blueprints/auth/resources.py
@@ -765,18 +765,16 @@ class ResetPasswordResource(Resource, ArgsMixin):
         """
         body = validation.validate_request_body(SendPasswordResetSchema)
 
+        # Always answer the same way whether or not the account exists or is
+        # active, so this public endpoint cannot be used to enumerate
+        # registered users.
+        generic_response = {"success": "Reset token sent"}
         try:
             user = persons_service.get_person_by_email(body.email)
-            if not user["active"]:
-                return (
-                    {"error": True, "message": "This user is inactive."},
-                    400,
-                )
         except PersonNotFoundException:
-            return (
-                {"error": True, "message": "Email not listed in database."},
-                400,
-            )
+            return generic_response
+        if not user["active"]:
+            return generic_response
 
         token = auth_service.generate_reset_token()
         auth_tokens_store.add(f"reset-token-{body.email}", token, ttl=3600 * 2)

--- a/zou/app/blueprints/comments/resources.py
+++ b/zou/app/blueprints/comments/resources.py
@@ -80,6 +80,7 @@ class DownloadAttachmentResource(Resource):
             chat = chats_service.get_chat_by_id(message["chat_id"])
             entity = entities_service.get_entity(chat["object_id"])
             user_service.check_project_access(entity["project_id"])
+            user_service.check_entity_access(chat["object_id"])
         else:
             raise permissions.PermissionDenied()
         try:

--- a/zou/app/blueprints/entities/resources.py
+++ b/zou/app/blueprints/entities/resources.py
@@ -84,6 +84,7 @@ class EntityNewsResource(Resource):
         """
         entity = entities_service.get_entity(entity_id)
         user_service.check_project_access(entity["project_id"])
+        user_service.check_entity_access(entity_id)
         return news_service.get_news_for_entity(entity_id)
 
 
@@ -151,6 +152,7 @@ class EntityPreviewFilesResource(Resource):
         """
         entity = entities_service.get_entity(entity_id)
         user_service.check_project_access(entity["project_id"])
+        user_service.check_entity_access(entity_id)
         return preview_files_service.get_preview_files_for_entity(entity_id)
 
 
@@ -215,6 +217,7 @@ class EntityTimeSpentsResource(Resource):
         """
         entity = entities_service.get_entity(entity_id)
         user_service.check_project_access(entity["project_id"])
+        user_service.check_entity_access(entity_id)
         return time_spents_service.get_time_spents_for_entity(entity_id)
 
 

--- a/zou/app/blueprints/previews/resources.py
+++ b/zou/app/blueprints/previews/resources.py
@@ -1249,8 +1249,6 @@ class BaseThumbnailResource(Resource):
         self.is_exist(instance_id)
         self.check_allowed_to_post(instance_id)
 
-        self.prepare_creation(instance_id)
-
         if "file" not in request.files:
             raise WrongParameterException("File not provided.")
 
@@ -1259,11 +1257,19 @@ class BaseThumbnailResource(Resource):
         thumbnail_path = thumbnail_utils.save_file(
             tmp_folder, instance_id, uploaded_file
         )
-        thumbnail_path = thumbnail_utils.turn_into_thumbnail(
-            thumbnail_path, size=self.size
-        )
-        file_store.add_picture("thumbnails", instance_id, thumbnail_path)
-        os.remove(thumbnail_path)
+        try:
+            thumbnail_path = thumbnail_utils.turn_into_thumbnail(
+                thumbnail_path, size=self.size
+            )
+            file_store.add_picture("thumbnails", instance_id, thumbnail_path)
+        finally:
+            if os.path.exists(thumbnail_path):
+                os.remove(thumbnail_path)
+
+        # Mark the avatar as present only once the thumbnail is stored, so a
+        # missing/invalid file or a storage failure cannot leave has_avatar
+        # set with no picture behind it (which would 404 every read).
+        self.prepare_creation(instance_id)
         preview_files_service.clear_variant_from_cache(
             instance_id, "thumbnails"
         )

--- a/zou/app/config.py
+++ b/zou/app/config.py
@@ -225,7 +225,8 @@ TELEMETRY_URL = os.getenv(
 
 REMOVE_FILES = envtobool("REMOVE_FILES", False)
 
-# Deprecated
+# Legacy defaults, still read by tasks_service, files_service and the
+# Shotgun importer; kept for backwards compatibility.
 TO_REVIEW_TASK_STATUS = "To review"
 DEFAULT_FILE_STATUS = "To review"
 DEFAULT_FILE_TREE = os.getenv("DEFAULT_FILE_TREE", "default")

--- a/zou/app/services/auth_service.py
+++ b/zou/app/services/auth_service.py
@@ -288,8 +288,13 @@ def remove_otp_revovery_code(person_id, recovery_hash):
     """
     Remove an otp recovery code for a person_id.
     """
+    # recovery_hash may arrive as str (serialized login path) or bytes
+    # (raw ORM value from get_current_user(unsafe=True)); normalize to the
+    # bytes stored in the column.
+    if isinstance(recovery_hash, str):
+        recovery_hash = recovery_hash.encode()
     person = Person.get(person_id)
-    person.otp_recovery_codes.remove(recovery_hash.encode())
+    person.otp_recovery_codes.remove(recovery_hash)
     flag_modified(person, "otp_recovery_codes")
     person.commit()
     persons_service.clear_person_cache()

--- a/zou/app/services/deletion_service.py
+++ b/zou/app/services/deletion_service.py
@@ -46,6 +46,7 @@ from zou.app.services.exception import (
     CommentNotFoundException,
     ModelWithRelationsDeletionException,
     PersonInProtectedAccounts,
+    PreviewBackgroundFileNotFoundException,
     PreviewFileNotFoundException,
 )
 
@@ -258,6 +259,8 @@ def remove_preview_background_file_by_id(
     preview_background_file = PreviewBackgroundFile.get(
         preview_background_file_id
     )
+    if preview_background_file is None:
+        raise PreviewBackgroundFileNotFoundException
     return remove_preview_background_file(preview_background_file, force=force)
 
 

--- a/zou/app/services/preview_files_service.py
+++ b/zou/app/services/preview_files_service.py
@@ -221,13 +221,6 @@ def set_preview_file_as_missing(preview_file_id):
     return update_preview_file(preview_file_id, {"status": "missing"})
 
 
-def set_preview_file_as_ready(preview_file_id):
-    """
-    Mark given preview file as ready.
-    """
-    return update_preview_file(preview_file_id, {"status": "ready"})
-
-
 def _abort_on_storage_failure(preview_file_id, operation, exc):
     """
     Log a file store backend failure (Swift 401, S3 timeout, network error,

--- a/zou/app/services/shots_service.py
+++ b/zou/app/services/shots_service.py
@@ -88,11 +88,6 @@ def get_scene_type():
     return entities_service.get_temporal_entity_type_by_name("Scene")
 
 
-@cache.memoize_function(1200)
-def get_camera_type():
-    return entities_service.get_entity_type_by_name("Camera")
-
-
 def get_episodes(criterions=None):
     """
     Get all episodes for given criterions.

--- a/zou/app/services/tasks_service.py
+++ b/zou/app/services/tasks_service.py
@@ -1514,17 +1514,6 @@ def get_or_create_status(
     return task_status.serialize()
 
 
-def update_task_status(task_status_id, data):
-    """
-    Update task status data with given task_id.
-    """
-    task_status = get_task_status_raw(task_status_id)
-    task_status.update(data)
-    clear_task_status_cache(task_status_id)
-    events.emit("task-status:update", {"task_status_id": task_status_id})
-    return task_status.serialize()
-
-
 def get_or_create_department(name, color="#000000"):
     """
     Create a new department it doesn't exist. If it exists, it returns the

--- a/zou/app/utils/permissions.py
+++ b/zou/app/utils/permissions.py
@@ -69,7 +69,7 @@ def has_person_permissions():
 
 def has_at_least_supervisor_permissions():
     """
-    Return True if user is an admin or a manager.
+    Return True if user is a supervisor, a manager or an admin.
     """
     return (
         supervisor_permission.can()

--- a/zou/cli.py
+++ b/zou/cli.py
@@ -444,7 +444,11 @@ def set_person_as_active(email, unactive):
             if persons_service.is_user_limit_reached() and not unactive:
                 raise IsUserLimitReachedException
             person = persons_service.get_person_by_email_raw(email)
-            person.update({"active": not unactive})
+            persons_service.update_person(
+                person.id,
+                {"active": not unactive},
+                bypass_protected_accounts=True,
+            )
             print(
                 f'Person {email} is set as an {"active" if not unactive else "unactive"} user.'
             )

--- a/zou/cli.py
+++ b/zou/cli.py
@@ -809,7 +809,7 @@ def sync_file_changes(event_source, source, logs_directory):
 @click.option("--source", default="http://localhost:8080/api")
 @click.option("--minutes", default=0)
 @click.option("--page-size", default=300)
-def sync_last_events(source, minutes, limit):
+def sync_last_events(source, minutes, page_size):
     """
     Retrieve last events that occured on source instance and import data related
     to them. It expects that credentials to connect to source instance are
@@ -820,7 +820,7 @@ def sync_last_events(source, minutes, limit):
     login = os.getenv("SYNC_LOGIN")
     password = os.getenv("SYNC_PASSWORD")
     commands.import_last_changes_from_another_instance(
-        source, login, password, minutes=minutes, limit=limit
+        source, login, password, minutes=minutes, limit=page_size
     )
 
 
@@ -828,7 +828,7 @@ def sync_last_events(source, minutes, limit):
 @click.option("--source", default="http://localhost:8080/api")
 @click.option("--minutes", default=20)
 @click.option("--page-size", default=50)
-def sync_last_files(source, minutes, limit):
+def sync_last_files(source, minutes, page_size):
     """
     Retrieve last preview files and thumbnails uploaded on source instance.
     It expects that credentials to connect to source instance are
@@ -839,7 +839,7 @@ def sync_last_files(source, minutes, limit):
     login = os.getenv("SYNC_LOGIN")
     password = os.getenv("SYNC_PASSWORD")
     commands.import_last_file_changes_from_another_instance(
-        source, login, password, minutes=minutes, limit=limit
+        source, login, password, minutes=minutes, limit=page_size
     )
 
 

--- a/zou/utils/movie.py
+++ b/zou/utils/movie.py
@@ -325,7 +325,11 @@ def add_empty_soundtrack(file_path, try_count=1):
 
     duration = None
     try:
-        probe = ffmpeg.probe(tmp_file_path, select_streams="v")
+        # Probe the source movie (tmp_file_path is the not-yet-created
+        # output, just removed above): this original duration is used below
+        # to trim the duplicate frames ffmpeg appends when adding the
+        # empty soundtrack.
+        probe = ffmpeg.probe(file_path, select_streams="v")
         duration = probe["format"]["duration"]
     except Exception:
         pass


### PR DESCRIPTION
**Problem**
- Disabling 2FA with a recovery code returned HTTP 500 (recovery hash typed as bytes, not str).
- `sync-last-events` and `sync-last-files` raised TypeError on every run (option/parameter mismatch).
- Avatar upload set has_avatar before validating and storing the file, so a failure left the flag with no picture (permanent 404).
- The movie duration trim probed a just-deleted file, so it never ran.
- Deleting an unknown preview background file returned 500 instead of 404.
- Password-reset requests returned different responses for known/unknown/inactive emails (account enumeration).
- The entities news/preview-files/time-spents endpoints and chat attachment download checked project access but not entity access (vendor metadata leak).
- The set-person-as-active CLI updated the model directly, skipping cache invalidation, reindexing and the person:update event.
- Three service functions were dead; several docs and comments were inaccurate.

**Solution**
- Normalize the recovery hash to bytes; add a regression test.
- Rename the CLI parameter to `page_size` and pass it through as the page limit.
- Set has_avatar only after a successful store; clean the temp file in a finally; add a no-file test.
- Probe the source movie instead of the removed output.
- Guard for None and raise PreviewBackgroundFileNotFoundException; add a service test.
- Return a uniform response and only email active, existing accounts; update the test.
- Add the missing check_entity_access calls.
- Route the CLI through persons_service.update_person.
- Remove the dead functions; fix the events/permissions/config/RELEASE docs.