### PR TITLE
[api] Remove the flask_restful dependency

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,12 +138,12 @@ app.register_blueprint(<name>_blueprint)
 ### Resource pattern
 
 ```python
-from flask_restful import Resource
+from flask.views import MethodView
 from flask_jwt_extended import jwt_required
 from zou.app.utils import permissions, validation
 from zou.app.blueprints.<name>.schemas import MySchema
 
-class MyResource(Resource):
+class MyResource(MethodView):
     @jwt_required()
     def post(self):
         permissions.check_manager_permissions()
@@ -161,7 +161,7 @@ For standard model CRUD, extend `BaseModelsResource` / `BaseModelResource` in `z
 
 ## Pydantic Validation (v2)
 
-All request body validation uses Pydantic v2 schemas. **Do not use `reqparse` or `ArgsMixin` for body parsing** — those are legacy patterns; no resource uses `reqparse` for bodies anymore (`ArgsMixin.get_args` remains for query parameters only).
+All request body validation uses Pydantic v2 schemas. **Do not use `ArgsMixin` for body parsing** — `ArgsMixin.get_args` is for query parameters only. `flask_restful` and `reqparse` are gone: resources are plain Flask `MethodView` classes.
 
 ### Schema pattern
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,6 @@ install_requires =
     flask-cors==6.0.2
     flask_mail==0.10.0
     flask_principal==0.4.0
-    flask_restful==0.3.10
     flask_sqlalchemy==3.1.1
     flask-fs2[swift, s3]==0.8.1
     flask-jwt-extended==4.7.3

--- a/specs/architecture.md
+++ b/specs/architecture.md
@@ -4,7 +4,7 @@ Zou is the REST API backend for Kitsu, a production management tool for animatio
 
 ## Tech stack
 
-- **Framework**: Flask + Flask-RESTful
+- **Framework**: Flask (resources are `MethodView` classes)
 - **Database**: PostgreSQL (psycopg3 driver) via Flask-SQLAlchemy
 - **Migrations**: Alembic via Flask-Migrate
 - **Auth**: Flask-JWT-Extended (access + refresh tokens)
@@ -84,7 +84,7 @@ Permissions are enforced at the blueprint/service layer. Every endpoint checks t
 
 ## Key design patterns
 
-1. **Blueprint + Resource**: Each feature is a Flask blueprint containing Flask-RESTful Resource classes.
+1. **Blueprint + Resource**: Each feature is a Flask blueprint containing Flask `MethodView` resource classes.
 2. **Service layer**: Blueprints delegate to stateless service functions. Services handle business logic, caching, and event emission.
 3. **Generic CRUD**: `BaseModelsResource` and `BaseModelResource` provide list/create and get/update/delete for any model. Subclasses override permission hooks.
 4. **Event-driven**: Mutations emit events via Redis pub/sub. The event stream daemon broadcasts to WebSocket clients for live UI updates.

--- a/specs/blueprints.md
+++ b/specs/blueprints.md
@@ -8,7 +8,7 @@ All blueprints are registered in `zou/app/api.py`. Each blueprint package define
 configure_api_from_blueprint(blueprint, routes)
 ```
 
-This wraps Flask-RESTful's `Api` around the blueprint and adds all routes.
+This registers each resource as a Flask `MethodView` on the blueprint via `add_url_rule`.
 
 ## Blueprint list
 

--- a/specs/plugins.md
+++ b/specs/plugins.md
@@ -37,10 +37,10 @@ frontend_studio_enabled = false
 The plugin module must expose a `routes` list:
 
 ```python
-from flask_restful import Resource
+from flask.views import MethodView
 from flask_jwt_extended import jwt_required
 
-class MyResource(Resource):
+class MyResource(MethodView):
     @jwt_required()
     def get(self):
         return {"data": "response"}

--- a/tests/fixtures/plugins/hello/resources.py
+++ b/tests/fixtures/plugins/hello/resources.py
@@ -1,6 +1,6 @@
-from flask_restful import Resource
+from flask.views import MethodView
 
 
-class HelloResource(Resource):
+class HelloResource(MethodView):
     def get(self):
         return {"Hello": "world"}

--- a/zou/app/__init__.py
+++ b/zou/app/__init__.py
@@ -143,6 +143,17 @@ def page_not_found(error):
     return jsonify(error=True, message=str(error)), 404
 
 
+@app.errorhandler(HTTPException)
+def http_error(error):
+    """
+    Return HTTP errors raised by resources (abort calls) as JSON instead
+    of the default werkzeug HTML page, as flask_restful used to do.
+    """
+    if error.response is not None:
+        return error.response
+    return jsonify(error=True, message=error.description), error.code
+
+
 @app.errorhandler(WrongIdFormatException)
 def id_parameter_format_error(error):
     return (

--- a/zou/app/blueprints/admin/resources.py
+++ b/zou/app/blueprints/admin/resources.py
@@ -1,5 +1,5 @@
 from flask import abort, current_app, request
-from flask_restful import Resource
+from flask.views import MethodView
 from sqlalchemy.exc import OperationalError, ProgrammingError
 
 from zou.app import config
@@ -7,7 +7,7 @@ from zou.app.models.person import Person
 from zou.app.stores import config_store
 
 
-class ConfigCheckResource(Resource):
+class ConfigCheckResource(MethodView):
 
     def get(self):
         token = request.headers.get("Authorization", "")

--- a/zou/app/blueprints/assets/resources.py
+++ b/zou/app/blueprints/assets/resources.py
@@ -1,5 +1,5 @@
 from flask import request
-from flask_restful import Resource
+from flask.views import MethodView
 from flask_jwt_extended import jwt_required
 
 from zou.app.utils import permissions, query, validation
@@ -32,7 +32,7 @@ def check_criterion_access(criterions):
     return True
 
 
-class AssetResource(Resource, ArgsMixin):
+class AssetResource(MethodView, ArgsMixin):
 
     @jwt_required()
     def get(self, asset_id):
@@ -131,7 +131,7 @@ class AssetResource(Resource, ArgsMixin):
         return "", 204
 
 
-class AllAssetsResource(Resource):
+class AllAssetsResource(MethodView):
 
     @jwt_required()
     def get(self):
@@ -218,7 +218,7 @@ class AllAssetsAliasResource(AllAssetsResource):
     pass
 
 
-class AssetsAndTasksResource(Resource, ArgsMixin):
+class AssetsAndTasksResource(MethodView, ArgsMixin):
 
     @jwt_required()
     def get(self):
@@ -304,7 +304,7 @@ class AssetsAndTasksResource(Resource, ArgsMixin):
         return assets_service.get_assets_and_tasks(criterions)
 
 
-class AssetTypeResource(Resource):
+class AssetTypeResource(MethodView):
 
     @jwt_required()
     def get(self, asset_type_id):
@@ -353,7 +353,7 @@ class AssetTypeResource(Resource):
         return assets_service.get_asset_type(asset_type_id)
 
 
-class AssetTypesResource(Resource):
+class AssetTypesResource(MethodView):
 
     @jwt_required()
     def get(self):
@@ -404,7 +404,7 @@ class AssetTypesResource(Resource):
         return assets_service.get_asset_types(criterions)
 
 
-class ProjectAssetTypesResource(Resource):
+class ProjectAssetTypesResource(MethodView):
 
     @jwt_required()
     def get(self, project_id):
@@ -451,7 +451,7 @@ class ProjectAssetTypesResource(Resource):
         return assets_service.get_asset_types_for_project(project_id)
 
 
-class ShotAssetTypesResource(Resource):
+class ShotAssetTypesResource(MethodView):
 
     @jwt_required()
     def get(self, shot_id):
@@ -499,7 +499,7 @@ class ShotAssetTypesResource(Resource):
         return assets_service.get_asset_types_for_shot(shot_id)
 
 
-class ProjectAssetsResource(Resource):
+class ProjectAssetsResource(MethodView):
 
     @jwt_required()
     def get(self, project_id):
@@ -581,7 +581,7 @@ class ProjectAssetsResource(Resource):
         return assets_service.get_assets(criterions)
 
 
-class ProjectAssetTypeAssetsResource(Resource):
+class ProjectAssetTypeAssetsResource(MethodView):
 
     @jwt_required()
     def get(self, project_id, asset_type_id):
@@ -665,7 +665,7 @@ class ProjectAssetTypeAssetsResource(Resource):
         return assets_service.get_assets(criterions)
 
 
-class AssetAssetsResource(Resource):
+class AssetAssetsResource(MethodView):
 
     @jwt_required()
     def get(self, asset_id):
@@ -719,7 +719,7 @@ class AssetAssetsResource(Resource):
         return breakdown_service.get_entity_casting(asset_id)
 
 
-class AssetTasksResource(Resource, ArgsMixin):
+class AssetTasksResource(MethodView, ArgsMixin):
 
     @jwt_required()
     def get(self, asset_id):
@@ -807,7 +807,7 @@ class AssetTasksResource(Resource, ArgsMixin):
         )
 
 
-class AssetTaskTypesResource(Resource):
+class AssetTaskTypesResource(MethodView):
 
     @jwt_required()
     def get(self, asset_id):
@@ -863,7 +863,7 @@ class AssetTaskTypesResource(Resource):
         return tasks_service.get_task_types_for_asset(asset_id)
 
 
-class NewAssetResource(Resource, ArgsMixin):
+class NewAssetResource(MethodView, ArgsMixin):
 
     @jwt_required()
     def post(self, project_id, asset_type_id):
@@ -985,7 +985,7 @@ class NewAssetResource(Resource, ArgsMixin):
         return asset, 201
 
 
-class AssetCastingResource(Resource):
+class AssetCastingResource(MethodView):
 
     @jwt_required()
     def get(self, asset_id):
@@ -1124,7 +1124,7 @@ class AssetCastingResource(Resource):
         return breakdown_service.update_casting(asset_id, casting)
 
 
-class AssetCastInResource(Resource):
+class AssetCastInResource(MethodView):
 
     @jwt_required()
     def get(self, asset_id):
@@ -1190,7 +1190,7 @@ class AssetCastInResource(Resource):
         return breakdown_service.get_cast_in(asset_id)
 
 
-class AssetShotAssetInstancesResource(Resource):
+class AssetShotAssetInstancesResource(MethodView):
 
     @jwt_required()
     def get(self, asset_id):
@@ -1247,7 +1247,7 @@ class AssetShotAssetInstancesResource(Resource):
         return breakdown_service.get_shot_asset_instances_for_asset(asset_id)
 
 
-class AssetSceneAssetInstancesResource(Resource):
+class AssetSceneAssetInstancesResource(MethodView):
     @jwt_required()
     def get(self, asset_id):
         """
@@ -1303,7 +1303,7 @@ class AssetSceneAssetInstancesResource(Resource):
         return breakdown_service.get_scene_asset_instances_for_asset(asset_id)
 
 
-class AssetAssetInstancesResource(Resource, ArgsMixin):
+class AssetAssetInstancesResource(MethodView, ArgsMixin):
     @jwt_required()
     def get(self, asset_id):
         """
@@ -1439,7 +1439,7 @@ class AssetAssetInstancesResource(Resource, ArgsMixin):
         return asset_instance, 201
 
 
-class BaseSetSharedAssetsResource(Resource, ArgsMixin):
+class BaseSetSharedAssetsResource(MethodView, ArgsMixin):
 
     @jwt_required()
     def post(self, project_id=None, asset_type_id=None, asset_ids=None):
@@ -1637,7 +1637,7 @@ class SetSharedAssetsResource(BaseSetSharedAssetsResource):
         return super().post(asset_ids=asset_ids)
 
 
-class ProjectAssetsSharedUsedResource(Resource):
+class ProjectAssetsSharedUsedResource(MethodView):
     @jwt_required()
     def get(self, project_id):
         """
@@ -1692,7 +1692,7 @@ class ProjectAssetsSharedUsedResource(Resource):
         return assets_service.get_shared_assets_used_in_project(project_id)
 
 
-class ProjectEpisodeAssetsSharedUsedResource(Resource):
+class ProjectEpisodeAssetsSharedUsedResource(MethodView):
 
     @jwt_required()
     def get(self, project_id, episode_id):

--- a/zou/app/blueprints/auth/resources.py
+++ b/zou/app/blueprints/auth/resources.py
@@ -2,7 +2,7 @@ import hmac
 import secrets
 
 from flask import request, jsonify, current_app, redirect, make_response
-from flask_restful import Resource
+from flask.views import MethodView
 from flask_principal import (
     Identity,
     AnonymousIdentity,
@@ -93,7 +93,7 @@ def _build_2fa_registration_response(response_data, user_id):
     return response
 
 
-class AuthenticatedResource(Resource):
+class AuthenticatedResource(MethodView):
 
     @jwt_required()
     def get(self):
@@ -125,7 +125,7 @@ class AuthenticatedResource(Resource):
         }
 
 
-class LogoutResource(Resource):
+class LogoutResource(MethodView):
 
     @jwt_required()
     @permissions.require_person
@@ -159,7 +159,7 @@ class LogoutResource(Resource):
             return logout_data
 
 
-class LoginResource(Resource, ArgsMixin):
+class LoginResource(MethodView, ArgsMixin):
 
     def post(self):
         """
@@ -407,7 +407,7 @@ class LoginResource(Resource, ArgsMixin):
         )
 
 
-class RefreshTokenResource(Resource):
+class RefreshTokenResource(MethodView):
     @jwt_required(refresh=True)
     @permissions.require_person
     def get(self):
@@ -450,7 +450,7 @@ class RefreshTokenResource(Resource):
             return {"access_token": access_token}
 
 
-class ChangePasswordResource(Resource, ArgsMixin):
+class ChangePasswordResource(MethodView, ArgsMixin):
 
     @jwt_required()
     @permissions.require_person
@@ -560,7 +560,7 @@ class ChangePasswordResource(Resource, ArgsMixin):
         return (body.old_password, body.password, body.password_2)
 
 
-class ResetPasswordResource(Resource, ArgsMixin):
+class ResetPasswordResource(MethodView, ArgsMixin):
 
     def put(self):
         """
@@ -721,7 +721,7 @@ class ResetPasswordResource(Resource, ArgsMixin):
         return {"success": "Reset token sent"}
 
 
-class TOTPResource(Resource, ArgsMixin):
+class TOTPResource(MethodView, ArgsMixin):
 
     @jwt_required()
     @permissions.require_person
@@ -876,7 +876,7 @@ class TOTPResource(Resource, ArgsMixin):
             )
 
 
-class EmailOTPResource(Resource, ArgsMixin):
+class EmailOTPResource(MethodView, ArgsMixin):
 
     def get(self):
         """
@@ -1079,7 +1079,7 @@ class EmailOTPResource(Resource, ArgsMixin):
             )
 
 
-class FIDOResource(Resource, ArgsMixin):
+class FIDOResource(MethodView, ArgsMixin):
     """
     Resource to allow a user to register/unregister FIDO device or to get a
     challenge for a FIDO device.
@@ -1269,7 +1269,7 @@ class FIDOResource(Resource, ArgsMixin):
             )
 
 
-class RecoveryCodesResource(Resource, ArgsMixin):
+class RecoveryCodesResource(MethodView, ArgsMixin):
 
     @jwt_required()
     @permissions.require_person
@@ -1345,7 +1345,7 @@ class RecoveryCodesResource(Resource, ArgsMixin):
             )
 
 
-class SAMLSSOResource(Resource, ArgsMixin):
+class SAMLSSOResource(MethodView, ArgsMixin):
     def post(self):
         """
         SAML SSO login
@@ -1452,7 +1452,7 @@ class SAMLSSOResource(Resource, ArgsMixin):
         return response
 
 
-class SAMLLoginResource(Resource, ArgsMixin):
+class SAMLLoginResource(MethodView, ArgsMixin):
 
     def get(self):
         """
@@ -1494,7 +1494,7 @@ class SAMLLoginResource(Resource, ArgsMixin):
         return redirect(redirect_url, code=302)
 
 
-class OIDCLoginResource(Resource, ArgsMixin):
+class OIDCLoginResource(MethodView, ArgsMixin):
     def get(self):
         """
         OIDC SSO login redirect
@@ -1519,7 +1519,7 @@ class OIDCLoginResource(Resource, ArgsMixin):
         return oidc.get_oidc_client().authorize_redirect(redirect_uri)
 
 
-class OIDCCallbackResource(Resource, ArgsMixin):
+class OIDCCallbackResource(MethodView, ArgsMixin):
     def get(self):
         """
         OIDC SSO callback

--- a/zou/app/blueprints/breakdown/resources.py
+++ b/zou/app/blueprints/breakdown/resources.py
@@ -1,5 +1,5 @@
 from flask import request
-from flask_restful import Resource
+from flask.views import MethodView
 from flask_jwt_extended import jwt_required
 
 from zou.app.services import (
@@ -19,7 +19,7 @@ from zou.app.blueprints.breakdown.schemas import (
 )
 
 
-class CastingResource(Resource):
+class CastingResource(MethodView):
     @jwt_required()
     def get(self, project_id, entity_id):
         """
@@ -175,7 +175,7 @@ class CastingResource(Resource):
         return breakdown_service.update_casting(entity_id, casting)
 
 
-class EpisodesCastingResource(Resource):
+class EpisodesCastingResource(MethodView):
     @jwt_required()
     def get(self, project_id):
         """
@@ -232,7 +232,7 @@ class EpisodesCastingResource(Resource):
         return breakdown_service.get_production_episodes_casting(project_id)
 
 
-class EpisodeSequenceAllCastingResource(Resource):
+class EpisodeSequenceAllCastingResource(MethodView):
     @jwt_required()
     def get(self, project_id, episode_id):
         """
@@ -298,7 +298,7 @@ class EpisodeSequenceAllCastingResource(Resource):
         )
 
 
-class SequenceAllCastingResource(Resource):
+class SequenceAllCastingResource(MethodView):
     @jwt_required()
     def get(self, project_id):
         """
@@ -364,7 +364,7 @@ class SequenceAllCastingResource(Resource):
         return breakdown_service.get_all_sequences_casting(project_id)
 
 
-class SequenceCastingResource(Resource):
+class SequenceCastingResource(MethodView):
     @jwt_required()
     def get(self, project_id, sequence_id):
         """
