### PR TITLE
Reject invalid person locales and repair broken entries

### DIFF
--- a/tests/models/test_person.py
+++ b/tests/models/test_person.py
@@ -3,7 +3,11 @@ import unittest
 
 from tests.base import ApiDBTestCase
 from zou.app.models.department import Department
-from zou.app.models.person import Person, normalize_country
+from zou.app.models.person import (
+    Person,
+    normalize_country,
+    normalize_locale,
+)
 
 from zou.app.utils import fields
 
@@ -27,6 +31,40 @@ class NormalizeCountryTestCase(unittest.TestCase):
     def test_malformed_values_are_rejected(self):
         for value in ["France", "FRA", "f", "f1", "éé", 123, ["FR"], 1.5]:
             self.assertEqual(normalize_country(value), (False, None))
+
+
+class NormalizeLocaleTestCase(unittest.TestCase):
+    """
+    Unit coverage for normalize_locale, the single source of truth shared by
+    the model validator and the API guard.
+    """
+
+    def test_valid_locales_are_trimmed_and_kept(self):
+        for value, expected in [
+            ("en_US", "en_US"),
+            ("fr_FR", "fr_FR"),
+            (" pt_BR ", "pt_BR"),
+            ("fr", "fr"),
+            ("en_us", "en_us"),  # Babel parses it back; casing is left as-is
+        ]:
+            self.assertEqual(normalize_locale(value), (True, expected))
+
+    def test_empty_values_mean_no_locale(self):
+        for value in [None, "", "   "]:
+            self.assertEqual(normalize_locale(value), (True, None))
+
+    def test_unparseable_values_are_rejected(self):
+        for value in [
+            "zz_ZZ",  # well-formed but unknown to Babel
+            "notlocale",
+            "en-US",  # wrong separator -> ValueError
+            "fr_FR_x",  # malformed identifier -> ValueError
+            "en_US_POSIX",  # valid Babel variant but too long for the column
+            123,
+            ["fr_FR"],
+            1.5,
+        ]:
+            self.assertEqual(normalize_locale(value), (False, None))
 
 
 class PersonTestCase(ApiDBTestCase):
@@ -270,6 +308,69 @@ class PersonTestCase(ApiDBTestCase):
         self.assertNotIn("country", person.present_minimal())
         safe = person.serialize_safe()
         self.assertEqual(safe["country"], "FR")
+
+    def test_person_locale_round_trip(self):
+        data = {
+            "first_name": "Locale",
+            "last_name": "Tester",
+            "email": "locale.tester@gmail.com",
+            "locale": "fr_FR",
+        }
+        person = self.post("data/persons", data)
+        self.assertEqual(person["locale"], "fr_FR")
+
+        # The stored value survives every read path (single GET, relations,
+        # list) instead of breaking serialization.
+        person_again = self.get(f"data/persons/{person['id']}")
+        self.assertEqual(person_again["locale"], "fr_FR")
+        person_with_relations = self.get(
+            f"data/persons/{person['id']}?relations=true"
+        )
+        self.assertEqual(person_with_relations["locale"], "fr_FR")
+        listed = next(
+            p for p in self.get("data/persons") if p["id"] == person["id"]
+        )
+        self.assertEqual(listed["locale"], "fr_FR")
+
+        self.put(f"data/persons/{person['id']}", {"locale": "pt_BR"})
+        person_again = self.get(f"data/persons/{person['id']}")
+        self.assertEqual(person_again["locale"], "pt_BR")
+
+        # Whitespace is trimmed on update.
+        self.put(f"data/persons/{person['id']}", {"locale": " ja_JP "})
+        person_again = self.get(f"data/persons/{person['id']}")
+        self.assertEqual(person_again["locale"], "ja_JP")
+
+    def test_create_person_with_invalid_locale(self):
+        data = {
+            "first_name": "Bad",
+            "last_name": "Locale",
+            "email": "bad.locale@gmail.com",
+            "locale": "zz_ZZ",
+        }
+        self.post("data/persons", data, 400)
+
+    def test_update_person_with_invalid_locale(self):
+        # The PUT guard rejects every unparseable category with a clean 400
+        # (never a 500 and never a poisoned entry): unknown locales, wrong
+        # separators, malformed identifiers and non-string bodies.
+        person = self.get_first("data/persons")
+        for value in ["zz_ZZ", "notlocale", "en-US", "fr_FR_x", 123, ["fr_FR"]]:
+            self.put(f"data/persons/{person['id']}", {"locale": value}, 400)
+
+    def test_locale_validator_never_raises_on_direct_write(self):
+        # Direct writes (SSO sign-in, imports, scripts) bypass the API guard,
+        # so the model validator must silently discard bad input instead of
+        # persisting a value that would break later reads.
+        person = Person.get_by(email="ema.doe@gmail.com")
+        person.update({"locale": "zz_ZZ"})
+        self.assertIsNone(person.locale)
+        person.update({"locale": ["fr_FR"]})
+        self.assertIsNone(person.locale)
+        person.update({"locale": "en-US"})
+        self.assertIsNone(person.locale)
+        person.update({"locale": " fr_FR "})
+        self.assertEqual(str(person.locale), "fr_FR")
 
     def test_update_person_with_duplicate_email(self):
         persons = sorted(self.get("data/persons"), key=itemgetter("email"))

