### PR TITLE
[audit] Cache, N+1, validation and error-handling fixes

### DIFF
--- a/tests/models/test_time_spent.py
+++ b/tests/models/test_time_spent.py
@@ -1,3 +1,4 @@
+import datetime
 import random
 
 from tests.base import ApiDBTestCase
@@ -21,11 +22,15 @@ class TimeSpentTestCase(ApiDBTestCase):
         self.generate_fixture_task_status()
         self.generate_fixture_assigner()
         self.generate_fixture_task()
+        # Distinct deterministic dates: (person, task, date) is unique, so
+        # letting mixer draw random dates makes the test flaky on collision.
+        dates = iter(datetime.date(2024, 1, day) for day in [1, 2, 3])
         self.tasks = self.generate_data(
             TimeSpent,
             3,
             task_id=self.task.id,
             person_id=self.person.id,
+            date=lambda: next(dates),
             duration=lambda: random.uniform(0.1, 10000),
         )
 

--- a/tests/source/csv/test_import_persons.py
+++ b/tests/source/csv/test_import_persons.py
@@ -188,6 +188,33 @@ class ImportCsvPersonsTestCase(ApiDBTestCase):
             ["Animation"],
         )
 
+    def test_import_persons_partial_import_reported(self):
+        """
+        Rows are committed one by one: a failing row stops the import but
+        keeps the rows before it, and the error payload reports the failing
+        line and how many rows were imported, so the client can fix the
+        file and re-run with update=true.
+        """
+        header = ";".join(f'"{column}"' for column in self.columns)
+        values = {column: "" for column in self.columns}
+        values["Last Name"] = "User"
+        values["First Name"] = "Valid"
+        values["Email"] = "valid.user@gmail.com"
+        row_valid = ";".join(f'"{values[column]}"' for column in self.columns)
+        values["First Name"] = "Broken"
+        values["Email"] = "broken.user@gmail.com"
+        values["Country"] = "France"
+        row_broken = ";".join(
+            f'"{values[column]}"' for column in self.columns
+        )
+        error = self._upload_csv(
+            f"{header}\n{row_valid}\n{row_broken}\n", code=400
+        )
+        self.assertEqual(error["line_number"], 3)
+        self.assertEqual(error["imported_rows"], 1)
+        self.assertIsNotNone(Person.get_by(email="valid.user@gmail.com"))
+        self.assertIsNone(Person.get_by(email="broken.user@gmail.com"))
+
     def _csv(self, **overrides):
         values = {column: "" for column in self.columns}
         values["First Name"] = "Test"

--- a/tests/source/csv/test_import_persons.py
+++ b/tests/source/csv/test_import_persons.py
@@ -204,9 +204,7 @@ class ImportCsvPersonsTestCase(ApiDBTestCase):
         values["First Name"] = "Broken"
         values["Email"] = "broken.user@gmail.com"
         values["Country"] = "France"
-        row_broken = ";".join(
-            f'"{values[column]}"' for column in self.columns
-        )
+        row_broken = ";".join(f'"{values[column]}"' for column in self.columns)
         error = self._upload_csv(
             f"{header}\n{row_valid}\n{row_broken}\n", code=400
         )

--- a/zou/app/__init__.py
+++ b/zou/app/__init__.py
@@ -223,21 +223,24 @@ def two_factor_auth_required(error):
     )
 
 
-if config.DEBUG:
-
-    @app.errorhandler(Exception)
-    def server_error(error):
-        # HTTPExceptions (404, 405, ...) carry their own status code; let
-        # Flask render them normally instead of masking every one as a 500
-        # with a stacktrace while in debug mode.
-        if isinstance(error, HTTPException):
-            return error
-        stacktrace = traceback.format_exc()
-        current_app.logger.error(stacktrace)
+@app.errorhandler(Exception)
+def server_error(error):
+    # HTTPExceptions (404, 405, ...) carry their own status code; let
+    # Flask render them normally instead of masking every one as a 500.
+    if isinstance(error, HTTPException):
+        return error
+    stacktrace = traceback.format_exc()
+    current_app.logger.error(
+        f"Unhandled error on {request.method} {request.path}\n{stacktrace}"
+    )
+    if config.DEBUG:
         return (
             jsonify(error=True, message=str(error), stacktrace=stacktrace),
             500,
         )
+    # No exception details for the client in production: the message can
+    # embed internals (SQL, paths); everything is in the logs above.
+    return jsonify(error=True, message="Internal server error."), 500
 
 
 def configure_auth():

--- a/zou/app/api.py
+++ b/zou/app/api.py
@@ -1,37 +1,40 @@
+import importlib
 import sys
-
-from zou.app.blueprints.assets import blueprint as assets_blueprint
-from zou.app.blueprints.auth import blueprint as auth_blueprint
-from zou.app.blueprints.breakdown import blueprint as breakdown_blueprint
-from zou.app.blueprints.chats import blueprint as chats_blueprint
-from zou.app.blueprints.comments import blueprint as comments_blueprint
-from zou.app.blueprints.crud import blueprint as crud_blueprint
-from zou.app.blueprints.departments import blueprint as departments_blueprint
-from zou.app.blueprints.entities import blueprint as entities_blueprint
-from zou.app.blueprints.events import blueprint as events_blueprint
-from zou.app.blueprints.export import blueprint as export_blueprint
-from zou.app.blueprints.files import blueprint as files_blueprint
-from zou.app.blueprints.index import blueprint as index_blueprint
-from zou.app.blueprints.search import blueprint as search_blueprint
-from zou.app.blueprints.news import blueprint as news_blueprint
-from zou.app.blueprints.persons import blueprint as persons_blueprint
-from zou.app.blueprints.playlists import blueprint as playlists_blueprint
-from zou.app.blueprints.shared import blueprint as shared_blueprint
-from zou.app.blueprints.projects import blueprint as projects_blueprint
-from zou.app.blueprints.project_templates import (
-    blueprint as project_templates_blueprint,
-)
-from zou.app.blueprints.previews import blueprint as previews_blueprint
-from zou.app.blueprints.source import blueprint as import_blueprint
-from zou.app.blueprints.shots import blueprint as shots_blueprint
-from zou.app.blueprints.tasks import blueprint as tasks_blueprint
-from zou.app.blueprints.user import blueprint as user_blueprint
-from zou.app.blueprints.edits import blueprint as edits_blueprint
-from zou.app.blueprints.concepts import blueprint as concepts_blueprint
 
 from zou.app import config
 from zou.app.utils.plugins import load_plugins
 from zou.app.utils import events