@@ -436,7 +436,7 @@ class SequenceCastingResource(Resource):
         return breakdown_service.get_sequence_casting(sequence_id)
 
 
-class AssetTypeCastingResource(Resource):
+class AssetTypeCastingResource(MethodView):
     @jwt_required()
     def get(self, project_id, asset_type_id):
         """
@@ -512,7 +512,7 @@ class AssetTypeCastingResource(Resource):
         )
 
 
-class ShotAssetInstancesResource(Resource, ArgsMixin):
+class ShotAssetInstancesResource(MethodView, ArgsMixin):
     @jwt_required()
     def get(self, shot_id):
         """
@@ -641,7 +641,7 @@ class ShotAssetInstancesResource(Resource, ArgsMixin):
         return shot, 201
 
 
-class RemoveShotAssetInstanceResource(Resource, ArgsMixin):
+class RemoveShotAssetInstanceResource(MethodView, ArgsMixin):
     @jwt_required()
     def delete(self, shot_id, asset_instance_id):
         """
@@ -677,7 +677,7 @@ class RemoveShotAssetInstanceResource(Resource, ArgsMixin):
         return "", 204
 
 
-class SceneAssetInstancesResource(Resource, ArgsMixin):
+class SceneAssetInstancesResource(MethodView, ArgsMixin):
     @jwt_required()
     def get(self, scene_id):
         """
@@ -809,7 +809,7 @@ class SceneAssetInstancesResource(Resource, ArgsMixin):
         return asset_instance, 201
 
 
-class SceneCameraInstancesResource(Resource):
+class SceneCameraInstancesResource(MethodView):
     @jwt_required()
     def get(self, scene_id):
         """
@@ -866,7 +866,7 @@ class SceneCameraInstancesResource(Resource):
         return breakdown_service.get_camera_instances_for_scene(scene_id)
 
 
-class ProjectEntityLinksResource(Resource, ArgsMixin):
+class ProjectEntityLinksResource(MethodView, ArgsMixin):
     @jwt_required()
     def get(self, project_id):
         """
@@ -946,7 +946,7 @@ class ProjectEntityLinksResource(Resource, ArgsMixin):
         )
 
 
-class ProjectEntityLinkResource(Resource):
+class ProjectEntityLinkResource(MethodView):
     @jwt_required()
     def delete(self, project_id, entity_link_id):
         """

--- a/zou/app/blueprints/chats/resources.py
+++ b/zou/app/blueprints/chats/resources.py
@@ -1,5 +1,5 @@
 from flask import request
-from flask_restful import Resource
+from flask.views import MethodView
 from flask_jwt_extended import jwt_required
 
 from zou.app.blueprints.chats.schemas import ChatMessageSchema
@@ -14,7 +14,7 @@ from zou.app.services import (
 from zou.app.services.exception import WrongParameterException
 
 
-class ChatResource(Resource):
+class ChatResource(MethodView):
 
     @jwt_required()
     def get(self, entity_id):
@@ -69,7 +69,7 @@ class ChatResource(Resource):
         return chat
 
 
-class ChatMessagesResource(Resource):
+class ChatMessagesResource(MethodView):
 
     @jwt_required()
     def get(self, entity_id):
@@ -223,7 +223,7 @@ class ChatMessagesResource(Resource):
         )
 
 
-class ChatMessageResource(Resource):
+class ChatMessageResource(MethodView):
 
     @jwt_required()
     def get(self, entity_id, chat_message_id):

--- a/zou/app/blueprints/comments/resources.py
+++ b/zou/app/blueprints/comments/resources.py
@@ -1,6 +1,6 @@
 
 from flask import request, send_file as flask_send_file, current_app
-from flask_restful import Resource
+from flask.views import MethodView
 from flask_jwt_extended import jwt_required
 
 from zou.app.mixin import ArgsMixin
@@ -27,7 +27,7 @@ from zou.app.services import (
 from zou.app import config
 
 
-class DownloadAttachmentResource(Resource):
+class DownloadAttachmentResource(MethodView):
 
     @jwt_required()
     def get(self, attachment_file_id, file_name):
@@ -109,7 +109,7 @@ class DownloadAttachmentResource(Resource):
             raise AttachmentFileNotFoundException
 
 
-class AckCommentResource(Resource):
+class AckCommentResource(MethodView):
 
     @jwt_required()
     def post(self, task_id, comment_id):
@@ -157,7 +157,7 @@ class AckCommentResource(Resource):
         return comments_service.acknowledge_comment(comment_id)
 
 
-class CommentTaskResource(Resource):
+class CommentTaskResource(MethodView):
 
     @jwt_required()
     def post(self, task_id):
@@ -298,7 +298,7 @@ class CommentTaskResource(Resource):
         )
 
 
-class AttachmentResource(Resource):
+class AttachmentResource(MethodView):
     @jwt_required()
     def delete(self, task_id, comment_id, attachment_id):
         """
@@ -346,7 +346,7 @@ class AttachmentResource(Resource):
         return "", 204
 
 
-class AddAttachmentToCommentResource(Resource):
+class AddAttachmentToCommentResource(MethodView):
     @jwt_required()
     def post(self, task_id, comment_id):
         """
@@ -435,7 +435,7 @@ class AddAttachmentToCommentResource(Resource):
         return comment["attachment_files"], 201
 
 
-class CommentManyTasksResource(Resource):
+class CommentManyTasksResource(MethodView):
 
     @jwt_required()
     def post(self, project_id):
@@ -598,7 +598,7 @@ class CommentManyTasksResource(Resource):
         return allowed_comments
 
 
-class ReplyCommentResource(Resource, ArgsMixin):
+class ReplyCommentResource(MethodView, ArgsMixin):
 
     @jwt_required()
     def post(self, task_id, comment_id):
@@ -683,7 +683,7 @@ class ReplyCommentResource(Resource, ArgsMixin):
         )
 
 
-class DeleteReplyCommentResource(Resource):
+class DeleteReplyCommentResource(MethodView):
 
     @jwt_required()
     def delete(self, task_id, comment_id, reply_id):
@@ -727,7 +727,7 @@ class DeleteReplyCommentResource(Resource):
         return comments_service.delete_reply(comment_id, reply_id)
 
 
-class ProjectAttachmentFiles(Resource):
+class ProjectAttachmentFiles(MethodView):
 
     @jwt_required()
     def get(self, project_id):
@@ -790,7 +790,7 @@ class ProjectAttachmentFiles(Resource):
         )
 
 
-class TaskAttachmentFiles(Resource):
+class TaskAttachmentFiles(MethodView):
 
     @jwt_required()
     def get(self, task_id):
@@ -856,7 +856,7 @@ class TaskAttachmentFiles(Resource):
         return comments_service.get_all_attachment_files_for_task(task_id)
 
 
-class MoveCommentResource(Resource):
+class MoveCommentResource(MethodView):
 
     @jwt_required()
     def post(self, task_id, comment_id):

--- a/zou/app/blueprints/concepts/resources.py
+++ b/zou/app/blueprints/concepts/resources.py
@@ -1,5 +1,5 @@
 from flask import request
-from flask_restful import Resource
+from flask.views import MethodView
 from flask_jwt_extended import jwt_required
 
 from zou.app.services import (
@@ -16,7 +16,7 @@ from zou.app.utils import query, permissions, validation
 from zou.app.blueprints.concepts.schemas import NewConceptSchema
 
 
-class ConceptResource(Resource, ArgsMixin):
+class ConceptResource(MethodView, ArgsMixin):
 
     @jwt_required()
     def get(self, concept_id):
@@ -116,7 +116,7 @@ class ConceptResource(Resource, ArgsMixin):
         return "", 204
 
 
-class AllConceptsResource(Resource):
+class AllConceptsResource(MethodView):
 
     @jwt_required()
     def get(self):
@@ -197,7 +197,7 @@ class AllConceptsResource(Resource):
         return concepts_service.get_concepts(criterions)
 
 
-class ConceptTaskTypesResource(Resource):
+class ConceptTaskTypesResource(MethodView):
 
     @jwt_required()
     def get(self, concept_id):
@@ -256,7 +256,7 @@ class ConceptTaskTypesResource(Resource):
         return tasks_service.get_task_types_for_concept(concept_id)
 
 
-class ConceptTasksResource(Resource, ArgsMixin):
+class ConceptTasksResource(MethodView, ArgsMixin):
 
     @jwt_required()
     def get(self, concept_id):
@@ -341,7 +341,7 @@ class ConceptTasksResource(Resource, ArgsMixin):
         )
 
 
-class ConceptPreviewsResource(Resource):
+class ConceptPreviewsResource(MethodView):
 
     @jwt_required()
     def get(self, concept_id):
@@ -409,7 +409,7 @@ class ConceptPreviewsResource(Resource):
         return playlists_service.get_preview_files_for_entity(concept_id)
 
 
-class ConceptsAndTasksResource(Resource):
+class ConceptsAndTasksResource(MethodView):
     @jwt_required()
     def get(self):
         """
@@ -504,7 +504,7 @@ class ConceptsAndTasksResource(Resource):
         return concepts_service.get_concepts_and_tasks(criterions)
 
 
-class ProjectConceptsResource(Resource, ArgsMixin):
+class ProjectConceptsResource(MethodView, ArgsMixin):
     @jwt_required()
     def get(self, project_id):
         """

--- a/zou/app/blueprints/crud/base.py
+++ b/zou/app/blueprints/crud/base.py
@@ -4,7 +4,7 @@ import orjson as json
 import sqlalchemy.orm as orm
 
 from flask import request, current_app
-from flask_restful import Resource
+from flask.views import MethodView
 from flask_jwt_extended import jwt_required
 
 from sqlalchemy.exc import IntegrityError, StatementError
@@ -18,9 +18,9 @@ from zou.app.services.exception import (
 )
 
 
-class BaseModelsResource(Resource, ArgsMixin):
+class BaseModelsResource(MethodView, ArgsMixin):
     def __init__(self, model):
-        Resource.__init__(self)
+        MethodView.__init__(self)
         self.model = model
         self.protected_fields = ["id", "created_at", "updated_at"]
 
@@ -351,9 +351,9 @@ class BaseModelsResource(Resource, ArgsMixin):
         )
 
 
-class BaseModelResource(Resource, ArgsMixin):
+class BaseModelResource(MethodView, ArgsMixin):
     def __init__(self, model):
-        Resource.__init__(self)
+        MethodView.__init__(self)
         self.protected_fields = ["id", "created_at", "updated_at"]
         self.model = model
         self.instance = None

--- a/zou/app/blueprints/crud/project.py
+++ b/zou/app/blueprints/crud/project.py
@@ -1,6 +1,6 @@
 from flask_jwt_extended import jwt_required
 
-from flask_restful import Resource
+from flask.views import MethodView
 
 
 from zou.app.mixin import ArgsMixin
@@ -551,7 +551,7 @@ class ProjectResource(BaseModelResource, ArgsMixin):
             return "", 204
 
 
-class ProjectTaskTypeLinksResource(Resource, ArgsMixin):
+class ProjectTaskTypeLinksResource(MethodView, ArgsMixin):
     @jwt_required()
     def post(self):
         """
@@ -629,7 +629,7 @@ class ProjectTaskTypeLinksResource(Resource, ArgsMixin):
         return task_type_link, 201
 
 
-class ProjectTaskStatusLinksResource(Resource, ArgsMixin):
+class ProjectTaskStatusLinksResource(MethodView, ArgsMixin):
     @jwt_required()
     def post(self):
         """

--- a/zou/app/blueprints/departments/resources.py
+++ b/zou/app/blueprints/departments/resources.py
@@ -1,4 +1,4 @@
-from flask_restful import Resource
+from flask.views import MethodView
 from flask_jwt_extended import jwt_required
 
 from zou.app.utils import permissions, validation
@@ -12,7 +12,7 @@ from zou.app.blueprints.departments.schemas import (
 )
 
 
-class AllDepartmentSoftwareResource(Resource, ArgsMixin):
+class AllDepartmentSoftwareResource(MethodView, ArgsMixin):
 
     @jwt_required()
     @permissions.require_admin
@@ -74,7 +74,7 @@ class AllDepartmentSoftwareResource(Resource, ArgsMixin):
         return softwares, 200
 
 
-class AddSoftwareToDepartmentResource(Resource, ArgsMixin):
+class AddSoftwareToDepartmentResource(MethodView, ArgsMixin):
 
     @jwt_required()
     @permissions.require_admin
@@ -146,7 +146,7 @@ class AddSoftwareToDepartmentResource(Resource, ArgsMixin):
         return software, 201
 
 
-class SoftwareDepartmentResource(Resource, ArgsMixin):
+class SoftwareDepartmentResource(MethodView, ArgsMixin):
 
     @jwt_required()
     @permissions.require_admin
@@ -252,7 +252,7 @@ class SoftwareDepartmentResource(Resource, ArgsMixin):
         return "", 204
 
 
-class AllDepartmentHardwareItemsResource(Resource, ArgsMixin):
+class AllDepartmentHardwareItemsResource(MethodView, ArgsMixin):
 
     @jwt_required()
     @permissions.require_admin
@@ -312,7 +312,7 @@ class AllDepartmentHardwareItemsResource(Resource, ArgsMixin):
         return hardware_items, 200
 
 
-class AddHardwareItemToDepartmentResource(Resource, ArgsMixin):
+class AddHardwareItemToDepartmentResource(MethodView, ArgsMixin):
 
     @jwt_required()
     @permissions.require_admin
@@ -388,7 +388,7 @@ class AddHardwareItemToDepartmentResource(Resource, ArgsMixin):
         return hardware_item_link, 201
 
 
-class HardwareItemDepartmentResource(Resource, ArgsMixin):
+class HardwareItemDepartmentResource(MethodView, ArgsMixin):
 
     @jwt_required()
     @permissions.require_admin

--- a/zou/app/blueprints/edits/resources.py
+++ b/zou/app/blueprints/edits/resources.py
@@ -1,5 +1,5 @@
 from flask import request
-from flask_restful import Resource
+from flask.views import MethodView
 from flask_jwt_extended import jwt_required
 
 from zou.app.services import (
@@ -16,7 +16,7 @@ from zou.app.utils import permissions, query, validation
 from zou.app.blueprints.edits.schemas import NewEditSchema
 
 
-class EditResource(Resource, ArgsMixin):
+class EditResource(MethodView, ArgsMixin):
     @jwt_required()
     def get(self, edit_id):
         """
@@ -116,7 +116,7 @@ class EditResource(Resource, ArgsMixin):
         return "", 204
 
 
-class EditsResource(Resource):
+class EditsResource(MethodView):
     @jwt_required()
     def get(self):
         """
@@ -199,7 +199,7 @@ class EditsResource(Resource):
         return edits_service.get_edits(criterions)
 
 
-class AllEditsResource(Resource):
+class AllEditsResource(MethodView):
     @jwt_required()
     def get(self):
         """
@@ -282,7 +282,7 @@ class AllEditsResource(Resource):
         return edits_service.get_edits(criterions)
 
 
-class EditTaskTypesResource(Resource):
+class EditTaskTypesResource(MethodView):
     @jwt_required()
     def get(self, edit_id):
         """
@@ -337,7 +337,7 @@ class EditTaskTypesResource(Resource):
         return tasks_service.get_task_types_for_edit(edit_id)
 
 
-class EditTasksResource(Resource, ArgsMixin):
+class EditTasksResource(MethodView, ArgsMixin):
     @jwt_required()
     def get(self, edit_id):
         """
@@ -417,7 +417,7 @@ class EditTasksResource(Resource, ArgsMixin):
         return tasks_service.get_tasks_for_edit(edit_id, relations=relations)
 
 
-class EpisodeEditTasksResource(Resource, ArgsMixin):
+class EpisodeEditTasksResource(MethodView, ArgsMixin):
     @jwt_required()
     def get(self, episode_id):
         """
@@ -501,7 +501,7 @@ class EpisodeEditTasksResource(Resource, ArgsMixin):
         )
 
 
-class EpisodeEditsResource(Resource, ArgsMixin):
+class EpisodeEditsResource(MethodView, ArgsMixin):
     @jwt_required()
     def get(self, episode_id):
         """
@@ -577,7 +577,7 @@ class EpisodeEditsResource(Resource, ArgsMixin):
         )
 
 
-class EditPreviewsResource(Resource):
+class EditPreviewsResource(MethodView):
     @jwt_required()
     def get(self, edit_id):
         """
@@ -642,7 +642,7 @@ class EditPreviewsResource(Resource):
         return playlists_service.get_preview_files_for_entity(edit_id)
 
 
-class EditsAndTasksResource(Resource):
+class EditsAndTasksResource(MethodView):
     @jwt_required()
     def get(self):
         """
@@ -753,7 +753,7 @@ class EditsAndTasksResource(Resource):
         return edits_service.get_edits_and_tasks(criterions)
 
 
-class ProjectEditsResource(Resource, ArgsMixin):
+class ProjectEditsResource(MethodView, ArgsMixin):
     @jwt_required()
     def get(self, project_id):
         """
@@ -928,7 +928,7 @@ class ProjectEditsResource(Resource, ArgsMixin):
         return edit, 201
 
 
-class EditVersionsResource(Resource):
+class EditVersionsResource(MethodView):
     """
     Retrieve data versions of given edit.
     """

--- a/zou/app/blueprints/entities/resources.py
+++ b/zou/app/blueprints/entities/resources.py
@@ -1,4 +1,4 @@
-from flask_restful import Resource
+from flask.views import MethodView
 
 from flask_jwt_extended import jwt_required
 
@@ -14,7 +14,7 @@ from zou.app.services import (
 from zou.app.utils import permissions, validation
 
 
-class EntityNewsResource(Resource):
+class EntityNewsResource(MethodView):
     @jwt_required()
     def get(self, entity_id):
         """
@@ -88,7 +88,7 @@ class EntityNewsResource(Resource):
         return news_service.get_news_for_entity(entity_id)
 
 
