### PR TITLE
[audit] Test coverage, dependency swaps and reqparse migration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,7 +161,7 @@ For standard model CRUD, extend `BaseModelsResource` / `BaseModelResource` in `z
 
 ## Pydantic Validation (v2)
 
-All request body validation uses Pydantic v2 schemas. **Do not use `reqparse` or `ArgsMixin` for body parsing** — those are legacy patterns. Two inherited `reqparse` usages remain (`comments/resources.py`, `chats/resources.py`): do not copy them, migrate them to Pydantic when you touch those resources.
+All request body validation uses Pydantic v2 schemas. **Do not use `reqparse` or `ArgsMixin` for body parsing** — those are legacy patterns; no resource uses `reqparse` for bodies anymore (`ArgsMixin.get_args` remains for query parameters only).
 
 ### Schema pattern
 

--- a/UNTESTED_ROUTES.md
+++ b/UNTESTED_ROUTES.md
@@ -17,8 +17,7 @@ To re-derive the list: compare the routes registered in
 |---|---|---|
 | FIDO/WebAuthn | `/auth/fido` (GET, PUT, POST, DELETE) | Needs a mocked WebAuthn authenticator (audit TEST-1) |
 | SAML SSO | `/auth/saml/sso`, `/auth/saml/login` | Needs a fixture IdP assertion (audit TEST-1); the 2FA gate logic is shared with OIDC, which is tested |
-| Video streaming | `/movies/originals/…`, `/movies/low/…` | Use the existing video fixture with ffmpeg mocked (audit TEST-2) |
-| Batch comments | `/actions/tasks/batch-comment`, `/actions/tasks/<id>/batch-comment` | Core review flow, no route test (audit TEST-2) |
+| Batch comments (multipart) | `/actions/tasks/batch-comment` with attached preview files | JSON body path is covered; the multipart upload variant is not |
 | Working file I/O | `/data/working-files/<id>/file` (GET, POST) | Skipped historically (binary I/O) |
 | Attachment upload | `/actions/tasks/<id>/comments/<id>/add-attachment`, attachment download/delete routes | Service layer covered since the audit; route-level upload still untested |
 | Output files with instances | `/data/asset-instances/<id>/entities/<id>/output-types/<id>/output-files` | Skipped historically (complex FK setup) |
@@ -36,3 +35,6 @@ To re-derive the list: compare the routes registered in
   `tests/thumbnails/`, including both `set-main-preview` routes.
 - `/data/tasks/<id>/comments/<id>/ack` got its first test along with
   the session-conflict fix (audit BUG-37).
+- Batch-comment routes (JSON body) and movie streaming
+  (original/low/download/404) are covered in `tests/comments/` and
+  `tests/previews/` (audit TEST-2).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,7 @@
 [tool.black]
 line-length = 79
+
+[tool.pytest.ini_options]
+markers = [
+    "integration: needs an external service (e.g. a running Meilisearch)",
+]

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,7 +56,6 @@ install_requires =
     itsdangerous==2.2.0
     Jinja2==3.1.6
     ldap3==2.9.1
-    matterhook-nlz==0.3
     meilisearch==0.41.0
     numpy==2.2.6
     opencv-python-headless==4.13.0.92

--- a/setup.cfg
+++ b/setup.cfg
@@ -77,7 +77,7 @@ install_requires =
     requests==2.34.0
     rq==2.8.0
     semver==3.0.4
-    slackclient==2.9.4
+    slack_sdk==3.43.0
     spdx-license-list==3.28.0
     sqlalchemy_utils==0.42.1
     sqlalchemy==2.0.49

--- a/tests/base.py
+++ b/tests/base.py
@@ -52,6 +52,29 @@ from flask import current_app
 
 TEST_FOLDER = os.path.join("tests", "tmp")
 
+
+def indexer_is_up():
+    """
+    Tell whether an indexer is configured (INDEXER_KEY) and the
+    Meilisearch instance answers, so integration tests are skipped
+    instead of erroring or hanging when it is absent.
+    """
+    import requests
+
+    from zou.app import config
+
+    if config.INDEXER["key"] is None:
+        return False
+    url = (
+        f"{config.INDEXER['protocol']}://{config.INDEXER['host']}"
+        f":{config.INDEXER['port']}/health"
+    )
+    try:
+        return requests.get(url, timeout=1).status_code == 200
+    except requests.RequestException:
+        return False
+
+
 auth_tokens_store.revoked_tokens_store = fakeredis.FakeStrictRedis(
     decode_responses=True
 )

--- a/tests/comments/test_route_comments.py
+++ b/tests/comments/test_route_comments.py
@@ -50,6 +50,49 @@ class CommentRoutesTestCase(ApiDBTestCase):
         )
         self.assertIsNotNone(result["id"])
 
+    def test_batch_comment_task(self):
+        comments = [
+            {"task_status_id": str(self.task_status.id), "text": "note 1"},
+            {"task_status_id": str(self.task_status.id), "text": "note 2"},
+        ]
+        result = self.post(
+            f"/actions/tasks/{self.task.id}/batch-comment",
+            {"comments": comments},
+        )
+        self.assertEqual(len(result), 2)
+        texts = [c["text"] for c in tasks_service.get_comments(self.task.id)]
+        self.assertIn("note 1", texts)
+        self.assertIn("note 2", texts)
+
+    def test_batch_comment_tasks(self):
+        self.generate_fixture_sequence()
+        self.generate_fixture_shot()
+        self.generate_fixture_shot_task()
+        comments = [
+            {
+                "task_id": str(self.task.id),
+                "task_status_id": str(self.task_status.id),
+                "text": "asset note",
+            },
+            {
+                "task_id": str(self.shot_task.id),
+                "task_status_id": str(self.task_status.id),
+                "text": "shot note",
+            },
+        ]
+        result = self.post(
+            "/actions/tasks/batch-comment", {"comments": comments}
+        )
+        self.assertEqual(len(result), 2)
+        asset_texts = [
+            c["text"] for c in tasks_service.get_comments(self.task.id)
+        ]
+        shot_texts = [
+            c["text"] for c in tasks_service.get_comments(self.shot_task.id)
+        ]
+        self.assertIn("asset note", asset_texts)
+        self.assertIn("shot note", shot_texts)
+
     def test_get_comment_embeds_author(self):
         comment = self.get(f"/data/comments/{self.comment['id']}")
         self.assertEqual(comment["person"]["id"], comment["person_id"])

--- a/tests/previews/test_route_movie_streaming.py
+++ b/tests/previews/test_route_movie_streaming.py
@@ -1,0 +1,88 @@
+import os
+
+from tests.base import ApiDBTestCase
+
+
+class MovieStreamingRoutesTestCase(ApiDBTestCase):
+    """
+    Upload a real movie (normalization disabled so the original file is
+    stored as-is) then stream it back through the movie routes.
+    """
+
+    def setUp(self):
+        super(MovieStreamingRoutesTestCase, self).setUp()
+
+        self.generate_fixture_project_status()
+        self.generate_fixture_project()
+        self.generate_fixture_asset_type()
+        self.generate_fixture_asset()
+        self.generate_fixture_department()
+        self.generate_fixture_task_type()
+        self.generate_fixture_task_status()
+        self.generate_fixture_task_status_wip()
+        self.generate_fixture_person()
+        self.generate_fixture_assigner()
+        self.generate_fixture_task()
+
+        self.task_id = str(self.task.id)
+        self.wip_status_id = str(self.task_status_wip.id)
+        self.movie_path = self.get_fixture_file_path(
+            os.path.join("videos", "test_preview_tiles.mp4")
+        )
+
+    def upload_movie_preview(self):
+        comment = self.post(
+            f"/actions/tasks/{self.task_id}/comment/",
+            {"task_status_id": self.wip_status_id, "comment": "c"},
+        )
+        preview_file = self.post(
+            f"/actions/tasks/{self.task_id}"
+            f"/comments/{comment['id']}/add-preview",
+            {},
+        )
+        self.upload_file(
+            f"/pictures/preview-files/{preview_file['id']}?normalize=false",
+            self.movie_path,
+        )
+        return preview_file["id"]
+
+    def test_stream_original_and_low_movie(self):
+        preview_file_id = self.upload_movie_preview()
+        with open(self.movie_path, "rb") as movie_file:
+            movie_content = movie_file.read()
+
+        response = self.app.get(
+            f"/movies/originals/preview-files/{preview_file_id}.mp4",
+            headers=self.base_headers,
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.mimetype, "video/mp4")
+        self.assertEqual(response.data, movie_content)
+
+        response = self.app.get(
+            f"/movies/low/preview-files/{preview_file_id}.mp4",
+            headers=self.base_headers,
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data, movie_content)
+
+    def test_download_original_movie(self):
+        preview_file_id = self.upload_movie_preview()
+        response = self.app.get(
+            f"/movies/originals/preview-files/{preview_file_id}/download",
+            headers=self.base_headers,
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(
+            "attachment", response.headers.get("Content-Disposition", "")
+        )
+
+    def test_stream_unknown_movie_returns_404(self):
+        self.upload_movie_preview()
+        from zou.app.utils import fields
+
+        response = self.app.get(
+            f"/movies/originals/preview-files/{fields.gen_uuid()}.mp4",
+            headers=self.base_headers,
+        )
+        self.assertEqual(response.status_code, 404)

--- a/tests/search/test_search.py
+++ b/tests/search/test_search.py
@@ -1,7 +1,16 @@
-from tests.base import ApiDBTestCase
+import pytest
 
+from tests.base import ApiDBTestCase, indexer_is_up
 
 from zou.app.services import index_service
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not indexer_is_up(),
+        reason="Needs a running Meilisearch (integration test)",
+    ),
+]
 
 
 class AssetSearchTestCase(ApiDBTestCase):

--- a/tests/services/test_index_service.py
+++ b/tests/services/test_index_service.py
@@ -1,8 +1,18 @@
 from unittest.mock import patch
 
-from tests.base import ApiDBTestCase
+import pytest
+
+from tests.base import ApiDBTestCase, indexer_is_up
 
 from zou.app.services import assets_service, index_service
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not indexer_is_up(),
+        reason="Needs a running Meilisearch (integration test)",
+    ),
+]
 from zou.app.services.exception import (
     EpisodeNotFoundException,
     SequenceNotFoundException,

--- a/tests/sync/test_events_sync.py
+++ b/tests/sync/test_events_sync.py
@@ -1,0 +1,39 @@
+import unittest
+
+from unittest import mock
+
+from zou.app.services import sync_service
+
+
+class FetchEventsTestCase(unittest.TestCase):
+    def test_paginates_until_short_page(self):
+        pages = [
+            [{"id": "ev-0"}, {"id": "ev-1"}, {"id": "ev-2"}],
+            [{"id": "ev-3"}, {"id": "ev-4"}],
+        ]
+        calls = []
+
+        def fake_fetch_all(path):
+            calls.append(path)
+            return pages[len(calls) - 1]
+
+        with mock.patch.object(
+            sync_service.gazu.client, "fetch_all", side_effect=fake_fetch_all
+        ):
+            events = sync_service._fetch_events(
+                "events/last?limit=3", 3, paginate=True
+            )
+        self.assertEqual(len(events), 5)
+        self.assertEqual(len(calls), 2)
+        self.assertIn("cursor_event_id=ev-2", calls[1])
+
+    def test_single_fetch_when_not_paginated(self):
+        full_page = [{"id": "ev-0"}, {"id": "ev-1"}, {"id": "ev-2"}]
+        with mock.patch.object(
+            sync_service.gazu.client, "fetch_all", return_value=full_page
+        ) as fetch_all:
+            events = sync_service._fetch_events(
+                "events/last?limit=3", 3, paginate=False
+            )
+        self.assertEqual(len(events), 3)
+        fetch_all.assert_called_once()

--- a/tests/utils/test_chats.py
+++ b/tests/utils/test_chats.py
@@ -1,0 +1,29 @@
+import unittest
+
+from unittest import mock
+
+from zou.app.utils import chats
+
+
+class SendToMattermostTestCase(unittest.TestCase):
+    def test_posts_payload_on_webhook_url(self):
+        webhook = "https://mattermost.example.com/hooks/abcdef123"
+        with mock.patch("requests.post") as post:
+            chats.send_to_mattermost(
+                webhook,
+                "john.doe",
+                {"message": "New comment", "project_name": "Caminandes"},
+            )
+        post.assert_called_once()
+        args, kwargs = post.call_args
+        self.assertEqual(args[0], webhook)
+        self.assertEqual(kwargs["json"]["text"], "New comment")
+        self.assertEqual(kwargs["json"]["channel"], "@john.doe")
+        self.assertEqual(kwargs["json"]["username"], "Kitsu - Caminandes")
+        self.assertEqual(kwargs["timeout"], 30)
+
+    def test_missing_webhook_or_userid_does_not_post(self):
+        with mock.patch("requests.post") as post:
+            chats.send_to_mattermost(None, "john.doe", {})
+            chats.send_to_mattermost("https://hook", None, {})
+        post.assert_not_called()

--- a/tests/utils/test_chats.py
+++ b/tests/utils/test_chats.py
@@ -5,6 +5,24 @@ from unittest import mock
 from zou.app.utils import chats
 
 
+class SendToSlackTestCase(unittest.TestCase):
+    def test_posts_message_to_user_channel(self):
+        with mock.patch("slack_sdk.WebClient") as client_class:
+            chats.send_to_slack("xoxb-token", "U123", "hello")
+        client_class.assert_called_once_with(token="xoxb-token")
+        client = client_class.return_value
+        client.chat_postMessage.assert_called_once()
+        kwargs = client.chat_postMessage.call_args.kwargs
+        self.assertEqual(kwargs["channel"], "@U123")
+        self.assertEqual(kwargs["blocks"][0]["text"]["text"], "hello")
+
+    def test_missing_token_or_userid_does_not_post(self):
+        with mock.patch("slack_sdk.WebClient") as client_class:
+            chats.send_to_slack(None, "U123", "hello")
+            chats.send_to_slack("xoxb-token", None, "hello")
+        client_class.assert_not_called()
+
+
 class SendToMattermostTestCase(unittest.TestCase):
     def test_posts_payload_on_webhook_url(self):
         webhook = "https://mattermost.example.com/hooks/abcdef123"

--- a/zou/app/blueprints/chats/resources.py
+++ b/zou/app/blueprints/chats/resources.py
@@ -1,8 +1,9 @@
 from flask import request
-from flask_restful import Resource, reqparse
+from flask_restful import Resource
 from flask_jwt_extended import jwt_required
 
-from zou.app.utils import permissions
+from zou.app.blueprints.chats.schemas import ChatMessageSchema
+from zou.app.utils import permissions, validation
 
 from zou.app.services import (
     chats_service,
@@ -204,16 +205,8 @@ class ChatMessagesResource(Resource):
         user_service.check_entity_access(entity["id"])
 
         person = persons_service.get_current_user()
-        if request.is_json:
-            location = ["values", "json"]
-        else:
-            location = ["values", "form"]
-        parser = reqparse.RequestParser()
-        parser.add_argument(
-            "message", type=str, required=True, location=location
-        )
-        args = parser.parse_args()
-        message = args["message"]
+        body = validation.validate_request_body(ChatMessageSchema)
+        message = body.message
         files = request.files
 
         chat = chats_service.get_chat(entity_id)

--- a/zou/app/blueprints/chats/schemas.py
+++ b/zou/app/blueprints/chats/schemas.py
@@ -1,0 +1,15 @@
+"""
+Pydantic schemas for request body validation in the chats blueprint.
+"""
+
+from pydantic import Field
+
+from zou.app.utils.validation import BaseSchema
+
+
+class ChatMessageSchema(BaseSchema):
+    """
+    Body for posting a message in an entity chat.
+    """
+
+    message: str = Field(..., description="Message text content")

--- a/zou/app/blueprints/comments/resources.py
+++ b/zou/app/blueprints/comments/resources.py
@@ -1,7 +1,6 @@
-import orjson as json
 
-from flask import abort, request, send_file as flask_send_file, current_app
-from flask_restful import Resource, reqparse
+from flask import request, send_file as flask_send_file, current_app
+from flask_restful import Resource
 from flask_jwt_extended import jwt_required
 
 from zou.app.mixin import ArgsMixin
@@ -11,6 +10,7 @@ from zou.app.services.exception import (
 )
 from zou.app.utils import permissions, date_helpers, validation
 from zou.app.blueprints.comments.schemas import (
+    CommentCreateSchema,
     CommentReplySchema,
     MoveCommentSchema,
 )
@@ -286,52 +286,15 @@ class CommentTaskResource(Resource):
         return comment, 201
 
     def get_arguments(self):
-        parser = reqparse.RequestParser()
-        if request.is_json:
-            location = ["values", "json"]
-            parser.add_argument(
-                "checklist",
-                type=dict,
-                action="append",
-                default=[],
-                location=location,
-            )
-            parser.add_argument(
-                "links",
-                type=str,
-                action="append",
-                default=[],
-                location=location,
-            )
-        else:
-            location = "values"
-            parser.add_argument("checklist", default="[]", location=location)
-            parser.add_argument("links", default="[]", location=location)
-        parser.add_argument(
-            "task_status_id",
-            required=True,
-            help="Task Status ID is missing",
-            location=location,
-        )
-        parser.add_argument("comment", default="", location=location)
-        parser.add_argument("person_id", default="", location=location)
-        parser.add_argument("created_at", default="", location=location)
-        parser.add_argument(
-            "for_client", type=bool, default=False, location=location
-        )
-        args = parser.parse_args()
+        body = validation.validate_request_body(CommentCreateSchema)
         return (
-            args["task_status_id"],
-            args["comment"],
-            args["person_id"],
-            args["created_at"],
-            (
-                args["checklist"]
-                if request.is_json
-                else json.loads(args["checklist"])
-            ),
-            (args["links"] if request.is_json else json.loads(args["links"])),
-            args["for_client"],
+            body.task_status_id,
+            body.comment,
+            body.person_id,
+            body.created_at,
+            body.checklist,
+            body.links,
+            body.for_client,
         )
 
 

--- a/zou/app/blueprints/comments/schemas.py
+++ b/zou/app/blueprints/comments/schemas.py
@@ -4,7 +4,9 @@ Pydantic schemas for request body validation in the comments blueprint.
 
 from typing import Optional
 
-from pydantic import Field
+import orjson as json
+
+from pydantic import Field, field_validator
 
 from zou.app.utils.validation import BaseSchema
 
@@ -25,3 +27,35 @@ class MoveCommentSchema(BaseSchema):
     target_task_id: str = Field(
         ..., description="Identifier of the task to move the comment to"
     )
+
+
+class CommentCreateSchema(BaseSchema):
+    """
+    Body for adding a comment to a task. Sent either as JSON or as a
+    multipart form (when files are attached), where checklist and links
+    arrive as JSON-encoded strings.
+    """
+
+    task_status_id: str = Field(..., description="Task status UUID")
+    comment: str = Field("", description="Comment text content")
+    person_id: str = Field("", description="Author UUID (managers only)")
+    created_at: str = Field(
+        "", description="Creation date override (managers only)"
+    )
+    checklist: list = Field(
+        default_factory=list, description="Checklist items"
+    )
+    links: list = Field(default_factory=list, description="Linked URLs")
+    for_client: bool = Field(
+        False, description="Make the comment visible to clients"
+    )
+
+    @field_validator("checklist", "links", mode="before")
+    @classmethod
+    def decode_json_strings(cls, value):
+        """
+        Accept the JSON-encoded strings sent by multipart forms.
+        """
+        if isinstance(value, str):
+            return json.loads(value) if value else []
+        return value

--- a/zou/app/services/sync_service.py
+++ b/zou/app/services/sync_service.py
@@ -605,6 +605,38 @@ def _push_batch(path, payload, batch_size=200, label=None, silent=True):
         logger.info(f"  {display}: pushed {total} rows")
 
 
+def _add_time_window(path, minutes):
+    """
+    Append before/after query parameters covering the last given minutes.
+    """
+    now = date_helpers.get_utc_now_datetime()
+    min_before = now - datetime.timedelta(minutes=minutes)
+    after = min_before.strftime("%Y-%m-%dT%H:%M:%S")
+    path += f'&before={now.strftime("%Y-%m-%dT%H:%M:%S")}'
+    path += f"&after={after}"
+    return path
+
+
+def _fetch_events(path, limit, paginate):
+    """
+    Fetch events from the source instance, newest first. When paginate is
+    set, follow the cursor until the whole time window is covered, so a
+    burst bigger than the page size does not silently drop events.
+    """
+    events = []
+    cursor = None
+    while True:
+        page_path = path
+        if cursor is not None:
+            page_path += f"&cursor_event_id={cursor}"
+        page = gazu.client.fetch_all(page_path)
+        events += page
+        if not paginate or len(page) < limit:
+            break
+        cursor = page[-1]["id"]
+    return events
+
+
 def run_last_events_sync(minutes=0, limit=300):
     """
     Retrieve last events from source instance and import related data and
@@ -612,12 +644,8 @@ def run_last_events_sync(minutes=0, limit=300):
     """
     path = f"events/last?limit={limit}"
     if minutes > 0:
-        now = date_helpers.get_utc_now_datetime()
-        min_before = now - datetime.timedelta(minutes=minutes)
-        after = min_before.strftime("%Y-%m-%dT%H:%M:%S")
-        path += f'&before={now.strftime("%Y-%m-%dT%H:%M:%S")}'
-        path += f"&after={after}"
-    events = gazu.client.fetch_all(path)
+        path = _add_time_window(path, minutes)
+    events = _fetch_events(path, limit, paginate=minutes > 0)
     events.reverse()
     for event in events:
         event_name = event["name"].split(":")[0]
@@ -625,7 +653,9 @@ def run_last_events_sync(minutes=0, limit=300):
             try:
                 sync_event(event)
             except Exception:
-                pass
+                logger.exception(
+                    f"Failed to sync event {event['id']} ({event['name']})"
+                )
 
 
 def run_last_events_files(minutes=0, limit=50):
@@ -635,12 +665,8 @@ def run_last_events_files(minutes=0, limit=50):
     """
     path = f"events/last?only_files=true&limit={limit}"
     if minutes > 0:
-        now = date_helpers.get_utc_now_datetime()
-        min_before = now - datetime.timedelta(minutes=minutes)
-        after = min_before.strftime("%Y-%m-%dT%H:%M:%S")
-        path += f'&before={now.strftime("%Y-%m-%dT%H:%M:%S")}'
-        path += f"&after={after}"
-    events = gazu.client.fetch_all(path)
+        path = _add_time_window(path, minutes)
+    events = _fetch_events(path, limit, paginate=minutes > 0)
     events.reverse()
     for event in events:
         event_name = event["name"].split(":")[0]

--- a/zou/app/utils/chats.py
+++ b/zou/app/utils/chats.py
@@ -48,23 +48,21 @@ def send_to_mattermost(webhook, userid, message):
     if webhook:
         if userid:
             try:
-                from matterhook import Webhook
+                import requests
 
-                arg = webhook.split("/")
-                server = f"{arg[0]}{arg[1]}//{arg[2]}"
-                hook = arg[4]
-
-                # mandatory parameters are url and your webhook API key
-                mwh = Webhook(server, hook)
-                mwh.username = f"Kitsu - {message['project_name']}"
-                mwh.icon_url = (
-                    f"{config.DOMAIN_PROTOCOL}://{config.DOMAIN_NAME}"
-                    f"/img/kitsu.b07d6464.png"
-                )
-
-                # send a message to the API_KEY's channel
-                mwh.send(message["message"], channel=f"@{userid}")
-
+                # A Mattermost incoming webhook is a plain POST of a
+                # JSON payload on the webhook URL.
+                payload = {
+                    "text": message["message"],
+                    "channel": f"@{userid}",
+                    "username": f"Kitsu - {message['project_name']}",
+                    "icon_url": (
+                        f"{config.DOMAIN_PROTOCOL}://{config.DOMAIN_NAME}"
+                        "/img/kitsu.b07d6464.png"
+                    ),
+                }
+                response = requests.post(webhook, json=payload, timeout=30)
+                response.raise_for_status()
             except Exception:
                 logger.error(
                     "Exception when sending a Mattermost notification:",

--- a/zou/app/utils/chats.py
+++ b/zou/app/utils/chats.py
@@ -17,7 +17,7 @@ def send_to_slack(token, userid, message):
     if token:
         if userid:
             try:
-                from slack import WebClient as SlackClient
+                from slack_sdk import WebClient as SlackClient
 
                 client = SlackClient(token=token)
                 blocks = [


### PR DESCRIPTION
## Problems

- Event sync fetched one hard-limited page and swallowed per-event errors
- Batch-comment and movie streaming routes, core of review, were untested; index tests hung without a Meilisearch
- matterhook-nlz is an obscure fork; slackclient is deprecated
- Two resources still parsed bodies with reqparse

## Solutions

- Cursor pagination over the sync time window, failures logged per event
- Route tests for both batch-comment endpoints and original/low streaming; index tests marked integration and skipped when no indexer
- Direct webhook POST via requests; slack_sdk migration
- CommentCreateSchema and ChatMessageSchema via validate_request_body; no body reqparse left