+
+# Blueprint packages of zou.app.blueprints to register, in registration
+# order. Each package exposes a `blueprint` object.
+BLUEPRINT_MODULES = [
+    "auth",
+    "assets",
+    "breakdown",
+    "chats",
+    "comments",
+    "crud",
+    "departments",
+    "entities",
+    "export",
+    "events",
+    "files",
+    "source",
+    "index",
+    "news",
+    "persons",
+    "playlists",
+    "shared",
+    "projects",
+    "project_templates",
+    "shots",
+    "tasks",
+    "previews",
+    "user",
+    "edits",
+    "search",
+    "concepts",
+]
 
 
 def configure(app):
@@ -51,32 +54,9 @@ def configure_api_routes(app):
     Register blueprints (modules). Each blueprint describe routes and
     associated resources (controllers).
     """
-    app.register_blueprint(auth_blueprint)
-    app.register_blueprint(assets_blueprint)
-    app.register_blueprint(breakdown_blueprint)
-    app.register_blueprint(chats_blueprint)
-    app.register_blueprint(comments_blueprint)
-    app.register_blueprint(crud_blueprint)
-    app.register_blueprint(departments_blueprint)
-    app.register_blueprint(entities_blueprint)
-    app.register_blueprint(export_blueprint)
-    app.register_blueprint(events_blueprint)
-    app.register_blueprint(files_blueprint)
-    app.register_blueprint(import_blueprint)
-    app.register_blueprint(index_blueprint)
-    app.register_blueprint(news_blueprint)
-    app.register_blueprint(persons_blueprint)
-    app.register_blueprint(playlists_blueprint)
-    app.register_blueprint(shared_blueprint)
-    app.register_blueprint(projects_blueprint)
-    app.register_blueprint(project_templates_blueprint)
-    app.register_blueprint(shots_blueprint)
-    app.register_blueprint(tasks_blueprint)
-    app.register_blueprint(previews_blueprint)
-    app.register_blueprint(user_blueprint)
-    app.register_blueprint(edits_blueprint)
-    app.register_blueprint(search_blueprint)
-    app.register_blueprint(concepts_blueprint)
+    for module_name in BLUEPRINT_MODULES:
+        module = importlib.import_module(f"zou.app.blueprints.{module_name}")
+        app.register_blueprint(module.blueprint)
 
     if config.ADMIN_TOKEN:
         from zou.app.blueprints.admin import blueprint as admin_blueprint
@@ -94,11 +74,12 @@ def register_event_handlers(app):
     sys.path.insert(0, app.config["EVENT_HANDLERS_FOLDER"])
     try:
         import event_handlers
-
-        events.register_all(event_handlers.event_map, app)
-    except ImportError:
-        # Event handlers folder is not properly configured.
-        # Handlers are optional, that's why this error is ignored.
-        # app.logger.info("No event handlers folder is configured.")
-        pass
+    except ModuleNotFoundError as exception:
+        # Handlers are optional: having no event handlers folder is fine,
+        # but a broken import inside the handlers themselves is not and
+        # must not be swallowed.
+        if exception.name != "event_handlers":
+            raise
+        return app
+    events.register_all(event_handlers.event_map, app)
     return app

--- a/zou/app/blueprints/crud/base.py
+++ b/zou/app/blueprints/crud/base.py
@@ -18,6 +18,26 @@ from zou.app.services.exception import (
 )
 
 
+def build_db_error_message(exception):
+    """
+    Client-safe message for database errors: the raw exception text embeds
+    SQL statements and bound parameter values, which must stay in the
+    server logs and never reach the client.
+    """
+    if isinstance(exception, IntegrityError):
+        origin = str(getattr(exception, "orig", exception)).lower()
+        if "duplicate key" in origin or "unique constraint" in origin:
+            return "A record with the same unique values already exists."
+        if "foreign key" in origin:
+            return "The change conflicts with records referencing this one."
+        if "not-null" in origin or "null value" in origin:
+            return "A required field is missing."
+        return "The data conflicts with database integrity rules."
+    if isinstance(exception, StatementError):
+        return "One of the provided values has an invalid format."
+    return str(exception)
+
+
 class BaseModelsResource(MethodView, ArgsMixin):
     def __init__(self, model):
         MethodView.__init__(self)
@@ -341,7 +361,7 @@ class BaseModelsResource(MethodView, ArgsMixin):
             KeyError,
         ) as exception:
             current_app.logger.error(str(exception), exc_info=1)
-            return {"message": str(exception)}, 400
+            return {"message": build_db_error_message(exception)}, 400
 
     def emit_create_event(self, instance_dict):
         return events.emit(
@@ -407,19 +427,17 @@ class BaseModelResource(MethodView, ArgsMixin):
         }
         for key, value in data.items():
             if key in columns and isinstance(value, str) and value != "":
-                for fmt in (
-                    "%Y-%m-%dT%H:%M:%S.%f",
-                    "%Y-%m-%dT%H:%M:%S",
-                    "%Y-%m-%d",
-                ):
-                    try:
-                        datetime.datetime.strptime(value, fmt)
-                        break
-                    except ValueError:
-                        continue
-                else:
+                try:
+                    # fromisoformat accepts what PostgreSQL does for ISO
+                    # 8601 (date only, time offsets...); Z must be mapped
+                    # to +00:00 while Python 3.10 is supported.
+                    datetime.datetime.fromisoformat(
+                        value.replace("Z", "+00:00")
+                    )
+                except ValueError:
                     raise WrongParameterException(
-                        f"Invalid date format for '{key}': '{value}'. Expected YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS."
+                        f"Invalid date format for '{key}': '{value}'. "
+                        "Expected an ISO 8601 date or datetime."
                     )
 
     def serialize_instance(self, data, relations=True):
@@ -586,7 +604,7 @@ class BaseModelResource(MethodView, ArgsMixin):
             StatementError,
         ) as exception:
             current_app.logger.error(str(exception), exc_info=1)
-            return {"message": str(exception)}, 400
+            return {"message": build_db_error_message(exception)}, 400
 
     @jwt_required()
     def delete(self, instance_id):
@@ -621,13 +639,9 @@ class BaseModelResource(MethodView, ArgsMixin):
             self.emit_delete_event(instance_dict)
             self.post_delete(instance_dict)
 
-        except IntegrityError as exception:
+        except (IntegrityError, StatementError) as exception:
             current_app.logger.error(str(exception), exc_info=1)
-            return {"message": str(exception)}, 400
-
-        except StatementError as exception:
-            current_app.logger.error(str(exception), exc_info=1)
-            return {"message": str(exception)}, 400
+            return {"message": build_db_error_message(exception)}, 400
 
         return "", 204
 

--- a/zou/app/blueprints/previews/resources.py
+++ b/zou/app/blueprints/previews/resources.py
@@ -1625,9 +1625,7 @@ class UpdateAnnotationsResource(MethodView, ArgsMixin):
         if not (is_manager or is_client or is_supervisor_allowed):
             raise permissions.PermissionDenied
 
-        body = validation_utils.validate_request_body(
-            AnnotationsUpdateSchema
-        )
+        body = validation_utils.validate_request_body(AnnotationsUpdateSchema)
         user = persons_service.get_current_user()
         return preview_files_service.update_preview_file_annotations(
             user["id"],

--- a/zou/app/blueprints/previews/resources.py
+++ b/zou/app/blueprints/previews/resources.py
@@ -12,6 +12,7 @@ from zou.app import config
 from zou.app.mixin import ArgsMixin
 from zou.app.utils import validation as validation_utils
 from zou.app.blueprints.previews.schemas import (
+    AnnotationsUpdateSchema,
     ExtractAnnotatedFrameSchema,
     PreviewFileUploadSchema,
     PreviewFilePositionSchema,
@@ -1624,17 +1625,17 @@ class UpdateAnnotationsResource(MethodView, ArgsMixin):
         if not (is_manager or is_client or is_supervisor_allowed):
             raise permissions.PermissionDenied
 
-        additions = request.json.get("additions", [])
-        updates = request.json.get("updates", [])
-        deletions = request.json.get("deletions", [])
+        body = validation_utils.validate_request_body(
+            AnnotationsUpdateSchema
+        )
         user = persons_service.get_current_user()
         return preview_files_service.update_preview_file_annotations(
             user["id"],
             task["project_id"],
             preview_file_id,
-            additions=additions,
-            updates=updates,
-            deletions=deletions,
+            additions=body.additions,
+            updates=body.updates,
+            deletions=body.deletions,
         )
 
 

--- a/zou/app/blueprints/previews/schemas.py
+++ b/zou/app/blueprints/previews/schemas.py
@@ -33,3 +33,13 @@ class ExtractAnnotatedFrameSchema(BaseSchema):
     """
 
     frame_number: Optional[int] = Field(None, ge=1)