-class EntityPreviewFilesResource(Resource):
+class EntityPreviewFilesResource(MethodView):
     @jwt_required()
     def get(self, entity_id):
         """
@@ -156,7 +156,7 @@ class EntityPreviewFilesResource(Resource):
         return preview_files_service.get_preview_files_for_entity(entity_id)
 
 
-class EntityTimeSpentsResource(Resource):
+class EntityTimeSpentsResource(MethodView):
     @jwt_required()
     def get(self, entity_id):
         """
@@ -221,7 +221,7 @@ class EntityTimeSpentsResource(Resource):
         return time_spents_service.get_time_spents_for_entity(entity_id)
 
 
-class EntitiesLinkedWithTasksResource(Resource):
+class EntitiesLinkedWithTasksResource(MethodView):
     @jwt_required()
     def get(self, entity_id):
         """
@@ -300,7 +300,7 @@ class EntitiesLinkedWithTasksResource(Resource):
         return entities_service.get_linked_entities_with_tasks(entity_id)
 
 
-class EntityTaskCreationResource(Resource):
+class EntityTaskCreationResource(MethodView):
     @jwt_required()
     def post(self, entity_id):
         """

--- a/zou/app/blueprints/events/resources.py
+++ b/zou/app/blueprints/events/resources.py
@@ -1,4 +1,4 @@
-from flask_restful import Resource
+from flask.views import MethodView
 from flask_jwt_extended import jwt_required
 
 from zou.app.mixin import ArgsMixin
@@ -8,7 +8,7 @@ from zou.app.services import events_service
 from zou.app.services.exception import WrongParameterException
 
 
-class EventsResource(Resource, ArgsMixin):
+class EventsResource(MethodView, ArgsMixin):
     @jwt_required()
     def get(self):
         """
@@ -142,7 +142,7 @@ class EventsResource(Resource, ArgsMixin):
         )
 
 
-class LoginLogsResource(Resource, ArgsMixin):
+class LoginLogsResource(MethodView, ArgsMixin):
     @jwt_required()
     def get(self):
         """

--- a/zou/app/blueprints/export/csv/assets.py
+++ b/zou/app/blueprints/export/csv/assets.py
@@ -1,4 +1,4 @@
-from flask_restful import Resource
+from flask.views import MethodView
 from flask import request
 from flask_jwt_extended import jwt_required
 from slugify import slugify
@@ -13,7 +13,7 @@ from zou.app.services import (
 from zou.app.utils import csv_utils, query
 
 
-class AssetsCsvExport(Resource):
+class AssetsCsvExport(MethodView):
     @jwt_required()
     def get(self, project_id):
         """

--- a/zou/app/blueprints/export/csv/base.py
+++ b/zou/app/blueprints/export/csv/base.py
@@ -1,13 +1,13 @@
 from flask import abort
 from flask_jwt_extended import jwt_required
 
-from flask_restful import Resource
+from flask.views import MethodView
 from zou.app.utils import csv_utils, permissions
 
 
-class BaseCsvExport(Resource):
+class BaseCsvExport(MethodView):
     def __init__(self):
-        Resource.__init__(self)
+        MethodView.__init__(self)
         self.file_name = "export"
 
     def check_permissions(self):

--- a/zou/app/blueprints/export/csv/casting.py
+++ b/zou/app/blueprints/export/csv/casting.py
@@ -1,4 +1,4 @@
-from flask_restful import Resource
+from flask.views import MethodView
 from flask_jwt_extended import jwt_required
 from slugify import slugify
 from sqlalchemy.orm import aliased
@@ -12,7 +12,7 @@ from zou.app.utils import csv_utils
 from zou.app.mixin import ArgsMixin
 
 
-class CastingCsvExport(Resource, ArgsMixin):
+class CastingCsvExport(MethodView, ArgsMixin):
     @jwt_required()
     def get(self, project_id):
         """

--- a/zou/app/blueprints/export/csv/edits.py
+++ b/zou/app/blueprints/export/csv/edits.py
@@ -1,4 +1,4 @@
-from flask_restful import Resource
+from flask.views import MethodView
 from flask_jwt_extended import jwt_required
 from slugify import slugify
 
@@ -12,7 +12,7 @@ from zou.app.services import (
 from zou.app.utils import csv_utils
 
 
-class EditsCsvExport(Resource):
+class EditsCsvExport(MethodView):
     @jwt_required()
     def get(self, project_id):
         """

--- a/zou/app/blueprints/export/csv/playlists.py
+++ b/zou/app/blueprints/export/csv/playlists.py
@@ -1,4 +1,4 @@
-from flask_restful import Resource
+from flask.views import MethodView
 from flask_jwt_extended import jwt_required
 from slugify import slugify
 
@@ -18,7 +18,7 @@ from zou.app.services import (
 from zou.app.utils import csv_utils
 
 
-class PlaylistCsvExport(Resource):
+class PlaylistCsvExport(MethodView):
     @jwt_required()
     def get(self, playlist_id):
         """

--- a/zou/app/blueprints/export/csv/shots.py
+++ b/zou/app/blueprints/export/csv/shots.py
@@ -1,4 +1,4 @@
-from flask_restful import Resource
+from flask.views import MethodView
 from flask import request
 from flask_jwt_extended import jwt_required
 from slugify import slugify
@@ -13,7 +13,7 @@ from zou.app.services import (
 from zou.app.utils import csv_utils, query
 
 
-class ShotsCsvExport(Resource):
+class ShotsCsvExport(MethodView):
     @jwt_required()
     def get(self, project_id):
         """

--- a/zou/app/blueprints/files/resources.py
+++ b/zou/app/blueprints/files/resources.py
@@ -2,7 +2,7 @@ import os
 
 from flask import request, abort, current_app
 from flask import send_file as flask_send_file
-from flask_restful import Resource
+from flask.views import MethodView
 from flask_jwt_extended import jwt_required
 from flask_fs.errors import FileNotFound
 from zou.app import config
@@ -95,7 +95,7 @@ def send_storage_file(
         )
 
 
-class WorkingFileFileResource(Resource):
+class WorkingFileFileResource(MethodView):
 
     def check_access(self, working_file_id):
         working_file = files_service.get_working_file(working_file_id)
@@ -249,7 +249,7 @@ class WorkingFileFileResource(Resource):
         return working_file, 201
 
 
-class WorkingFilePathResource(Resource, ArgsMixin):
+class WorkingFilePathResource(MethodView, ArgsMixin):
 
     @jwt_required()
     def post(self, task_id):
@@ -384,7 +384,7 @@ class WorkingFilePathResource(Resource, ArgsMixin):
         )
 
 
-class EntityOutputFilePathResource(Resource, ArgsMixin):
+class EntityOutputFilePathResource(MethodView, ArgsMixin):
 
     @jwt_required()
     def post(self, entity_id):
@@ -520,7 +520,7 @@ class EntityOutputFilePathResource(Resource, ArgsMixin):
         return body.model_dump()
 
 
-class InstanceOutputFilePathResource(Resource, ArgsMixin):
+class InstanceOutputFilePathResource(MethodView, ArgsMixin):
 
     @jwt_required()
     def post(self, asset_instance_id, temporal_entity_id):
@@ -659,7 +659,7 @@ class InstanceOutputFilePathResource(Resource, ArgsMixin):
         return body.model_dump()
 
 
-class LastWorkingFilesResource(Resource):
+class LastWorkingFilesResource(MethodView):
 
     @jwt_required()
     def get(self, task_id):
@@ -716,7 +716,7 @@ class LastWorkingFilesResource(Resource):
         return result
 
 
-class TaskWorkingFilesResource(Resource):
+class TaskWorkingFilesResource(MethodView):
 
     @jwt_required()
     def get(self, task_id):
@@ -777,7 +777,7 @@ class TaskWorkingFilesResource(Resource):
         return result
 
 
-class NewWorkingFileResource(Resource, ArgsMixin):
+class NewWorkingFileResource(MethodView, ArgsMixin):
 
     @jwt_required()
     def post(self, task_id):
@@ -959,7 +959,7 @@ class NewWorkingFileResource(Resource, ArgsMixin):
         )
 
 
-class ModifiedFileResource(Resource):
+class ModifiedFileResource(MethodView):
 
     @jwt_required()
     def put(self, working_file_id):
@@ -1007,7 +1007,7 @@ class ModifiedFileResource(Resource):
         return working_file
 
 
-class CommentWorkingFileResource(Resource, ArgsMixin):
+class CommentWorkingFileResource(MethodView, ArgsMixin):
 
     @jwt_required()
     def put(self, working_file_id):
@@ -1077,7 +1077,7 @@ class CommentWorkingFileResource(Resource, ArgsMixin):
         return working_file
 
 
-class NewEntityOutputFileResource(Resource, ArgsMixin):
+class NewEntityOutputFileResource(MethodView, ArgsMixin):
 
     @jwt_required()
     def post(self, entity_id):
@@ -1323,7 +1323,7 @@ class NewEntityOutputFileResource(Resource, ArgsMixin):
         return output_file
 
 
-class NewInstanceOutputFileResource(Resource, ArgsMixin):
+class NewInstanceOutputFileResource(MethodView, ArgsMixin):
 
     @jwt_required()
     def post(self, asset_instance_id, temporal_entity_id):
@@ -1591,7 +1591,7 @@ class NewInstanceOutputFileResource(Resource, ArgsMixin):
         return output_file
 
 
-class GetNextEntityOutputFileRevisionResource(Resource, ArgsMixin):
+class GetNextEntityOutputFileRevisionResource(MethodView, ArgsMixin):
 
     @jwt_required()
     def post(self, entity_id):
@@ -1663,7 +1663,7 @@ class GetNextEntityOutputFileRevisionResource(Resource, ArgsMixin):
         return {"next_revision": next_revision_number}, 200
 
 
-class GetNextInstanceOutputFileRevisionResource(Resource, ArgsMixin):
+class GetNextInstanceOutputFileRevisionResource(MethodView, ArgsMixin):
 
     @jwt_required()
     def post(self, asset_instance_id, temporal_entity_id):
@@ -1750,7 +1750,7 @@ class GetNextInstanceOutputFileRevisionResource(Resource, ArgsMixin):
         return {"next_revision": next_revision_number}, 200
 
 
-class LastEntityOutputFilesResource(Resource, ArgsMixin):
+class LastEntityOutputFilesResource(MethodView, ArgsMixin):
 
     @jwt_required()
     def get(self, entity_id):
@@ -1865,7 +1865,7 @@ class LastEntityOutputFilesResource(Resource, ArgsMixin):
         )
 
 
-class LastInstanceOutputFilesResource(Resource, ArgsMixin):
+class LastInstanceOutputFilesResource(MethodView, ArgsMixin):
 
     @jwt_required()
     def get(self, asset_instance_id, temporal_entity_id):
@@ -1990,7 +1990,7 @@ class LastInstanceOutputFilesResource(Resource, ArgsMixin):
         )
 
 
-class EntityOutputTypesResource(Resource):
+class EntityOutputTypesResource(MethodView):
 
     @jwt_required()
     def get(self, entity_id):
@@ -2050,7 +2050,7 @@ class EntityOutputTypesResource(Resource):
         return files_service.get_output_types_for_entity(entity_id)
 
 
-class InstanceOutputTypesResource(Resource):
+class InstanceOutputTypesResource(MethodView):
 
     @jwt_required()
     def get(self, asset_instance_id, temporal_entity_id):
@@ -2121,7 +2121,7 @@ class InstanceOutputTypesResource(Resource):
         )
 
 
-class EntityOutputTypeOutputFilesResource(Resource, ArgsMixin):
+class EntityOutputTypeOutputFilesResource(MethodView, ArgsMixin):
 
     @jwt_required()
     def get(self, entity_id, output_type_id):
@@ -2208,7 +2208,7 @@ class EntityOutputTypeOutputFilesResource(Resource, ArgsMixin):
         return output_files
 
 
-class InstanceOutputTypeOutputFilesResource(Resource, ArgsMixin):
+class InstanceOutputTypeOutputFilesResource(MethodView, ArgsMixin):
 
     @jwt_required()
     def get(self, asset_instance_id, temporal_entity_id, output_type_id):
@@ -2312,7 +2312,7 @@ class InstanceOutputTypeOutputFilesResource(Resource, ArgsMixin):
         )
 
 
-class ProjectOutputFilesResource(Resource, ArgsMixin):
+class ProjectOutputFilesResource(MethodView, ArgsMixin):
 
     @jwt_required()
     def get(self, project_id):
@@ -2430,7 +2430,7 @@ class ProjectOutputFilesResource(Resource, ArgsMixin):
         )
 
 
-class EntityOutputFilesResource(Resource, ArgsMixin):
+class EntityOutputFilesResource(MethodView, ArgsMixin):
 
     @jwt_required()
     def get(self, entity_id):
@@ -2550,7 +2550,7 @@ class EntityOutputFilesResource(Resource, ArgsMixin):
         )
 
 
-class InstanceOutputFilesResource(Resource):
+class InstanceOutputFilesResource(MethodView):
 
     @jwt_required()
     def get(self, asset_instance_id):
@@ -2686,7 +2686,7 @@ class InstanceOutputFilesResource(Resource):
         )
 
 
-class FileResource(Resource):
+class FileResource(MethodView):
 
     @jwt_required()
     def get(self, file_id):
@@ -2761,7 +2761,7 @@ class FileResource(Resource):
         return file_dict
 
 
-class SetTreeResource(Resource, ArgsMixin):
+class SetTreeResource(MethodView, ArgsMixin):
 
     @jwt_required()
     def post(self, project_id):
@@ -2836,7 +2836,7 @@ class SetTreeResource(Resource, ArgsMixin):
         return project
 
 
-class EntityWorkingFilesResource(Resource, ArgsMixin):
+class EntityWorkingFilesResource(MethodView, ArgsMixin):
 
     @jwt_required()
     def get(self, entity_id):
@@ -2935,7 +2935,7 @@ class EntityWorkingFilesResource(Resource, ArgsMixin):
         )
 
 
-class GuessFromPathResource(Resource, ArgsMixin):
+class GuessFromPathResource(MethodView, ArgsMixin):
 
     @jwt_required()
     def post(self):

--- a/zou/app/blueprints/index/resources.py
+++ b/zou/app/blueprints/index/resources.py
@@ -5,7 +5,7 @@ import redis
 import requests
 from flask import Response, abort
 from flask_jwt_extended import jwt_required
-from flask_restful import Resource
+from flask.views import MethodView
 
 from zou import __version__
 from zou.app import app, config
@@ -19,7 +19,7 @@ from zou.app.utils import date_helpers, permissions, shell
 from zou.app.utils.redis import get_redis_url
 
 
-class IndexResource(Resource):
+class IndexResource(MethodView):
     def get(self):
         """
         Get API name and version
@@ -44,7 +44,7 @@ class IndexResource(Resource):
         return {"api": config.APP_NAME, "version": __version__}
 
 
-class BaseStatusResource(Resource):
+class BaseStatusResource(MethodView):
 
     def get_status(self):
         is_db_up = self._check_database()
@@ -380,7 +380,7 @@ class InfluxStatusResource(BaseStatusResource):
         }
 
 
-class StatsResource(Resource):
+class StatsResource(MethodView):
     @jwt_required()
     def get(self):
         """
@@ -418,7 +418,7 @@ class StatsResource(Resource):
         return stats_service.get_main_stats()
 
 
-class ConfigResource(Resource):
+class ConfigResource(MethodView):
     def get(self):
         """
         Get the configuration of the Kitsu instance
@@ -490,7 +490,7 @@ class ConfigResource(Resource):
         return conf
 
 
-class TestEventsResource(Resource):
+class TestEventsResource(MethodView):
     def get(self):
         """
         Generate a test event

--- a/zou/app/blueprints/news/resources.py
+++ b/zou/app/blueprints/news/resources.py
@@ -1,4 +1,4 @@
-from flask_restful import Resource, inputs
+from flask.views import MethodView
 from flask_jwt_extended import jwt_required
 
 from zou.app.mixin import ArgsMixin
@@ -9,7 +9,7 @@ from zou.app.services import (
     persons_service,
 )
 from zou.app.services.exception import NewsNotFoundException
-from zou.app.utils import permissions
+from zou.app.utils import fields, permissions
 
 
 class NewsMixin(ArgsMixin):
@@ -65,7 +65,7 @@ class NewsMixin(ArgsMixin):
                     "only_preview",
                     False,
                     False,
-                    inputs.boolean,
+                    fields.boolean,
                 ),
                 "task_type_id",
                 "task_status_id",
@@ -91,7 +91,7 @@ class NewsMixin(ArgsMixin):
         )
 
 
-class ProjectNewsResource(Resource, NewsMixin, ArgsMixin):
+class ProjectNewsResource(MethodView, NewsMixin, ArgsMixin):
 
     @jwt_required()
     def get(self, project_id):
@@ -223,7 +223,7 @@ class ProjectNewsResource(Resource, NewsMixin, ArgsMixin):
         return self.get_news([project_id])
 
 
-class NewsResource(Resource, NewsMixin, ArgsMixin):
+class NewsResource(MethodView, NewsMixin, ArgsMixin):
 
     @jwt_required()
     def get(self):
@@ -348,7 +348,7 @@ class NewsResource(Resource, NewsMixin, ArgsMixin):
         return self.get_news(project_ids=open_project_ids)
 
 
-class ProjectSingleNewsResource(Resource):
+class ProjectSingleNewsResource(MethodView):
 
     @jwt_required()
     def get(self, project_id, news_id):

--- a/zou/app/blueprints/persons/resources.py
+++ b/zou/app/blueprints/persons/resources.py
@@ -2,7 +2,7 @@ import datetime
 import ipaddress
 
 from flask import abort, request, current_app
-from flask_restful import Resource
+from flask.views import MethodView
 from flask_jwt_extended import jwt_required
 
 from zou.app.mixin import ArgsMixin
@@ -65,7 +65,7 @@ def _get_project_department_ids_for_person_access(person_id):
     return (project_ids, department_ids)
 
 
-class DesktopLoginsResource(Resource, ArgsMixin):
+class DesktopLoginsResource(MethodView, ArgsMixin):
 
     @jwt_required()
     def get(self, person_id):
@@ -199,7 +199,7 @@ class DesktopLoginsResource(Resource, ArgsMixin):
         return desktop_login_log, 201
 
 
-class PresenceLogsResource(Resource):
+class PresenceLogsResource(MethodView):
 
     @jwt_required()
     def get(self, month_date):
@@ -241,7 +241,7 @@ class PresenceLogsResource(Resource):
         return csv_utils.build_csv_response(presence_logs)
 
 
-class TimeSpentsResource(Resource, ArgsMixin):
+class TimeSpentsResource(MethodView, ArgsMixin):
 
     @jwt_required()
     def get(self, person_id):
@@ -333,7 +333,7 @@ class TimeSpentsResource(Resource, ArgsMixin):
             )
 
 
-class DateTimeSpentsResource(Resource):
+class DateTimeSpentsResource(MethodView):
 
     @jwt_required()
     def get(self, person_id, date):
@@ -408,7 +408,7 @@ class DateTimeSpentsResource(Resource):
             raise WrongParameterException("Invalid month or year.")
 
 
-class DayOffResource(Resource):
+class DayOffResource(MethodView):
 
     @jwt_required()
     def get(self, person_id, date):
@@ -475,7 +475,7 @@ class DayOffResource(Resource):
             raise WrongParameterException("Invalid date format.")
 
 
-class PersonDurationTimeSpentsResource(Resource, ArgsMixin):
+class PersonDurationTimeSpentsResource(MethodView, ArgsMixin):
 
     def get_project_department_arguments(self, person_id):
         project_id = self.get_project_id()
@@ -621,7 +621,7 @@ class PersonMonthTimeSpentsResource(PersonDurationTimeSpentsResource):
             raise WrongParameterException("Invalid date format.")
 
 
-class PersonMonthAllTimeSpentsResource(Resource):
+class PersonMonthAllTimeSpentsResource(MethodView):
 
     @jwt_required()
     def get(self, person_id, year, month):
@@ -880,7 +880,7 @@ class PersonQuotaMixin(ArgsMixin):
             raise WrongParameterException("Invalid month or year.")
 
 
-class PersonMonthQuotaShotsResource(Resource, PersonQuotaMixin):
+class PersonMonthQuotaShotsResource(MethodView, PersonQuotaMixin):
 
     def get_person_quotas(self, person_id, year, month, **kwargs):
         return shots_service.get_month_quota_shots(
@@ -943,7 +943,7 @@ class PersonMonthQuotaShotsResource(Resource, PersonQuotaMixin):
         return super().get(person_id, year, month)
 
 
-class PersonWeekQuotaShotsResource(Resource, PersonQuotaMixin):
+class PersonWeekQuotaShotsResource(MethodView, PersonQuotaMixin):
 
     def get_person_quotas(self, person_id, year, week, **kwargs):
         return shots_service.get_week_quota_shots(
@@ -1006,7 +1006,7 @@ class PersonWeekQuotaShotsResource(Resource, PersonQuotaMixin):
         return super().get(person_id, year, week)
 
 
-class PersonDayQuotaShotsResource(Resource, PersonQuotaMixin):
+class PersonDayQuotaShotsResource(MethodView, PersonQuotaMixin):
 
     def get_person_quotas(self, person_id, year, month, day, **kwargs):
         return shots_service.get_day_quota_shots(
@@ -1078,7 +1078,7 @@ class PersonDayQuotaShotsResource(Resource, PersonQuotaMixin):
         return super().get(person_id, year, month, day)
 
 
-class TimeSpentDurationResource(Resource, ArgsMixin):
+class TimeSpentDurationResource(MethodView, ArgsMixin):
     """
     Parent class for all durations time spents resource.
     """
@@ -1258,7 +1258,7 @@ class TimeSpentWeekResource(TimeSpentDurationResource):
         )
 
 
-class InvitePersonResource(Resource):
+class InvitePersonResource(MethodView):
 
     @jwt_required()
     def get(self, person_id):
@@ -1301,7 +1301,7 @@ class InvitePersonResource(Resource):
         return {"success": True, "message": "Email sent"}
 
 
-class ResetPasswordLinkResource(Resource):
+class ResetPasswordLinkResource(MethodView):
 
     @jwt_required()
     def post(self, person_id):
@@ -1356,7 +1356,7 @@ class ResetPasswordLinkResource(Resource):
             return {"error": True, "message": exception.description}, 400
 
 
-class DayOffForMonthResource(Resource, ArgsMixin):
+class DayOffForMonthResource(MethodView, ArgsMixin):
 
     @jwt_required()
     def get(self, year, month):
@@ -1403,7 +1403,7 @@ class DayOffForMonthResource(Resource, ArgsMixin):
             )
 
 
-class PersonWeekDayOffResource(Resource, ArgsMixin):
+class PersonWeekDayOffResource(MethodView, ArgsMixin):
 
     @jwt_required()
     def get(self, person_id, year, week):
@@ -1455,7 +1455,7 @@ class PersonWeekDayOffResource(Resource, ArgsMixin):
         )
 
 
-class PersonMonthDayOffResource(Resource, ArgsMixin):
+class PersonMonthDayOffResource(MethodView, ArgsMixin):
 
     @jwt_required()
     def get(self, person_id, year, month):
@@ -1507,7 +1507,7 @@ class PersonMonthDayOffResource(Resource, ArgsMixin):
         )
 
 
-class PersonYearDayOffResource(Resource, ArgsMixin):
+class PersonYearDayOffResource(MethodView, ArgsMixin):
 
     @jwt_required()
     def get(self, person_id, year):
@@ -1550,7 +1550,7 @@ class PersonYearDayOffResource(Resource, ArgsMixin):
         )
 
 
-class PersonDayOffResource(Resource, ArgsMixin):
+class PersonDayOffResource(MethodView, ArgsMixin):
 
     @jwt_required()
     def get(self, person_id):
@@ -1586,7 +1586,7 @@ class PersonDayOffResource(Resource, ArgsMixin):
         )
 
 
-class AddToDepartmentResource(Resource, ArgsMixin):
+class AddToDepartmentResource(MethodView, ArgsMixin):
 
     @jwt_required()
     def post(self, person_id):
@@ -1654,7 +1654,7 @@ class AddToDepartmentResource(Resource, ArgsMixin):
         return person, 201
 
 
-class RemoveFromDepartmentResource(Resource, ArgsMixin):
+class RemoveFromDepartmentResource(MethodView, ArgsMixin):
 
     @jwt_required()
     def delete(self, person_id, department_id):
@@ -1696,7 +1696,7 @@ class RemoveFromDepartmentResource(Resource, ArgsMixin):
         return "", 204
 
 
-class ChangePasswordForPersonResource(Resource, ArgsMixin):
+class ChangePasswordForPersonResource(MethodView, ArgsMixin):
 
     @jwt_required()
     def post(self, person_id):
@@ -1814,7 +1814,7 @@ class ChangePasswordForPersonResource(Resource, ArgsMixin):
             )
 
 
-class DisableTwoFactorAuthenticationPersonResource(Resource, ArgsMixin):
+class DisableTwoFactorAuthenticationPersonResource(MethodView, ArgsMixin):
 
     @jwt_required()
     def delete(self, person_id):
@@ -1901,7 +1901,7 @@ class DisableTwoFactorAuthenticationPersonResource(Resource, ArgsMixin):
             }, 400
 
 
-class ClearAvatarPersonResource(Resource):
+class ClearAvatarPersonResource(MethodView):
     @jwt_required()
     def delete(self, person_id):
         """

--- a/zou/app/blueprints/playlists/resources.py
+++ b/zou/app/blueprints/playlists/resources.py
@@ -7,7 +7,7 @@ from flask import (
     request,
     send_file as flask_send_file,
 )
-from flask_restful import Resource
+from flask.views import MethodView
 from flask_jwt_extended import jwt_required
 
 from zou.app import config
@@ -41,7 +41,7 @@ from zou.app.utils import fs, permissions, validation
 from zou.utils.movie import EncodingParameters
 
 
-class ProjectPlaylistsResource(Resource, ArgsMixin):
+class ProjectPlaylistsResource(MethodView, ArgsMixin):
 
     @jwt_required()
     def get(self, project_id):
@@ -122,7 +122,7 @@ class ProjectPlaylistsResource(Resource, ArgsMixin):
         )
 
 
-class EpisodePlaylistsResource(Resource, ArgsMixin):
+class EpisodePlaylistsResource(MethodView, ArgsMixin):
 
     @jwt_required()
     def get(self, project_id, episode_id):
@@ -193,7 +193,7 @@ class EpisodePlaylistsResource(Resource, ArgsMixin):
         )
 
 
