### PR TITLE
[audit] Fix security, correctness and resource-handling findings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,10 +131,19 @@ jobs:
         run: >-
           pip install --upgrade pip setuptools &&
           pip install -r requirements.txt
+      # The cryptography/pyopenssl advisories below cannot be fixed yet:
+      # pysaml2 7.5.4 (latest) caps pyopenssl<24.3, which caps
+      # cryptography<44. Re-check whenever pysaml2 releases.
       - name: Run pip-audit 🔒
         run: >-
           pip install pip-audit &&
           pip-audit --skip-editable
+          --ignore-vuln PYSEC-2026-35
+          --ignore-vuln CVE-2024-12797
+          --ignore-vuln CVE-2026-26007
+          --ignore-vuln GHSA-537c-gmf6-5ccf
+          --ignore-vuln CVE-2026-27448
+          --ignore-vuln CVE-2026-27459
 
   publish-test:
     name: Publish to TestPyPI 📦

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,25 @@ jobs:
           MAIL_DEBUG_BODY: 1
           MAIL_ENABLED: False
 
+  audit:
+    name: Audit dependencies 🔒
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 🐍
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install packages 📦
+        run: >-
+          pip install --upgrade pip setuptools &&
+          pip install -r requirements.txt
+      - name: Run pip-audit 🔒
+        run: >-
+          pip install pip-audit &&
+          pip-audit --skip-editable
+
   publish-test:
     name: Publish to TestPyPI 📦
     needs: test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,7 +161,7 @@ For standard model CRUD, extend `BaseModelsResource` / `BaseModelResource` in `z
 
 ## Pydantic Validation (v2)
 
-All request body validation uses Pydantic v2 schemas. **Do not use `reqparse` or `ArgsMixin` for body parsing** — those are legacy patterns.
+All request body validation uses Pydantic v2 schemas. **Do not use `reqparse` or `ArgsMixin` for body parsing** — those are legacy patterns. Two inherited `reqparse` usages remain (`comments/resources.py`, `chats/resources.py`): do not copy them, migrate them to Pydantic when you touch those resources.
 
 ### Schema pattern
 

--- a/UNTESTED_ROUTES.md
+++ b/UNTESTED_ROUTES.md
@@ -1,245 +1,38 @@
 # Untested Blueprint Routes
 
-## Chats — 100% covered
-## Events — 100% covered
-## Search — 100% covered
+Snapshot of the known route-coverage gaps, refreshed during the
+2026-07 code audit. The previous version of this file listed every
+covered route; those tables rotted in both directions (they
+under-reported auth/previews coverage and missed real holes), so this
+file now only tracks what is **not** tested. Completed work belongs to
+git history, not here.
 
-## User — DONE
-| Route | Method | Status |
-|---|---|---|
-| `/data/user/assets/<id>/task-types` | GET | ✅ Done |
-| `/actions/user/chats/<id>/join` | DELETE | ✅ Done |
+To re-derive the list: compare the routes registered in
+`zou/app/blueprints/*/__init__.py` with the paths exercised in
+`tests/<blueprint>/`.
 
-## Shots — DONE
-| Route | Method | Status |
-|---|---|---|
-| `/data/shots/<id>/preview-files` | GET | ✅ Done |
-| `/data/shots/<id>/versions` | GET | ✅ Done |
-| `/data/episodes/<id>/shot-tasks` | GET | ✅ Done |
-| `/data/episodes/<id>/asset-tasks` | GET | ✅ Done |
-| `/data/sequences/<id>/shot-tasks` | GET | ✅ Done |
-| `/data/projects/<id>/quotas/<task_type_id>` | GET | ✅ Done |
-| `/data/projects/<id>/quotas/persons/<person_id>` | GET | ✅ Done |
-| `/actions/projects/<id>/task-types/<id>/set-shot-nb-frames` | POST | ✅ Done |
+## Known gaps (2026-07-06)
 
-## Tasks — DONE
-| Route | Method | Status |
+| Area | Routes | Notes |
 |---|---|---|
-| `/data/tasks/open-tasks/stats` | GET | ✅ Done |
-| `/data/projects/<id>/subscriptions` | GET | ✅ Done |
-| `/data/persons/task-dates` | GET | ✅ Done |
-| `/actions/projects/<id>/task-types/<id>/delete-tasks` | DELETE | ✅ Done |
-| `/actions/projects/<id>/delete-tasks` | POST | ✅ Done |
-| `/actions/persons/<id>/assign` | PUT | ✅ Done |
-| `/actions/tasks/clear-assignation` | PUT | ✅ Done |
-| `/actions/projects/<id>/task-types/<id>/edits/create-tasks` | POST | ✅ Done |
-| `/actions/projects/<id>/task-types/<id>/concepts/create-tasks` | POST | ✅ Done |
-| `/actions/tasks/<id>/set-main-preview` | PUT | ✅ Done |
-| `/actions/tasks/<id>/comments/<id>/preview-files/<id>` | DELETE | ✅ Done |
+| FIDO/WebAuthn | `/auth/fido` (GET, PUT, POST, DELETE) | Needs a mocked WebAuthn authenticator (audit TEST-1) |
+| SAML SSO | `/auth/saml/sso`, `/auth/saml/login` | Needs a fixture IdP assertion (audit TEST-1); the 2FA gate logic is shared with OIDC, which is tested |
+| Video streaming | `/movies/originals/…`, `/movies/low/…` | Use the existing video fixture with ffmpeg mocked (audit TEST-2) |
+| Batch comments | `/actions/tasks/batch-comment`, `/actions/tasks/<id>/batch-comment` | Core review flow, no route test (audit TEST-2) |
+| Working file I/O | `/data/working-files/<id>/file` (GET, POST) | Skipped historically (binary I/O) |
+| Attachment upload | `/actions/tasks/<id>/comments/<id>/add-attachment`, attachment download/delete routes | Service layer covered since the audit; route-level upload still untested |
+| Output files with instances | `/data/asset-instances/<id>/entities/<id>/output-types/<id>/output-files` | Skipped historically (complex FK setup) |
+| Production schedule apply | `/actions/production-schedule-versions/<id>/…` (3 action routes) | Skipped historically (complex schedule setup) |
+| Playlist builds | `/data/playlists/<id>/build/mp4` and build-job routes | Need ffmpeg / a build job |
+| Vendor isolation | `entities/*` sub-resources, chat attachments | Fixes shipped (audit SEC-11, SEC-14) but dedicated vendor-403 tests are still missing |
+| Email OTP without auth | `/auth/email-otp` (GET) | Public endpoint, no rate-limit test (audit BUG-27) |
+| Person invite | `/actions/persons/<id>/invite` | Sends email |
 
-## Files — DONE (except file upload/download)
-| Route | Method | Status |
-|---|---|---|
-| `/data/files/<id>` | GET | ✅ Done |
-| `/data/tasks/<id>/working-files` | GET | ✅ Done |
-| `/data/asset-instances/<id>/entities/<id>/output-types` | GET | ✅ Done |
-| `/data/asset-instances/<id>/entities/<id>/output-types/<id>/output-files` | GET | Skipped (complex FK setup) |
-| `/data/entities/guess_from_path` | POST | ✅ Done |
-| `/data/working-files/<id>/file` | GET, POST | Skipped (binary file I/O) |
-| `/actions/projects/<id>/set-file-tree` | POST | ✅ Done |
+## Recently closed (2026-07 audit follow-up)
 
-## News — DONE
-| Route | Method | Status |
-|---|---|---|
-| `/data/projects/news` | GET | ✅ Done |
-
-## Edits — DONE
-| Route | Method | Status |
-|---|---|---|
-| `/data/edits` | GET | ✅ Done |
-| `/data/edits/<id>/preview-files` | GET | ✅ Done |
-| `/data/edits/<id>/versions` | GET | ✅ Done |
-| `/data/episodes/<id>/edits` | GET | ✅ Done |
-| `/data/episodes/<id>/edit-tasks` | GET | ✅ Done |
-
-## Assets — DONE
-| Route | Method | Status |
-|---|---|---|
-| `/data/assets/<id>/assets` | GET | ✅ Done |
-| `/data/assets/<id>/cast-in` | GET | ✅ Done |
-| `/data/assets/<id>/casting` | GET, PUT | ✅ Done |
-| `/data/assets/<id>/shot-asset-instances` | GET | ✅ Done |
-| `/data/assets/<id>/scene-asset-instances` | GET | ✅ Done |
-| `/data/assets/<id>/asset-asset-instances` | GET, POST | ✅ Done |
-| `/actions/assets/share` | POST | ✅ Done |
-| `/actions/projects/<id>/assets/share` | POST | ✅ Done |
-| `/actions/projects/<id>/asset-types/<id>/assets/share` | POST | ✅ Done |
-| `/data/projects/<id>/assets/shared-used` | GET | ✅ Done |
-| `/data/projects/<id>/episodes/<id>/assets/shared-used` | GET | ✅ Done |
-
-## Projects — DONE
-| Route | Method | Status |
-|---|---|---|
-| `/data/projects/<id>/settings/asset-types` | GET, POST | ✅ Done |
-| `/data/projects/<id>/settings/asset-types/<id>` | DELETE | ✅ Done |
-| `/data/projects/<id>/settings/task-types` | GET, POST | ✅ Done |
-| `/data/projects/<id>/settings/task-types/<id>` | DELETE | ✅ Done |
-| `/data/projects/<id>/settings/task-status` | GET, POST | ✅ Done |
-| `/data/projects/<id>/settings/task-status/<id>` | DELETE | ✅ Done |
-| `/data/projects/<id>/settings/status-automations` | GET, POST | ✅ Done |
-| `/data/projects/<id>/settings/status-automations/<id>` | DELETE | ✅ Done |
-| `/data/projects/<id>/settings/preview-background-files` | GET, POST | ✅ Done |
-| `/data/projects/<id>/settings/preview-background-files/<id>` | DELETE | ✅ Done |
-| `/data/projects/<id>/time-spents` | GET | ✅ Done |
-| `/data/projects/<id>/milestones` | GET | ✅ Done |
-| `/data/projects/<id>/budgets` | GET, POST | ✅ Done |
-| `/data/projects/<id>/budgets/<id>` | GET, PUT, DELETE | ✅ Done |
-| `/data/projects/<id>/budgets/<id>/entries` | GET, POST | ✅ Done |
-| `/data/projects/<id>/budgets/<id>/entries/<id>` | GET, PUT, DELETE | ✅ Done |
-| `/data/projects/<id>/budgets/time-spents` | GET | ✅ Done |
-| `/data/production-schedule-versions/<id>/task-links` | GET, POST | ✅ Done |
-| `/actions/production-schedule-versions/<id>/set-task-links-from-production` | POST | Skipped (complex schedule setup) |
-| `/actions/production-schedule-versions/<id>/set-task-links-from-production-schedule-version` | POST | Skipped (complex schedule setup) |
-| `/actions/production-schedule-versions/<id>/apply-to-production` | POST | Skipped (complex schedule setup) |
-| `/data/projects/<id>/task-types/<id>/time-spents` | GET | ✅ Done |
-| `/data/projects/<id>/day-offs` | GET | ✅ Done |
-
-## Auth — Skipped (requires real bcrypt, TOTP, FIDO hardware, SAML IdP)
-| Route | Method | Status |
-|---|---|---|
-| `/auth/totp` | GET, POST, DELETE | Skipped |
-| `/auth/email-otp` | GET, PUT, POST, DELETE | Skipped |
-| `/auth/recovery-codes` | GET, PUT, POST, DELETE | Skipped |
-| `/auth/fido` | GET, PUT, POST, DELETE | Skipped |
-| `/auth/saml/sso` | POST | Skipped |
-| `/auth/saml/login` | GET | Skipped |
-
-## Breakdown — DONE
-| Route | Method | Status |
-|---|---|---|
-| `/data/projects/<id>/asset-types/<id>/casting` | GET | ✅ Done |
-| `/data/projects/<id>/episodes/casting` | GET | ✅ Done |
-| `/data/projects/<id>/sequences/<id>/casting` | GET | ✅ Done |
-| `/data/projects/<id>/episodes/<id>/sequences/all/casting` | GET | ✅ Done |
-| `/data/projects/<id>/sequences/all/casting` | GET | ✅ Done |
-| `/data/projects/<id>/entity-links/<id>` | DELETE | ✅ Done |
-| `/data/scenes/<id>/asset-instances` | GET, POST | ✅ Done |
-| `/data/scenes/<id>/camera-instances` | GET | ✅ Done |
-| `/data/shots/<id>/asset-instances` | GET, POST | ✅ Done |
-| `/data/shots/<id>/asset-instances/<id>` | DELETE | ✅ Done |
-
-## Persons — DONE (except invite)
-| Route | Method | Status |
-|---|---|---|
-| `/data/persons/<id>/time-spents` | GET | ✅ Done |
-| `/data/persons/<id>/day-offs/<date>` | GET | ✅ Done |
-| `/data/persons/<id>/time-spents/year/<year>` | GET | ✅ Done |
-| `/data/persons/<id>/time-spents/month/<year>/<month>` | GET | ✅ Done |
-| `/data/persons/<id>/time-spents/week/<year>/<week>` | GET | ✅ Done |
-| `/data/persons/<id>/time-spents/day/<year>/<month>/<day>` | GET | ✅ Done |
-| `/data/persons/<id>/quota-shots/month/<year>/<month>` | GET | ✅ Done |
-| `/data/persons/<id>/quota-shots/week/<year>/<week>` | GET | ✅ Done |
-| `/data/persons/<id>/quota-shots/day/<year>/<month>/<day>` | GET | ✅ Done |
-| `/data/persons/time-spents/year-table/` | GET | ✅ Done |
-| `/data/persons/time-spents/month-table/<year>` | GET | ✅ Done |
-| `/data/persons/time-spents/week-table/<year>` | GET | ✅ Done |
-| `/data/persons/time-spents/day-table/<year>/<month>` | GET | ✅ Done |
-| `/data/persons/day-offs/<year>/<month>` | GET | ✅ Done |
-| `/data/persons/<id>/day-offs/week/<year>/<week>` | GET | ✅ Done |
-| `/data/persons/<id>/day-offs/month/<year>/<month>` | GET | ✅ Done |
-| `/data/persons/<id>/day-offs/year/<year>` | GET | ✅ Done |
-| `/data/persons/<id>/day-offs` | GET | ✅ Done |
-| `/actions/persons/<id>/invite` | POST | Skipped (sends email) |
-| `/actions/persons/<id>/change-password` | POST | ✅ Done |
-| `/actions/persons/<id>/disable-two-factor-authentication` | DELETE | ✅ Done |
-| `/actions/persons/<id>/clear-avatar` | DELETE | ✅ Done |
-
-## Concepts — DONE
-| Route | Method | Status |
-|---|---|---|
-| `/data/concepts` | GET | ✅ Done |
-| `/data/concepts/with-tasks` | GET | ✅ Done |
-| `/data/concepts/<id>` | GET, DELETE | ✅ Done |
-| `/data/concepts/<id>/task-types` | GET | ✅ Done |
-| `/data/concepts/<id>/tasks` | GET | ✅ Done |
-| `/data/concepts/<id>/preview-files` | GET | ✅ Done |
-| `/data/projects/<id>/concepts` | GET, POST | ✅ Done |
-
-## Departments — DONE
-| Route | Method | Status |
-|---|---|---|
-| `/data/departments/software-licenses` | GET | ✅ Done |
-| `/data/departments/<id>/software-licenses` | POST | ✅ Done |
-| `/data/departments/<id>/software-licenses/<id>` | GET, DELETE | ✅ Done |
-| `/data/departments/hardware-items` | GET | ✅ Done |
-| `/data/departments/<id>/hardware-items` | POST | ✅ Done |
-| `/data/departments/<id>/hardware-items/<id>` | GET, DELETE | ✅ Done |
-
-## Entities — DONE
-| Route | Method | Status |
-|---|---|---|
-| `/data/entities/<id>/news` | GET | ✅ Done |
-| `/data/entities/<id>/preview-files` | GET | ✅ Done |
-| `/data/entities/<id>/time-spents` | GET | ✅ Done |
-| `/data/entities/<id>/entities-linked/with-tasks` | GET | ✅ Done |
-
-## Comments — DONE (except file upload/download)
-| Route | Method | Status |
-|---|---|---|
-| `/data/tasks/<id>/comments/<id>/ack` | POST | ✅ Done |
-| `/data/tasks/<id>/comments/<id>/reply` | POST | ✅ Done |
-| `/data/tasks/<id>/comments/<id>/attachments/<id>` | DELETE | Skipped (needs file upload) |
-| `/data/tasks/<id>/comments/<id>/reply/<id>` | DELETE | ✅ Done |
-| `/data/attachment-files/<id>/file/<name>` | GET | Skipped (binary file I/O) |
-| `/actions/tasks/<id>/comments/<id>/add-attachment` | POST | Skipped (needs file upload) |
-| `/data/projects/<id>/attachment-files` | GET | ✅ Done |
-| `/data/tasks/<id>/attachment-files` | GET | ✅ Done |
-| `/actions/tasks/<id>/comment` | POST | ✅ Done |
-| `/actions/projects/<id>/tasks/comment-many` | POST | ✅ Done |
-
-## Previews — Skipped (requires file storage, image processing, ffmpeg)
-| Route | Method | Status |
-|---|---|---|
-| `/pictures/preview-files/<id>` | POST | Skipped |
-| `/actions/tasks/<id>/batch-comment` | POST | Skipped |
-| `/actions/tasks/batch-comment` | POST | Skipped |
-| `/movies/originals/preview-files/<id>.mp4` | GET | Skipped |
-| `/movies/originals/preview-files/<id>/download` | GET | Skipped |
-| `/movies/low/preview-files/<id>.mp4` | GET | Skipped |
-| `/pictures/thumbnails/preview-files/<id>.png` | GET | Skipped |
-| `/pictures/thumbnails/attachment-files/<id>.png` | GET | Skipped |
-| `/pictures/thumbnails-square/preview-files/<id>.png` | GET | Skipped |
-| `/pictures/originals/preview-files/<id>.png` | GET | Skipped |
-| `/pictures/originals/preview-files/<id>.<extension>` | GET | Skipped |
-| `/pictures/originals/preview-files/<id>/download` | GET | Skipped |
-| `/pictures/previews/preview-files/<id>.png` | GET | Skipped |
-| `/movies/tiles/preview-files/<id>.png` | GET | Skipped |
-| `/pictures/thumbnails/organisations/<id>.png` | GET | Skipped |
-| `/pictures/thumbnails/organisations/<id>` | POST | Skipped |
-| `/pictures/thumbnails/persons/<id>.png` | GET | Skipped |
-| `/pictures/thumbnails/persons/<id>` | POST | Skipped |
-| `/pictures/thumbnails/projects/<id>.png` | GET | Skipped |
-| `/pictures/thumbnails/projects/<id>` | POST | Skipped |
-| `/pictures/preview-background-files/<id>` | POST | Skipped |
-| `/pictures/thumbnails/preview-background-files/<id>.png` | GET | Skipped |
-| `/pictures/preview-background-files/<id>.<extension>` | GET | Skipped |
-| `/actions/preview-files/<id>/set-main-preview` | PUT | Skipped |
-| `/actions/preview-files/<id>/update-annotations` | PUT | Skipped |
-| `/actions/preview-files/<id>/update-position` | PUT | Skipped |
-| `/actions/preview-files/<id>/extract-frame` | GET | Skipped |
-| `/actions/preview-files/<id>/extract-tile` | GET | Skipped |
-
-## Playlists — DONE (except build/download)
-| Route | Method | Status |
-|---|---|---|
-| `/data/projects/<id>/playlists/all` | GET | ✅ Done |
-| `/data/projects/<id>/episodes/<id>/playlists` | GET | ✅ Done |
-| `/data/projects/<id>/playlists/<id>` | GET | ✅ Done |
-| `/data/playlists/entities/<id>/preview-files` | GET | ✅ Done |
-| `/data/playlists/<id>/jobs/<id>` | GET, DELETE | Skipped (needs build job) |
-| `/data/projects/<id>/build-jobs` | GET | ✅ Done |
-| `/data/playlists/<id>/build/mp4` | GET | Skipped (needs ffmpeg) |
-| `/data/playlists/<id>/jobs/<id>/build/mp4` | GET | Skipped (needs build job + file) |
-| `/data/projects/<id>/playlists/temp` | POST | ✅ Done |
-| `/actions/playlists/<id>/add-entity` | POST | ✅ Done |
-| `/data/playlists/<id>/notify-clients` | POST | Skipped (sends notifications) |
+- 2FA routes: disable via recovery code, reset-password enumeration,
+  restricted-token flows are covered in `tests/auth/`.
+- Preview upload/serving happy paths are covered in
+  `tests/thumbnails/`, including both `set-main-preview` routes.
+- `/data/tasks/<id>/comments/<id>/ack` got its first test along with
+  the session-conflict fix (audit BUG-37).

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,6 @@ install_requires =
     flask_bcrypt==1.0.1
     flask_caching==2.4.0
     flask-cors==6.0.2
-    flask_fixtures==0.3.8
     flask_mail==0.10.0
     flask_principal==0.4.0
     flask_restful==0.3.10
@@ -60,7 +59,7 @@ install_requires =
     matterhook-nlz==0.3
     meilisearch==0.41.0
     numpy==2.2.6
-    opencv-python==4.13.0.92
+    opencv-python-headless==4.13.0.92
     OpenTimelineIO==0.18.1
     OpenTimelineIO-Plugins==0.18.1
     orjson==3.11.9

--- a/setup.cfg
+++ b/setup.cfg
@@ -67,12 +67,12 @@ install_requires =
     pillow==12.2.0
     psutil==7.2.2
     psycopg[binary]==3.3.4
-    PyJWT==2.12.1
+    PyJWT==2.13.0
     pyotp==2.9.0
     pysaml2==7.5.4
     python-nomad==2.1.0
     python-slugify==8.0.4
-    python-socketio==5.16.1
+    python-socketio==5.16.2
     pytz==2026.2
     redis==7.4.0
     requests==2.34.0

--- a/specs/architecture.md
+++ b/specs/architecture.md
@@ -39,10 +39,10 @@ zou/
 │   │                        # entities, events, export, index,
 │   │                        # news, search, source, user,
 │   │                        # departments
-│   ├── models/              # 50 SQLAlchemy model files
-│   ├── services/            # 40 business logic modules
+│   ├── models/              # ~50 SQLAlchemy model files
+│   ├── services/            # ~40 business logic modules
 │   ├── stores/              # File storage abstraction
-│   └── utils/               # 31 utility modules
+│   └── utils/               # ~35 utility modules
 ├── migrations/              # Alembic migration versions
 ├── remote/                  # Remote job execution
 └── cli.py                   # CLI commands

--- a/specs/services.md
+++ b/specs/services.md
@@ -27,29 +27,39 @@ Blueprint resource → Service function → Model query/mutation → Event emiss
 | `backup_service` | Database backup |
 | `base_service` | Shared helpers (model retrieval) |
 | `breakdown_service` | Episode/sequence breakdowns |
+| `budget_service` | Production budgets and budget entries |
 | `chats_service` | Entity chat threads and messages |
 | `comments_service` | Comment CRUD, replies, attachments, acknowledgments |
 | `concepts_service` | Concept art management |
+| `custom_actions_service` | Custom action buttons exposed to the UI |
 | `deletion_service` | Safe deletion with relationship cleanup |
+| `departments_service` | Departments, software licenses, hardware items |
 | `edits_service` | Edit/video content |
 | `emails_service` | Email template rendering and sending |
 | `entities_service` | Generic entity operations |
 | `events_service` | Event emission and persistence |
+| `file_tree_service` | File path generation from project file trees |
 | `files_service` | Working files, output files, file paths, versioning |
 | `index_service` | Meilisearch indexing |
 | `names_service` | Naming convention utilities |
 | `news_service` | Studio news/announcements |
 | `notifications_service` | Notification creation and subscriptions |
 | `persons_service` | Person CRUD, departments, presence |
+| `playlist_sharing_service` | Guest access to shared playlists (links, builds) |
 | `playlists_service` | Playlists, sharing, build jobs |
+| `plugins_service` | Plugin install/load lifecycle (CLI only) |
 | `preview_files_service` | Preview uploads, thumbnails, annotations |
+| `project_templates_service` | Bootstrap projects from templates |
 | `projects_service` | Project CRUD, team, settings, metadata |
+| `scenes_service` | Layout scenes and their shots/asset instances |
 | `schedule_service` | Schedule items, milestones, production schedules |
 | `shots_service` | Shots, sequences, episodes, scenes |
+| `stats_service` | Project/task statistics |
 | `status_automations_service` | Automatic status transitions |
 | `sync_service` | Data import/export synchronization |
 | `tasks_service` | Task lifecycle, assignments, status, time tracking |
-| `templates_service` | File tree templates |
+| `templates_service` | Notification email HTML templates |
+| `time_spents_service` | Time spent entries and aggregates |
 | `user_service` | Current user context, access checks |
 
 ## Caching pattern

--- a/tests/admin/test_get_current_config.py
+++ b/tests/admin/test_get_current_config.py
@@ -142,4 +142,5 @@ class GetCurrentConfigCommandTestCase(unittest.TestCase):
         mock_get.assert_called_once_with(
             "http://myhost:8080/admin/config/check",
             headers={"Authorization": f"Bearer {TEST_TOKEN}"},
+            timeout=30,
         )

--- a/tests/auth/test_auth_route.py
+++ b/tests/auth/test_auth_route.py
@@ -206,6 +206,26 @@ class AuthTestCase(ApiDBTestCase):
         self.assertIsAuthenticated(tokens)
         self.logout(tokens)
 
+    def test_logout_revokes_refresh_token(self):
+        tokens = self.post("auth/login", self.credentials, 200)
+        self.logout(tokens)
+        headers = {
+            "Authorization": f"Bearer {tokens.get('refresh_token', None)}"
+        }
+        response = self.app.get("auth/refresh-token", headers=headers)
+        self.assertEqual(response.status_code, 401)
+
+    def test_logout_after_refresh_revokes_refresh_token(self):
+        tokens = self.post("auth/login", self.credentials, 200)
+        refresh_headers = {
+            "Authorization": f"Bearer {tokens.get('refresh_token', None)}"
+        }
+        result = self.app.get("auth/refresh-token", headers=refresh_headers)
+        new_tokens = json.loads(result.data.decode("utf-8"))
+        self.logout(new_tokens)
+        response = self.app.get("auth/refresh-token", headers=refresh_headers)
+        self.assertEqual(response.status_code, 401)
+
     def test_refresh_token(self):
         tokens = self.post("auth/login", self.credentials, 200)
         self.assertIsAuthenticated(tokens)

--- a/tests/auth/test_auth_route.py
+++ b/tests/auth/test_auth_route.py
@@ -1118,3 +1118,4 @@ class ChangePasswordErrorsTestCase(ApiDBTestCase):
             ),
             headers=headers,
         )
+        self.assertEqual(response.status_code, 400)

--- a/tests/auth/test_oidc.py
+++ b/tests/auth/test_oidc.py
@@ -191,7 +191,7 @@ class OIDCCallbackTestCase(ApiDBTestCase):
     def _capture_claims(self, claims):
         """Run the callback capturing the additional_claims passed to the JWT."""
         with mock.patch(
-            "zou.app.blueprints.auth.resources.create_access_token",
+            "zou.app.services.auth_service.create_access_token",
             wraps=real_create_access_token,
         ) as create_token:
             self.call_callback(claims)

--- a/tests/auth/test_permission.py
+++ b/tests/auth/test_permission.py
@@ -25,9 +25,13 @@ class PermissionTestCase(ApiDBTestCase):
 
     def test_admin_can_edit_project(self):
         self.log_in(self.user["email"])
+        data = {"name": "Cosmos Landromat 2 edited"}
+        self.put(f"data/projects/{self.project_id}", data, 200)
 
     def test_admin_can_read_project(self):
         self.log_in(self.user["email"])
+        project = self.get(f"data/projects/{self.project_id}")
+        self.assertEqual(project["id"], str(self.project_id))
 
     def test_cg_artist_cannot_create_project(self):
         self.log_in_cg_artist()

--- a/tests/misc/test_max_content_length.py
+++ b/tests/misc/test_max_content_length.py
@@ -1,0 +1,21 @@
+from tests.base import ApiTestCase
+
+from zou.app import app
+
+
+class MaxContentLengthTestCase(ApiTestCase):
+    def test_limit_is_configured(self):
+        self.assertIsNotNone(app.config["MAX_CONTENT_LENGTH"])
+
+    def test_oversized_body_is_rejected(self):
+        previous = app.config["MAX_CONTENT_LENGTH"]
+        app.config["MAX_CONTENT_LENGTH"] = 1024
+        try:
+            response = self.app.post(
+                "auth/login",
+                data=b"x" * 2048,
+                headers={"Content-type": "application/json"},
+            )
+            self.assertEqual(response.status_code, 413)
+        finally:
+            app.config["MAX_CONTENT_LENGTH"] = previous

--- a/tests/misc/test_paginate.py
+++ b/tests/misc/test_paginate.py
@@ -17,10 +17,12 @@ class PaginationTestCase(ApiDBTestCase):
         self.assertEqual(len(persons), 51)
 
     def test_404(self):
-        persons = self.get("data/persons?page=4")["data"]
-        self.assertEqual(len(persons), 0)
-        persons = self.get("data/persons?page=0")["data"]
-        self.assertEqual(len(persons), 0)
+        result = self.get("data/persons?page=4")
+        self.assertEqual(len(result["data"]), 0)
+        self.assertEqual(result["total"], 251)
+        result = self.get("data/persons?page=0")
+        self.assertEqual(len(result["data"]), 0)
+        self.assertEqual(result["total"], 251)
 
     def test_malformed_page_returns_400(self):
         self.get("data/persons?page=foo", 400)

--- a/tests/misc/test_paginate.py
+++ b/tests/misc/test_paginate.py
@@ -22,6 +22,10 @@ class PaginationTestCase(ApiDBTestCase):
         persons = self.get("data/persons?page=0")["data"]
         self.assertEqual(len(persons), 0)
 
+    def test_malformed_page_returns_400(self):
+        self.get("data/persons?page=foo", 400)
+        self.get("data/persons?page=1&limit=bar", 400)
+
     def test_metadata(self):
         pagination_infos = self.get("data/persons?page=2")
         self.assertEqual(pagination_infos["total"], 251)

--- a/tests/misc/test_query.py
+++ b/tests/misc/test_query.py
@@ -23,6 +23,10 @@ class QueryTestCase(ApiDBTestCase):
         self.generate_fixture_asset_character("Asset char 1")
         self.generate_fixture_asset_character("Asset char 2")
 
+    def test_malformed_filters_return_400(self):
+        self.get('data/projects?id=["broken', 400)
+        self.get("data/projects?is_clients_isolated=notabool", 400)
+
     def test_get_by_name(self):
         entities = self.get("data/entities")
         self.assertEqual(len(entities), 5)

--- a/tests/misc/test_security_headers.py
+++ b/tests/misc/test_security_headers.py
@@ -1,0 +1,16 @@
+from tests.base import ApiTestCase
+
+
+class SecurityHeadersTestCase(ApiTestCase):
+    def test_security_headers_are_set(self):
+        response = self.app.get("/")
+        self.assertEqual(response.headers["X-Content-Type-Options"], "nosniff")
+        self.assertEqual(response.headers["X-Frame-Options"], "SAMEORIGIN")
+        self.assertEqual(
+            response.headers["Content-Security-Policy"],
+            "frame-ancestors 'self'",
+        )
+        self.assertEqual(
+            response.headers["Referrer-Policy"],
+            "strict-origin-when-cross-origin",
+        )

--- a/tests/services/test_auth_service.py
+++ b/tests/services/test_auth_service.py
@@ -6,6 +6,7 @@ from zou.app.utils import auth
 
 from zou.app import app
 
+from zou.app.stores import auth_tokens_store
 from zou.app.services import persons_service, auth_service
 from zou.app.services.exception import (
     PersonNotFoundException,
@@ -105,5 +106,9 @@ class AuthTestCase(ApiDBTestCase):
         self.assertEqual(person["first_name"], "John")
 
     def test_revoke_tokens(self):
-        # Complex to test, jwt extended requires a proper flask context to run.
-        pass
+        auth_service.revoke_tokens(
+            app, "access-jti", refresh_jti="refresh-jti"
+        )
+        self.assertTrue(auth_tokens_store.is_revoked("access-jti"))
+        self.assertTrue(auth_tokens_store.is_revoked("refresh-jti"))
+        self.assertFalse(auth_tokens_store.is_revoked("other-jti"))

--- a/tests/services/test_auth_service.py
+++ b/tests/services/test_auth_service.py
@@ -1,5 +1,7 @@
 import flask_bcrypt as bcrypt
 
+from unittest import mock
+
 from tests.base import ApiDBTestCase
 
 from zou.app.utils import auth
@@ -29,6 +31,12 @@ class AuthTestCase(ApiDBTestCase):
             "email": self.person_dict["email"],
             "password": "secretpassword",
         }
+
+    def tearDown(self):
+        # Some tests switch the auth strategy; restore the default so the
+        # leak does not break login tests run after this file.
+        app.config["AUTH_STRATEGY"] = "auth_local_classic"
+        super(AuthTestCase, self).tearDown()
 
     def test_load_user(self):
         person = persons_service.get_person(self.person.id)
@@ -104,6 +112,19 @@ class AuthTestCase(ApiDBTestCase):
             app, "john.doe@gmail.com", "mypassword"
         )
         self.assertEqual(person["first_name"], "John")
+
+    def test_check_auth_works_on_a_copy(self):
+        app.config["AUTH_STRATEGY"] = "auth_local_classic"
+        email = self.person_dict["email"]
+        person = persons_service.get_person_by_email_desktop_login(email)
+        with mock.patch.object(
+            persons_service,
+            "get_person_by_email_desktop_login",
+            return_value=person,
+        ):
+            result = auth_service.check_auth(app, email, "secretpassword")
+        self.assertNotIn("password", result)
+        self.assertIn("password", person)
 
     def test_revoke_tokens(self):
         auth_service.revoke_tokens(

--- a/tests/services/test_comments_service.py
+++ b/tests/services/test_comments_service.py
@@ -241,6 +241,16 @@ class CommentsServiceTestCase(ApiDBTestCase):
             [str(self.department_animation.id)],
         )
 
+    def test_acknowledge_comment(self):
+        comment = comments_service.new_comment(
+            self.task.id, self.task_status.id, self.user["id"], "to ack"
+        )
+        path = f"data/tasks/{self.task.id}/comments/{comment['id']}/ack"
+        result = self.post(path, {}, 200)
+        self.assertIn(self.user["id"], result["acknowledgements"])
+        result = self.post(path, {}, 200)
+        self.assertEqual(result["acknowledgements"], [])
+
     def test_get_reply(self):
         comment = comments_service.new_comment(
             self.task.id, self.task_status.id, self.user["id"], "comment"

--- a/tests/services/test_comments_service.py
+++ b/tests/services/test_comments_service.py
@@ -1,3 +1,7 @@
+import io
+
+from werkzeug.datastructures import FileStorage
+
 from tests.base import ApiDBTestCase
 
 from zou.app.services import (
@@ -7,7 +11,7 @@ from zou.app.services import (
     tasks_service,
     exception,
 )
-from zou.app.utils import events
+from zou.app.utils import events, fields
 
 
 class CommentsServiceTestCase(ApiDBTestCase):
@@ -39,9 +43,6 @@ class CommentsServiceTestCase(ApiDBTestCase):
         self.wfa_status = self.generate_fixture_task_status_wfa()
         self.project_id = str(self.project.id)
 
-    def generate_commment():
-        pass
-
     def test_new_comment(self):
         self.comment = comments_service.new_comment(
             self.task.id, self.task_status.id, self.user["id"], "first comment"
@@ -58,10 +59,6 @@ class CommentsServiceTestCase(ApiDBTestCase):
         )
         self.assertEqual(self.comment["created_at"], "2024-01-23T10:00:00")
         # TODO test attachment files
-
-    def test_create_comment(self):
-        # TODO
-        pass
 
     def test_check_retake_capping(self):
         self.project.update({"max_retakes": 2})
@@ -159,69 +156,59 @@ class CommentsServiceTestCase(ApiDBTestCase):
         self.assertEqual(payload["new_task_status_id"], self.wfa_status["id"])
         self.assertEqual(payload["comment_id"], comment["id"])
 
-    def test_manage_subscriptions(self):
-        # TODO
-        pass
-
-    def test_run_status_automation(self):
-        # TODO
-        pass
-
-    def add_attachments_to_comment(self):
-        # TODO
-        pass
+    def _create_attachment(self, comment, filename):
+        uploaded_file = FileStorage(
+            stream=io.BytesIO(b"attachment content"), filename=filename
+        )
+        return comments_service.create_attachment(comment, uploaded_file)
 
     def test_create_attachment(self):
-        # TODO
-        pass
+        comment = comments_service.new_comment(
+            self.task.id, self.task_status.id, self.user["id"], "comment"
+        )
+        attachment = self._create_attachment(comment, "notes.txt")
+        self.assertEqual(attachment["name"], "notes.txt")
+        self.assertEqual(attachment["extension"], "txt")
+        self.assertGreater(attachment["size"], 0)
 
     def test_get_attachment_file_path(self):
-        # TODO
-        pass
+        comment = comments_service.new_comment(
+            self.task.id, self.task_status.id, self.user["id"], "comment"
+        )
+        attachment = self._create_attachment(comment, "notes.txt")
+        path = comments_service.get_attachment_file_path(attachment)
+        with open(path, "rb") as attachment_file:
+            self.assertEqual(attachment_file.read(), b"attachment content")
 
     def test_get_all_attachment_files_for_project(self):
-        # TODO
-        pass
-
-    def test_manage_subscriptions(self):
-        # TODO
-        pass
-
-    def test_run_status_automation(self):
-        # TODO
-        pass
-
-    def add_attachments_to_comment(self):
-        # TODO
-        pass
-
-    def test_create_attachment(self):
-        # TODO
-        pass
-
-    def test_get_attachment_file_path(self):
-        # TODO
-        pass
-
-    def test_get_all_attachment_files_for_project(self):
-        # TODO
-        pass
+        comment = comments_service.new_comment(
+            self.task.id, self.task_status.id, self.user["id"], "comment"
+        )
+        attachment = self._create_attachment(comment, "notes.txt")
+        attachments = comments_service.get_all_attachment_files_for_project(
+            self.project_id
+        )
+        self.assertEqual(len(attachments), 1)
+        self.assertEqual(attachments[0]["id"], attachment["id"])
+        attachments = comments_service.get_all_attachment_files_for_project(
+            fields.gen_uuid()
+        )
+        self.assertEqual(len(attachments), 0)
 
     def test_get_all_attachment_files_for_task(self):
-        # TODO
-        pass
-
-    def test_acknowledge_comment(self):
-        # TODO
-        pass
-
-    def test_ack_comment(self):
-        # TODO
-        pass
-
-    def test_unack_comment(self):
-        # TODO
-        pass
+        comment = comments_service.new_comment(
+            self.task.id, self.task_status.id, self.user["id"], "comment"
+        )
+        attachment = self._create_attachment(comment, "notes.txt")
+        attachments = comments_service.get_all_attachment_files_for_task(
+            str(self.task.id)
+        )
+        self.assertEqual(len(attachments), 1)
+        self.assertEqual(attachments[0]["id"], attachment["id"])
+        attachments = comments_service.get_all_attachment_files_for_task(
+            fields.gen_uuid()
+        )
+        self.assertEqual(len(attachments), 0)
 
     def test_reply_comment(self):
         reply_text = "first reply"
@@ -254,13 +241,36 @@ class CommentsServiceTestCase(ApiDBTestCase):
             [str(self.department_animation.id)],
         )
 
-    def get_reply(self):
-        # TODO
-        pass
+    def test_get_reply(self):
+        comment = comments_service.new_comment(
+            self.task.id, self.task_status.id, self.user["id"], "comment"
+        )
+        reply = comments_service.reply_comment(
+            comment["id"], "the reply", person_id=self.user["id"]
+        )
+        found = comments_service.get_reply(comment["id"], reply["id"])
+        self.assertEqual(found["text"], "the reply")
+        self.assertRaises(
+            exception.ReplyNotFoundException,
+            comments_service.get_reply,
+            comment["id"],
+            fields.gen_uuid(),
+        )
 
-    def delete_reply(self):
-        # TODO
-        pass
+    def test_delete_reply(self):
+        comment = comments_service.new_comment(
+            self.task.id, self.task_status.id, self.user["id"], "comment"
+        )
+        reply = comments_service.reply_comment(
+            comment["id"], "the reply", person_id=self.user["id"]
+        )
+        comments_service.delete_reply(comment["id"], reply["id"])
+        self.assertRaises(
+            exception.ReplyNotFoundException,
+            comments_service.get_reply,
+            comment["id"],
+            reply["id"],
+        )
 
     def test_reset_mentions(self):
         self.comment = comments_service.new_comment(
@@ -418,7 +428,6 @@ class CommentsServiceTestCase(ApiDBTestCase):
         )
         self.assertIsNotNone(comment["id"])
         self.assertEqual(comment["text"], comment_text)
-        text = ""
         comments = tasks_service.get_comments(modeling_task.id)
         self.assertEqual(len(comments), 1)
         self.assertTrue("Animation" in comments[0]["text"])

--- a/tests/services/test_deletion_service.py
+++ b/tests/services/test_deletion_service.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 from tests.base import ApiDBTestCase
 
 from zou.app.models.comment import Comment
@@ -98,6 +100,19 @@ class DeletionServiceTestCase(ApiDBTestCase):
         result = deletion_service.remove_preview_file_by_id(preview_id)
         self.assertEqual(result["id"], preview_id)
         self.assertIsNone(PreviewFile.get(preview_id))
+
+    def test_remove_preview_file_keeps_files_when_db_delete_fails(self):
+        self.generate_fixture_preview_file()
+        with mock.patch.object(
+            deletion_service, "clear_movie_files"
+        ) as clear_files, mock.patch.object(
+            PreviewFile, "delete", side_effect=RuntimeError
+        ):
+            with self.assertRaises(RuntimeError):
+                deletion_service.remove_preview_file_by_id(
+                    str(self.preview_file.id), force=True
+                )
+        clear_files.assert_not_called()
 
     def test_remove_preview_file_by_id_not_found(self):
         with self.assertRaises(PreviewFileNotFoundException):

--- a/tests/services/test_deletion_service.py
+++ b/tests/services/test_deletion_service.py
@@ -46,6 +46,14 @@ class DeletionServiceTestCase(ApiDBTestCase):
         result = deletion_service.remove_comment(comment_id)
         self.assertEqual(result["id"], comment_id)
 
+    def test_remove_comment_with_deleted_task(self):
+        self.generate_fixture_comment()
+        comment_id = self.comment["id"]
+        with mock.patch.object(Task, "get", return_value=None):
+            result = deletion_service.remove_comment(comment_id)
+        self.assertEqual(result["id"], comment_id)
+        self.assertIsNone(Comment.get(comment_id))
+
     def test_remove_comment_not_found(self):
         with self.assertRaises(CommentNotFoundException):
             deletion_service.remove_comment(

--- a/tests/services/test_notifications_service.py
+++ b/tests/services/test_notifications_service.py
@@ -1,7 +1,11 @@
 from tests.base import ApiDBTestCase
 
 from zou.app.models.notification import Notification
-from zou.app.services import comments_service, notifications_service
+from zou.app.services import (
+    comments_service,
+    notifications_service,
+    projects_service,
+)
 
 
 class NotificationsServiceTestCase(ApiDBTestCase):
@@ -270,3 +274,21 @@ class NotificationsServiceTestCase(ApiDBTestCase):
         )
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0], str(self.person.id))
+
+    def test_get_mentioned_people_leaves_comment_untouched(self):
+        self.generate_fixture_comment()
+        self.generate_fixture_department()
+        self.person.departments.append(self.department)
+        self.person.save()
+        projects_service.add_team_member(
+            str(self.project.id), str(self.person.id)
+        )
+        comment = {
+            "mentions": [],
+            "department_mentions": [str(self.department.id)],
+        }
+        result = notifications_service.get_mentioned_people(
+            str(self.project.id), comment
+        )
+        self.assertEqual(result, [str(self.person.id)])
+        self.assertEqual(comment["mentions"], [])

--- a/tests/services/test_preview_files_service.py
+++ b/tests/services/test_preview_files_service.py
@@ -391,6 +391,26 @@ class PlaylistTestCase(ApiDBTestCase):
             persisted_preview_file["annotations"],
         )
 
+    def test_save_variants_cleans_up_on_upload_failure(self):
+        import shutil
+
+        self.generate_fixture_preview_file()
+        folder = tempfile.mkdtemp()
+        picture_path = os.path.join(folder, "original.png")
+        shutil.copyfile(
+            self.get_fixture_file_path(os.path.join("thumbnails", "th01.png")),
+            picture_path,
+        )
+        with patch(
+            "zou.app.services.preview_files_service.file_store.add_picture",
+            side_effect=RuntimeError("storage down"),
+        ):
+            with self.assertRaises(RuntimeError):
+                preview_files_service.save_variants(
+                    str(self.preview_file.id), picture_path
+                )
+        self.assertEqual(os.listdir(folder), [])
+
     def test_get_preview_file_dimensions(self):
         self.assertFalse(_is_valid_resolution(""))
         self.assertFalse(_is_valid_resolution(None))

--- a/tests/services/test_tasks_service.py
+++ b/tests/services/test_tasks_service.py
@@ -155,6 +155,13 @@ class TaskServiceTestCase(ApiDBTestCase):
         self.assertEqual(self.task.assignees[0].id, self.person.id)
         self.assertEqual(self.task.assigner_id, self.assigner.id)
 
+    def test_assign_task_is_idempotent(self):
+        self.task.assignees = []
+        self.task.save()
+        tasks_service.assign_task(self.task.id, self.person.id)
+        tasks_service.assign_task(self.task.id, self.person.id)
+        self.assertEqual(len(self.task.assignees), 1)
+
     def test_get_department_from_task(self):
         department = tasks_service.get_department_from_task(self.task.id)
         self.assertEqual(department["name"], "Modeling")

--- a/tests/source/csv/test_import_assets.py
+++ b/tests/source/csv/test_import_assets.py
@@ -142,6 +142,7 @@ class ImportCsvAssetsTestCase(ApiDBTestCase):
             os.path.join("csv", "assets_broken_03.csv")
         )
         error = self.upload_file(path, file_path_fixture, 400)
-        self.assertEqual(error["line_number"], 1)
+        # The header is file line 1, so the first data row is line 2.
+        self.assertEqual(error["line_number"], 2)
         entities = Entity.query.all()
         self.assertEqual(len(entities), 0)

--- a/tests/sync/test_create_from_import.py
+++ b/tests/sync/test_create_from_import.py
@@ -1,3 +1,7 @@
+from unittest import mock
+
+from sqlalchemy.exc import IntegrityError
+
 from tests.base import ApiDBTestCase
 
 from zou.app.models.entity import Entity, EntityLink
@@ -68,6 +72,52 @@ class CreateFromImportTestCase(ApiDBTestCase):
         Entity.create_from_import(entity_dict)
         entity = Entity.get(entity_dict["id"])
         self.assertEqual(entity_dict["name"], entity.name)
+
+    def test_create_from_import_list_skips_broken_rows(self):
+        def entity_dict(entity_id, name, entity_type_id):
+            return {
+                "id": entity_id,
+                "entities_out": [],
+                "created_at": "2019-06-20T12:28:16",
+                "updated_at": "2019-08-16T11:44:31",
+                "name": name,
+                "description": "",
+                "canceled": False,
+                "project_id": str(self.project.id),
+                "entity_type_id": entity_type_id,
+                "preview_file_id": None,
+                "entities_in": [],
+                "type": "Asset",
+            }
+
+        valid_type_id = str(self.asset_type_character.id)
+        first_id = "11111111-3186-4405-8dc8-d6cb3a68ff1c"
+        broken_id = "22222222-3186-4405-8dc8-d6cb3a68ff1c"
+        last_id = "33333333-3186-4405-8dc8-d6cb3a68ff1c"
+
+        # Simulate a broken row: a real FK violation would roll back the
+        # test harness outer transaction, so raise from the import
+        # instead (in production each row commits independently).
+        original = Entity.create_from_import.__func__
+
+        def flaky_import(data):
+            if data["id"] == broken_id:
+                raise IntegrityError("insert", {}, Exception("boom"))
+            return original(Entity, data)
+
+        with mock.patch.object(
+            Entity, "create_from_import", side_effect=flaky_import
+        ):
+            Entity.create_from_import_list(
+                [
+                    entity_dict(first_id, "Lama", valid_type_id),
+                    entity_dict(broken_id, "Broken", valid_type_id),
+                    entity_dict(last_id, "Alpaga", valid_type_id),
+                ]
+            )
+        self.assertIsNotNone(Entity.get(first_id))
+        self.assertIsNone(Entity.get(broken_id))
+        self.assertIsNotNone(Entity.get(last_id))
 
     def test_entity_link(self):
         entity_link_dict = {

--- a/tests/sync/test_download_file.py
+++ b/tests/sync/test_download_file.py
@@ -1,0 +1,33 @@
+import os
+import tempfile
+import unittest
+
+from zou.app.services import sync_service
+
+
+class DownloadFileTestCase(unittest.TestCase):
+    def test_partial_file_removed_on_error(self):
+        folder = tempfile.mkdtemp()
+        file_path = os.path.join(folder, "preview.mp4")
+
+        def failing_dl_func(prefix, preview_file_id):
+            yield b"partial content"
+            raise RuntimeError("stream interrupted")
+
+        sync_service.download_file(
+            file_path, "previews", failing_dl_func, "preview-id"
+        )
+        self.assertFalse(os.path.exists(file_path))
+
+    def test_successful_download_keeps_file(self):
+        folder = tempfile.mkdtemp()
+        file_path = os.path.join(folder, "preview.mp4")
+
+        def dl_func(prefix, preview_file_id):
+            yield b"full content"
+
+        sync_service.download_file(
+            file_path, "previews", dl_func, "preview-id"
+        )
+        with open(file_path, "rb") as downloaded:
+            self.assertEqual(downloaded.read(), b"full content")

--- a/tests/tasks/test_task_routes.py
+++ b/tests/tasks/test_task_routes.py
@@ -256,6 +256,20 @@ class TaskRoutesTestCase(ApiDBTestCase):
         entity = self.get(f"/data/entities/{task['entity_id']}")
         self.assertIsNotNone(entity.get("preview_file_id"))
 
+    def test_set_main_preview_as_client(self):
+        # A client can review but must not redefine the entity thumbnail.
+        self.generate_fixture_preview_file()
+        self.generate_fixture_user_client()
+        projects_service.add_team_member(
+            self.project_id, self.user_client["id"]
+        )
+        self.log_in_client()
+        self.put(
+            f"/actions/tasks/{self.task.id}/set-main-preview",
+            {},
+            403,
+        )
+
     def test_delete_tasks_for_task_type(self):
         self.delete(
             f"/actions/projects/{self.project_id}"

--- a/tests/thumbnails/test_route_thumbnail.py
+++ b/tests/thumbnails/test_route_thumbnail.py
@@ -4,7 +4,7 @@ import hashlib
 from tests.base import ApiDBTestCase
 
 from zou.app.utils import fs, thumbnail
-from zou.app.services import assets_service
+from zou.app.services import assets_service, projects_service
 
 from PIL import Image
 
@@ -120,6 +120,18 @@ class RouteThumbnailTestCase(ApiDBTestCase):
 
         asset = assets_service.get_asset(self.asset_id)
         self.assertEqual(asset["preview_file_id"], str(self.preview_file_id))
+
+    def test_set_main_preview_as_client(self):
+        # A client can review but must not redefine the entity thumbnail.
+        self.generate_fixture_user_client()
+        projects_service.add_team_member(
+            str(self.project.id), self.user_client["id"]
+        )
+        self.log_in_client()
+        path = (
+            f"/actions/preview-files/{self.preview_file_id}/set-main-preview"
+        )
+        self.put(path, {}, 403)
 
     def test_add_preview_background(self):
         self.generate_fixture_preview_background_file()

--- a/zou/app/__init__.py
+++ b/zou/app/__init__.py
@@ -217,10 +217,10 @@ def configure_auth():
     from zou.app.services import persons_service
     from zou.app.services.auth_service import logout
 
-    def check_active_identity(identity, identity_type, jti):
+    def check_active_identity(identity, identity_type, jti, refresh_jti=None):
         if not identity.active:
             if identity_type == "person":
-                logout(jti=jti)
+                logout(jti=jti, refresh_jti=refresh_jti)
             current_app.logger.error(
                 f"Identity {identity.id} is not active anymore"
             )
@@ -246,7 +246,12 @@ def configure_auth():
             identity = persons_service.get_person_raw_cached(payload["sub"])
         except PersonNotFoundException:
             return wrong_auth_handler()
-        check_active_identity(identity, identity_type, jti=payload["jti"])
+        check_active_identity(
+            identity,
+            identity_type,
+            jti=payload["jti"],
+            refresh_jti=payload.get("refresh_jti"),
+        )
 
         if payload.get("requires_2fa_setup"):
             allowed_paths = {

--- a/zou/app/__init__.py
+++ b/zou/app/__init__.py
@@ -121,9 +121,19 @@ def set_security_headers(response):
     """
     Add baseline security headers to every response. nosniff stops the
     browser from MIME-sniffing a response into an executable type, e.g.
-    rendering an uploaded file served as octet-stream as HTML.
+    rendering an uploaded file served as octet-stream as HTML. The
+    frame headers block cross-origin embedding (clickjacking) while
+    keeping same-origin embedding allowed, since Kitsu and Zou share
+    the same origin in the standard deployment.
     """
     response.headers.setdefault("X-Content-Type-Options", "nosniff")
+    response.headers.setdefault("X-Frame-Options", "SAMEORIGIN")
+    response.headers.setdefault(
+        "Content-Security-Policy", "frame-ancestors 'self'"
+    )
+    response.headers.setdefault(
+        "Referrer-Policy", "strict-origin-when-cross-origin"
+    )
     return response
 
 

--- a/zou/app/blueprints/auth/resources.py
+++ b/zou/app/blueprints/auth/resources.py
@@ -599,7 +599,7 @@ class ChangePasswordResource(Resource, ArgsMixin):
             time_string = format_datetime(
                 date_helpers.get_utc_now_datetime(),
                 tzinfo=user["timezone"],
-                locale=user["locale"],
+                locale=locale,
             )
             person_IP = request.headers.get("X-Forwarded-For", None) or ""
             subject = get_email_translation(
@@ -781,7 +781,7 @@ class ResetPasswordResource(Resource, ArgsMixin):
         time_string = format_datetime(
             date_helpers.get_utc_now_datetime(),
             tzinfo=user["timezone"],
-            locale=user["locale"],
+            locale=locale,
         )
         person_IP = request.headers.get("X-Forwarded-For", None) or ""
         organisation = persons_service.get_organisation()

--- a/zou/app/blueprints/auth/resources.py
+++ b/zou/app/blueprints/auth/resources.py
@@ -1503,8 +1503,23 @@ class SAMLSSOResource(Resource, ArgsMixin):
         )
 
         if user["active"]:
+            # Honour 2FA enforcement unless SAML sessions are configured
+            # to skip it (e.g. when the identity provider already
+            # enforces MFA), mirroring the OIDC callback.
+            requires_2fa_setup = False
+            if config.ENFORCE_2FA and not config.SAML_SKIP_2FA:
+                if not auth_service.is_user_exempt_from_2fa(user, app):
+                    if not auth_service.person_two_factor_authentication_enabled(
+                        user
+                    ):
+                        requires_2fa_setup = True
+
+            additional_claims = {"identity_type": "person"}
+            if requires_2fa_setup:
+                additional_claims["requires_2fa_setup"] = True
+
             access_token, refresh_token = auth_service.create_auth_tokens(
-                user["id"], {"identity_type": "person"}
+                user["id"], additional_claims
             )
             identity_changed.send(
                 current_app._get_current_object(),

--- a/zou/app/blueprints/auth/resources.py
+++ b/zou/app/blueprints/auth/resources.py
@@ -11,7 +11,6 @@ from flask_principal import (
 from flask_jwt_extended import (
     jwt_required,
     create_access_token,
-    create_refresh_token,
     set_access_cookies,
     set_refresh_cookies,
     unset_jwt_cookies,
@@ -79,13 +78,8 @@ def _build_2fa_registration_response(response_data, user_id):
     the requires_2fa_setup claim so the user gets full access.
     """
     additional_claims = {"identity_type": "person"}
-    access_token = create_access_token(
-        identity=user_id,
-        additional_claims=additional_claims,
-    )
-    refresh_token = create_refresh_token(
-        identity=user_id,
-        additional_claims=additional_claims,
+    access_token, refresh_token = auth_service.create_auth_tokens(
+        user_id, additional_claims
     )
     response_data["access_token"] = access_token
     response_data["refresh_token"] = refresh_token
@@ -148,7 +142,8 @@ class LogoutResource(Resource):
             description: Logout successful
         """
         try:
-            auth_service.logout(get_jwt()["jti"])
+            payload = get_jwt()
+            auth_service.logout(payload["jti"], payload.get("refresh_jti"))
             identity_changed.send(
                 current_app._get_current_object(), identity=AnonymousIdentity()
             )
@@ -266,13 +261,8 @@ class LoginResource(Resource, ArgsMixin):
             if requires_2fa_setup:
                 additional_claims["requires_2fa_setup"] = True
 
-            access_token = create_access_token(
-                identity=user["id"],
-                additional_claims=additional_claims,
-            )
-            refresh_token = create_refresh_token(
-                identity=user["id"],
-                additional_claims=additional_claims,
+            access_token, refresh_token = auth_service.create_auth_tokens(
+                user["id"], additional_claims
             )
             identity_changed.send(
                 current_app._get_current_object(),
@@ -443,6 +433,10 @@ class RefreshTokenResource(Resource):
                     user_unsafe
                 ):
                     additional_claims["requires_2fa_setup"] = True
+
+        # Keep the refresh token jti in the new access token so a later
+        # logout still revokes the refresh token.
+        additional_claims["refresh_jti"] = get_jwt()["jti"]
 
         access_token = create_access_token(
             identity=user["id"],
@@ -1509,17 +1503,8 @@ class SAMLSSOResource(Resource, ArgsMixin):
         )
 
         if user["active"]:
-            access_token = create_access_token(
-                identity=user["id"],
-                additional_claims={
-                    "identity_type": "person",
-                },
-            )
-            refresh_token = create_refresh_token(
-                identity=user["id"],
-                additional_claims={
-                    "identity_type": "person",
-                },
+            access_token, refresh_token = auth_service.create_auth_tokens(
+                user["id"], {"identity_type": "person"}
             )
             identity_changed.send(
                 current_app._get_current_object(),
@@ -1687,13 +1672,8 @@ class OIDCCallbackResource(Resource, ArgsMixin):
             if requires_2fa_setup:
                 additional_claims["requires_2fa_setup"] = True
 
-            access_token = create_access_token(
-                identity=user["id"],
-                additional_claims=additional_claims,
-            )
-            refresh_token = create_refresh_token(
-                identity=user["id"],
-                additional_claims=additional_claims,
+            access_token, refresh_token = auth_service.create_auth_tokens(
+                user["id"], additional_claims
             )
             identity_changed.send(
                 current_app._get_current_object(),

--- a/zou/app/blueprints/crud/base.py
+++ b/zou/app/blueprints/crud/base.py
@@ -109,7 +109,12 @@ class BaseModelsResource(Resource, ArgsMixin):
                     many_join_filter.append((key, value))
 
                 elif value_is_list:
-                    value_array = json.loads(value)
+                    try:
+                        value_array = json.loads(value)
+                    except ValueError:
+                        raise WrongParameterException(
+                            f"Malformed list filter for field {key}."
+                        )
                     in_filter.append(
                         field_key.in_(
                             [

--- a/zou/app/blueprints/crud/base.py
+++ b/zou/app/blueprints/crud/base.py
@@ -63,7 +63,7 @@ class BaseModelsResource(Resource, ArgsMixin):
         if (total < offset) or (page < 1):
             result = {
                 "data": [],
-                "total": 0,
+                "total": total,
                 "nb_pages": nb_pages,
                 "limit": limit,
                 "offset": offset,

--- a/zou/app/blueprints/crud/base.py
+++ b/zou/app/blueprints/crud/base.py
@@ -3,7 +3,7 @@ import math
 import orjson as json
 import sqlalchemy.orm as orm
 
-from flask import request, abort, current_app
+from flask import request, current_app
 from flask_restful import Resource
 from flask_jwt_extended import jwt_required
 
@@ -243,8 +243,8 @@ class BaseModelsResource(Resource, ArgsMixin):
                 self.check_read_permissions(options)
                 query = self.apply_filters(query, options)
                 query = self.add_project_permission_filter(query)
-                page = int(options.get("page", "-1"))
-                limit = int(options.get("limit", 0))
+                page = self.get_page()
+                limit = self.get_limit()
                 relations = self.get_bool_parameter("relations")
                 is_paginated = page > -1
 

--- a/zou/app/blueprints/previews/resources.py
+++ b/zou/app/blueprints/previews/resources.py
@@ -303,12 +303,15 @@ class BaseNewPreviewFilePicture:
         file_name = f"{instance_id}.{extension}"
         file_path = os.path.join(tmp_folder, file_name)
         uploaded_file.save(file_path)
-        file_store.add_file("previews", instance_id, file_path)
-        file_size = fs.get_file_size(file_path)
-        preview_files_service.update_preview_file(
-            instance_id, {"file_size": file_size}, silent=True
-        )
-        os.remove(file_path)
+        try:
+            file_store.add_file("previews", instance_id, file_path)
+            file_size = fs.get_file_size(file_path)
+            preview_files_service.update_preview_file(
+                instance_id, {"file_size": file_size}, silent=True
+            )
+        finally:
+            if os.path.exists(file_path):
+                os.remove(file_path)
         return file_path
 
     def emit_app_preview_event(self, preview_file_id):

--- a/zou/app/blueprints/previews/resources.py
+++ b/zou/app/blueprints/previews/resources.py
@@ -1451,6 +1451,10 @@ class SetMainPreviewResource(Resource, ArgsMixin):
         task = tasks_service.get_task(preview_file["task_id"])
         user_service.check_project_access(task["project_id"])
         user_service.check_entity_access(task["entity_id"])
+        # Clients review content but must not redefine how an entity is
+        # illustrated.
+        if permissions.has_client_permissions():
+            raise permissions.PermissionDenied
         if frame_number is not None:
             if preview_file["extension"] != "mp4":
                 raise WrongParameterException(

--- a/zou/app/blueprints/shared/resources.py
+++ b/zou/app/blueprints/shared/resources.py
@@ -1,4 +1,4 @@
-from flask import g, request
+from flask import current_app, g, request
 from flask_fs.errors import FileNotFound
 from flask_restful import Resource
 
@@ -190,7 +190,9 @@ class SharedPlaylistCommentsResource(Resource):
                     playlist_sharing_service.get_shared_task_comments(task_id)
                 )
             except Exception:
-                pass
+                current_app.logger.exception(
+                    f"Failed to load shared comments for task {task_id}."
+                )
         return comments
 
     @require_valid_playlist_share_link(with_password=True)

--- a/zou/app/blueprints/source/csv/base.py
+++ b/zou/app/blueprints/source/csv/base.py
@@ -70,8 +70,10 @@ class BaseCsvImportResource(Resource, ArgsMixin):
         self.prepare_import(*args)
         with open(file_path, newline="", encoding="utf-8") as csvfile:
             reader = csv.DictReader(csvfile, dialect=self.get_dialect(csvfile))
-            line_number = 1
             for row in reader:
+                # reader.line_num is the real file line (header included),
+                # so errors point at the line the user sees in the file.
+                line_number = reader.line_num
                 try:
                     row = self.import_row(row, *args)
                     result.append(row)
@@ -89,7 +91,6 @@ class BaseCsvImportResource(Resource, ArgsMixin):
                     )
                 except Exception as e:
                     raise ImportRowException(str(e), line_number)
-                line_number += 1
         return result
 
     def get_dialect(self, csvfile):

--- a/zou/app/blueprints/tasks/resources.py
+++ b/zou/app/blueprints/tasks/resources.py
@@ -1,8 +1,8 @@
 import datetime
 
 
-from flask import abort, request
-from flask_restful import Resource, inputs
+from flask import request
+from flask_restful import Resource
 from flask_jwt_extended import jwt_required
 
 from zou.app.services.exception import (
@@ -2665,6 +2665,10 @@ class SetTaskMainPreviewResource(Resource):
         task = tasks_service.get_task(task_id)
         user_service.check_project_access(task["project_id"])
         user_service.check_entity_access(task["entity_id"])
+        # Clients review content but must not redefine how an entity is
+        # illustrated.
+        if permissions.has_client_permissions():
+            raise permissions.PermissionDenied
         preview_file = preview_files_service.get_last_preview_file_for_task(
             task_id
         )

--- a/zou/app/config.py
+++ b/zou/app/config.py
@@ -169,6 +169,7 @@ LDAP_SSL = envtobool("LDAP_SSL", False)
 SAML_ENABLED = envtobool("SAML_ENABLED", False)
 SAML_IDP_NAME = os.getenv("SAML_IDP_NAME", "")
 SAML_METADATA_URL = os.getenv("SAML_METADATA_URL", "")
+SAML_SKIP_2FA = envtobool("SAML_SKIP_2FA", False)
 
 OIDC_ENABLED = envtobool("OIDC_ENABLED", False)
 OIDC_IDP_NAME = os.getenv("OIDC_IDP_NAME", "")

--- a/zou/app/config.py
+++ b/zou/app/config.py
@@ -92,6 +92,10 @@ PREVIEW_FOLDER = os.getenv(
 )
 PREVIEW_SAVE_SOURCE_FILE = envtobool("PREVIEW_SAVE_SOURCE_FILE", False)
 MAX_IMAGE_PIXELS = int(os.getenv("MAX_IMAGE_PIXELS", 20000 * 20000))
+# Cap on any request body size (Flask MAX_CONTENT_LENGTH). Generous by
+# default so multi-GB movie uploads keep working while unbounded bodies
+# can no longer fill the disk. Set to 0 to disable the limit.
+MAX_CONTENT_LENGTH = int(os.getenv("MAX_CONTENT_LENGTH", 10 * 1024**3)) or None
 TMP_DIR = os.getenv("TMP_DIR", os.path.join(tempfile.gettempdir(), "zou"))
 
 EVENT_STREAM_HOST = os.getenv("EVENT_STREAM_HOST", "localhost")

--- a/zou/app/mixin.py
+++ b/zou/app/mixin.py
@@ -75,15 +75,23 @@ class ArgsMixin(object):
         """
         Returns page requested by the user as an integer.
         """
-        options = request.args
-        return int(options.get("page", "-1"))
+        return self.get_integer_parameter("page", -1)
 
     def get_limit(self):
         """
         Returns limit requested by the user as an integer.
         """
-        options = request.args
-        return int(options.get("limit", 0))
+        return self.get_integer_parameter("limit", 0)
+
+    def get_integer_parameter(self, field_name, default=0):
+        """
+        Returns an integer query parameter, raising a 400 error when the
+        value is not a valid integer.
+        """
+        try:
+            return int(request.args.get(field_name, default))
+        except ValueError:
+            raise WrongParameterException(f"{field_name} must be an integer.")
 
     def get_sort_by(self):
         """

--- a/zou/app/models/base.py
+++ b/zou/app/models/base.py
@@ -1,7 +1,12 @@
+import logging
+
 from sqlalchemy_utils import UUIDType
 from sqlalchemy import func, orm
+from sqlalchemy.exc import IntegrityError
 from zou.app import db
 from zou.app.utils import date_helpers, fields
+
+logger = logging.getLogger(__name__)
 
 
 class BaseMixin(object):
@@ -182,7 +187,15 @@ class BaseMixin(object):
         if "data" in data_list:
             data_list = data_list["data"]
         for data in data_list:
-            cls.create_from_import(data)
+            try:
+                cls.create_from_import(data)
+            except IntegrityError:
+                # One broken row must not lose the rest of the list. The
+                # session was already rolled back by create/save.
+                logger.error(
+                    f"Failed to import {cls.__name__} {data.get('id')}",
+                    exc_info=1,
+                )
 
     @classmethod
     def delete_from_import(cls, instance_id):

--- a/zou/app/models/event.py
+++ b/zou/app/models/event.py
@@ -21,3 +21,12 @@ class ApiEvent(db.Model, BaseMixin, SerializerMixin):
         UUIDType(binary=False), db.ForeignKey("project.id"), index=True
     )
     data = db.Column(JSONB)
+
+    # The event log is always read sorted by creation date, optionally
+    # filtered by project, so both access paths need an index.
+    __table_args__ = (
+        db.Index("ix_api_event_created_at", "created_at"),
+        db.Index(
+            "ix_api_event_project_id_created_at", "project_id", "created_at"
+        ),
+    )

--- a/zou/app/services/auth_service.py
+++ b/zou/app/services/auth_service.py
@@ -113,6 +113,10 @@ def check_auth(
     if login_failed_attemps > 0:
         update_login_failed_attemps(person["id"], 0)
 
+    # The person dict may come straight from the memoize cache: strip the
+    # secrets from a copy so the cached entry is left untouched.
+    person = dict(person)
+
     if "password" in person:
         del person["password"]
 

--- a/zou/app/services/auth_service.py
+++ b/zou/app/services/auth_service.py
@@ -504,7 +504,7 @@ def send_email_otp(person):
     time_string = format_datetime(
         date_helpers.get_utc_now_datetime(),
         tzinfo=person["timezone"],
-        locale=person["locale"],
+        locale=locale,
     )
     person_IP = request.headers.get("X-Forwarded-For", None) or ""
     subject = get_email_translation(

--- a/zou/app/services/auth_service.py
+++ b/zou/app/services/auth_service.py
@@ -5,6 +5,11 @@ import string
 from datetime import timedelta
 
 from flask import request, session, current_app
+from flask_jwt_extended import (
+    create_access_token,
+    create_refresh_token,
+    get_jti,
+)
 from babel.dates import format_datetime
 
 
@@ -676,11 +681,37 @@ def generate_new_recovery_codes(person_id):
     return otp_recovery_codes
 
 
-def revoke_tokens(app, jti):
+def create_auth_tokens(identity, additional_claims=None):
     """
-    Remove access and refresh tokens from auth token store.
+    Create an access token and a refresh token pair. The refresh token jti
+    is embedded in the access token claims so that logout can revoke both
+    tokens at once.
+    """
+    if additional_claims is None:
+        additional_claims = {}
+    refresh_token = create_refresh_token(
+        identity=identity, additional_claims=additional_claims
+    )
+    access_token = create_access_token(
+        identity=identity,
+        additional_claims={
+            **additional_claims,
+            "refresh_jti": get_jti(refresh_token),
+        },
+    )
+    return access_token, refresh_token
+
+
+def revoke_tokens(app, jti, refresh_jti=None):
+    """
+    Add given token ids to the auth token blocklist. Each entry lives as
+    long as the token it revokes can still be presented.
     """
     auth_tokens_store.add(jti, "true", app.config["JWT_ACCESS_TOKEN_EXPIRES"])
+    if refresh_jti is not None:
+        auth_tokens_store.add(
+            refresh_jti, "true", app.config["JWT_REFRESH_TOKEN_EXPIRES"]
+        )
 
 
 def is_default_password(app, password):
@@ -745,8 +776,8 @@ def check_login_failed_attemps(person):
     return login_failed_attemps
 
 
-def logout(jti):
+def logout(jti, refresh_jti=None):
     try:
-        revoke_tokens(current_app, jti)
+        revoke_tokens(current_app, jti, refresh_jti=refresh_jti)
     except Exception:
         pass

--- a/zou/app/services/comments_service.py
+++ b/zou/app/services/comments_service.py
@@ -12,6 +12,7 @@ from zou.app.models.attachment_file import AttachmentFile
 from zou.app.models.comment import Comment
 from zou.app.models.department import Department
 from zou.app.models.notification import Notification
+from zou.app.models.person import Person
 from zou.app.models.project import Project
 from zou.app.models.task import Task
 from zou.app.models.task_status import TaskStatus
@@ -578,8 +579,11 @@ def acknowledge_comment(comment_id):
     comment = tasks_service.get_comment_raw(comment_id)
     task = tasks_service.get_task(str(comment.object_id))
     project_id = task["project_id"]
-    current_user = persons_service.get_current_user_raw()
-    current_user_id = str(current_user.id)
+    # Reload the person through the session: appending the cached
+    # current_user instance to the relationship raises an identity
+    # conflict when another instance of the row lives in the session.
+    current_user_id = persons_service.get_current_user()["id"]
+    current_user = Person.get(current_user_id)
 
     acknowledgements = fields.serialize_orm_arrays(comment.acknowledgements)
     is_already_ack = current_user_id in acknowledgements

--- a/zou/app/services/deletion_service.py
+++ b/zou/app/services/deletion_service.py
@@ -216,17 +216,22 @@ def remove_preview_file(preview_file, force=False):
     if news is not None:
         news.update({"preview_file_id": None})
 
-    if config.REMOVE_FILES or force:
-        if preview_file.extension == "png":
-            clear_picture_files(preview_file.id)
-        elif preview_file.extension == "mp4":
-            clear_movie_files(preview_file.id)
-        else:
-            clear_generic_files(preview_file.id)
+    preview_file_id = str(preview_file.id)
+    extension = preview_file.extension
 
     preview_file.comments = []
     preview_file.save()
     preview_file.delete()
+
+    # Remove the physical files only once the DB row is gone: if the
+    # delete fails, the row must not end up pointing at missing files.
+    if config.REMOVE_FILES or force:
+        if extension == "png":
+            clear_picture_files(preview_file_id)
+        elif extension == "mp4":
+            clear_movie_files(preview_file_id)
+        else:
+            clear_generic_files(preview_file_id)
 
     # Update last preview file uploaded on task
     if task.last_preview_file_id == preview_file.id:

--- a/zou/app/services/deletion_service.py
+++ b/zou/app/services/deletion_service.py
@@ -89,7 +89,11 @@ def remove_comment(comment_id):
                 {"comment_id": comment.id},
                 project_id=str(task.project_id),
             )
-            return comment.serialize()
+        else:
+            # The task may already be gone; still notify listeners so
+            # they drop the comment from their state.
+            events.emit("comment:delete", {"comment_id": comment.id})
+        return comment.serialize()
     else:
         raise CommentNotFoundException
 

--- a/zou/app/services/notifications_service.py
+++ b/zou/app/services/notifications_service.py
@@ -6,7 +6,6 @@ from zou.app.models.notification import Notification
 from zou.app.models.person import Person, DepartmentLink
 from zou.app.models.subscription import Subscription
 from zou.app.models.task import Task
-from zou.app.models.task_type import TaskType
 
 from zou.app.services import (
     assets_service,
@@ -176,7 +175,9 @@ def get_mentioned_people(project_id, comment):
     Return all people mentioned in the comment: the one listed via their name
     and the one listed via their department.
     """
-    mentions = comment["mentions"]
+    # Copy the list: appending in place would corrupt the comment dict,
+    # which may come from the cache or be reused by the caller.
+    mentions = list(comment["mentions"])
     for department_id in comment["department_mentions"]:
         persons = projects_service.get_department_team(
             project_id, department_id

--- a/zou/app/services/preview_files_service.py
+++ b/zou/app/services/preview_files_service.py
@@ -44,6 +44,7 @@ from zou.app.services.exception import (
     AnnotationNotFoundException,
     WrongParameterException,
     PreviewFileNotFoundException,
+    PreviewProcessingFailedException,
     ProjectNotFoundException,
     EpisodeNotFoundException,
 )
@@ -348,10 +349,8 @@ def prepare_and_store_movie(
                     result = _run_remote_normalize_movie(
                         current_app, preview_file_id, fps, width, height
                     )
-                    if result is True:
-                        err = None
-                    else:
-                        err = result
+                    if result is not True:
+                        raise PreviewProcessingFailedException(result)
 
                     normalized_movie_path = fs.get_file_path_and_file(
                         config,
@@ -372,17 +371,16 @@ def prepare_and_store_movie(
                         width=width,
                         height=height,
                     )
+                    if err:
+                        # The normalized files were never produced: fail
+                        # before storing anything.
+                        raise PreviewProcessingFailedException(err)
                     file_store.add_movie(
                         "previews", preview_file_id, normalized_movie_path
                     )
                     file_store.add_movie(
                         "lowdef", preview_file_id, normalized_movie_low_path
                     )
-                if err:
-                    current_app.logger.error(
-                        f"Fail to normalize: {uploaded_movie_path}"
-                    )
-                    current_app.logger.error(err)
 
                 current_app.logger.info(
                     f"file normalized {normalized_movie_path}"

--- a/zou/app/services/preview_files_service.py
+++ b/zou/app/services/preview_files_service.py
@@ -221,6 +221,18 @@ def set_preview_file_as_missing(preview_file_id):
     return update_preview_file(preview_file_id, {"status": "missing"})
 
 
+def _remove_temp_files(*paths):
+    """
+    Remove movie processing temp files, ignoring the ones already gone.
+    """
+    for path in paths:
+        if path is not None:
+            try:
+                os.remove(path)
+            except FileNotFoundError:
+                pass
+
+
 def _abort_on_storage_failure(preview_file_id, operation, exc):
     """
     Log a file store backend failure (Swift 401, S3 timeout, network error,
@@ -258,6 +270,7 @@ def prepare_and_store_movie(
                     "source", preview_file_id, uploaded_movie_path
                 )
             except Exception as exc:
+                _remove_temp_files(uploaded_movie_path)
                 return _abort_on_storage_failure(
                     preview_file_id, "source movie upload", exc
                 )
@@ -300,7 +313,9 @@ def prepare_and_store_movie(
                 exc_info=1,
             )
 
+        normalized_movie_path = None
         normalized_movie_low_path = None
+        original_picture_path = None
         try:
             project = get_project_from_preview_file(preview_file_id)
             entity = get_entity_from_preview_file(preview_file_id)
@@ -315,6 +330,7 @@ def prepare_and_store_movie(
                 )
                 time.sleep(2)
                 preview_file = set_preview_file_as_broken(preview_file_id)
+                _remove_temp_files(uploaded_movie_path)
                 return preview_file
 
         fps = get_preview_file_fps(project, entity)
@@ -377,6 +393,11 @@ def prepare_and_store_movie(
                     current_app.logger.error(exc.stderr)
                 current_app.logger.error("failed", exc_info=1)
                 preview_file = set_preview_file_as_broken(preview_file_id)
+                _remove_temp_files(
+                    uploaded_movie_path,
+                    normalized_movie_path,
+                    normalized_movie_low_path,
+                )
                 return preview_file
         else:
             try:
@@ -387,6 +408,7 @@ def prepare_and_store_movie(
                     "lowdef", preview_file_id, uploaded_movie_path
                 )
             except Exception as exc:
+                _remove_temp_files(uploaded_movie_path)
                 return _abort_on_storage_failure(
                     preview_file_id, "movie upload", exc
                 )
@@ -407,6 +429,12 @@ def prepare_and_store_movie(
             try:
                 save_variants(preview_file_id, original_picture_path)
             except Exception as exc:
+                _remove_temp_files(
+                    uploaded_movie_path,
+                    normalized_movie_path,
+                    normalized_movie_low_path,
+                    original_picture_path,
+                )
                 return _abort_on_storage_failure(
                     preview_file_id, "thumbnail variants upload", exc
                 )
@@ -485,10 +513,13 @@ def save_variants(preview_file_id, original_picture_path, with_original=True):
     )
     if with_original:
         variants.append(("original", original_picture_path))
-    for prefix, path in variants:
-        file_store.add_picture(prefix, preview_file_id, path)
-        os.remove(path)
-        clear_variant_from_cache(preview_file_id, prefix)
+    try:
+        for prefix, path in variants:
+            file_store.add_picture(prefix, preview_file_id, path)
+            clear_variant_from_cache(preview_file_id, prefix)
+    finally:
+        # A failed upload must not leak the remaining variant files.
+        _remove_temp_files(*[path for _, path in variants])
 
     return variants
 
@@ -1191,6 +1222,9 @@ def _bundle_annotated_frames_into_zip(entries):
         with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
             for arcname, src_path in entries:
                 zf.write(src_path, arcname=arcname)
+    except Exception:
+        _remove_temp_files(zip_path)
+        raise
     finally:
         _cleanup_entries(entries)
     return zip_path
@@ -1218,6 +1252,9 @@ def _bundle_annotated_frames_into_pdf(entries):
             append_images=tail,
             resolution=150.0,
         )
+    except Exception:
+        _remove_temp_files(pdf_path)
+        raise
     finally:
         for img in images:
             img.close()

--- a/zou/app/services/sync_service.py
+++ b/zou/app/services/sync_service.py
@@ -1062,7 +1062,12 @@ def download_file(file_path, prefix, dl_func, preview_file_id):
                 tmp_file.write(chunk)
         logger.info(f"{file_path} downloaded")
     except Exception:
-        pass
+        # A partial file would be mistaken for a valid download on the
+        # next sync run: remove it and log instead of failing the whole
+        # sync for one file.
+        logger.exception(f"Failed to download {prefix} {preview_file_id}")
+        if os.path.exists(file_path):
+            os.remove(file_path)
 
 
 def download_preview(preview_file):

--- a/zou/app/services/tasks_service.py
+++ b/zou/app/services/tasks_service.py
@@ -1970,7 +1970,6 @@ def reset_tasks_data(project_id):
 
 
 def reset_task_data(task_id):
-    clear_task_cache(task_id)
     task = Task.get(task_id)
     retake_count = 0
     real_start_date = None
@@ -2035,6 +2034,9 @@ def reset_task_data(task_id):
             "task_status_id": task_status_id,
         }
     )
+    # Invalidate after the write, otherwise a concurrent read re-caches
+    # the stale row between the invalidation and the update.
+    clear_task_cache(task_id)
     project_id = str(task.project_id)
     events.emit(
         "task:update", {"task_id": str(task.id)}, project_id=project_id

--- a/zou/app/services/tasks_service.py
+++ b/zou/app/services/tasks_service.py
@@ -1706,7 +1706,8 @@ def assign_task(task_id, person_id, assigner_id=None):
     task = get_task_raw(task_id)
     project_id = str(task.project_id)
     person = persons_service.get_person_raw(person_id)
-    task.assignees.append(person)
+    if person not in task.assignees:
+        task.assignees.append(person)
     if assigner_id is not None:
         task.assigner_id = assigner_id
     task.save()

--- a/zou/app/services/telemetry_services.py
+++ b/zou/app/services/telemetry_services.py
@@ -35,4 +35,4 @@ def send_main_infos():
         "python_version": platform.python_version(),
     }
 
-    requests.post(config.TELEMETRY_URL, json=data)
+    requests.post(config.TELEMETRY_URL, json=data, timeout=30)

--- a/zou/app/stores/auth_tokens_store.py
+++ b/zou/app/stores/auth_tokens_store.py
@@ -1,7 +1,11 @@
+import logging
 import sys
+
 import redis
 
 from zou.app import config
+
+logger = logging.getLogger(__name__)
 
 try:
     revoked_tokens_store = redis.StrictRedis(
@@ -15,7 +19,7 @@ try:
 except redis.ConnectionError:
     revoked_tokens_store = None
     if "pytest" not in sys.modules:
-        print("Cannot access to the required Redis instance")
+        logger.error("Cannot access to the required Redis instance")
 
 
 def add(key, token, ttl=None):

--- a/zou/app/stores/config_store.py
+++ b/zou/app/stores/config_store.py
@@ -1,8 +1,11 @@
+import logging
 import sys
 
 import redis
 
 from zou.app import config
+
+logger = logging.getLogger(__name__)
 
 USER_LIMIT_KEY = "config:user_limit"
 DEFAULT_TIMEZONE_KEY = "config:default_timezone"
@@ -23,7 +26,7 @@ try:
 except redis.ConnectionError:
     config_store = None
     if "pytest" not in sys.modules:
-        print("Cannot access to the required Redis instance")
+        logger.error("Cannot access to the required Redis instance")
 
 
 def _get_redis_raw(key):
@@ -31,7 +34,7 @@ def _get_redis_raw(key):
         try:
             return config_store.get(key)
         except redis.ConnectionError:
-            pass
+            logger.warning(f"Redis unavailable while reading {key}")
     return None
 
 
@@ -42,7 +45,7 @@ def _get(key, fallback):
             if value is not None:
                 return value
         except redis.ConnectionError:
-            pass
+            logger.warning(f"Redis unavailable while reading {key}")
     return fallback
 
 
@@ -53,7 +56,7 @@ def _sync(key, env_value):
             if current is None or str(current) != str(env_value):
                 config_store.set(key, env_value)
         except redis.ConnectionError:
-            pass
+            logger.warning(f"Redis unavailable while syncing {key}")
     return env_value
 
 

--- a/zou/app/utils/cache.py
+++ b/zou/app/utils/cache.py
@@ -28,7 +28,7 @@ _is_simple_cache = False
 
 if config.CACHE_TYPE is not None:
     cache = Cache(config={"CACHE_TYPE": config.CACHE_TYPE})
-    _is_simple_cache = config.CACHE_TYPE == "simple"
+    _is_simple_cache = config.CACHE_TYPE in ("simple", "SimpleCache")
 else:
     try:
         redis_cache = redis.StrictRedis(

--- a/zou/app/utils/query.py
+++ b/zou/app/utils/query.py
@@ -186,7 +186,10 @@ def apply_sort_by(model, query, sort_by):
 
 def cast_value(value, field_key):
     if field_key.type.python_type is bool:
-        return string.strtobool(value)
+        try:
+            return string.strtobool(value)
+        except ValueError:
+            raise WrongParameterException(f"Invalid boolean value: {value}")
     elif field_key.type.python_type is uuid.UUID:
         if (
             value

--- a/zou/app/utils/saml.py
+++ b/zou/app/utils/saml.py
@@ -19,7 +19,9 @@ def saml_client_for(metadata_url):
         f"{config.DOMAIN_PROTOCOL}://{config.DOMAIN_NAME}/api/auth/saml/sso"
     )
 
-    rv = requests.get(metadata_url)
+    # saml_client_for is also called at runtime when the SAML login route
+    # rebuilds the client, so a hung IdP must not block a worker forever.
+    rv = requests.get(metadata_url, timeout=30)
 
     settings = {
         "entityid": f"{config.DOMAIN_PROTOCOL}://{config.DOMAIN_NAME}/api/auth/saml/login",

--- a/zou/cli.py
+++ b/zou/cli.py
@@ -528,7 +528,9 @@ if os.getenv("ADMIN_TOKEN"):
         url = f"{host}/admin/config/check"
         try:
             response = requests.get(
-                url, headers={"Authorization": f"Bearer {token}"}
+                url,
+                headers={"Authorization": f"Bearer {token}"},
+                timeout=30,
             )
             response.raise_for_status()
         except requests.ConnectionError:

--- a/zou/migrations/versions/a3d9c1e7b5f2_add_created_at_indexes_to_api_event.py
+++ b/zou/migrations/versions/a3d9c1e7b5f2_add_created_at_indexes_to_api_event.py
@@ -1,0 +1,57 @@
+"""add created_at indexes to api_event
+
+Revision ID: a3d9c1e7b5f2
+Revises: f1a2b3c4d5e6
+Create Date: 2026-07-06 09:20:00.000000
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "a3d9c1e7b5f2"
+down_revision = "f1a2b3c4d5e6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # The event log is always read sorted by creation date, optionally
+    # filtered by project. api_event can be huge, so build the indexes
+    # concurrently to avoid locking writes during the migration.
+    # Caveat: if a concurrent build is interrupted, Postgres keeps an
+    # INVALID index that if_not_exists will skip on retry; drop it
+    # manually (check pg_index.indisvalid) before re-running.
+    with op.get_context().autocommit_block():
+        op.create_index(
+            "ix_api_event_created_at",
+            "api_event",
+            ["created_at"],
+            unique=False,
+            postgresql_concurrently=True,
+            if_not_exists=True,
+        )
+        op.create_index(
+            "ix_api_event_project_id_created_at",
+            "api_event",
+            ["project_id", "created_at"],
+            unique=False,
+            postgresql_concurrently=True,
+            if_not_exists=True,
+        )
+
+
+def downgrade():
+    with op.get_context().autocommit_block():
+        op.drop_index(
+            "ix_api_event_project_id_created_at",
+            table_name="api_event",
+            postgresql_concurrently=True,
+            if_exists=True,
+        )
+        op.drop_index(
+            "ix_api_event_created_at",
+            table_name="api_event",
+            postgresql_concurrently=True,
+            if_exists=True,
+        )

--- a/zou/utils/movie.py
+++ b/zou/utils/movie.py
@@ -67,7 +67,7 @@ def generate_thumbnail(movie_path):
         log_ffmpeg_error(e, "an error occured during generate_thumbnail")
         raise (e)
     except Exception:
-        print("Error while generating thumbnail")
+        logger.error("Error while generating thumbnail", exc_info=1)
         raise
     return file_target_path
 

--- a/zou/utils/movie.py
+++ b/zou/utils/movie.py
@@ -6,6 +6,7 @@ import math
 import shutil
 import subprocess
 import tempfile
+import uuid
 
 import ffmpeg
 
@@ -50,7 +51,9 @@ def generate_thumbnail(movie_path):
     takes a picture at the first frame of the movie.
     """
     file_source_name = os.path.basename(movie_path)
-    file_target_name = f"{file_source_name[:-4]}.png"
+    # Unique suffix: two concurrent processings of the same movie must
+    # not write to the same temp path.
+    file_target_name = f"{file_source_name[:-4]}_{uuid.uuid4().hex}.png"
     file_target_path = os.path.join(tempfile.gettempdir(), file_target_name)
 
     try:
@@ -77,7 +80,9 @@ def extract_frame_from_movie(movie_path, frame_number, movie_fps):
     import opentimelineio as otio
 
     file_source_name = os.path.basename(movie_path)
-    file_target_name = f"{file_source_name[:-4]}_{frame_number}.png"
+    file_target_name = (
+        f"{file_source_name[:-4]}_{frame_number}_{uuid.uuid4().hex}.png"
+    )
     file_target_path = os.path.join(tempfile.gettempdir(), file_target_name)
 
     frame_time = otio.opentime.RationalTime(
@@ -105,7 +110,7 @@ def generate_tile(movie_path):
     Generates a tile from a movie.
     """
     file_source_name = os.path.basename(movie_path)
-    file_target_name = f"{file_source_name[:-4]}_tile.png"
+    file_target_name = f"{file_source_name[:-4]}_tile_{uuid.uuid4().hex}.png"
     file_target_path = os.path.join(tempfile.gettempdir(), file_target_name)
     video_track = get_video_track(movie_path, "generate_tile")
     duration = get_movie_duration(video_track=video_track)
@@ -256,9 +261,10 @@ def normalize_movie(movie_path, fps, width, height):
     Generates a high def movie and a low def movie.
     """
     file_source_name = os.path.basename(movie_path)
-    file_target_name = f"{file_source_name[:-8]}.mp4"
+    unique_suffix = uuid.uuid4().hex
+    file_target_name = f"{file_source_name[:-8]}_{unique_suffix}.mp4"
     file_target_path = os.path.join(tempfile.gettempdir(), file_target_name)
-    low_file_target_name = f"{file_source_name[:-8]}_low.mp4"
+    low_file_target_name = f"{file_source_name[:-8]}_{unique_suffix}_low.mp4"
     low_file_target_path = os.path.join(
         tempfile.gettempdir(), low_file_target_name
     )


### PR DESCRIPTION
## Problems

- Logout never revoked the refresh token; SAML SSO ignored `ENFORCE_2FA`
- No clickjacking/referrer headers, no request body size limit
- `check_auth` corrupted the memoized person dict; `acknowledge_comment` raised a session conflict
- Malformed pagination/filter params returned 500; out-of-range pages reported `total: 0`
- Movie processing leaked temp files on errors, raced on temp names, stored failed normalizations as successes
- Sync dropped a whole page on one broken row and kept partial downloads; no timeout on outbound HTTP
- No index on `api_event.created_at` despite every read sorting on it
- `assign_task` 500ed on reassignment; stale task cache; CSV errors off by one line; clients could set main previews
- No Dependabot/pip-audit; unused and GUI dependencies
- Phantom test coverage and stale docs

## Solutions

- Refresh jti embedded in the access token and revoked at logout; SAML gets the OIDC 2FA gate + `SAML_SKIP_2FA`
- Global security headers; env-configurable `MAX_CONTENT_LENGTH` (10 GiB default)
- Secrets stripped on a copy; person reloaded through the session (first `/ack` test)
- Bad params raise 400; real total kept on out-of-range pages
- Error exits clean temp files, unique temp names, normalization failures raise before storage, DB row deleted before files
- Per-row import error handling, partial downloads removed and logged, timeouts added
- `created_at` + `(project_id, created_at)` indexes, created concurrently
- Idempotent `assign_task`, cache invalidated after write, `reader.line_num`, client 403 on set-main-preview
- Dependabot + pip-audit CI; `flask_fixtures` dropped; headless OpenCV
- Real tests replace stubs; `UNTESTED_ROUTES.md` rewritten as a gap list; services table completed