+
+
+class AnnotationsUpdateSchema(BaseSchema):
+    """
+    Body for updating the annotations of a preview file.
+    """
+
+    additions: list = Field(default_factory=list)
+    updates: list = Field(default_factory=list)
+    deletions: list = Field(default_factory=list)

--- a/zou/app/blueprints/source/csv/base.py
+++ b/zou/app/blueprints/source/csv/base.py
@@ -18,10 +18,11 @@ class ImportRowException(Exception):
     message = ""
     line_number = 0
 
-    def __init__(self, message, line_number):
+    def __init__(self, message, line_number, imported_rows=0):
         Exception.__init__(self, message)
         self.message = message
         self.line_number = line_number
+        self.imported_rows = imported_rows
 
 
 class RowException(Exception):
@@ -59,12 +60,19 @@ class BaseCsvImportResource(MethodView, ArgsMixin):
             "error": True,
             "message": exception.message,
             "line_number": exception.line_number,
+            "imported_rows": exception.imported_rows,
         }
 
     def format_error(self, exception):
         return {"error": True, "message": str(exception)}
 
     def run_import(self, file_path, *args):
+        """
+        Import rows one by one, each committed on its own: a failure stops
+        the import but keeps previously imported rows (imported_rows in
+        the error payload tells the client how many). Fixing the file and
+        re-importing with update=true completes the job idempotently.
+        """
         result = []
         self.check_permissions(*args)
         self.prepare_import(*args)
@@ -78,19 +86,27 @@ class BaseCsvImportResource(MethodView, ArgsMixin):
                     row = self.import_row(row, *args)
                     result.append(row)
                 except IntegrityError as e:
-                    raise ImportRowException(e._message(), line_number)
+                    raise ImportRowException(
+                        e._message(), line_number, len(result)
+                    )
                 except RowException as e:
-                    raise ImportRowException(e.message, line_number)
+                    raise ImportRowException(
+                        e.message, line_number, len(result)
+                    )
                 except KeyError as e:
                     raise ImportRowException(
-                        f"A columns is missing: {str(e)}", line_number
+                        f"A columns is missing: {str(e)}",
+                        line_number,
+                        len(result),
                     )
                 except ValueError as e:
                     raise ImportRowException(
-                        f"A value is invalid: {str(e)}", line_number
+                        f"A value is invalid: {str(e)}",
+                        line_number,
+                        len(result),
                     )
                 except Exception as e:
-                    raise ImportRowException(str(e), line_number)
+                    raise ImportRowException(str(e), line_number, len(result))
         return result
 
     def get_dialect(self, csvfile):

--- a/zou/app/blueprints/tasks/resources.py
+++ b/zou/app/blueprints/tasks/resources.py
@@ -821,7 +821,7 @@ class CreateShotTasksResource(MethodView):
         user_service.check_manager_project_access(project_id)
         task_type = tasks_service.get_task_type(task_type_id)
 
-        shot_ids = request.json
+        shot_ids = validation.validate_id_list(required=False)
         shots = []
         if isinstance(shot_ids, list) and len(shot_ids) > 0:
             for shot_id in shot_ids:
@@ -918,7 +918,7 @@ class CreateConceptTasksResource(MethodView):
             raise permissions.PermissionDenied
         task_type = tasks_service.get_task_type(task_type_id)
 