-class ProjectPlaylistResource(Resource):
+class ProjectPlaylistResource(MethodView):
 
     @jwt_required()
     def get(self, project_id, playlist_id):
@@ -259,7 +259,7 @@ class ProjectPlaylistResource(Resource):
         )
 
 
-class EntityPreviewsResource(Resource):
+class EntityPreviewsResource(MethodView):
 
     @jwt_required()
     def get(self, entity_id):
@@ -308,7 +308,7 @@ class EntityPreviewsResource(Resource):
         return playlists_service.get_preview_files_for_entity(entity_id)
 
 
-class PlaylistAddEntityResource(Resource, ArgsMixin):
+class PlaylistAddEntityResource(MethodView, ArgsMixin):
 
     @jwt_required()
     def post(self, playlist_id):
@@ -364,7 +364,7 @@ class PlaylistAddEntityResource(Resource, ArgsMixin):
         return updated_playlist
 
 
-class PlaylistDownloadResource(Resource):
+class PlaylistDownloadResource(MethodView):
 
     @jwt_required()
     def get(self, playlist_id, build_job_id):
@@ -451,7 +451,7 @@ class PlaylistDownloadResource(Resource):
         )
 
 
-class BuildPlaylistMovieResource(Resource, ArgsMixin):
+class BuildPlaylistMovieResource(MethodView, ArgsMixin):
 
     @jwt_required()
     def get(self, playlist_id):
@@ -560,7 +560,7 @@ class BuildPlaylistMovieResource(Resource, ArgsMixin):
             return job
 
 
-class PlaylistZipDownloadResource(Resource):
+class PlaylistZipDownloadResource(MethodView):
 
     @jwt_required()
     def get(self, playlist_id):
@@ -619,7 +619,7 @@ class PlaylistZipDownloadResource(Resource):
         )
 
 
-class BuildJobResource(Resource):
+class BuildJobResource(MethodView):
 
     @jwt_required()
     def get(self, playlist_id, build_job_id):
@@ -716,7 +716,7 @@ class BuildJobResource(Resource):
         return "", 204
 
 
-class ProjectBuildJobsResource(Resource):
+class ProjectBuildJobsResource(MethodView):
 
     @jwt_required()
     def get(self, project_id):
@@ -766,7 +766,7 @@ class ProjectBuildJobsResource(Resource):
         return playlists_service.get_build_jobs_for_project(project_id)
 
 
-class ProjectAllPlaylistsResource(Resource, ArgsMixin):
+class ProjectAllPlaylistsResource(MethodView, ArgsMixin):
 
     @jwt_required()
     def get(self, project_id):
@@ -817,7 +817,7 @@ class ProjectAllPlaylistsResource(Resource, ArgsMixin):
         return playlists_service.get_playlists_for_project(project_id, page)
 
 
-class TempPlaylistResource(Resource, ArgsMixin):
+class TempPlaylistResource(MethodView, ArgsMixin):
 
     @jwt_required()
     def post(self, project_id):
@@ -893,7 +893,7 @@ class TempPlaylistResource(Resource, ArgsMixin):
         )
 
 
-class NotifyClientsResource(Resource, ArgsMixin):
+class NotifyClientsResource(MethodView, ArgsMixin):
 
     @jwt_required()
     def post(self, playlist_id):
@@ -956,7 +956,7 @@ class NotifyClientsResource(Resource, ArgsMixin):
         return {"status": "success"}
 
 
-class PlaylistShareLinksResource(Resource):
+class PlaylistShareLinksResource(MethodView):
     """
     Manage share links for a playlist (manager+).
     """
@@ -987,7 +987,7 @@ class PlaylistShareLinksResource(Resource):
         return share_link, 201
 
 
-class PlaylistShareLinkResource(Resource):
+class PlaylistShareLinkResource(MethodView):
     """
     Revoke a specific share link (manager+).
     """
@@ -1008,7 +1008,7 @@ class PlaylistShareLinkResource(Resource):
         return playlist_sharing_service.revoke_share_link(token)
 
 
-class PlaylistShareLinkInviteResource(Resource):
+class PlaylistShareLinkInviteResource(MethodView):
     """
     Email a share link to one or more recipients (manager+).
 

--- a/zou/app/blueprints/previews/resources.py
+++ b/zou/app/blueprints/previews/resources.py
@@ -3,7 +3,7 @@ import orjson as json
 
 from flask import request, current_app
 from flask import send_file as flask_send_file
-from flask_restful import Resource
+from flask.views import MethodView
 from flask_jwt_extended import jwt_required
 from flask_fs.errors import FileNotFound
 from werkzeug.exceptions import NotFound
@@ -428,7 +428,7 @@ class BaseNewPreviewFilePicture:
 
 
 class CreatePreviewFilePictureResource(
-    BaseNewPreviewFilePicture, Resource, ArgsMixin
+    BaseNewPreviewFilePicture, MethodView, ArgsMixin
 ):
 
     @jwt_required()
@@ -604,7 +604,7 @@ class BaseBatchComment(BaseNewPreviewFilePicture, ArgsMixin):
         return new_comments, 201
 
 
-class AddTaskBatchCommentResource(BaseBatchComment, Resource):
+class AddTaskBatchCommentResource(BaseBatchComment, MethodView):
 
     @jwt_required()
     def post(self, task_id):
@@ -651,7 +651,7 @@ class AddTaskBatchCommentResource(BaseBatchComment, Resource):
         return self.process_comments(task_id)
 
 
-class AddTasksBatchCommentResource(BaseBatchComment, Resource):
+class AddTasksBatchCommentResource(BaseBatchComment, MethodView):
 
     @jwt_required()
     def post(self):
@@ -689,13 +689,13 @@ class AddTasksBatchCommentResource(BaseBatchComment, Resource):
         return self.process_comments()
 
 
-class BasePreviewFileResource(Resource):
+class BasePreviewFileResource(MethodView):
     """
     Base class to download a preview file.
     """
 
     def __init__(self):
-        Resource.__init__(self)
+        MethodView.__init__(self)
         self.preview_file = None
         self.last_modified = None
 
@@ -999,10 +999,10 @@ class PreviewFileDownloadResource(BasePreviewFileResource):
             raise PreviewFileNotFoundException
 
 
-class AttachmentThumbnailResource(Resource):
+class AttachmentThumbnailResource(MethodView):
 
     def __init__(self):
-        Resource.__init__(self)
+        MethodView.__init__(self)
         self.attachment_file = None
 
     def is_allowed(self, attachment_id):
@@ -1174,7 +1174,7 @@ class PreviewFileOriginalResource(BasePreviewFileThumbnailResource):
         BasePreviewPictureResource.__init__(self, "original")
 
 
-class BaseThumbnailResource(Resource):
+class BaseThumbnailResource(MethodView):
     """
     Base class to post and get a thumbnail.
     """
@@ -1186,7 +1186,7 @@ class BaseThumbnailResource(Resource):
         update_model_func,
         size=thumbnail_utils.RECTANGLE_SIZE,
     ):
-        Resource.__init__(self)
+        MethodView.__init__(self)
         self.data_type = data_type
         self.get_model_func = get_model_func
         self.update_model_func = update_model_func
@@ -1396,7 +1396,7 @@ class CreateProjectThumbnailResource(ProjectThumbnailResource):
         return user_service.check_manager_project_access(instance_id)
 
 
-class SetMainPreviewResource(Resource, ArgsMixin):
+class SetMainPreviewResource(MethodView, ArgsMixin):
     """
     Set given preview as main preview of the related entity. This preview will
     be used to illustrate the entity.
@@ -1473,7 +1473,7 @@ class SetMainPreviewResource(Resource, ArgsMixin):
         return entity
 
 
-class UpdatePreviewPositionResource(Resource, ArgsMixin):
+class UpdatePreviewPositionResource(MethodView, ArgsMixin):
     """
     Allow to change orders of previews for a single revision.
     """
@@ -1534,7 +1534,7 @@ class UpdatePreviewPositionResource(Resource, ArgsMixin):
         )
 
 
-class UpdateAnnotationsResource(Resource, ArgsMixin):
+class UpdateAnnotationsResource(MethodView, ArgsMixin):
 
     @jwt_required()
     def put(self, preview_file_id):
@@ -1638,7 +1638,7 @@ class UpdateAnnotationsResource(Resource, ArgsMixin):
         )
 
 
-class RunningPreviewFiles(Resource, ArgsMixin):
+class RunningPreviewFiles(MethodView, ArgsMixin):
     """
     Retrieve all preview files from open productions with states equals
     to processing or broken
@@ -1710,7 +1710,7 @@ class RunningPreviewFiles(Resource, ArgsMixin):
         )
 
 
-class ExtractFrameFromPreview(Resource, ArgsMixin):
+class ExtractFrameFromPreview(MethodView, ArgsMixin):
     """
     Extract the current frame of the preview
     """
@@ -1772,7 +1772,7 @@ class ExtractFrameFromPreview(Resource, ArgsMixin):
             os.remove(extracted_frame_path)
 
 
-class ExtractAnnotatedFrameFromPreview(Resource):
+class ExtractAnnotatedFrameFromPreview(MethodView):
     """
     Extract a frame (movie) or the picture itself, with its matching
     annotation rendered on top.
@@ -1875,7 +1875,7 @@ def _serve_annotated_frames_bundle(
         os.remove(bundle_path)
 
 
-class ExtractAllAnnotatedFramesFromPreview(Resource):
+class ExtractAllAnnotatedFramesFromPreview(MethodView):
     """
     Build a zip archive containing every annotated frame (movie) or
     every annotated copy of the picture preview.
@@ -1923,7 +1923,7 @@ class ExtractAllAnnotatedFramesFromPreview(Resource):
         )
 
 
-class ExtractAllAnnotatedFramesAsPdfFromPreview(Resource):
+class ExtractAllAnnotatedFramesAsPdfFromPreview(MethodView):
     """
     Build a multi-page PDF containing every annotated frame (movie) or
     every annotated copy of the picture preview.
@@ -1971,7 +1971,7 @@ class ExtractAllAnnotatedFramesAsPdfFromPreview(Resource):
         )
 
 
