### PR TITLE
Fix multiple Alembic migration heads after rebase

### DIFF
--- a/zou/migrations/versions/f2c9a1b7e4d8_sanitize_invalid_person_locales.py
+++ b/zou/migrations/versions/f2c9a1b7e4d8_sanitize_invalid_person_locales.py
@@ -10,7 +10,7 @@ value Babel cannot parse. NULL is safe here, the read paths fall back to the
 default locale.
 
 Revision ID: f2c9a1b7e4d8
-Revises: f1a2b3c4d5e6
+Revises: a3d9c1e7b5f2
 Create Date: 2026-07-06 10:00:00.000000
 
 """
@@ -24,7 +24,7 @@ from babel.core import UnknownLocaleError
 
 # revision identifiers, used by Alembic.
 revision = "f2c9a1b7e4d8"
-down_revision = "f1a2b3c4d5e6"
+down_revision = "a3d9c1e7b5f2"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
**Problem**
- Two migrations branched off `f1a2b3c4d5e6` — `a3d9c1e7b5f2` (api_event created_at indexes) and `f2c9a1b7e4d8` (sanitize person locales) — leaving two Alembic heads, so `zou upgrade-db` fails with `MultipleHeads`.

**Solution**
- Re-parent the locale migration onto the api_event index migration, restoring a single linear head.
