### PR TITLE
Stop the test suite from wiping the configured preview store

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+import os
+import tempfile
+
+# Force an isolated preview store before any zou module reads the config.
+# Without this, running the tests from a working checkout resolves
+# PREVIEW_FOLDER to ./previews — a live development store — which route
+# tests then write into and which teardowns may remove entirely.
+os.environ["PREVIEW_FOLDER"] = tempfile.mkdtemp(prefix="zou-test-previews-")

--- a/tests/utils/test_thumbnail.py
+++ b/tests/utils/test_thumbnail.py
@@ -5,7 +5,6 @@ from PIL import Image
 
 from werkzeug.datastructures import FileStorage
 
-from zou.app import app
 from zou.app.utils import thumbnail, fs
 
 TEST_FOLDER = os.path.join("tests", "tmp")
@@ -27,8 +26,10 @@ class ThumbnailTestCase(unittest.TestCase):
     def tearDown(self):
         super(ThumbnailTestCase, self).tearDown()
         fs.rm_rf(self.folder_name)
+        # Only remove what these tests create (everything lives in
+        # TEST_FOLDER). Never touch PREVIEW_FOLDER: outside CI it can
+        # resolve to a live development preview store.
         fs.rm_rf(TEST_FOLDER)
-        fs.rm_rf(app.config["PREVIEW_FOLDER"])
 
     def test_turn_into_thumbnail(self):
         file_path_fixture = self.get_fixture_file_path("thumbnails/th01.png")


### PR DESCRIPTION
## Problems

- `ThumbnailTestCase.tearDown` ran `fs.rm_rf(app.config["PREVIEW_FOLDER"])` after every test — yet none of the thumbnail tests write anything into `PREVIEW_FOLDER` (they all work inside `tests/tmp`).
- `PREVIEW_FOLDER` defaults to `<cwd>/previews`, so running `pytest` from a working checkout resolves it to a **live development preview store**. A plain test run deletes every preview file on the machine — no special environment required. This just destroyed a real dev store (all preview binaries lost; only the database metadata survived).
- More broadly, nothing isolated the test file storage: route-level tests uploading previews also wrote into whatever real store the ambient config pointed at.

## Solutions

- Remove the `rm_rf(PREVIEW_FOLDER)` teardown: the thumbnail tests now only clean up `tests/tmp`, the folder they actually use.
- Add `tests/conftest.py` forcing `PREVIEW_FOLDER` to a throwaway `tempfile.mkdtemp()` directory before any zou module reads the config, so the whole suite (including `FS_ROOT`, derived from it) is isolated from real stores regardless of where pytest is launched from.

Verified both ways with a sentinel file in `./previews`: on the unfixed code a test run deletes it; with the fix it survives and the 12 thumbnail/file-store tests pass.