-        concept_ids = request.json
+        concept_ids = validation.validate_id_list(required=False)
         concepts = []
         if isinstance(concept_ids, list) and len(concept_ids) > 0:
             for concept_id in concept_ids:
@@ -1025,7 +1025,7 @@ class CreateEntityTasksResource(MethodView):
             )
         )
 
-        entity_ids = request.json
+        entity_ids = validation.validate_id_list(required=False)
         entities = []
         if isinstance(entity_ids, list) and len(entity_ids) > 0:
             for entity_id in entity_ids:
@@ -1119,7 +1119,7 @@ class CreateAssetTasksResource(MethodView):
         user_service.check_manager_project_access(project_id)
         task_type = tasks_service.get_task_type(task_type_id)
 
-        asset_ids = request.json
+        asset_ids = validation.validate_id_list(required=False)
         assets = []
         if isinstance(asset_ids, list) and len(asset_ids) > 0:
             for asset_id in asset_ids:
@@ -1211,7 +1211,7 @@ class CreateEditTasksResource(MethodView):
         user_service.check_manager_project_access(project_id)
         task_type = tasks_service.get_task_type(task_type_id)
 
-        edit_ids = request.json
+        edit_ids = validation.validate_id_list(required=False)
         edits = []
         if isinstance(edit_ids, list) and len(edit_ids) > 0:
             for edit_id in edit_ids:
@@ -2232,9 +2232,7 @@ class DeleteTasksResource(MethodView):
                       example: ["a24a6ea4-ce75-4665-a070-57453082c25"]
         """
         user_service.check_manager_project_access(project_id)
-        task_ids = request.json
-        if not isinstance(task_ids, list):
-            raise WrongParameterException("Request body must be a JSON array.")
+        task_ids = validation.validate_id_list()
         task_ids = deletion_service.remove_tasks(project_id, task_ids)
         for task_id in task_ids:
             tasks_service.clear_task_cache(task_id)

--- a/zou/app/config.py
+++ b/zou/app/config.py
@@ -3,7 +3,8 @@ import sys
 import datetime
 import tempfile
 
-from zou.app.utils import dbhelpers
+from sqlalchemy.engine.url import URL
+
 from zou.app.utils.env import envtobool, env_with_semicolon_to_list
 
 PROPAGATE_EXCEPTIONS = True
@@ -63,7 +64,9 @@ DATABASE = {
     "password": os.getenv("DB_PASSWORD", "mysecretpassword"),
     "database": os.getenv("DB_DATABASE", "zoudb"),
 }
-SQLALCHEMY_DATABASE_URI = dbhelpers.get_db_uri()
+SQLALCHEMY_DATABASE_URI = URL.create(**DATABASE).render_as_string(
+    hide_password=False
+)
 SQLALCHEMY_TRACK_MODIFICATIONS = False
 SQLALCHEMY_ENGINE_OPTIONS = {
     "pool_size": int(os.getenv("DB_POOL_SIZE", 30)),

--- a/zou/app/indexer/indexing.py
+++ b/zou/app/indexer/indexing.py
@@ -77,7 +77,7 @@ def clear_index(index_name):
     """
     Clear all data into the index matching given name.
     """
-    cache.cache.delete_memoized(get_index)
+    cache.cache.delete_memoized(get_index, index_name)
     index = get_index(index_name)
     task = index.delete_all_documents()
     get_client().wait_for_task(

--- a/zou/app/models/base.py
+++ b/zou/app/models/base.py
@@ -105,9 +105,37 @@ class BaseMixin(object):
             db.session.commit()
         except Exception:
             db.session.rollback()
-            db.session.remove()
             raise
         return instance
+
+    @classmethod
+    def _resolve_relations(cls, data):
+        """
+        Map relationship fields of data to lists of ORM instances. Values
+        can be ids, dicts holding an id or already-loaded instances;
+        unknown ids are dropped. Non-relationship fields are left out.
+        """
+        resolved = {}
+        for key, value in data.items():
+            field_key = getattr(cls, key, None)
+            if not hasattr(field_key, "property") or not isinstance(
+                field_key.property, orm.properties.RelationshipProperty
+            ):
+                continue
+            class_ = field_key.property.entity.class_
+            values = []
+            if value is not None:
+                for id in value:
+                    if isinstance(id, str):
+                        v = class_.get(id)
+                    elif isinstance(id, dict):
+                        v = class_.get(id["id"])
+                    else:
+                        v = id
+                    if v is not None:
+                        values.append(v)
+            resolved[key] = values
+        return resolved
 
     @classmethod
     def create_no_commit(cls, **kw):
@@ -115,28 +143,7 @@ class BaseMixin(object):
         Shorthand to create an entry via the database session without commiting
         the request.
         """
-        for key, value in kw.items():
-            if hasattr(cls, key):
-                field_key = getattr(cls, key)
-
-                if hasattr(field_key, "property"):
-                    if isinstance(
-                        field_key.property,
-                        orm.properties.RelationshipProperty,
-                    ):
-                        class_ = field_key.property.entity.class_
-                        values = []
-                        if value is not None:
-                            for id in value:
-                                if isinstance(id, str):
-                                    v = class_.get(id)
-                                elif isinstance(id, dict):
-                                    v = class_.get(id["id"])
-                                else:
-                                    v = id
-                                if v is not None:
-                                    values.append(v)
-                        kw[key] = values
+        kw.update(cls._resolve_relations(kw))
         instance = cls(**kw)
         db.session.add(instance)
         return instance
@@ -213,7 +220,6 @@ class BaseMixin(object):
             db.session.commit()
         except Exception:
             db.session.rollback()
-            db.session.remove()
             raise
 
     def save(self):
@@ -227,7 +233,6 @@ class BaseMixin(object):
             db.session.commit()
         except Exception:
             db.session.rollback()
-            db.session.remove()
             raise
 
     def delete(self):
@@ -240,7 +245,6 @@ class BaseMixin(object):
             db.session.commit()
         except Exception:
             db.session.rollback()
-            db.session.remove()
             raise
 
     def delete_no_commit(self):
@@ -261,7 +265,6 @@ class BaseMixin(object):
             db.session.commit()
         except Exception:
             db.session.rollback()
-            db.session.remove()
             raise
 
     def update_no_commit(self, data):