--- a/zou/app/blueprints/crud/person.py
+++ b/zou/app/blueprints/crud/person.py
@@ -9,6 +9,7 @@ from zou.app.models.person import (
     CONTRACT_TYPES,
     TWO_FACTOR_AUTHENTICATION_TYPES,
     normalize_country,
+    normalize_locale,
 )
 from zou.app.services import (
     deletion_service,
@@ -40,6 +41,21 @@ def check_country(data):
     if not is_valid:
         raise WrongParameterException(
             "Invalid country code, expected an ISO 3166-1 alpha-2 code."
+        )
+
+
+def check_locale(data):
+    """
+    Reject a locale that Python Babel cannot parse with a clean 400. Empty or
+    missing values are treated as "no locale" and accepted. Without this guard
+    the raw value would be stored and then break every later read of the
+    person, since the model re-parses the locale through Babel on load.
+    """
+    is_valid, _ = normalize_locale(data.get("locale"))
+    if not is_valid:
+        raise WrongParameterException(
+            "Invalid locale, expected a name available in Python Babel "
+            "(e.g. en_US, fr_FR)."
         )
 
 
@@ -300,6 +316,7 @@ class PersonsResource(BaseModelsResource):
         ]:
             raise WrongParameterException("Invalid contract_type")
         check_country(data)
+        check_locale(data)
         if "two_factor_authentication" in data and data[
             "two_factor_authentication"
         ] not in [
@@ -607,6 +624,7 @@ class PersonResource(BaseModelResource, ArgsMixin):
         ]:
             raise WrongParameterException("Invalid contract_type")
         check_country(data)