-class ExtractTileFromPreview(Resource):
+class ExtractTileFromPreview(MethodView):
     """
     Extract a tile from a preview_file
     """
@@ -2022,7 +2022,7 @@ class ExtractTileFromPreview(Resource):
             os.remove(extracted_tile_path)
 
 
-class CreatePreviewBackgroundFileResource(Resource):
+class CreatePreviewBackgroundFileResource(MethodView):
     """
     Main resource to add a preview background file. It stores the preview background
     file and generates a rectangle thumbnail.
@@ -2196,7 +2196,7 @@ class CreatePreviewBackgroundFileResource(Resource):
         )
 
 
-class PreviewBackgroundFileResource(Resource):
+class PreviewBackgroundFileResource(MethodView):
     """
     Main resource to download a preview background file.
     """

--- a/zou/app/blueprints/project_templates/resources.py
+++ b/zou/app/blueprints/project_templates/resources.py
@@ -1,6 +1,6 @@
 from flask import request
 from flask_jwt_extended import jwt_required
-from flask_restful import Resource
+from flask.views import MethodView
 
 from zou.app.mixin import ArgsMixin
 from zou.app.services import project_templates_service
@@ -16,7 +16,7 @@ from zou.app.utils import permissions
 # ---------------------------------------------------------------------------
 
 
-class ProjectTemplateTaskTypesResource(Resource, ArgsMixin):
+class ProjectTemplateTaskTypesResource(MethodView, ArgsMixin):
     @jwt_required()
     def get(self, template_id):
         """
@@ -61,7 +61,7 @@ class ProjectTemplateTaskTypesResource(Resource, ArgsMixin):
         return link, 201
 
 
-class ProjectTemplateTaskTypeResource(Resource):
+class ProjectTemplateTaskTypeResource(MethodView):
     @jwt_required()
     def delete(self, template_id, task_type_id):
         """
@@ -80,7 +80,7 @@ class ProjectTemplateTaskTypeResource(Resource):
         return "", 204
 
 
-class ProjectTemplateTaskStatusesResource(Resource, ArgsMixin):
+class ProjectTemplateTaskStatusesResource(MethodView, ArgsMixin):
     @jwt_required()
     def get(self, template_id):
         """
@@ -127,7 +127,7 @@ class ProjectTemplateTaskStatusesResource(Resource, ArgsMixin):
         return link, 201
 
 
-class ProjectTemplateTaskStatusResource(Resource):
+class ProjectTemplateTaskStatusResource(MethodView):
     @jwt_required()
     def delete(self, template_id, task_status_id):
         """
@@ -146,7 +146,7 @@ class ProjectTemplateTaskStatusResource(Resource):
         return "", 204
 
 
-class ProjectTemplateAssetTypesResource(Resource, ArgsMixin):
+class ProjectTemplateAssetTypesResource(MethodView, ArgsMixin):
     @jwt_required()
     def get(self, template_id):
         """
@@ -184,7 +184,7 @@ class ProjectTemplateAssetTypesResource(Resource, ArgsMixin):
         return entry, 201
 
 
-class ProjectTemplateAssetTypeResource(Resource):
+class ProjectTemplateAssetTypeResource(MethodView):
     @jwt_required()
     def delete(self, template_id, asset_type_id):
         """
@@ -203,7 +203,7 @@ class ProjectTemplateAssetTypeResource(Resource):
         return "", 204
 
 
-class ProjectTemplateStatusAutomationsResource(Resource, ArgsMixin):
+class ProjectTemplateStatusAutomationsResource(MethodView, ArgsMixin):
     @jwt_required()
     def get(self, template_id):
         """
@@ -243,7 +243,7 @@ class ProjectTemplateStatusAutomationsResource(Resource, ArgsMixin):
         return entry, 201
 
 
-class ProjectTemplateStatusAutomationResource(Resource):
+class ProjectTemplateStatusAutomationResource(MethodView):
     @jwt_required()
     def delete(self, template_id, status_automation_id):
         """
@@ -262,7 +262,7 @@ class ProjectTemplateStatusAutomationResource(Resource):
         return "", 204
 
 
-class ProjectTemplateBackgroundsResource(Resource, ArgsMixin):
+class ProjectTemplateBackgroundsResource(MethodView, ArgsMixin):
     @jwt_required()
     def get(self, template_id):
         """
@@ -300,7 +300,7 @@ class ProjectTemplateBackgroundsResource(Resource, ArgsMixin):
         return entry, 201
 
 
-class ProjectTemplateBackgroundResource(Resource):
+class ProjectTemplateBackgroundResource(MethodView):
     @jwt_required()
     def delete(self, template_id, preview_background_file_id):
         """
@@ -319,7 +319,7 @@ class ProjectTemplateBackgroundResource(Resource):
         return "", 204
 
 
-class ProjectTemplateDefaultBackgroundResource(Resource):
+class ProjectTemplateDefaultBackgroundResource(MethodView):
     @jwt_required()
     def put(self, template_id):
         """
@@ -342,7 +342,7 @@ class ProjectTemplateDefaultBackgroundResource(Resource):
         return template, 200
 
 
-class ProjectTemplateMetadataDescriptorsResource(Resource):
+class ProjectTemplateMetadataDescriptorsResource(MethodView):
     @jwt_required()
     def put(self, template_id):
         """
@@ -375,7 +375,7 @@ class ProjectTemplateMetadataDescriptorsResource(Resource):
 # ---------------------------------------------------------------------------
 
 
-class ProjectTemplateFromProjectResource(Resource, ArgsMixin):
+class ProjectTemplateFromProjectResource(MethodView, ArgsMixin):
     @jwt_required()
     def post(self, project_id):
         """
@@ -405,7 +405,7 @@ class ProjectTemplateFromProjectResource(Resource, ArgsMixin):
         return template, 201
 
 
-class ApplyProjectTemplateResource(Resource):
+class ApplyProjectTemplateResource(MethodView):
     @jwt_required()
     def post(self, project_id, template_id):
         """

--- a/zou/app/blueprints/projects/resources.py
+++ b/zou/app/blueprints/projects/resources.py
@@ -1,5 +1,5 @@
 from flask import abort
-from flask_restful import Resource
+from flask.views import MethodView
 from flask_jwt_extended import jwt_required
 
 
@@ -38,7 +38,7 @@ from zou.app.services.exception import (
 from zou.app.models.metadata_descriptor import METADATA_DESCRIPTOR_TYPES
 
 
-class OpenProjectsResource(Resource, ArgsMixin):
+class OpenProjectsResource(MethodView, ArgsMixin):
     """
     Return the list of projects currently running. Most of the time, past
     projects are not needed.
@@ -93,7 +93,7 @@ class OpenProjectsResource(Resource, ArgsMixin):
             return user_service.get_open_projects(name)
 
 
-class AllProjectsResource(Resource, ArgsMixin):
+class AllProjectsResource(MethodView, ArgsMixin):
     """
     Return all projects listed in database. Ensure that user has at least
     the manager level before that.
@@ -156,7 +156,7 @@ class AllProjectsResource(Resource, ArgsMixin):
                 return [user_service.get_project_by_name(name)]
 
 
-class ProductionTeamResource(Resource, ArgsMixin):
+class ProductionTeamResource(MethodView, ArgsMixin):
     """
     Allow to manage the people listed in a production team.
     """
@@ -276,7 +276,7 @@ class ProductionTeamResource(Resource, ArgsMixin):
         )
 
 
-class ProductionTeamRemoveResource(Resource):
+class ProductionTeamRemoveResource(MethodView):
 
     @jwt_required()
     def delete(self, project_id, person_id):
@@ -312,7 +312,7 @@ class ProductionTeamRemoveResource(Resource):
         return "", 204
 
 
-class ProductionAssetTypeResource(Resource, ArgsMixin):
+class ProductionAssetTypeResource(MethodView, ArgsMixin):
     """
     Allow to add an asset type linked to a production.
     """
@@ -377,7 +377,7 @@ class ProductionAssetTypeResource(Resource, ArgsMixin):
         return project, 201
 
 
-class ProductionAssetTypeRemoveResource(Resource):
+class ProductionAssetTypeRemoveResource(MethodView):
 
     @jwt_required()
     def delete(self, project_id, asset_type_id):
@@ -413,7 +413,7 @@ class ProductionAssetTypeRemoveResource(Resource):
         return "", 204
 
 
-class ProductionTaskTypesResource(Resource, ArgsMixin):
+class ProductionTaskTypesResource(MethodView, ArgsMixin):
     """
     Retrieve task types linked to the production
     """
@@ -449,7 +449,7 @@ class ProductionTaskTypesResource(Resource, ArgsMixin):
         return projects_service.get_project_task_types(project_id)
 
 
-class ProductionTaskTypeResource(Resource, ArgsMixin):
+class ProductionTaskTypeResource(MethodView, ArgsMixin):
     """
     Allow to add a task type linked to a production.
     """
@@ -518,7 +518,7 @@ class ProductionTaskTypeResource(Resource, ArgsMixin):
         return project, 201
 
 
-class ProductionTaskTypeRemoveResource(Resource):
+class ProductionTaskTypeRemoveResource(MethodView):
     """
     Allow to remove a task type linked to a production.
     """
@@ -557,7 +557,7 @@ class ProductionTaskTypeRemoveResource(Resource):
         return "", 204
 
 
-class ProductionTaskStatusResource(Resource, ArgsMixin):
+class ProductionTaskStatusResource(MethodView, ArgsMixin):
     """
     Allow to add a task type linked to a production.
     """
@@ -652,7 +652,7 @@ class ProductionTaskStatusResource(Resource, ArgsMixin):
         return project, 201
 
 
-class ProductionTaskStatusRemoveResource(Resource):
+class ProductionTaskStatusRemoveResource(MethodView):
     """
     Allow to remove a task status linked to a production.
     """
@@ -691,7 +691,7 @@ class ProductionTaskStatusRemoveResource(Resource):
         return "", 204
 
 
-class ProductionStatusAutomationResource(Resource, ArgsMixin):
+class ProductionStatusAutomationResource(MethodView, ArgsMixin):
     """
     Allow to add a status automation linked to a production.
     """
@@ -784,7 +784,7 @@ class ProductionStatusAutomationResource(Resource, ArgsMixin):
         return project, 201
 
 
-class ProductionStatusAutomationRemoveResource(Resource):
+class ProductionStatusAutomationRemoveResource(MethodView):
     """
     Allow to remove a status automation linked to a production.
     """
@@ -825,7 +825,7 @@ class ProductionStatusAutomationRemoveResource(Resource):
         return "", 204
 
 
-class ProductionPreviewBackgroundFileResource(Resource, ArgsMixin):
+class ProductionPreviewBackgroundFileResource(MethodView, ArgsMixin):
     """
     Allow to add a preview background file linked to a production.
     """
@@ -920,7 +920,7 @@ class ProductionPreviewBackgroundFileResource(Resource, ArgsMixin):
         return project, 201
 
 
-class ProductionPreviewBackgroundFileRemoveResource(Resource):
+class ProductionPreviewBackgroundFileRemoveResource(MethodView):
     """
     Allow to remove a preview background file linked to a production.
     """
@@ -961,7 +961,7 @@ class ProductionPreviewBackgroundFileRemoveResource(Resource):
         return "", 204
 
 
-class ProductionMetadataDescriptorsResource(Resource, ArgsMixin):
+class ProductionMetadataDescriptorsResource(MethodView, ArgsMixin):
     """
     Resource to get and create metadata descriptors. It serves to describe
     extra fields listed in the data attribute of entities.
@@ -1125,7 +1125,7 @@ class ProductionMetadataDescriptorsResource(Resource, ArgsMixin):
         )
 
 
-class ProductionMetadataDescriptorResource(Resource, ArgsMixin):
+class ProductionMetadataDescriptorResource(MethodView, ArgsMixin):
     """
     Resource to get, update or delete a metadata descriptor. Descriptors serve
     to describe extra fields listed in the data attribute of entities.
@@ -1289,7 +1289,7 @@ class ProductionMetadataDescriptorResource(Resource, ArgsMixin):
         return "", 204
 
 
-class ProductionMetadataDescriptorsReorderResource(Resource, ArgsMixin):
+class ProductionMetadataDescriptorsReorderResource(MethodView, ArgsMixin):
 
     @jwt_required()
     def post(self, project_id):
@@ -1392,7 +1392,7 @@ class ProductionMetadataDescriptorsReorderResource(Resource, ArgsMixin):
         )
 
 
-class ProductionTimeSpentsResource(Resource):
+class ProductionTimeSpentsResource(MethodView):
     """
     Resource to retrieve time spents for given production.
     """
@@ -1428,7 +1428,7 @@ class ProductionTimeSpentsResource(Resource):
         return tasks_service.get_time_spents_for_project(project_id)
 
 
-class ProductionMilestonesResource(Resource):
+class ProductionMilestonesResource(MethodView):
     """
     Resource to retrieve milestones for given production.
     """
@@ -1464,7 +1464,7 @@ class ProductionMilestonesResource(Resource):
         return schedule_service.get_milestones_for_project(project_id)
 
 
-class ProductionScheduleItemsResource(Resource):
+class ProductionScheduleItemsResource(MethodView):
     """
     Resource to retrieve schedule items for given production.
     """
@@ -1501,7 +1501,7 @@ class ProductionScheduleItemsResource(Resource):
         return schedule_service.get_schedule_items(project_id)
 
 
-class ProductionTaskTypeScheduleItemsResource(Resource):
+class ProductionTaskTypeScheduleItemsResource(MethodView):
     """
     Resource to retrieve schedule items for given production.
     """
@@ -1538,7 +1538,7 @@ class ProductionTaskTypeScheduleItemsResource(Resource):
         return schedule_service.get_task_types_schedule_items(project_id)
 
 
-class ProductionAssetTypesScheduleItemsResource(Resource):
+class ProductionAssetTypesScheduleItemsResource(MethodView):
     """
     Resource to retrieve asset types schedule items for given task type.
     """
@@ -1585,7 +1585,7 @@ class ProductionAssetTypesScheduleItemsResource(Resource):
         )
 
 
-class ProductionEpisodesScheduleItemsResource(Resource, ArgsMixin):
+class ProductionEpisodesScheduleItemsResource(MethodView, ArgsMixin):
     """
     Resource to retrieve episodes schedule items for given task type.
     """
@@ -1634,7 +1634,7 @@ class ProductionEpisodesScheduleItemsResource(Resource, ArgsMixin):
         )
 
 
-class ProductionSequencesScheduleItemsResource(Resource):
+class ProductionSequencesScheduleItemsResource(MethodView):
     """
     Resource to retrieve sequences schedule items for given task type.
     """
@@ -1681,7 +1681,7 @@ class ProductionSequencesScheduleItemsResource(Resource):
         )
 
 
-class ProductionBudgetsResource(Resource, ArgsMixin):
+class ProductionBudgetsResource(MethodView, ArgsMixin):
 
     @jwt_required()
     def get(self, project_id):
@@ -1781,7 +1781,7 @@ class ProductionBudgetsResource(Resource, ArgsMixin):
         )
 
 
-class ProductionBudgetResource(Resource, ArgsMixin):
+class ProductionBudgetResource(MethodView, ArgsMixin):
     """
     Resource to retrieve a budget for given production.
     """
@@ -1919,7 +1919,7 @@ class ProductionBudgetResource(Resource, ArgsMixin):
         return "", 204
 
 
-class ProductionBudgetEntriesResource(Resource, ArgsMixin):
+class ProductionBudgetEntriesResource(MethodView, ArgsMixin):
 
     @jwt_required()
     def get(self, project_id, budget_id):
@@ -2064,7 +2064,7 @@ class ProductionBudgetEntriesResource(Resource, ArgsMixin):
         )
 
 
-class ProductionBudgetEntryResource(Resource, ArgsMixin):
+class ProductionBudgetEntryResource(MethodView, ArgsMixin):
 
     @jwt_required()
     def get(self, project_id, budget_id, entry_id):
@@ -2253,7 +2253,7 @@ class ProductionBudgetEntryResource(Resource, ArgsMixin):
         return "", 204
 
 
-class ProductionMonthTimeSpentsResource(Resource, ArgsMixin):
+class ProductionMonthTimeSpentsResource(MethodView, ArgsMixin):
 
     @jwt_required()
     def get(self, project_id):
@@ -2290,7 +2290,7 @@ class ProductionMonthTimeSpentsResource(Resource, ArgsMixin):
         )
 
 
-class ProductionScheduleVersionTaskLinksResource(Resource, ArgsMixin):
+class ProductionScheduleVersionTaskLinksResource(MethodView, ArgsMixin):
 
     @jwt_required()
     def get(self, production_schedule_version_id):
@@ -2359,7 +2359,7 @@ class ProductionScheduleVersionTaskLinksResource(Resource, ArgsMixin):
 
 
 class ProductionScheduleVersionSetTaskLinksFromTasksResource(
-    Resource, ArgsMixin
+    MethodView, ArgsMixin
 ):
 
     @jwt_required()
@@ -2404,7 +2404,7 @@ class ProductionScheduleVersionSetTaskLinksFromTasksResource(
         )
 
 
-class ProductionScheduleVersionApplyToProductionResource(Resource, ArgsMixin):
+class ProductionScheduleVersionApplyToProductionResource(MethodView, ArgsMixin):
 
     @jwt_required()
     def post(self, production_schedule_version_id):
@@ -2450,7 +2450,7 @@ class ProductionScheduleVersionApplyToProductionResource(Resource, ArgsMixin):
 
 
 class ProductionScheduleVersionSetTaskLinksFromProductionScheduleVersionResource(
-    Resource, ArgsMixin
+    MethodView, ArgsMixin
 ):
 
     @jwt_required()
@@ -2529,7 +2529,7 @@ class ProductionScheduleVersionSetTaskLinksFromProductionScheduleVersionResource
         )
 
 
-class ProductionTaskTypesTimeSpentsResource(Resource, ArgsMixin):
+class ProductionTaskTypesTimeSpentsResource(MethodView, ArgsMixin):
     """
     Retrieve time spents for a task type in the production
     """
@@ -2622,7 +2622,7 @@ class ProductionTaskTypesTimeSpentsResource(Resource, ArgsMixin):
             )
 
 
-class ProductionDayOffsResource(Resource, ArgsMixin):
+class ProductionDayOffsResource(MethodView, ArgsMixin):
     """
     Retrieve all day offs for a production
     """

--- a/zou/app/blueprints/search/resources.py
+++ b/zou/app/blueprints/search/resources.py
@@ -1,4 +1,4 @@
-from flask_restful import Resource
+from flask.views import MethodView
 
 from flask_jwt_extended import jwt_required
 
@@ -8,7 +8,7 @@ from zou.app.services import index_service, projects_service, user_service
 from zou.app.blueprints.search.schemas import SearchSchema
 
 
-class SearchResource(Resource, ArgsMixin):
+class SearchResource(MethodView, ArgsMixin):
     @jwt_required()
     def post(self):
         """