@@ -270,30 +273,12 @@ class BaseMixin(object):
         instance fields. It doesn't generate a commit.
         """
         self.updated_at = date_helpers.get_utc_now_datetime()
+        resolved = self._resolve_relations(data)
         for key, value in data.items():
-            if hasattr(self.__class__, key):
-                field_key = getattr(self.__class__, key)
-
-                if hasattr(field_key, "property"):
-                    if isinstance(
-                        field_key.property,
-                        orm.properties.RelationshipProperty,
-                    ):
-                        class_ = field_key.property.entity.class_
-                        values = []
-                        if value is not None:
-                            for id in value:
-                                if isinstance(id, str):
-                                    v = class_.get(id)
-                                elif isinstance(id, dict):
-                                    v = class_.get(id["id"])
-                                else:
-                                    v = id
-                                if v is not None:
-                                    values.append(v)
-                        setattr(self, key, values)
-                    else:
-                        setattr(self, key, value)
+            field_key = getattr(self.__class__, key, None)
+            if not hasattr(field_key, "property"):
+                continue
+            setattr(self, key, resolved.get(key, value))
         db.session.add(self)
 
     def set_links(self, ids, LinkTable, field_left, field_right):

--- a/zou/app/models/person.py
+++ b/zou/app/models/person.py
@@ -7,7 +7,7 @@ from sqlalchemy_utils import (
     TimezoneType,
     ChoiceType,
 )
-from sqlalchemy import Index
+from sqlalchemy import func, Index
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import validates
 from sqlalchemy.dialects.postgresql import JSONB
@@ -17,6 +17,7 @@ from babel import Locale
 from babel.core import UnknownLocaleError
 
 from zou.app.models.serializer import SerializerMixin
+from zou.app.utils import fields
 from zou.app.models.department import Department
 from zou.app.models.base import BaseMixin
 from zou.app import db
@@ -283,10 +284,17 @@ class Person(db.Model, BaseMixin, SerializerMixin):
 
     @full_name.expression
     def full_name(cls):
-        if cls.first_name and cls.last_name:
-            return cls.first_name + " " + cls.last_name
-        else:
-            return cls.first_name + cls.last_name
+        # The previous form branched on bool(Column), which is always
+        # true, and produced NULL as soon as one name part was NULL.
+        # concat_ws skips NULLs; nullif maps empty strings to NULL so the
+        # result matches the Python property for every combination.
+        return func.trim(
+            func.concat_ws(
+                " ",
+                func.nullif(cls.first_name, ""),
+                func.nullif(cls.last_name, ""),
+            )
+        )
 
     def fido_devices(self):
         if self.fido_credentials is None:
@@ -312,22 +320,29 @@ class Person(db.Model, BaseMixin, SerializerMixin):
         )
 
     def present_minimal(self, relations=False, milliseconds=False):
-        data = SerializerMixin.serialize(
-            self, "Person", relations=relations, milliseconds=milliseconds
-        )
+        """
+        Build the minimal person dict directly: serializing all columns to
+        keep a dozen fields was a hot path (embedded author of every
+        comment and reply).
+        """
+        departments = []
+        if relations:
+            departments = [
+                str(department.id) for department in self.departments
+            ]
         return {
-            "id": data["id"],
-            "type": data["type"],
-            "first_name": data["first_name"],
-            "last_name": data["last_name"],
+            "id": str(self.id),
+            "type": "Person",
+            "first_name": self.first_name,
+            "last_name": self.last_name,
             "full_name": self.full_name,
-            "has_avatar": data["has_avatar"],
-            "active": data["active"],
-            "departments": data.get("departments", []),
-            "studio_id": data["studio_id"],
-            "role": data["role"],
-            "desktop_login": data["desktop_login"],
-            "is_bot": data["is_bot"],
+            "has_avatar": self.has_avatar,
+            "active": self.active,
+            "departments": departments,
+            "studio_id": str(self.studio_id) if self.studio_id else None,
+            "role": fields.serialize_value(self.role),
+            "desktop_login": self.desktop_login,
+            "is_bot": self.is_bot,
         }
 
     def set_departments(self, department_ids):

--- a/zou/app/models/serializer.py
+++ b/zou/app/models/serializer.py
@@ -8,11 +8,33 @@ class SerializerMixin(object):
     Helpers to facilitate JSON serialization of models.
     """
 
