### PR TITLE
[ci] Don't mask HTTPExceptions as 500 in debug mode

### DIFF
--- a/tests/auth/test_auth_route.py
+++ b/tests/auth/test_auth_route.py
@@ -134,7 +134,11 @@ class AuthTestCase(ApiDBTestCase):
             data=json.dumps(subscription_data),
             headers={"Content-type": "application/json"},
         )
-        self.assertEqual(response.status_code, 404)
+        # With the route removed, nothing matches the path: a plain 404 in
+        # production. Under DEBUG the frontend file-serving catch-all
+        # (/<fs>/<filename>, GET-only) is registered and captures the path, so
+        # the POST is refused with a 405. Either way registration is refused.
+        self.assertIn(response.status_code, (404, 405))
 
     def test_change_password(self):
         credentials = dict(self.credentials)

--- a/zou/app/__init__.py
+++ b/zou/app/__init__.py
@@ -17,6 +17,7 @@ from flask_sqlalchemy import SQLAlchemy
 from flask_migrate import Migrate
 from flask_mail import Mail
 
+from werkzeug.exceptions import HTTPException
 from jwt import ExpiredSignatureError
 from babel.core import UnknownLocaleError
 from meilisearch.errors import (
@@ -215,6 +216,11 @@ if config.DEBUG:
 
     @app.errorhandler(Exception)
     def server_error(error):
+        # HTTPExceptions (404, 405, ...) carry their own status code; let
+        # Flask render them normally instead of masking every one as a 500
+        # with a stacktrace while in debug mode.
+        if isinstance(error, HTTPException):
+            return error
         stacktrace = traceback.format_exc()
         current_app.logger.error(stacktrace)
         return (


### PR DESCRIPTION
**Problem**
- Under DEBUG (as run in CI), the catch-all `Exception` error handler returned a 500 with a stacktrace for every error, including `HTTPException`s that already carry a status code — so a POST to the removed `/auth/register` route surfaced as 500 instead of the 405 raised by the debug-only file-serving catch-all, breaking `test_register_route_is_gone`.

**Solution**
- Let `HTTPException`s pass through the debug handler so they render with their real status code, and assert the register route answers 404 (production) or 405 (debug).