--- a/zou/app/blueprints/shared/resources.py
+++ b/zou/app/blueprints/shared/resources.py
@@ -1,6 +1,6 @@
 from flask import current_app, g, request
 from flask_fs.errors import FileNotFound
-from flask_restful import Resource
+from flask.views import MethodView
 
 from zou.app.blueprints.previews.resources import (
     ALLOWED_FILE_EXTENSION,
@@ -34,7 +34,7 @@ from zou.app.services.exception import (
 from zou.app.utils import permissions, validation
 
 
-class SharedPlaylistResource(Resource):
+class SharedPlaylistResource(MethodView):
     @require_valid_playlist_share_link(with_password=True)
     def get(self, token):
         """
@@ -73,7 +73,7 @@ class SharedPlaylistResource(Resource):
         return playlist_sharing_service.enrich_shots_with_entity_info(playlist)
 
 
-class SharedPlaylistGuestResource(Resource):
+class SharedPlaylistGuestResource(MethodView):
     @require_valid_playlist_share_link()
     def post(self, token):
         """
@@ -140,7 +140,7 @@ class SharedPlaylistGuestResource(Resource):
         return guest, 201
 
 
-class SharedPlaylistCommentsResource(Resource):
+class SharedPlaylistCommentsResource(MethodView):
     @require_valid_playlist_share_link(with_password=True)
     def get(self, token):
         """
@@ -309,7 +309,7 @@ class SharedPlaylistCommentsResource(Resource):
         return comment, 201
 
 
-class SharedPlaylistCommentResource(Resource):
+class SharedPlaylistCommentResource(MethodView):
     """
     Edit or delete a single comment authored by a guest.
     """
@@ -373,7 +373,7 @@ class SharedPlaylistCommentResource(Resource):
             return {"error": "Comment not found"}, 404
 
 
-class SharedPlaylistCommentAttachmentsResource(Resource):
+class SharedPlaylistCommentAttachmentsResource(MethodView):
     """
     Add an attachment file to a guest-owned comment.
     """
@@ -406,7 +406,7 @@ class SharedPlaylistCommentAttachmentsResource(Resource):
             return {"error": "Comment not found"}, 404
 
 
-class SharedPlaylistCommentAttachmentResource(Resource):
+class SharedPlaylistCommentAttachmentResource(MethodView):
     """
     Delete one attachment from a guest-owned comment.
     """
@@ -435,7 +435,7 @@ class SharedPlaylistCommentAttachmentResource(Resource):
             return {"error": "Comment not found"}, 404
 
 
-class SharedPlaylistAttachmentFileResource(Resource):
+class SharedPlaylistAttachmentFileResource(MethodView):
     """
     Download an attachment that belongs to a visible shared comment.
     """
@@ -459,7 +459,7 @@ class SharedPlaylistAttachmentFileResource(Resource):
             return {"error": "Attachment not found"}, 404
 
 
-class SharedPlaylistAnnotationsResource(Resource):
+class SharedPlaylistAnnotationsResource(MethodView):
     @require_valid_playlist_share_link()
     def put(self, token):
         """
@@ -569,7 +569,7 @@ def _is_task_in_shared_playlist(token, task_id):
     return False
 
 
-class SharedPlaylistPreviewFileResource(Resource):
+class SharedPlaylistPreviewFileResource(MethodView):
     @require_valid_playlist_share_link()
     def get(self, token, preview_file_id):
         """
@@ -610,7 +610,7 @@ class SharedPlaylistPreviewFileResource(Resource):
         return files_service.get_preview_file(preview_file_id)
 
 
-class SharedPlaylistPreviewFileMovieResource(Resource):
+class SharedPlaylistPreviewFileMovieResource(MethodView):
     @require_valid_playlist_share_link()
     def get(self, token, preview_file_id):
         """
@@ -665,7 +665,7 @@ class SharedPlaylistPreviewFileMovieResource(Resource):
             raise PreviewFileNotFoundException
 
 
-class SharedPlaylistPreviewFileThumbnailResource(Resource):
+class SharedPlaylistPreviewFileThumbnailResource(MethodView):
     @require_valid_playlist_share_link()
     def get(self, token, preview_file_id):
         """
@@ -719,7 +719,7 @@ class SharedPlaylistPreviewFileThumbnailResource(Resource):
             raise PreviewFileNotFoundException
 
 
-class SharedPlaylistPreviewFileOriginalResource(Resource):
+class SharedPlaylistPreviewFileOriginalResource(MethodView):
     @require_valid_playlist_share_link()
     def get(self, token, preview_file_id):
         """
@@ -773,7 +773,7 @@ class SharedPlaylistPreviewFileOriginalResource(Resource):
             raise PreviewFileNotFoundException
 
 
-class SharedPlaylistPreviewFileExtensionResource(Resource):
+class SharedPlaylistPreviewFileExtensionResource(MethodView):
     @require_valid_playlist_share_link()
     def get(self, token, preview_file_id, extension):
         """
@@ -851,7 +851,7 @@ class SharedPlaylistPreviewFileExtensionResource(Resource):
             raise PreviewFileNotFoundException
 
 
-class SharedPlaylistPreviewFileTileResource(Resource):
+class SharedPlaylistPreviewFileTileResource(MethodView):
     @require_valid_playlist_share_link()
     def get(self, token, preview_file_id):
         """
@@ -905,7 +905,7 @@ class SharedPlaylistPreviewFileTileResource(Resource):
             raise PreviewFileNotFoundException
 
 
-class SharedPlaylistPreviewFileDownloadResource(Resource):
+class SharedPlaylistPreviewFileDownloadResource(MethodView):
     @require_valid_playlist_share_link()
     def get(self, token, preview_file_id):
         """
@@ -972,7 +972,7 @@ class SharedPlaylistPreviewFileDownloadResource(Resource):
             raise PreviewFileNotFoundException
 
 
-class SharedPlaylistContextResource(Resource):
+class SharedPlaylistContextResource(MethodView):
     @require_valid_playlist_share_link(with_password=True)
     def get(self, token):
         """

--- a/zou/app/blueprints/shots/resources.py
+++ b/zou/app/blueprints/shots/resources.py
@@ -1,5 +1,5 @@
 from flask import request
-from flask_restful import Resource
+from flask.views import MethodView
 from flask_jwt_extended import jwt_required
 
 from zou.app.services import (
@@ -30,7 +30,7 @@ from zou.app.services.exception import (
 )
 
 
-class ShotResource(Resource, ArgsMixin):
+class ShotResource(MethodView, ArgsMixin):
     @jwt_required()
     def get(self, shot_id):
         """
@@ -204,7 +204,7 @@ class ShotResource(Resource, ArgsMixin):
         return "", 204
 
 
-class SceneResource(Resource):
+class SceneResource(MethodView):
     @jwt_required()
     def get(self, scene_id):
         """
@@ -273,7 +273,7 @@ class SceneResource(Resource):
         return "", 204
 
 
-class ShotsResource(Resource):
+class ShotsResource(MethodView):
     @jwt_required()
     def get(self):
         """
@@ -342,7 +342,7 @@ class ShotsResource(Resource):
         return shots_service.get_shots(criterions)
 
 
-class AllShotsResource(Resource):
+class AllShotsResource(MethodView):
     @jwt_required()
     def get(self):
         """
@@ -411,7 +411,7 @@ class AllShotsResource(Resource):
         return shots_service.get_shots(criterions)
 
 
-class ScenesResource(Resource):
+class ScenesResource(MethodView):
     @jwt_required()
     def get(self):
         """
@@ -457,7 +457,7 @@ class ScenesResource(Resource):
         return shots_service.get_scenes(criterions)
 
 
-class ShotAssetsResource(Resource):
+class ShotAssetsResource(MethodView):
     @jwt_required()
     def get(self, shot_id):
         """
@@ -502,7 +502,7 @@ class ShotAssetsResource(Resource):
         return breakdown_service.get_entity_casting(shot_id)
 
 
-class ShotTaskTypesResource(Resource):
+class ShotTaskTypesResource(MethodView):
     @jwt_required()
     def get(self, shot_id):
         """
@@ -542,7 +542,7 @@ class ShotTaskTypesResource(Resource):
         return tasks_service.get_task_types_for_shot(shot_id)
 
 
-class ShotTasksResource(Resource, ArgsMixin):
+class ShotTasksResource(MethodView, ArgsMixin):
     @jwt_required()
     def get(self, shot_id):
         """
@@ -606,7 +606,7 @@ class ShotTasksResource(Resource, ArgsMixin):
         return tasks_service.get_tasks_for_shot(shot_id, relations=relations)
 
 
-class SequenceShotTasksResource(Resource, ArgsMixin):
+class SequenceShotTasksResource(MethodView, ArgsMixin):
     @jwt_required()
     def get(self, sequence_id):
         """
@@ -664,7 +664,7 @@ class SequenceShotTasksResource(Resource, ArgsMixin):
         )
 
 
-class EpisodeShotTasksResource(Resource, ArgsMixin):
+class EpisodeShotTasksResource(MethodView, ArgsMixin):
     @jwt_required()
     def get(self, episode_id):
         """
@@ -722,7 +722,7 @@ class EpisodeShotTasksResource(Resource, ArgsMixin):
         )
 
 
-class EpisodeAssetTasksResource(Resource, ArgsMixin):
+class EpisodeAssetTasksResource(MethodView, ArgsMixin):
     @jwt_required()
     def get(self, episode_id):
         """
@@ -780,7 +780,7 @@ class EpisodeAssetTasksResource(Resource, ArgsMixin):
         )
 
 
-class EpisodeShotsResource(Resource, ArgsMixin):
+class EpisodeShotsResource(MethodView, ArgsMixin):
     @jwt_required()
     def get(self, episode_id):
         """
@@ -832,7 +832,7 @@ class EpisodeShotsResource(Resource, ArgsMixin):
         )
 
 
-class ShotPreviewsResource(Resource):
+class ShotPreviewsResource(MethodView):
     @jwt_required()
     def get(self, shot_id):
         """
@@ -887,7 +887,7 @@ class ShotPreviewsResource(Resource):
         return playlists_service.get_preview_files_for_entity(shot_id)
 
 
-class SequenceTasksResource(Resource, ArgsMixin):
+class SequenceTasksResource(MethodView, ArgsMixin):
     @jwt_required()
     def get(self, sequence_id):
         """
@@ -949,7 +949,7 @@ class SequenceTasksResource(Resource, ArgsMixin):
         )
 
 
-class SequenceTaskTypesResource(Resource):
+class SequenceTaskTypesResource(MethodView):
     @jwt_required()
     def get(self, sequence_id):
         """
@@ -989,7 +989,7 @@ class SequenceTaskTypesResource(Resource):
         return tasks_service.get_task_types_for_sequence(sequence_id)
 
 
-class ShotsAndTasksResource(Resource):
+class ShotsAndTasksResource(MethodView):
 
     @jwt_required()
     def get(self):
@@ -1054,7 +1054,7 @@ class ShotsAndTasksResource(Resource):
         return shots_service.get_shots_and_tasks(criterions)
 
 
-class SceneAndTasksResource(Resource):
+class SceneAndTasksResource(MethodView):
     @jwt_required()
     def get(self):
         """
@@ -1115,7 +1115,7 @@ class SceneAndTasksResource(Resource):
         return entities_service.get_entities_and_tasks(criterions)
 
 
-class SequenceAndTasksResource(Resource):
+class SequenceAndTasksResource(MethodView):
     @jwt_required()
     def get(self):
         """
@@ -1192,7 +1192,7 @@ class SequenceAndTasksResource(Resource):
         return entities_service.get_entities_and_tasks(criterions)
 
 
-class EpisodeAndTasksResource(Resource):
+class EpisodeAndTasksResource(MethodView):
     @jwt_required()
     def get(self):
         """
@@ -1262,7 +1262,7 @@ class EpisodeAndTasksResource(Resource):
         return entities_service.get_entities_and_tasks(criterions)
 
 
-class ProjectShotsResource(Resource, ArgsMixin):
+class ProjectShotsResource(MethodView, ArgsMixin):
     @jwt_required()
     def get(self, project_id):
         """
@@ -1399,7 +1399,7 @@ class ProjectShotsResource(Resource, ArgsMixin):
         return shot, 201
 
 
-class ProjectSequencesResource(Resource, ArgsMixin):
+class ProjectSequencesResource(MethodView, ArgsMixin):
     @jwt_required()
     def get(self, project_id):
         """
@@ -1523,7 +1523,7 @@ class ProjectSequencesResource(Resource, ArgsMixin):
         return sequence, 201
 
 
-class ProjectEpisodesResource(Resource, ArgsMixin):
+class ProjectEpisodesResource(MethodView, ArgsMixin):
     @jwt_required()
     def get(self, project_id):
         """
@@ -1654,7 +1654,7 @@ class ProjectEpisodesResource(Resource, ArgsMixin):
         )
 
 
-class ProjectEpisodeStatsResource(Resource):
+class ProjectEpisodeStatsResource(MethodView):
     @jwt_required()
     def get(self, project_id):
         """
@@ -1719,7 +1719,7 @@ class ProjectEpisodeStatsResource(Resource):
         )
 
 
-class ProjectEpisodeRetakeStatsResource(Resource):
+class ProjectEpisodeRetakeStatsResource(MethodView):
     @jwt_required()
     def get(self, project_id):
         """
@@ -1862,7 +1862,7 @@ class ProjectEpisodeRetakeStatsResource(Resource):
         )
 
 
-class EpisodeResource(Resource, ArgsMixin):
+class EpisodeResource(MethodView, ArgsMixin):
     @jwt_required()
     def get(self, episode_id):
         """
@@ -1940,7 +1940,7 @@ class EpisodeResource(Resource, ArgsMixin):
         return "", 204
 
 
-class EpisodesResource(Resource):
+class EpisodesResource(MethodView):
     @jwt_required()
     def get(self):
         """
@@ -1998,7 +1998,7 @@ class EpisodesResource(Resource):
         return shots_service.get_episodes(criterions)
 
 
-class EpisodeSequencesResource(Resource):
+class EpisodeSequencesResource(MethodView):
     @jwt_required()
     def get(self, episode_id):
         """
@@ -2061,7 +2061,7 @@ class EpisodeSequencesResource(Resource):
             return shots_service.get_sequences(criterions)
 
 
-class EpisodeTaskTypesResource(Resource):
+class EpisodeTaskTypesResource(MethodView):
     @jwt_required()
     def get(self, episode_id):
         """
@@ -2100,7 +2100,7 @@ class EpisodeTaskTypesResource(Resource):
         return tasks_service.get_task_types_for_episode(episode_id)
 
 
-class EpisodeTasksResource(Resource):
+class EpisodeTasksResource(MethodView):
     @jwt_required()
     def get(self, episode_id):
         """
@@ -2163,7 +2163,7 @@ class EpisodeTasksResource(Resource):
         return tasks_service.get_tasks_for_episode(episode_id)
 
 
-class SequenceResource(Resource, ArgsMixin):
+class SequenceResource(MethodView, ArgsMixin):
     @jwt_required()
     def get(self, sequence_id):
         """
@@ -2238,7 +2238,7 @@ class SequenceResource(Resource, ArgsMixin):
         return "", 204
 
 
-class SequencesResource(Resource):
+class SequencesResource(MethodView):
     @jwt_required()
     def get(self):
         """
@@ -2299,7 +2299,7 @@ class SequencesResource(Resource):
         return shots_service.get_sequences(criterions)
 
 
-class SequenceShotsResource(Resource):
+class SequenceShotsResource(MethodView):
     @jwt_required()
     def get(self, sequence_id):
         """
@@ -2359,7 +2359,7 @@ class SequenceShotsResource(Resource):
         return shots_service.get_shots(criterions)
 
 
-class ProjectScenesResource(Resource, ArgsMixin):
+class ProjectScenesResource(MethodView, ArgsMixin):
     @jwt_required()
     def get(self, project_id):
         """
@@ -2479,7 +2479,7 @@ class ProjectScenesResource(Resource, ArgsMixin):
         return scene, 201
 
 
-class SequenceScenesResource(Resource):
+class SequenceScenesResource(MethodView):
     @jwt_required()
     def get(self, sequence_id):
         """
@@ -2527,7 +2527,7 @@ class SequenceScenesResource(Resource):
         return shots_service.get_scenes_for_sequence(sequence_id)
 
 
-class SceneTaskTypesResource(Resource):
+class SceneTaskTypesResource(MethodView):
     @jwt_required()
     def get(self, scene_id):
         """
@@ -2567,7 +2567,7 @@ class SceneTaskTypesResource(Resource):
         return tasks_service.get_task_types_for_scene(scene_id)
 
 
-class SceneTasksResource(Resource):
+class SceneTasksResource(MethodView):
     @jwt_required()
     def get(self, scene_id):
         """
@@ -2622,7 +2622,7 @@ class SceneTasksResource(Resource):
         return tasks_service.get_tasks_for_scene(scene_id)
 
 
-class SceneShotsResource(Resource, ArgsMixin):
+class SceneShotsResource(MethodView, ArgsMixin):
     @jwt_required()
     def get(self, scene_id):
         """