+        check_locale(data)
         if "two_factor_authentication" in data and data[
             "two_factor_authentication"
         ] not in [

--- a/zou/app/models/person.py
+++ b/zou/app/models/person.py
@@ -14,6 +14,7 @@ from sqlalchemy.dialects.postgresql import JSONB
 
 from pytz import timezone as pytz_timezone
 from babel import Locale
+from babel.core import UnknownLocaleError
 
 from zou.app.models.serializer import SerializerMixin
 from zou.app.models.department import Department
@@ -85,6 +86,46 @@ def normalize_country(value):
     if len(normalized) == 2 and normalized.isascii() and normalized.isalpha():
         return True, normalized
     return False, None
+
+
+def normalize_locale(value):
+    """
+    Normalize a locale to a name Python Babel can parse back. Returns an
+    ``(is_valid, normalized)`` tuple:
+
+      - ``(True, "en_US")`` for a locale Babel recognizes (any casing and
+        surrounding whitespace); the value is trimmed but kept as-is rather
+        than re-serialized to Babel's canonical form, so ``zh_CN`` is not
+        rewritten to ``zh_Hans_CN`` and stays within the column width;
+      - ``(True, None)`` for an empty or ``None`` value (i.e. "no locale");
+      - ``(False, None)`` for a value Babel cannot parse (unknown locale,
+        malformed identifier, non-string input such as a SAML single-element
+        list) or one too long for the column.
+
+    Single source of truth shared by the API guard (raises 400 on invalid)
+    and the model validator (silently discards invalid). Without it an
+    unparseable value would be stored verbatim and then break every later
+    read of the person, since LocaleType re-parses the stored column value
+    through Babel on load.
+    """
+    if value is None:
+        return True, None
+    if isinstance(value, Locale):
+        return True, str(value)
+    if not isinstance(value, str):
+        return False, None
+    normalized = value.strip()
+    if normalized == "":
+        return True, None
+    # The locale column is a Unicode(10); a longer value would overflow the
+    # column even if Babel accepts it (e.g. the "en_US_POSIX" variant).
+    if len(normalized) > 10:
+        return False, None
+    try:
+        Locale.parse(normalized)
+    except (UnknownLocaleError, ValueError, TypeError):
+        return False, None
+    return True, normalized
 
 
 class DepartmentLink(db.Model):
@@ -212,6 +253,24 @@ class Person(db.Model, BaseMixin, SerializerMixin):
         if not is_valid:
             logger.warning(
                 f"Discarded invalid country value for person: {value!r}"
+            )
+        return normalized
+
+    @validates("locale")
+    def validate_locale(self, key, value):
+        """
+        Keep only locales Python Babel can parse back. Empty or malformed
+        values are stored as None (the read path then falls back to the
+        default locale). API requests are rejected upstream with a clean
+        400; this is the last-resort guard for direct writes (SSO sign-in,
+        imports, scripts) that never raises. Without it an unparseable value
+        would be persisted verbatim and break every later read of the person,
+        since LocaleType re-parses the stored column through Babel on load.
+        """
+        is_valid, normalized = normalize_locale(value)
+        if not is_valid:
+            logger.warning(
+                f"Discarded invalid locale value for person: {value!r}"
             )
         return normalized
 

--- a/zou/migrations/versions/f2c9a1b7e4d8_sanitize_invalid_person_locales.py
+++ b/zou/migrations/versions/f2c9a1b7e4d8_sanitize_invalid_person_locales.py
@@ -1,0 +1,56 @@
+"""sanitize person locales that Python Babel cannot parse
+
+An unparseable locale (e.g. "da_DA" instead of "da_DK") used to be stored
+verbatim on the person, then broke every later read since LocaleType re-parses
+the column through Babel on load. A single poisoned row takes down login and
+the whole persons list. New writes are now rejected upstream, but rows that
+were already poisoned must be healed: this migration reads the raw locale
+values (bypassing the coercion that raises on those rows) and blanks out any
+value Babel cannot parse. NULL is safe here, the read paths fall back to the
+default locale.
+
+Revision ID: f2c9a1b7e4d8
+Revises: f1a2b3c4d5e6
+Create Date: 2026-07-06 10:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+from babel import Locale
+from babel.core import UnknownLocaleError
+
+
+# revision identifiers, used by Alembic.
+revision = "f2c9a1b7e4d8"
+down_revision = "f1a2b3c4d5e6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    connection = op.get_bind()
+    # Read raw strings through a textual query so the LocaleType coercion,
+    # which raises on the poisoned rows, is never triggered.
+    rows = connection.execute(
+        sa.text("SELECT id, locale FROM person WHERE locale IS NOT NULL")
+    ).fetchall()
+
+    invalid_ids = []
+    for person_id, locale in rows:
+        try:
+            Locale.parse(locale)
+        except (UnknownLocaleError, ValueError, TypeError):
+            invalid_ids.append(person_id)
+
+    for person_id in invalid_ids:
+        connection.execute(
+            sa.text("UPDATE person SET locale = NULL WHERE id = :id"),
+            {"id": person_id},
+        )
+
+
+def downgrade():
+    # The original invalid values are intentionally not restored.
+    pass


### PR DESCRIPTION
**Problem**
- An unparseable locale (e.g., `da_DA` instead of `da_DK`) was stored verbatim on a person, then raised `UnknownLocaleError` on every read since `LocaleType` re-parses the column through Babel on load — a single poisoned row takes down login and the whole person's list.

**Solution**
- Validate the locale on create/update like the country field — a `normalize_locale` single source of truth, an `@validates` model guard for direct writes (SSO, imports, scripts), and a `check_locale` API guard — so an invalid value is rejected with a clean 400 instead of being persisted.
- Add a migration that blanks any already-stored locale Babel cannot parse (NULL falls back to the default locale), so existing poisoned rows recover on `zou upgrade-db`.