-    def is_join(self, attr):
-        return hasattr(getattr(self.__class__, attr), "impl") and isinstance(
-            getattr(self.__class__, attr).impl,
+    @classmethod
+    def _is_join_attr(cls, attr):
+        descriptor = getattr(cls, attr)
+        return hasattr(descriptor, "impl") and isinstance(
+            descriptor.impl,
             orm.attributes.CollectionAttributeImpl,
         )
+
+    @classmethod
+    def _serializable_attrs(cls):
+        """
+        Return (all attrs, non-join attrs) for the model, computed once
+        per class: inspecting descriptors for every attribute of every
+        row dominated serialize_list profiles.
+        """
+        cached = cls.__dict__.get("_serializable_attrs_cache")
+        if cached is None:
+            attrs = tuple(inspect(cls).all_orm_descriptors.keys())
+            plain = tuple(
+                attr for attr in attrs if not cls._is_join_attr(attr)
+            )
+            cached = (attrs, plain)
+            cls._serializable_attrs_cache = cached
+        return cached
+
+    def is_join(self, attr):
+        return self._is_join_attr(attr)
 
     def serialize(
         self,
@@ -21,14 +43,14 @@ class SerializerMixin(object):
         milliseconds=False,
         ignored_attrs=[],
     ):
-        attrs = inspect(self.__class__).all_orm_descriptors.keys()
+        all_attrs, plain_attrs = self._serializable_attrs()
+        attrs = all_attrs if relations else plain_attrs
         obj_dict = {
             attr: serialize_value(
                 getattr(self, attr), milliseconds=milliseconds
             )
             for attr in attrs
             if attr not in ignored_attrs
-            and (relations or not self.is_join(attr))
         }
         obj_dict["type"] = obj_type or type(self).__name__
         return obj_dict

--- a/zou/app/services/assets_service.py
+++ b/zou/app/services/assets_service.py
@@ -45,7 +45,7 @@ def clear_asset_cache(asset_id):
 
 
 def clear_asset_type_cache():
-    cache.cache.delete_memoized(get_asset_types)
+    cache.cache.delete_memoized(get_all_asset_types)
 
 
 def get_temporal_type_ids():
@@ -378,15 +378,27 @@ def get_assets_and_tasks(criterions=None, with_episode_ids=False):
     return list(asset_map.values())
 
 
-@cache.memoize_function(240)
 def get_asset_types(criterions=None):
     """
-    Retrieve all asset types available.
+    Retrieve all asset types available. Only the no-criterion variant is
+    memoized: criterion dicts vary per request and used to pollute the
+    cache with entries that were never hit again.
     """
-    if criterions is None:
-        criterions = {}
+    if not criterions:
+        return get_all_asset_types()
     query = EntityType.query.filter(build_entity_type_asset_type_filter())
     query = query_utils.apply_criterions_to_db_query(Entity, query, criterions)
+    return EntityType.serialize_list(
+        query.all(), obj_type="AssetType", relations=True
+    )
+
+
+@cache.memoize_function(240)
+def get_all_asset_types():
+    """
+    Retrieve all asset types, without criterion.
+    """
+    query = EntityType.query.filter(build_entity_type_asset_type_filter())
     return EntityType.serialize_list(
         query.all(), obj_type="AssetType", relations=True
     )

--- a/zou/app/services/assets_service.py
+++ b/zou/app/services/assets_service.py
@@ -481,7 +481,7 @@ def get_raw_asset_by_shotgun_id(shotgun_id):
     return get_asset_raw(asset["id"])
 
 
-@cache.memoize_function(120)
+@cache.memoize_function_single_flight(120)
 def get_full_asset(asset_id):
     """
     Return asset matching given id with additional information (project name,

--- a/zou/app/services/comments_service.py
+++ b/zou/app/services/comments_service.py
@@ -58,6 +58,10 @@ def get_attachment_file(attachment_file_id):
     return attachment_file.serialize()
 
 
+def clear_attachment_file_cache(attachment_file_id):
+    cache.cache.delete_memoized(get_attachment_file, attachment_file_id)
+
+
 def get_attachment_file_path(attachment_file):
     """
     Get attachement file path when stored locally.

--- a/zou/app/services/concepts_service.py
+++ b/zou/app/services/concepts_service.py
@@ -70,7 +70,7 @@ def get_concept(concept_id, relations=False):
     )
 
 
-@cache.memoize_function(120)
+@cache.memoize_function_single_flight(120)
 def get_full_concept(concept_id):
     """
     Return given concept as a dictionary with extra data like project.

--- a/zou/app/services/deletion_service.py
+++ b/zou/app/services/deletion_service.py
@@ -299,10 +299,13 @@ def remove_attachment_file(attachment_file):
     Remove all files related to given attachment file, then remove the
     attachment file entry from the database.
     """
+    from zou.app.services import comments_service
+
     if config.REMOVE_FILES:
         file_store.remove_file("attachments", str(attachment_file.id))
     attachment_dict = attachment_file.serialize()
     attachment_file.delete()
+    comments_service.clear_attachment_file_cache(attachment_dict["id"])
     return attachment_dict
 
 

--- a/zou/app/services/edits_service.py
+++ b/zou/app/services/edits_service.py
@@ -256,7 +256,7 @@ def get_edit(edit_id, relations=False):
     )
 
 
-@cache.memoize_function(120)
+@cache.memoize_function_single_flight(120)
 def get_full_edit(edit_id):
     """
     Return given edit as a dictionary with extra data like project.

--- a/zou/app/services/edits_service.py
+++ b/zou/app/services/edits_service.py
@@ -272,8 +272,7 @@ def is_edit(entity):
     """
     Returns True if given entity has 'Edit' as entity type
     """
-    edit_type = get_edit_type()
-    return str(entity["entity_type_id"]) == edit_type["id"]
+    return entities_service.is_edit(entity)
 
 
 def get_edits_for_project(project_id, only_assigned=False):

--- a/zou/app/services/entities_service.py
+++ b/zou/app/services/entities_service.py
@@ -34,7 +34,15 @@ from zou.app.services.exception import (
 
 
 def clear_entity_cache(entity_id):
+    # Deferred import: names_service imports entities_service. Renaming a
+    # parent (sequence, episode) still leaves children names cached up to
+    # their TTL; only the entity's own name is invalidated here.
+    from zou.app.services import names_service
+
     cache.cache.delete_memoized(get_entity, entity_id)
+    cache.cache.delete_memoized(
+        names_service.get_full_entity_name, entity_id
+    )
 
 
 def clear_entity_type_cache(entity_type_id):

--- a/zou/app/services/entities_service.py
+++ b/zou/app/services/entities_service.py
@@ -40,9 +40,7 @@ def clear_entity_cache(entity_id):
     from zou.app.services import names_service
 
     cache.cache.delete_memoized(get_entity, entity_id)
-    cache.cache.delete_memoized(
-        names_service.get_full_entity_name, entity_id
-    )
+    cache.cache.delete_memoized(names_service.get_full_entity_name, entity_id)
 
 
 def clear_entity_type_cache(entity_type_id):

--- a/zou/app/services/entities_service.py
+++ b/zou/app/services/entities_service.py
@@ -50,6 +50,14 @@ def get_temporal_entity_type_by_name(name):
     return entity_type
 
 
+def is_edit(entity):
+    """
+    Return True if given entity dict has 'Edit' as entity type.
+    """
+    edit_type = get_temporal_entity_type_by_name("Edit")
+    return str(entity["entity_type_id"]) == edit_type["id"]
+
+
 @cache.memoize_function(240)
 def get_entity_type(entity_type_id):
     """

--- a/zou/app/services/news_service.py
+++ b/zou/app/services/news_service.py
@@ -73,10 +73,14 @@ def delete_news_for_comment(comment_id):
     if len(news_list) > 0:
         task = tasks_service.get_task(news_list[0].task_id)
         for news in news_list:
+            news_id = str(news.id)
             news.delete()