@@ -2718,7 +2718,7 @@ class SceneShotsResource(Resource, ArgsMixin):
         return scenes_service.add_shot_to_scene(scene, shot), 201
 
 
-class RemoveShotFromSceneResource(Resource):
+class RemoveShotFromSceneResource(MethodView):
     @jwt_required()
     def delete(self, scene_id, shot_id):
         """
@@ -2750,7 +2750,7 @@ class RemoveShotFromSceneResource(Resource):
         return "", 204
 
 
-class ShotVersionsResource(Resource):
+class ShotVersionsResource(MethodView):
     """
     Get shot versions
     """
@@ -2796,7 +2796,7 @@ class ShotVersionsResource(Resource):
         return shots_service.get_shot_versions(shot_id)
 
 
-class ProjectQuotasResource(Resource, ArgsMixin):
+class ProjectQuotasResource(MethodView, ArgsMixin):
 
     @jwt_required()
     def get(self, project_id, task_type_id):
@@ -2887,7 +2887,7 @@ class ProjectQuotasResource(Resource, ArgsMixin):
             )
 
 
-class ProjectPersonQuotasResource(Resource, ArgsMixin):
+class ProjectPersonQuotasResource(MethodView, ArgsMixin):
 
     @jwt_required()
     def get(self, project_id, person_id):
@@ -2984,7 +2984,7 @@ class ProjectPersonQuotasResource(Resource, ArgsMixin):
             )
 
 
-class SetShotsFramesResource(Resource, ArgsMixin):
+class SetShotsFramesResource(MethodView, ArgsMixin):
     @jwt_required()
     def post(self, project_id, task_type_id):
         """

--- a/zou/app/blueprints/source/csv/base.py
+++ b/zou/app/blueprints/source/csv/base.py
@@ -5,7 +5,7 @@ import csv
 from sqlalchemy.exc import IntegrityError
 
 from flask import request, current_app
-from flask_restful import Resource
+from flask.views import MethodView
 from flask_jwt_extended import jwt_required
 
 from zou.app.mixin import ArgsMixin
@@ -32,7 +32,7 @@ class RowException(Exception):
         self.message = message
 
 
-class BaseCsvImportResource(Resource, ArgsMixin):
+class BaseCsvImportResource(MethodView, ArgsMixin):
     @jwt_required()
     def post(self, *args):
         uploaded_file = request.files["file"]

--- a/zou/app/blueprints/source/kitsu.py
+++ b/zou/app/blueprints/source/kitsu.py
@@ -1,7 +1,7 @@
 from sqlalchemy.exc import IntegrityError
 
 from flask import request
-from flask_restful import Resource
+from flask.views import MethodView
 from flask_jwt_extended import jwt_required
 
 from zou.app.models.attachment_file import AttachmentFile
@@ -52,9 +52,9 @@ def _project_id_from_attachment(entry):
     return None
 
 
-class BaseImportKitsuResource(Resource, ArgsMixin):
+class BaseImportKitsuResource(MethodView, ArgsMixin):
     def __init__(self, model):
-        Resource.__init__(self)
+        MethodView.__init__(self)
         self.model = model
 
     @jwt_required()

--- a/zou/app/blueprints/source/otio.py
+++ b/zou/app/blueprints/source/otio.py
@@ -5,12 +5,13 @@ import re
 from string import Template
 
 from flask import request, current_app
-from flask_restful import Resource, inputs
+from flask.views import MethodView
 from flask_jwt_extended import jwt_required
 
 from zou.app import config
 
 from zou.app.mixin import ArgsMixin
+from zou.app.utils import fields
 from zou.app.services import (
     shots_service,
     projects_service,
@@ -39,7 +40,7 @@ mapping_substitutions_to_regex = {
 }
 
 
-class OTIOBaseResource(Resource, ArgsMixin):
+class OTIOBaseResource(MethodView, ArgsMixin):
 
     @jwt_required()
     def post(self, project_id, episode_id=None):
@@ -421,7 +422,7 @@ class OTIOImportResource(OTIOBaseResource):
                     False,
                     str,
                 ),
-                ("match_case", True, False, inputs.boolean),
+                ("match_case", True, False, fields.boolean),
             ]
         )
 
@@ -555,6 +556,6 @@ class OTIOImportEpisodeResource(OTIOBaseResource):
                     False,
                     str,
                 ),
-                ("match_case", True, False, inputs.boolean),
+                ("match_case", True, False, fields.boolean),
             ]
         )

--- a/zou/app/blueprints/source/shotgun/base.py
+++ b/zou/app/blueprints/source/shotgun/base.py
@@ -1,5 +1,5 @@
 from flask import request, current_app
-from flask_restful import Resource
+from flask.views import MethodView
 from flask_jwt_extended import jwt_required
 
 from zou.app.utils import fields, permissions
@@ -21,9 +21,9 @@ from zou.app.services.exception import (
 from sqlalchemy.exc import IntegrityError, DataError
 
 
-class BaseImportShotgunResource(Resource):
+class BaseImportShotgunResource(MethodView):
     def __init__(self):
-        Resource.__init__(self)
+        MethodView.__init__(self)
 
     @jwt_required()
     def post(self):
@@ -197,9 +197,9 @@ class BaseImportShotgunResource(Resource):
         return name[:3] == "sg_"
 
 
-class ImportRemoveShotgunBaseResource(Resource):
+class ImportRemoveShotgunBaseResource(MethodView):
     def __init__(self, model, delete_func=None, entity_type_id=None):
-        Resource.__init__(self)
+        MethodView.__init__(self)
         self.model = model
         self.delete_func = delete_func
         self.entity_type_id = entity_type_id

--- a/zou/app/blueprints/source/shotgun/import_errors.py
+++ b/zou/app/blueprints/source/shotgun/import_errors.py
@@ -1,5 +1,5 @@
 from flask import request
-from flask_restful import Resource
+from flask.views import MethodView
 from flask_jwt_extended import jwt_required
 
 from sqlalchemy.exc import StatementError
@@ -8,10 +8,10 @@ from werkzeug.exceptions import NotFound
 from zou.app.models.data_import_error import DataImportError
 
 
-class ShotgunImportErrorsResource(Resource):
+class ShotgunImportErrorsResource(MethodView):
 
     def __init__(self):
-        Resource.__init__(self)
+        MethodView.__init__(self)
 
     @jwt_required()
     def get(self):
@@ -121,9 +121,9 @@ class ShotgunImportErrorsResource(Resource):
         return error.serialize(), 201
 
 
-class ShotgunImportErrorResource(Resource):
+class ShotgunImportErrorResource(MethodView):
     def __init__(self):
-        Resource.__init__(self)
+        MethodView.__init__(self)
 
     @jwt_required()
     def delete(self, error_id):

--- a/zou/app/blueprints/source/shotgun/steps.py
+++ b/zou/app/blueprints/source/shotgun/steps.py
@@ -1,5 +1,5 @@
 from flask import current_app
-from flask_restful import Resource
+from flask.views import MethodView
 from flask_jwt_extended import jwt_required
 
 from zou.app.models.department import Department
@@ -15,7 +15,7 @@ from zou.app.blueprints.source.shotgun.base import (
 
 class ImportShotgunStepsResource(BaseImportShotgunResource):
     def __init__(self):
-        Resource.__init__(self)
+        MethodView.__init__(self)
 
     @jwt_required()
     def post(self):

--- a/zou/app/blueprints/tasks/resources.py
+++ b/zou/app/blueprints/tasks/resources.py
@@ -2,7 +2,7 @@ import datetime
 
 
 from flask import request
-from flask_restful import Resource
+from flask.views import MethodView
 from flask_jwt_extended import jwt_required
 
 from zou.app.services.exception import (
@@ -48,7 +48,7 @@ from zou.app.blueprints.tasks.schemas import (
 )
 
 
-class AddPreviewResource(Resource, ArgsMixin):
+class AddPreviewResource(MethodView, ArgsMixin):
 
     @jwt_required()
     def post(self, task_id, comment_id):
@@ -131,7 +131,7 @@ class AddPreviewResource(Resource, ArgsMixin):
         return preview_file, 201
 
 
-class AddExtraPreviewResource(Resource, ArgsMixin):
+class AddExtraPreviewResource(MethodView, ArgsMixin):
 
     @jwt_required()
     def post(self, task_id, comment_id, preview_file_id):
@@ -269,7 +269,7 @@ class AddExtraPreviewResource(Resource, ArgsMixin):
         return "", 204
 
 
-class TaskPreviewsResource(Resource):
+class TaskPreviewsResource(MethodView):
 
     @jwt_required()
     def get(self, task_id):
@@ -325,7 +325,7 @@ class TaskPreviewsResource(Resource):
         return files_service.get_preview_files_for_task(task_id)
 
 
-class TaskCommentsResource(Resource):
+class TaskCommentsResource(MethodView):
 
     @jwt_required()
     def get(self, task_id):
@@ -386,7 +386,7 @@ class TaskCommentsResource(Resource):
         )
 
 
-class TaskCommentResource(Resource):
+class TaskCommentResource(MethodView):
 
     @jwt_required()
     def get(self, task_id, comment_id):
@@ -511,7 +511,7 @@ class TaskCommentResource(Resource):
         return "", 204
 
 
-class PersonTasksResource(Resource):
+class PersonTasksResource(MethodView):
 
     @jwt_required()
     def get(self, person_id):
@@ -590,7 +590,7 @@ class PersonTasksResource(Resource):
         return tasks_service.get_person_tasks(person_id, projects)
 
 
-class PersonRelatedTasksResource(Resource):
+class PersonRelatedTasksResource(MethodView):
 
     @jwt_required()
     def get(self, person_id, task_type_id):
@@ -666,7 +666,7 @@ class PersonRelatedTasksResource(Resource):
         return tasks_service.get_person_related_tasks(person_id, task_type_id)
 
 
-class PersonDoneTasksResource(Resource):
+class PersonDoneTasksResource(MethodView):
 
     @jwt_required()
     def get(self, person_id):
@@ -745,7 +745,7 @@ class PersonDoneTasksResource(Resource):
         return tasks_service.get_person_done_tasks(person_id, projects)
 
 
-class CreateShotTasksResource(Resource):
+class CreateShotTasksResource(MethodView):
 
     @jwt_required()
     def post(self, project_id, task_type_id):
@@ -837,7 +837,7 @@ class CreateShotTasksResource(Resource):
         return tasks, 201
 
 
-class CreateConceptTasksResource(Resource):
+class CreateConceptTasksResource(MethodView):
 
     @jwt_required()
     def post(self, project_id, task_type_id):
@@ -937,7 +937,7 @@ class CreateConceptTasksResource(Resource):
         return tasks, 201
 
 
-class CreateEntityTasksResource(Resource):
+class CreateEntityTasksResource(MethodView):
 
     @jwt_required()
     def post(self, project_id, entity_type, task_type_id):
@@ -1043,7 +1043,7 @@ class CreateEntityTasksResource(Resource):
         return tasks, 201
 
 
-class CreateAssetTasksResource(Resource):
+class CreateAssetTasksResource(MethodView):
 
     @jwt_required()
     def post(self, project_id, task_type_id):
@@ -1135,7 +1135,7 @@ class CreateAssetTasksResource(Resource):
         return tasks, 201
 
 
-class CreateEditTasksResource(Resource):
+class CreateEditTasksResource(MethodView):
 
     @jwt_required()
     def post(self, project_id, task_type_id):
@@ -1227,7 +1227,7 @@ class CreateEditTasksResource(Resource):
         return tasks, 201
 
 
-class ToReviewResource(Resource, ArgsMixin):
+class ToReviewResource(MethodView, ArgsMixin):
 
     @jwt_required()
     def put(self, task_id):
@@ -1350,7 +1350,7 @@ class ToReviewResource(Resource, ArgsMixin):
         return {"folder_path": folder_path, "file_name": file_name}
 
 
-class ClearAssignationResource(Resource, ArgsMixin):
+class ClearAssignationResource(MethodView, ArgsMixin):
 
     @jwt_required()
     def put(self):
@@ -1413,7 +1413,7 @@ class ClearAssignationResource(Resource, ArgsMixin):
         return tasks
 
 
-class TasksAssignResource(Resource, ArgsMixin):
+class TasksAssignResource(MethodView, ArgsMixin):
 
     @jwt_required()
     def put(self, person_id):
@@ -1520,7 +1520,7 @@ class TasksAssignResource(Resource, ArgsMixin):
         return tasks
 
 
-class TaskAssignResource(Resource, ArgsMixin):
+class TaskAssignResource(MethodView, ArgsMixin):
 
     @jwt_required()
     def put(self, task_id):
@@ -1610,7 +1610,7 @@ class TaskAssignResource(Resource, ArgsMixin):
         return task
 
 
-class TaskFullResource(Resource):
+class TaskFullResource(MethodView):
 
     @jwt_required()
     def get(self, task_id):
@@ -1704,7 +1704,7 @@ class TaskFullResource(Resource):
         return task
 
 
-class TaskForEntityResource(Resource):
+class TaskForEntityResource(MethodView):
 
     @jwt_required()
     def get(self, entity_id, task_type_id):
@@ -1777,7 +1777,7 @@ class TaskForEntityResource(Resource):
         )
 
 
-class SetTimeSpentResource(Resource, ArgsMixin):
+class SetTimeSpentResource(MethodView, ArgsMixin):
 
     @jwt_required()
     def post(self, task_id, date, person_id):
@@ -1947,7 +1947,7 @@ class SetTimeSpentResource(Resource, ArgsMixin):
             raise WrongParameterException("Wrong date format.")
 
 
-class AddTimeSpentResource(Resource, ArgsMixin):
+class AddTimeSpentResource(MethodView, ArgsMixin):
 
     @jwt_required()
     def post(self, task_id, date, person_id):
@@ -2041,7 +2041,7 @@ class AddTimeSpentResource(Resource, ArgsMixin):
             raise WrongParameterException("Wrong date format.")
 
 
-class GetTimeSpentResource(Resource):
+class GetTimeSpentResource(MethodView):
 
     @jwt_required()
     def get(self, task_id):
@@ -2096,7 +2096,7 @@ class GetTimeSpentResource(Resource):
         return tasks_service.get_time_spents(task_id)
 
 
-class GetTimeSpentDateResource(Resource):
+class GetTimeSpentDateResource(MethodView):
 
     @jwt_required()
     def get(self, task_id, date):
@@ -2161,7 +2161,7 @@ class GetTimeSpentDateResource(Resource):
             raise WrongParameterException("Wrong date format.")
 
 
-class DeleteAllTasksForTaskTypeResource(Resource):
+class DeleteAllTasksForTaskTypeResource(MethodView):
 
     @jwt_required()
     def delete(self, project_id, task_type_id):
@@ -2201,7 +2201,7 @@ class DeleteAllTasksForTaskTypeResource(Resource):
         return "", 204
 
 
-class DeleteTasksResource(Resource):
+class DeleteTasksResource(MethodView):
 
     @jwt_required()
     def post(self, project_id):
@@ -2241,7 +2241,7 @@ class DeleteTasksResource(Resource):
         return task_ids, 200
 
 
-class ProjectSubscriptionsResource(Resource):
+class ProjectSubscriptionsResource(MethodView):
 
     @jwt_required()
     @permissions.require_admin
@@ -2292,7 +2292,7 @@ class ProjectSubscriptionsResource(Resource):
         return notifications_service.get_subscriptions_for_project(project_id)
 
 
-class ProjectNotificationsResource(Resource, ArgsMixin):
+class ProjectNotificationsResource(MethodView, ArgsMixin):
 
     @jwt_required()
     @permissions.require_admin
@@ -2369,7 +2369,7 @@ class ProjectNotificationsResource(Resource, ArgsMixin):
         )
 
 
-class ProjectTasksResource(Resource, ArgsMixin):
+class ProjectTasksResource(MethodView, ArgsMixin):
 
     @jwt_required()
     def get(self, project_id):
@@ -2466,7 +2466,7 @@ class ProjectTasksResource(Resource, ArgsMixin):
         )
 
 
-class ProjectCommentsResource(Resource, ArgsMixin):
+class ProjectCommentsResource(MethodView, ArgsMixin):
 
     @jwt_required()
     def get(self, project_id):
@@ -2536,7 +2536,7 @@ class ProjectCommentsResource(Resource, ArgsMixin):
         return tasks_service.get_comments_for_project(project_id, page, limit)
 
 
-class ProjectPreviewFilesResource(Resource, ArgsMixin):
+class ProjectPreviewFilesResource(MethodView, ArgsMixin):
 
     @jwt_required()
     @permissions.require_admin
@@ -2608,7 +2608,7 @@ class ProjectPreviewFilesResource(Resource, ArgsMixin):
         return files_service.get_preview_files_for_project(project_id, page)
 
 
-class SetTaskMainPreviewResource(Resource):
+class SetTaskMainPreviewResource(MethodView):
     @jwt_required()
     def put(self, task_id):
         """
@@ -2680,7 +2680,7 @@ class SetTaskMainPreviewResource(Resource):
         return entity
 
 
-class PersonsTasksDatesResource(Resource, ArgsMixin):
+class PersonsTasksDatesResource(MethodView, ArgsMixin):
 
     @jwt_required()
     def get(self):
@@ -2748,7 +2748,7 @@ class PersonsTasksDatesResource(Resource, ArgsMixin):
         )
 
 
-class OpenTasksResource(Resource, ArgsMixin):
+class OpenTasksResource(MethodView, ArgsMixin):
 
     @jwt_required()
     def get(self):
@@ -2903,7 +2903,7 @@ class OpenTasksResource(Resource, ArgsMixin):
         )
 
 
-class OpenTasksStatsResource(Resource, ArgsMixin):
+class OpenTasksStatsResource(MethodView, ArgsMixin):
 
     @jwt_required()
     def get(self):

--- a/zou/app/blueprints/user/resources.py
+++ b/zou/app/blueprints/user/resources.py
@@ -1,5 +1,5 @@
 from flask import abort, request
-from flask_restful import Resource, inputs
+from flask.views import MethodView
 
 from zou.app.mixin import ArgsMixin
 from zou.app.services import (
@@ -26,7 +26,7 @@ from zou.app.services.exception import (
 )
 
 
-class AssetTasksResource(Resource):
+class AssetTasksResource(MethodView):
 
     def get(self, asset_id):
         """
