### PR TITLE
[breakdown] Detach asset from episode when uncast from all its shots

### DIFF
--- a/tests/services/test_breakdown_service.py
+++ b/tests/services/test_breakdown_service.py
@@ -1,8 +1,10 @@
 from tests.base import ApiDBTestCase
 
+from zou.app.models.entity import Entity
 from zou.app.services import (
     assets_service,
     breakdown_service,
+    entities_service,
     projects_service,
     tasks_service,
 )
@@ -215,6 +217,111 @@ class BreakdownServiceTestCase(ApiDBTestCase):
         self.assertEqual(second["nb_entities_out"], 1)
         self.assertEqual(second["added_asset_ids"], [])
         self.assertEqual(second["removed_asset_ids"], [asset_character_id])
+
+    def test_update_casting_keeps_asset_in_episode_while_another_shot_uses_it(
+        self,
+    ):
+        """
+        Casting an asset in a shot auto-casts it in the parent episode too.
+        Removing that asset from one shot must not detach it from the
+        episode while another shot of that episode still casts it
+        (cgwire/kitsu#1388).
+        """
+        asset_id = str(self.asset.id)
+        # generate_fixture_shot() reassigns self.shot to the newly created
+        # shot, so keep an explicit reference to the original one.
+        first_shot = self.shot
+        other_shot = self.generate_fixture_shot("SH02")
+
+        breakdown_service.update_casting(
+            first_shot.id, [{"asset_id": asset_id, "nb_occurences": 1}]
+        )
+        breakdown_service.update_casting(
+            other_shot.id, [{"asset_id": asset_id, "nb_occurences": 1}]
+        )
+        episode_casting = breakdown_service.get_casting(self.episode.id)
+        self.assertEqual(
+            [cast["asset_id"] for cast in episode_casting], [asset_id]
+        )
+
+        # Un-cast the asset from the first shot only: the episode still
+        # casts it through the second shot.
+        breakdown_service.update_casting(first_shot.id, [])
+        episode_casting = breakdown_service.get_casting(self.episode.id)
+        self.assertEqual(
+            [cast["asset_id"] for cast in episode_casting], [asset_id]
+        )
+
+        # Un-cast the asset from the last remaining shot: it must now
+        # disappear from the episode casting (and asset list) too.
+        breakdown_service.update_casting(other_shot.id, [])
+        episode_casting = breakdown_service.get_casting(self.episode.id)
+        self.assertEqual(episode_casting, [])
+        episode = entities_service.get_entity(self.episode.id)
+        self.assertEqual(episode["nb_entities_out"], 0)
+
+    def test_update_casting_removal_from_shot_emits_episode_event(self):
+        """
+        Detaching the asset from the episode (because it is no longer
+        casted in any of its shots) must emit an episode:casting-update
+        event, the same way casting it in a shot emits an asset:update
+        event, so listeners can refresh the episode's asset list.
+        """
+        captured = []
+
+        class _Handler:
+            __name__ = "episode_casting_update_handler"
+
+            def __init__(self, sink):
+                self.sink = sink
+
+            def handle_event(self, data=None):
+                self.sink.append(data or {})
+
+        events.unregister_all()
+        handler = _Handler(captured)
+        events.register(
+            "episode:casting-update", "episode_casting_update_handler", handler
+        )
+
+        asset_id = str(self.asset.id)
+        breakdown_service.update_casting(
+            self.shot.id, [{"asset_id": asset_id, "nb_occurences": 1}]
+        )
+        self.assertEqual(captured, [])
+
+        breakdown_service.update_casting(self.shot.id, [])
+        self.assertEqual(len(captured), 1)
+        self.assertEqual(captured[0]["episode_id"], str(self.episode.id))
+        self.assertEqual(captured[0]["removed_asset_ids"], [asset_id])
+        self.assertEqual(captured[0]["nb_entities_out"], 0)
+
+    def test_update_casting_removal_from_shot_without_episode_does_not_fail(
+        self,
+    ):
+        """
+        A shot whose sequence has no parent episode (non-episodic
+        production) must not break when an asset is un-cast from it.
+        """
+        no_episode_sequence = Entity.create(
+            name="NoEpisodeSequence",
+            project_id=self.project.id,
+            entity_type_id=self.sequence_type.id,
+        )
+        no_episode_shot = Entity.create(
+            name="NoEpisodeShot",
+            project_id=self.project.id,
+            entity_type_id=self.shot_type.id,
+            parent_id=no_episode_sequence.id,
+        )
+        asset_id = str(self.asset.id)
+        breakdown_service.update_casting(
+            no_episode_shot.id,
+            [{"asset_id": asset_id, "nb_occurences": 1}],
+        )
+        breakdown_service.update_casting(no_episode_shot.id, [])
+        casting = breakdown_service.get_casting(no_episode_shot.id)
+        self.assertEqual(casting, [])
 
     def test_add_instance_to_shot(self):
         instances = breakdown_service.get_asset_instances_for_shot(

--- a/zou/app/services/breakdown_service.py
+++ b/zou/app/services/breakdown_service.py
@@ -325,6 +325,11 @@ def update_casting(entity_id, casting):
             {"shot_id": entity_id, **casting_diff},
             project_id=str(entity.project_id),
         )