+            cache.cache.delete_memoized(
+                get_news, task["project_id"], news_id
+            )
             events.emit(
                 "news:delete",
-                {"news_id": news.id},
+                {"news_id": news_id},
                 project_id=task["project_id"],
             )
     return fields.serialize_list(news_list)

--- a/zou/app/services/news_service.py
+++ b/zou/app/services/news_service.py
@@ -75,9 +75,7 @@ def delete_news_for_comment(comment_id):
         for news in news_list:
             news_id = str(news.id)
             news.delete()
-            cache.cache.delete_memoized(
-                get_news, task["project_id"], news_id
-            )
+            cache.cache.delete_memoized(get_news, task["project_id"], news_id)
             events.emit(
                 "news:delete",
                 {"news_id": news_id},
@@ -277,9 +275,7 @@ def _get_news_total(query, limit):
     # count() wraps the whole 5-join select in a subquery; counting the
     # news column over the same joins gives the same total without
     # materializing the select (order_by must go, aggregates forbid it).
-    total = (
-        query.order_by(None).with_entities(func.count(News.id)).scalar()
-    )
+    total = query.order_by(None).with_entities(func.count(News.id)).scalar()
     nb_pages = int(math.ceil(total / float(limit)))
     return total, nb_pages
 

--- a/zou/app/services/news_service.py
+++ b/zou/app/services/news_service.py
@@ -274,7 +274,12 @@ def get_last_news_for_project(
 
 
 def _get_news_total(query, limit):
-    total = query.count()
+    # count() wraps the whole 5-join select in a subquery; counting the
+    # news column over the same joins gives the same total without
+    # materializing the select (order_by must go, aggregates forbid it).
+    total = (
+        query.order_by(None).with_entities(func.count(News.id)).scalar()
+    )
     nb_pages = int(math.ceil(total / float(limit)))
     return total, nb_pages
 

--- a/zou/app/services/shots_service.py
+++ b/zou/app/services/shots_service.py
@@ -685,8 +685,7 @@ def is_edit(entity):
     """
     Returns True if given entity has 'Edit' as entity type
     """
-    edit_type = get_edit_type()
-    return str(entity["entity_type_id"]) == edit_type["id"]
+    return entities_service.is_edit(entity)
 
 
 def is_episode(entity):

--- a/zou/app/services/shots_service.py
+++ b/zou/app/services/shots_service.py
@@ -423,7 +423,7 @@ def get_shot(shot_id, relations=False):
     )
 
 
-@cache.memoize_function(120)
+@cache.memoize_function_single_flight(120)
 def get_full_shot(shot_id):
     """
     Return given shot as a dictionary with extra data like project and
@@ -506,7 +506,7 @@ def get_sequence(sequence_id):
     return get_sequence_raw(sequence_id).serialize(obj_type="Sequence")
 
 
-@cache.memoize_function(120)
+@cache.memoize_function_single_flight(120)
 def get_full_sequence(sequence_id):
     """
     Return given sequence as a dictionary with extra data like project name.

--- a/zou/app/services/tasks_service.py
+++ b/zou/app/services/tasks_service.py
@@ -454,7 +454,10 @@ def _resolve_episode_and_build_task_dict(
             except EpisodeNotFoundException:
                 episode_name = "MP"
 
-    task_dict = get_task(str(task.id), relations=True)
+    # Serialize the Task instance already carried by the row instead of
+    # re-fetching it through get_task (one query per row on cache miss).
+    # Assignees are attached in batch by the callers.
+    task_dict = task.serialize()
     if entity_type_name == "Sequence" and entity_parent_id is not None:
         episode_id = entity_parent_id
         episode = shots_service.get_episode(episode_id)
@@ -1123,6 +1126,8 @@ def get_person_tasks(person_id, projects, is_done=None):
             ]
         tasks.append(task_dict)
 
+    if tasks:
+        _attach_assignee_ids(tasks)
     _add_last_comments_to_tasks(tasks)
     return tasks
 
@@ -1200,6 +1205,8 @@ def get_person_tasks_to_check(project_ids=None, department_ids=None):
         )
         tasks.append(task_dict)
 
+    if tasks:
+        _attach_assignee_ids(tasks)
     _add_last_comments_to_tasks(tasks)
     return tasks
 
@@ -2251,6 +2258,9 @@ def get_open_tasks(
             }
         )
         tasks.append(task_dict)