@@ -100,7 +100,7 @@ class AssetTasksResource(Resource):
         return user_service.get_tasks_for_entity(asset_id)
 
 
-class AssetTaskTypesResource(Resource):
+class AssetTaskTypesResource(MethodView):
 
     def get(self, asset_id):
         """
@@ -169,7 +169,7 @@ class AssetTaskTypesResource(Resource):
         return user_service.get_task_types_for_entity(asset_id)
 
 
-class ShotTaskTypesResource(Resource):
+class ShotTaskTypesResource(MethodView):
 
     def get(self, shot_id):
         """
@@ -238,7 +238,7 @@ class ShotTaskTypesResource(Resource):
         return user_service.get_task_types_for_entity(shot_id)
 
 
-class SceneTaskTypesResource(Resource):
+class SceneTaskTypesResource(MethodView):
     """
     Return tasks related to given scene for current user.
     """
@@ -310,7 +310,7 @@ class SceneTaskTypesResource(Resource):
         return user_service.get_task_types_for_entity(scene_id)
 
 
-class SequenceTaskTypesResource(Resource):
+class SequenceTaskTypesResource(MethodView):
 
     def get(self, sequence_id):
         """
@@ -379,7 +379,7 @@ class SequenceTaskTypesResource(Resource):
         return user_service.get_task_types_for_entity(sequence_id)
 
 
-class AssetTypeAssetsResource(Resource):
+class AssetTypeAssetsResource(MethodView):
 
     def get(self, project_id, asset_type_id):
         """
@@ -457,7 +457,7 @@ class AssetTypeAssetsResource(Resource):
         )
 
 
-class OpenProjectsResource(Resource, ArgsMixin):
+class OpenProjectsResource(MethodView, ArgsMixin):
 
     def get(self):
         """
@@ -529,7 +529,7 @@ class OpenProjectsResource(Resource, ArgsMixin):
         return user_service.get_open_projects(name=name)
 
 
-class ProjectSequencesResource(Resource):
+class ProjectSequencesResource(MethodView):
 
     def get(self, project_id):
         """
@@ -596,7 +596,7 @@ class ProjectSequencesResource(Resource):
         return user_service.get_sequences_for_project(project_id)
 
 
-class ProjectEpisodesResource(Resource):
+class ProjectEpisodesResource(MethodView):
 
     def get(self, project_id):
         """
@@ -659,7 +659,7 @@ class ProjectEpisodesResource(Resource):
         return user_service.get_project_episodes(project_id)
 
 
-class ProjectAssetTypesResource(Resource):
+class ProjectAssetTypesResource(MethodView):
 
     def get(self, project_id):
         """
@@ -725,7 +725,7 @@ class ProjectAssetTypesResource(Resource):
         return user_service.get_asset_types_for_project(project_id)
 
 
-class SequenceShotsResource(Resource):
+class SequenceShotsResource(MethodView):
 
     def get(self, sequence_id):
         """
@@ -792,7 +792,7 @@ class SequenceShotsResource(Resource):
         return user_service.get_shots_for_sequence(sequence_id)
 
 
-class SequenceScenesResource(Resource):
+class SequenceScenesResource(MethodView):
 
     def get(self, sequence_id):
         """
@@ -859,7 +859,7 @@ class SequenceScenesResource(Resource):
         return user_service.get_scenes_for_sequence(sequence_id)
 
 
-class ShotTasksResource(Resource):
+class ShotTasksResource(MethodView):
 
     def get(self, shot_id):
         """
@@ -934,7 +934,7 @@ class ShotTasksResource(Resource):
         return user_service.get_tasks_for_entity(shot_id)
 
 
-class SceneTasksResource(Resource):
+class SceneTasksResource(MethodView):
 
     def get(self, scene_id):
         """
@@ -1009,7 +1009,7 @@ class SceneTasksResource(Resource):
         return user_service.get_tasks_for_entity(scene_id)
 
 
-class SequenceTasksResource(Resource):
+class SequenceTasksResource(MethodView):
 
     def get(self, sequence_id):
         """
@@ -1085,7 +1085,7 @@ class SequenceTasksResource(Resource):
         return user_service.get_tasks_for_entity(sequence_id)
 
 
-class TodosResource(Resource):
+class TodosResource(MethodView):
 
     def get(self):
         """
@@ -1150,7 +1150,7 @@ class TodosResource(Resource):
         return user_service.get_todos()
 
 
-class ToChecksResource(Resource):
+class ToChecksResource(MethodView):
 
     def get(self):
         """
@@ -1216,7 +1216,7 @@ class ToChecksResource(Resource):
         return user_service.get_tasks_to_check()
 
 
-class DoneResource(Resource):
+class DoneResource(MethodView):
 
     def get(self):
         """
@@ -1281,7 +1281,7 @@ class DoneResource(Resource):
         return user_service.get_done_tasks()
 
 
-class FiltersResource(Resource, ArgsMixin):
+class FiltersResource(MethodView, ArgsMixin):
 
     def get(self):
         """
@@ -1468,7 +1468,7 @@ class FiltersResource(Resource, ArgsMixin):
         )
 
 
-class FilterResource(Resource, ArgsMixin):
+class FilterResource(MethodView, ArgsMixin):
 
     def put(self, filter_id):
         """
@@ -1602,7 +1602,7 @@ class FilterResource(Resource, ArgsMixin):
         return "", 204
 
 
-class FilterGroupsResource(Resource, ArgsMixin):
+class FilterGroupsResource(MethodView, ArgsMixin):
 
     def get(self):
         """
@@ -1782,7 +1782,7 @@ class FilterGroupsResource(Resource, ArgsMixin):
         )
 
 
-class FilterGroupResource(Resource, ArgsMixin):
+class FilterGroupResource(MethodView, ArgsMixin):
 
     def get(self, filter_group_id):
         """
@@ -1977,7 +1977,7 @@ class FilterGroupResource(Resource, ArgsMixin):
         return "", 204
 
 
-class DesktopLoginLogsResource(Resource, ArgsMixin):
+class DesktopLoginLogsResource(MethodView, ArgsMixin):
 
     def get(self):
         """
@@ -2090,7 +2090,7 @@ class DesktopLoginLogsResource(Resource, ArgsMixin):
         return desktop_login_log, 201
 
 
-class NotificationsResource(Resource, ArgsMixin):
+class NotificationsResource(MethodView, ArgsMixin):
 
     def get(self):
         """
@@ -2239,7 +2239,7 @@ class NotificationsResource(Resource, ArgsMixin):
         )
 
 
-class NotificationResource(Resource, ArgsMixin):
+class NotificationResource(MethodView, ArgsMixin):
 
     def get(self, notification_id):
         """
@@ -2386,7 +2386,7 @@ class NotificationResource(Resource, ArgsMixin):
         return user_service.update_notification(notification_id, body.read)
 
 
-class MarkAllNotificationsAsReadResource(Resource):
+class MarkAllNotificationsAsReadResource(MethodView):
 
     def post(self):
         """
@@ -2412,7 +2412,7 @@ class MarkAllNotificationsAsReadResource(Resource):
         return {"success": True}
 
 
-class HasTaskSubscribedResource(Resource):
+class HasTaskSubscribedResource(MethodView):
 
     def get(self, task_id):
         """
@@ -2443,7 +2443,7 @@ class HasTaskSubscribedResource(Resource):
         return user_service.has_task_subscription(task_id)
 
 
-class TaskSubscribeResource(Resource):
+class TaskSubscribeResource(MethodView):
 
     def post(self, task_id):
         """
@@ -2500,7 +2500,7 @@ class TaskSubscribeResource(Resource):
         return user_service.subscribe_to_task(task_id), 201
 
 
-class TaskUnsubscribeResource(Resource):
+class TaskUnsubscribeResource(MethodView):
 
     def delete(self, task_id):
         """
@@ -2528,7 +2528,7 @@ class TaskUnsubscribeResource(Resource):
         return "", 204
 
 
-class HasSequenceSubscribedResource(Resource):
+class HasSequenceSubscribedResource(MethodView):
 
     def get(self, sequence_id, task_type_id):
         """
@@ -2569,7 +2569,7 @@ class HasSequenceSubscribedResource(Resource):
         )
 
 
-class SequenceSubscribeResource(Resource):
+class SequenceSubscribeResource(MethodView):
 
     def post(self, sequence_id, task_type_id):
         """
@@ -2643,7 +2643,7 @@ class SequenceSubscribeResource(Resource):
         return subscription, 201
 
 
-class SequenceUnsubscribeResource(Resource):
+class SequenceUnsubscribeResource(MethodView):
 
     def delete(self, sequence_id, task_type_id):
         """
@@ -2679,7 +2679,7 @@ class SequenceUnsubscribeResource(Resource):
         return "", 204
 
 
-class SequenceSubscriptionsResource(Resource):
+class SequenceSubscriptionsResource(MethodView):
 
     def get(self, project_id, task_type_id):
         """
@@ -2723,7 +2723,7 @@ class SequenceSubscriptionsResource(Resource):
         )
 
 
-class TimeSpentsResource(Resource, ArgsMixin):
+class TimeSpentsResource(MethodView, ArgsMixin):
     """
     Get all time spents for the current user.
     Optionnaly can accept date range parameters.
@@ -2823,7 +2823,7 @@ class TimeSpentsResource(Resource, ArgsMixin):
             )
 
 
-class DateTimeSpentsResource(Resource):
+class DateTimeSpentsResource(MethodView):
 
     def get(self, date):
         """
@@ -2895,7 +2895,7 @@ class DateTimeSpentsResource(Resource):
             raise WrongParameterException("Wrong date format.")
 
 
-class TaskTimeSpentResource(Resource):
+class TaskTimeSpentResource(MethodView):
 
     def get(self, task_id, date):
         """
@@ -2974,7 +2974,7 @@ class TaskTimeSpentResource(Resource):
             raise WrongParameterException("Wrong date format.")
 
 
-class DayOffResource(Resource):
+class DayOffResource(MethodView):
 
     def get(self, date):
         """
@@ -3034,7 +3034,7 @@ class DayOffResource(Resource):
             raise WrongParameterException("Wrong date format.")
 
 
-class ContextResource(Resource):
+class ContextResource(MethodView):
 
     def get(self):
         """
@@ -3143,7 +3143,7 @@ class ContextResource(Resource):
         return user_service.get_context()
 
 
-class ClearAvatarResource(Resource):
+class ClearAvatarResource(MethodView):
 
     def delete(self):
         """
@@ -3162,7 +3162,7 @@ class ClearAvatarResource(Resource):
         return "", 204
 
 
-class ChatsResource(Resource):
+class ChatsResource(MethodView):
 
     def get(self):
         """
@@ -3218,7 +3218,7 @@ class ChatsResource(Resource):
         return chats_service.get_chats_for_person(user["id"])
 
 
-class JoinChatResource(Resource):
+class JoinChatResource(MethodView):
 
     def post(self, entity_id):
         """

--- a/zou/app/mixin.py
+++ b/zou/app/mixin.py
@@ -1,4 +1,3 @@
-from flask_restful import reqparse
 from flask import request
 
 from zou.app.utils import date_helpers, fields
@@ -14,16 +13,26 @@ class ArgsMixin(object):
         """
         Retrieve arguments from GET or POST queries.
         """
-        parser = reqparse.RequestParser()
         if location is None:
             location = ["values", "json"] if request.is_json else ["values"]
+        elif isinstance(location, str):
+            location = [location]
 
+        sources = []
+        for source_name in location:
+            if source_name == "json":
+                json_body = request.get_json(silent=True)
+                if isinstance(json_body, dict):
+                    sources.append(json_body)
+            else:
+                sources.append(getattr(request, source_name))
+
+        args = {}
         for descriptor in descriptors:
             action = None
             data_type = str
             required = False
             default = None
-            help = None
 
             if isinstance(descriptor, (list, tuple)):
                 if len(descriptor) == 5:
@@ -46,19 +55,47 @@ class ArgsMixin(object):
                 default = descriptor.get("default", default)
                 action = descriptor.get("action", action)
                 data_type = descriptor.get("type", data_type)
-                help = descriptor.get("help", help)
 
-            parser.add_argument(
-                name,
-                required=required,
-                default=default,
-                action=action,
-                type=data_type,
-                help=help,
-                location=location,
+            args[name] = self._parse_arg(
+                sources, name, default, required, data_type, action
             )
+        return args
 
-        return parser.parse_args()
+    @staticmethod
+    def _parse_arg(sources, name, default, required, data_type, action):
+        """
+        Resolve a single argument against the request sources: first source
+        holding the name wins, values are cast with data_type, and
+        action="append" collects every occurrence as a list.
+        """
+        source = next((s for s in sources if name in s), None)
+        if source is None:
+            if required:
+                raise WrongParameterException(
+                    f"Missing required parameter: {name}"
+                )
+            return default
+
+        def convert(value):
+            if value is None or data_type is None:
+                return value
+            try:
+                return data_type(value)
+            except (TypeError, ValueError):
+                raise WrongParameterException(
+                    f"Wrong value for parameter {name}."
+                )
+
+        if action == "append":
+            if hasattr(source, "getlist"):
+                values = source.getlist(name)
+            else:
+                values = source[name]
+                if not isinstance(values, list):
+                    values = [values]
+            return [convert(value) for value in values]
+
+        return convert(source.get(name))
 
     def clear_empty_fields(self, data, ignored_fields=None):
         """

--- a/zou/app/utils/api.py
+++ b/zou/app/utils/api.py
@@ -1,24 +1,16 @@
-from flask_restful import Api
-from zou.app.utils.flask import output_json
+from flask.views import MethodView
 
 
 def configure_api_from_blueprint(blueprint, route_tuples, decorators=None):
     """
-    Creates a Flask Restful api object based on information from given
-    blueprint. API is configured to return JSON objects.
-
-    Each blueprint is describe by a list of tuple. Each tuple is composed of a
-    route and the related resource (controller).
+    Register route tuples (path, resource class) on the given blueprint.
+    Resources are Flask MethodView classes; JSON serialization of dict and
+    list return values is handled natively by Flask through the app JSON
+    provider (orjson).
     """
-
-    api = Api(blueprint, catch_all_404s=True, decorators=decorators)
-
-    api.representations = {
-        "application/json": output_json,
-    }
-
-    for route_tuple in route_tuples:
-        path, resource = route_tuple
-        api.add_resource(resource, path)
-
-    return api
+    for path, resource in route_tuples:
+        view_func = resource.as_view(resource.__name__)
+        for decorator in decorators or []:
+            view_func = decorator(view_func)
+        blueprint.add_url_rule(path, view_func=view_func)
+    return blueprint

--- a/zou/app/utils/fields.py
+++ b/zou/app/utils/fields.py
@@ -139,3 +139,20 @@ def is_valid_id(value):
     Check if a given string is a valid UUID.
     """
     return _UUID_RE.match(value)
+
+
+def boolean(value):
+    """
+    Parse "true"/"false" (case insensitive, also "1"/"0"/"on") as a boolean.
+    Meant as a query argument type; raises ValueError on anything else.
+    """
+    if isinstance(value, bool):
+        return value
+    if not value:
+        raise ValueError("boolean type must be non-null")
+    value = value.lower()
+    if value in ("true", "1", "on"):
+        return True
+    if value in ("false", "0"):
+        return False
+    raise ValueError(f"Invalid literal for boolean(): {value}")

--- a/zou/app/utils/flask.py
+++ b/zou/app/utils/flask.py
@@ -2,22 +2,11 @@ from ua_parser import user_agent_parser
 from werkzeug.user_agent import UserAgent
 from werkzeug.utils import cached_property
 from flask.json.provider import JSONProvider
-from flask import make_response, request, abort
+from flask import request, abort
 
 import orjson
 
 orjson_options = orjson.OPT_NON_STR_KEYS
-
-
-def output_json(data, code, headers=None):
-    """
-    Makes a Flask response with a JSON encoded body
-    """
-    dumped = orjson.dumps(data, option=orjson_options)
-
-    resp = make_response(dumped, code)
-    resp.headers.extend(headers or {})
-    return resp
 
 
 class ORJSONProvider(JSONProvider):

--- a/zou/app/utils/plugins.py
+++ b/zou/app/utils/plugins.py
@@ -17,7 +17,7 @@ from alembic import command
 from alembic.config import Config
 from collections.abc import MutableMapping
 from flask import Blueprint, send_from_directory, abort, current_app
-from flask_restful import Resource
+from flask.views import MethodView
 from pathlib import Path
 from sqlalchemy import MetaData
 from sqlalchemy.util import FacadeDict
@@ -26,7 +26,7 @@ from zou.app import db, app
 from zou.app.utils.api import configure_api_from_blueprint
 
 
-class StaticResource(Resource):
+class StaticResource(MethodView):
 
     plugin_id = None
 

--- a/zou/plugin_template/resources.py
+++ b/zou/plugin_template/resources.py
@@ -1,10 +1,10 @@
-from flask_restful import Resource
+from flask.views import MethodView
 from flask_jwt_extended import jwt_required
 
 from .models import Count
 
 
-class HelloWorld(Resource):
+class HelloWorld(MethodView):
 
     @jwt_required()
     def get(self):


### PR DESCRIPTION
**Problem**
- flask_restful is unmaintained and Zou only used a thin slice of it (Resource dispatch, JSON output, reqparse for query args)
- Flask covers all of it natively since 2.2 (MethodView, dict/list serialization via the orjson provider)

**Solution**
- Migrate all resources and the two CRUD bases to `flask.views.MethodView`; `configure_api_from_blueprint` keeps its signature and registers views with `add_url_rule`
- Add a generic `HTTPException` JSON handler so `abort()` responses stay JSON
- Replace `reqparse` in `ArgsMixin.get_args` with a native parser (same descriptor formats, type casting and `action=append` semantics) and `inputs.boolean` with `fields.boolean`
- Drop the dependency and `output_json`; plugins importing flask_restful directly must subclass `MethodView` instead (drop-in, works with both old and new Zou)