+        if removed_asset_ids:
+            episode_id = _get_episode_id_for_shot(entity_dict)
+            if episode_id is not None:
+                for asset_id in removed_asset_ids:
+                    _detach_asset_from_episode_if_unused(asset_id, episode_id)
     elif shots_service.is_episode(entity_dict):
         events.emit(
             "episode:casting-update",
@@ -423,6 +428,61 @@ def _remove_asset_from_episode_shots(asset_id, episode_id):
             project_id=str(shot.project_id),
         )
     return shots
+
+
+def _get_episode_id_for_shot(shot):
+    """
+    Return the ID of the episode given shot belongs to, or None if its
+    sequence has no parent episode.
+    """
+    sequence = shots_service.get_sequence(str(shot["parent_id"]))
+    return sequence["parent_id"]
+
+
+def _detach_asset_from_episode_if_unused(asset_id, episode_id):
+    """
+    Casting an asset in a shot automatically casts it in the parent episode
+    too (see `_create_episode_casting_link`). Symmetrically, once an asset is
+    removed from a shot's casting, remove it from the episode as well, unless
+    it is still casted in another shot of that episode.
+    """
+    shots = shots_service.get_shots_for_episode(episode_id)
+    shot_ids = [shot["id"] for shot in shots]
+    is_still_casted_in_a_shot = (
+        len(shot_ids) > 0
+        and EntityLink.query.filter(EntityLink.entity_in_id.in_(shot_ids))
+        .filter(EntityLink.entity_out_id == asset_id)
+        .first()
+        is not None
+    )
+    if is_still_casted_in_a_shot:
+        return
+
+    link = EntityLink.get_by(entity_in_id=episode_id, entity_out_id=asset_id)
+    if link is None:
+        return
+
+    episode = entities_service.get_entity_raw(episode_id)
+    link.delete()
+    episode.update({"nb_entities_out": max(episode.nb_entities_out - 1, 0)})
+    events.emit(
+        "episode:casting-update",
+        {
+            "episode_id": str(episode_id),
+            "nb_entities_out": episode.nb_entities_out,
+            "added_asset_ids": [],
+            "removed_asset_ids": [str(asset_id)],
+        },
+        project_id=str(episode.project_id),
+    )
+    # Mirror the asset:update event emitted when the link was auto-created
+    # in `_create_episode_casting_link`, so listeners refresh the asset the
+    # same way on both sides of the auto-casting link.
+    events.emit(
+        "asset:update",
+        {"asset_id": str(asset_id)},
+        project_id=str(episode.project_id),
+    )
 
 
 def _create_episode_casting_link(entity, asset_id, nb_occurences=1, label=""):


### PR DESCRIPTION
## Problems

- Casting an asset in a shot automatically casts it in the parent episode (`_create_episode_casting_link`), but removing the asset from the shot never reversed that link: the asset stayed stuck in the episode casting — and therefore in the episode's asset list — with no way to remove it short of deleting it (fixes cgwire/kitsu#1388)
- The existing symmetry only covered the other direction: removing an asset from the episode's own casting cascades to all its shots (`_remove_asset_from_episode_shots`), so shot-side removals silently accumulated stale episode links

## Solutions

- When a shot casting update removes assets, detach each removed asset from the parent episode **only if it is no longer casted in any other shot of that episode** — an asset used by several shots keeps its episode link until the last shot drops it
- Emit `episode:casting-update` (with the removed asset in `removed_asset_ids`) and `asset:update` on detach, mirroring the events emitted when the link was auto-created, so listeners refresh the episode asset list live
- Cover the new behavior with service tests: multi-shot retention, event emission, and shots without a parent episode (non-episodic productions)