+
+    if tasks:
+        _attach_assignee_ids(tasks)
 
     result = {
         "data": [],

--- a/zou/app/stores/queue_store.py
+++ b/zou/app/stores/queue_store.py
@@ -1,26 +1,36 @@
+import logging
 import redis
-import sys
 
 from rq import Queue
 from zou.app import config
 
-try:
-    if config.ENABLE_JOB_QUEUE:
-        queue_store = redis.StrictRedis(
-            host=config.KEY_VALUE_STORE["host"],
-            port=config.KEY_VALUE_STORE["port"],
-            db=config.KV_JOB_DB_INDEX,
-            password=config.KEY_VALUE_STORE["password"],
-            decode_responses=True,
-        )
-        queue_store.get("test")
-except redis.ConnectionError:
-    try:
-        import fakeredis
+logger = logging.getLogger(__name__)
 
-        queue_store = fakeredis.FakeStrictRedis()
-    except Exception:
-        sys.exit(1)
+queue_store = None
+job_queue = None
 
 if config.ENABLE_JOB_QUEUE:
+    queue_store = redis.StrictRedis(
+        host=config.KEY_VALUE_STORE["host"],
+        port=config.KEY_VALUE_STORE["port"],
+        db=config.KV_JOB_DB_INDEX,
+        password=config.KEY_VALUE_STORE["password"],
+        decode_responses=True,
+    )
+    try:
+        queue_store.ping()
+    except redis.ConnectionError:
+        if config.DEBUG:
+            # Dev convenience only: jobs enqueued on fakeredis are never
+            # executed. In production a job queue without Redis means
+            # silently losing every job, so we fail at startup instead.
+            import fakeredis
+
+            logger.warning(
+                "Job queue Redis is unreachable, falling back to fakeredis: "
+                "enqueued jobs will NOT run."
+            )
+            queue_store = fakeredis.FakeStrictRedis()
+        else:
+            raise
     job_queue = Queue(connection=queue_store)

--- a/zou/app/utils/cache.py
+++ b/zou/app/utils/cache.py
@@ -16,12 +16,15 @@ leaves the cached object untouched.
 """
 
 import copy
+import logging
 import redis
 
 from functools import wraps
 
 from flask_caching import Cache
 from zou.app import config
+
+logger = logging.getLogger(__name__)
 
 cache = None
 _is_simple_cache = False
@@ -49,6 +52,16 @@ else:
             }
         )
     except redis.ConnectionError:
+        # SimpleCache is per-process: with several workers each one keeps
+        # its own copy and delete_memoized() only invalidates the local
+        # one, so mutations made by one worker keep being served stale by
+        # the others until their TTL expires.
+        logger.warning(
+            "Cache Redis is unreachable, falling back to in-memory "
+            "SimpleCache. With multiple workers, cache invalidation is "
+            "BROKEN across processes: stale data may be served. Fix the "
+            "Redis connection or set CACHE_TYPE explicitly."
+        )
         cache = Cache(config={"CACHE_TYPE": "simple"})
         _is_simple_cache = True
 

--- a/zou/app/utils/cache.py
+++ b/zou/app/utils/cache.py
@@ -91,6 +91,37 @@ def memoize_function(timeout=120):
     return decorator
 
 
+def memoize_function_single_flight(timeout=120):
+    """
+    Like memoize_function, plus a Redis lock around cache-miss rebuilds:
+    when a hot entry expires, concurrent requests rebuild it once instead
+    of all at once (anti-stampede). Reserved for functions that never
+    return None, since a None hit is indistinguishable from a miss.
+    """
+
+    def decorator(func):
+        cached_func = memoize_function(timeout)(func)
+
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            from zou.app.stores.redis_lock import with_lock
+
+            key = cached_func.make_cache_key(
+                cached_func.uncached, *args, **kwargs
+            )
+            if cache.get(key) is not None:
+                return cached_func(*args, **kwargs)
+            with with_lock(f"single-flight-{key}"):
+                return cached_func(*args, **kwargs)
+
+        wrapper.make_cache_key = cached_func.make_cache_key
+        wrapper.uncached = cached_func.uncached
+        wrapper.cache_timeout = cached_func.cache_timeout
+        return wrapper
+
+    return decorator
+
+
 def invalidate(*args):
     cache.delete_memoized(*args)
 

--- a/zou/app/utils/dbhelpers.py
+++ b/zou/app/utils/dbhelpers.py
@@ -1,13 +1,6 @@
 from sqlalchemy import create_engine, inspect, text
 from sqlalchemy_utils import database_exists, create_database
-from sqlalchemy.engine.url import URL
 from sqlalchemy.orm import close_all_sessions
-
-
-def get_db_uri():
-    from zou.app.config import DATABASE
-
-    return URL.create(**DATABASE).render_as_string(hide_password=False)
 
 
 def reset_all():

--- a/zou/app/utils/events.py
+++ b/zou/app/utils/events.py
@@ -87,7 +87,11 @@ def emit(event, data=None, persist=True, project_id=None):
             try:
                 func.handle_event(data)
             except Exception:
-                current_app.logger.error("Error handling event", exc_info=1)
+                current_app.logger.error(
+                    f"Error handling event {event} "
+                    f"with {type(func).__name__}",
+                    exc_info=1,
+                )
 
 
 def save_event(event, data, project_id=None):

--- a/zou/app/utils/validation.py
+++ b/zou/app/utils/validation.py
@@ -82,9 +82,7 @@ def validate_id_list(required=True):
             return None
         raise WrongParameterException("Request body must be a JSON array.")
     for entity_id in payload:
-        if not isinstance(entity_id, str) or not fields.is_valid_id(
-            entity_id
-        ):
+        if not isinstance(entity_id, str) or not fields.is_valid_id(entity_id):
             raise WrongParameterException(
                 "Request body must only contain valid UUIDs."
             )

--- a/zou/app/utils/validation.py
+++ b/zou/app/utils/validation.py
@@ -12,6 +12,7 @@ from flask import request
 from pydantic import BaseModel, ConfigDict, ValidationError
 
 from zou.app.services.exception import WrongParameterException
+from zou.app.utils import fields
 
 
 class BaseSchema(BaseModel):
@@ -65,3 +66,26 @@ def validate_request_body(SchemaClass, *, data=None):
             "Validation error.",
             dict={"errors": errors},
         )
+
+
+def validate_id_list(required=True):
+    """
+    Validate that the request body is a JSON array of UUID strings and
+    return it. Bulk endpoints (create tasks for shots, batch delete...)
+    take a bare array as body. With required=False an absent or empty
+    body returns None: those endpoints treat it as "no explicit
+    selection" and target every entity of the scope.
+    """
+    payload = request.get_json(silent=True)
+    if not isinstance(payload, list):
+        if not required and payload in (None, {}):
+            return None
+        raise WrongParameterException("Request body must be a JSON array.")
+    for entity_id in payload:
+        if not isinstance(entity_id, str) or not fields.is_valid_id(
+            entity_id
+        ):
+            raise WrongParameterException(
+                "Request body must only contain valid UUIDs."
+            )
+    return payload


### PR DESCRIPTION
**Problem**
- Cache: silent SimpleCache/fakeredis fallbacks (broken invalidation, lost jobs), stampede on expired `get_full_*` aggregates, memoized entries never invalidated, untargeted purges
- Performance: per-row descriptor inspection in `serialize_list`, `get_task` per row in todos views, 5-join count on every news feed page, `present_minimal` serializing all columns
- Robustness: CRUD 400s leaked SQL internals, date validation rejected valid ISO 8601, bulk endpoints read unvalidated JSON arrays, unhandled prod errors returned HTML without logs, session left unusable after failed commits
- Flaky `time_spent` fixture collided on the unique constraint

**Solution**
- Loud warnings or startup failure on degraded cache/queue backends; single-flight rebuilds; invalidation on mutation; targeted `delete_memoized`
- Class-level serializable attribute cache, batched assignees, count over the same joins, direct minimal dicts
- Sanitized DB error messages, `fromisoformat` validation, `validate_id_list` + Pydantic schema for remaining raw bodies, generic JSON 500 handler with server-side logging, rollback without `session.remove()`
- Deterministic distinct dates in time spent fixtures