### PR TITLE
[tests] FIDO/SAML coverage, test isolation and dependency cleanup

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -16,6 +16,9 @@ _REAL_BCRYPT_FILES = {
     # Share-link passwords are hashed with bcrypt; the verification
     # path must not be patched to always-True for this file.
     "test_playlist_sharing.py",
+    # Recovery codes are hashed with bcrypt and their verification is
+    # exactly what the FIDO unregister tests assert.
+    "test_fido.py",
 }
 
 # flask_bcrypt module-level functions create a Bcrypt() instance without

--- a/setup.cfg
+++ b/setup.cfg
@@ -97,6 +97,7 @@ dev =
 
 test =
     fakeredis==2.35.1
+    freezegun==1.5.2
     mixer==7.2.2
     prometheus-client==0.25.0
     pytest-cov==7.1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,7 +51,6 @@ install_requires =
     gevent-websocket==0.10.1
     gevent==26.4.0
     gunicorn==26.0.0
-    isoweek==1.3.3
     itsdangerous==2.2.0
     Jinja2==3.1.6
     ldap3==2.9.1
@@ -102,6 +101,11 @@ test =
     prometheus-client==0.25.0
     pytest-cov==7.1.0
     pytest==9.0.3
+
+prodpg =
+    # Production builds should prefer the C implementation linked against
+    # the system libpq instead of the binary wheel (frozen libpq/libssl).
+    psycopg[c]==3.3.4
 
 monitoring =
     prometheus-flask-exporter==0.23.2

--- a/tests/auth/test_fido.py
+++ b/tests/auth/test_fido.py
@@ -1,0 +1,112 @@
+"""
+FIDO/WebAuthn route tests. The registration options and session state go
+through the real fido2 server; only the cryptographic attestation check
+(register_complete) is mocked, since it requires a hardware authenticator.
+"""
+
+import orjson as json
+
+from unittest import mock
+
+from tests.base import ApiDBTestCase
+
+from zou.app.models.person import Person
+
+
+class FidoRoutesTestCase(ApiDBTestCase):
+
+    def _fake_auth_data(self):
+        auth_data = mock.MagicMock()
+        auth_data.credential_data.aaguid = b"\x01" * 16
+        auth_data.credential_data.credential_id = b"\x02" * 32
+        auth_data.credential_data.public_key = {
+            1: 2,
+            3: -7,
+            -1: 1,
+            -2: b"\x03" * 32,
+            -3: b"\x04" * 32,
+        }
+        return auth_data
+
+    def _register_device(self, device_name="security-key"):
+        self.put("auth/fido", {})
+        with mock.patch.object(
+            self.flask_app.extensions["fido_server"],
+            "register_complete",
+            return_value=self._fake_auth_data(),
+        ):
+            return self.post(
+                "auth/fido",
+                {
+                    "registration_response": {"id": "fake"},
+                    "device_name": device_name,
+                },
+                200,
+            )
+
+    def test_get_challenge_unknown_user(self):
+        self.get("auth/fido?email=ghost@nowhere.com", 404)
+
+    def test_get_challenge_fido_not_enabled(self):
+        self.get(f"auth/fido?email={self.user['email']}", 400)
+
+    def test_pre_register_returns_webauthn_options(self):
+        options = self.put("auth/fido", {})
+        self.assertIn("challenge", options)
+        self.assertEqual(options["rp"]["name"], "Kitsu")
+        self.assertEqual(options["user"]["name"], self.user["email"])
+
+    def test_register_without_preregistration(self):
+        self.post(
+            "auth/fido",
+            {"registration_response": {"id": "fake"}, "device_name": "key"},
+            400,
+        )
+
+    def test_register_device(self):
+        result = self._register_device()
+        self.assertTrue(len(result["otp_recovery_codes"]) > 0)
+        self.assertIn("access_token", result)
+        person = Person.get(self.user["id"])
+        self.assertTrue(person.fido_enabled)
+        self.assertEqual(
+            person.fido_credentials[0]["device_name"], "security-key"
+        )
+        self.assertEqual(
+            person.preferred_two_factor_authentication.code, "fido"
+        )
+
+    def test_registered_user_gets_a_challenge(self):
+        self._register_device()
+        challenge = self.get(f"auth/fido?email={self.user['email']}")
+        self.assertIn("challenge", challenge)
+
+    def test_unregister_device(self):
+        result = self._register_device()
+        recovery_code = result["otp_recovery_codes"][0]
+        response = self.app.delete(
+            "auth/fido",
+            data=json.dumps(
+                {
+                    "device_name": "security-key",
+                    "recovery_code": recovery_code,
+                }
+            ),
+            headers=self.post_headers,
+        )
+        self.assertEqual(response.status_code, 200)
+        person = Person.get(self.user["id"])
+        self.assertFalse(person.fido_enabled)
+        self.assertEqual(person.fido_credentials, [])
+
+    def test_unregister_device_wrong_otp(self):
+        self._register_device()
+        response = self.app.delete(
+            "auth/fido",
+            data=json.dumps(
+                {"device_name": "security-key", "recovery_code": "wrong"}
+            ),
+            headers=self.post_headers,
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertTrue(Person.get(self.user["id"]).fido_enabled)

--- a/tests/auth/test_saml.py
+++ b/tests/auth/test_saml.py
@@ -1,0 +1,115 @@
+"""
+SAML SSO route tests. The pysaml2 client (network + XML signature checks)
+is mocked: only Zou's own behaviour is exercised, that is the enabled
+gate, user provisioning from the assertion, updates on later logins and
+the auth cookies.
+"""
+
+from unittest import mock
+
+from tests.base import ApiDBTestCase
+
+from zou.app import config
+from zou.app.models.person import Person
+from zou.app.services import persons_service
+
+
+def _fake_authn_response(email, ava):
+    response = mock.MagicMock()
+    response.get_identity.return_value = ava
+    response.get_subject.return_value.text = email
+    response.ava = ava
+    return response
+
+
+class SamlRoutesTestCase(ApiDBTestCase):
+
+    def setUp(self):
+        super().setUp()
+        self._saml_enabled = config.SAML_ENABLED
+        config.SAML_ENABLED = True
+        self.flask_app.extensions["saml_client"] = mock.MagicMock()
+
+    def tearDown(self):
+        config.SAML_ENABLED = self._saml_enabled
+        super().tearDown()
+
+    def _post_sso(self, email, ava):
+        self.flask_app.extensions[
+            "saml_client"
+        ].parse_authn_request_response.return_value = _fake_authn_response(
+            email, ava
+        )
+        return self.app.post(
+            "auth/saml/sso",
+            data={"SAMLResponse": "fake"},
+            headers=self.base_headers,
+        )
+
+    def test_sso_disabled_returns_400(self):
+        config.SAML_ENABLED = False
+        response = self.app.post(
+            "auth/saml/sso",
+            data={"SAMLResponse": "fake"},
+            headers=self.base_headers,
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_login_redirect_disabled_returns_400(self):
+        config.SAML_ENABLED = False
+        response = self.app.get("auth/saml/login", headers=self.base_headers)
+        self.assertEqual(response.status_code, 400)
+
+    def test_login_redirect_points_to_idp(self):
+        self.flask_app.extensions[
+            "saml_client"
+        ].prepare_for_authenticate.return_value = (
+            None,
+            {"headers": [("Location", "https://idp.example.com/sso")]},
+        )
+        response = self.app.get("auth/saml/login", headers=self.base_headers)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            response.headers["Location"], "https://idp.example.com/sso"
+        )
+
+    def test_sso_provisions_new_user(self):
+        response = self._post_sso(
+            "newcomer@example.com",
+            {
+                "first_name": ["Jane"],
+                "last_name": ["Doe"],
+                "country": ["fr"],
+            },
+        )
+        self.assertEqual(response.status_code, 302)
+        person = persons_service.get_person_by_email("newcomer@example.com")
+        self.assertEqual(person["first_name"], "Jane")
+        self.assertEqual(person["last_name"], "Doe")
+        # country is normalized to its canonical uppercase form.
+        self.assertEqual(person["country"], "FR")
+        self.assertIn("access_token_cookie", response.headers["Set-Cookie"])
+
+    def test_sso_updates_existing_user(self):
+        self.generate_fixture_person(
+            first_name="Old", last_name="Name", email="known@example.com"
+        )
+        self._post_sso(
+            "known@example.com",
+            {"first_name": ["New"], "last_name": ["Name"]},
+        )
+        person = persons_service.get_person_by_email("known@example.com")
+        self.assertEqual(person["first_name"], "New")
+
+    def test_sso_drops_malformed_country(self):
+        self._post_sso(
+            "badcountry@example.com",
+            {
+                "first_name": ["Ada"],
+                "last_name": ["Lovelace"],
+                "country": ["Wonderland"],
+            },
+        )
+        person = Person.get_by(email="badcountry@example.com")
+        self.assertIsNotNone(person)
+        self.assertIn(person.country, (None, ""))

--- a/tests/base.py
+++ b/tests/base.py
@@ -107,7 +107,15 @@ class ApiTestCase(unittest.TestCase):
         self.app = app.test_client()
         self.base_headers = {}
         self.post_headers = {"Content-type": "application/json"}
-        app.app_context().push()
+        # No mail during tests, whatever the environment says.
+        app.config["MAIL_ENABLED"] = False
+        app_context = app.app_context()
+        app_context.push()
+        self.addCleanup(app_context.pop)
+        # The fakeredis stores are module-level: without a flush, revoked
+        # tokens and config entries leak from one test to the next.
+        self.addCleanup(auth_tokens_store.revoked_tokens_store.flushall)
+        self.addCleanup(config_store.config_store.flushall)
 
         from zou.app.utils import cache
 

--- a/tests/events/test_event_routes.py
+++ b/tests/events/test_event_routes.py
@@ -1,5 +1,7 @@
 from datetime import datetime, timedelta
 
+from freezegun import freeze_time
+
 from tests.base import ApiDBTestCase
 from zou.app.models.event import ApiEvent
 from zou.app.models.login_log import LoginLog
@@ -7,6 +9,9 @@ from zou.app.models.login_log import LoginLog
 from zou.app.services import assets_service, events_service
 
 
+# Frozen mid-day time: these tests build date-boundary filters (before/
+# after) from now(), which flakes around midnight otherwise.
+@freeze_time("2026-07-06T12:00:00")
 class EventsRoutesTestCase(ApiDBTestCase):
     def setUp(self):
         super(EventsRoutesTestCase, self).setUp()

--- a/tests/events/test_event_routes.py
+++ b/tests/events/test_event_routes.py
@@ -6,7 +6,7 @@ from tests.base import ApiDBTestCase
 from zou.app.models.event import ApiEvent
 from zou.app.models.login_log import LoginLog
 
-from zou.app.services import assets_service, events_service
+from zou.app.services import assets_service
 
 
 # Frozen mid-day time: these tests build date-boundary filters (before/

--- a/tests/files/test_route_file_tree.py
+++ b/tests/files/test_route_file_tree.py
@@ -37,17 +37,6 @@ class FolderPathTestCase(ApiDBTestCase):
             "3ds_max",
         )
 
-    def test_get_path_shot(self):
-        data = {"software": self.software_max.id}
-        result = self.post(
-            f"/data/tasks/{self.shot_task.id}/working-file-path", data, 200
-        )
-        self.assertEqual(
-            result["path"],
-            "/simple/productions/cosmos_landromat/shots/s01/p01/animation/"
-            "3ds_max",
-        )
-
     def test_get_path_scene(self):
         data = {"software": self.software_max.id}
         result = self.post(

--- a/tests/models/test_salary_scale.py
+++ b/tests/models/test_salary_scale.py
@@ -43,9 +43,7 @@ class SalaryScaleTestCase(ApiDBTestCase):
             f"data/salary-scales/{salary_scale['id']}"
         )
         self.assertEqual(salary_scale_again["salary"], 640)
-        self.put_404(
-            f"data/salary-scales/{fields.gen_uuid()}", {"salary": 1}
-        )
+        self.put_404(f"data/salary-scales/{fields.gen_uuid()}", {"salary": 1})
 
     def test_delete_salary_scale(self):
         self.generate_fixture_department()

--- a/tests/models/test_salary_scale.py
+++ b/tests/models/test_salary_scale.py
@@ -1,20 +1,58 @@
 from tests.base import ApiDBTestCase
 
 from zou.app.models.department import Department
+from zou.app.models.person import POSITION_TYPES, SENIORITY_TYPES
 from zou.app.models.salary_scale import SalaryScale
 
 from zou.app.utils import fields
 
 
 class SalaryScaleTestCase(ApiDBTestCase):
-    def setUp(self):
-        super(SalaryScaleTestCase, self).setUp()
-        # self.generate_data(SalaryScale, 3)
 
     def test_get_salary_scales(self):
-        pass
-        # salary_scales = self.get("data/salary-scales")
-        # self.assertEqual(len(salary_scales), 3)
+        """
+        The list route auto-creates the missing (department, position,
+        seniority) entries before returning them.
+        """
+        self.generate_fixture_department()
+        departments = Department.query.all()
+        salary_scales = self.get("data/salary-scales")
+        expected = (
+            len(departments) * len(POSITION_TYPES) * len(SENIORITY_TYPES)
+        )
+        self.assertEqual(len(salary_scales), expected)
+        self.assertEqual(
+            {scale["department_id"] for scale in salary_scales},
+            {str(department.id) for department in departments},
+        )
+
+    def test_get_salary_scale(self):
+        self.generate_fixture_department()
+        salary_scale = self.get_first("data/salary-scales")
+        salary_scale_again = self.get(
+            f"data/salary-scales/{salary_scale['id']}"
+        )
+        self.assertEqual(salary_scale, salary_scale_again)
+        self.get_404(f"data/salary-scales/{fields.gen_uuid()}")
+
+    def test_update_salary_scale(self):
+        self.generate_fixture_department()
+        salary_scale = self.get_first("data/salary-scales")
+        self.put(f"data/salary-scales/{salary_scale['id']}", {"salary": 640})
+        salary_scale_again = self.get(
+            f"data/salary-scales/{salary_scale['id']}"
+        )
+        self.assertEqual(salary_scale_again["salary"], 640)
+        self.put_404(
+            f"data/salary-scales/{fields.gen_uuid()}", {"salary": 1}
+        )
+
+    def test_delete_salary_scale(self):
+        self.generate_fixture_department()
+        salary_scale = self.get_first("data/salary-scales")
+        self.delete(f"data/salary-scales/{salary_scale['id']}")
+        self.get_404(f"data/salary-scales/{salary_scale['id']}")
+        self.delete_404(f"data/salary-scales/{fields.gen_uuid()}")
 
     def test_delete_department_cascades_salary_scales(self):
         """
@@ -46,40 +84,3 @@ class SalaryScaleTestCase(ApiDBTestCase):
         self.assertEqual(
             SalaryScale.query.filter_by(department_id=department.id).count(), 0
         )
-
-    """
-    def test_get_salary_scale(self):
-        salary_scale = self.get_first("data/salary-scales")
-        salary_scale_again = self.get(
-            f"data/salary-scales/{salary_scale['id']}"
-        )
-        self.assertEqual(salary_scale, salary_scale_again)
-        self.get_404(f"data/salary-scales/{fields.gen_uuid()}")
-
-    def test_create_salary_scale(self):
-        data = {"position": "artist", "seniority": "junior", "daily_salary": 500}
-        self.salary_scale = self.post("data/salary-scales", data)
-        self.assertIsNotNone(self.salary_scale["id"])
-
-        salary_scales = self.get("data/salary-scales")
-        self.assertEqual(len(salary_scales), 4)
-
-    def test_update_salary_scale(self):
-        salary_scale = self.get_first("data/salary-scales")
-        data = {"position": "lead", "seniority": "senior", "daily_salary": 600}
-        self.put(f"data/salary-scales/{salary_scale['id']}", data)
-        salary_scale_again = self.get(
-            f"data/salary-scales/{salary_scale['id']}"
-        )
-        self.assertEqual(data["position"], salary_scale_again["position"])
-        self.put_404(f"data/salary-scales/{fields.gen_uuid()}", data)
-
-    def test_delete_salary_scale(self):
-        salary_scales = self.get("data/salary-scales")
-        self.assertEqual(len(salary_scales), 3)
-        salary_scale = salary_scales[0]
-        self.delete(f"data/salary-scales/{salary_scale['id']}")
-        salary_scales = self.get("data/salary-scales")
-        self.assertEqual(len(salary_scales), 2)
-        self.delete_404(f"data/salary-scales/{fields.gen_uuid()}")
-    """

--- a/tests/services/test_events_service.py
+++ b/tests/services/test_events_service.py
@@ -1,11 +1,16 @@
 from datetime import datetime, timedelta
 
+from freezegun import freeze_time
+
 from tests.base import ApiDBTestCase
 
 from zou.app.models.event import ApiEvent
 from zou.app.services import events_service, assets_service
 
 
+# Frozen mid-day time: these tests build date-boundary filters (before/
+# after) from now(), which flakes around midnight otherwise.
+@freeze_time("2026-07-06T12:00:00")
 class EventsServiceTestCase(ApiDBTestCase):
     def setUp(self):
         super(EventsServiceTestCase, self).setUp()

--- a/tests/services/test_news_service.py
+++ b/tests/services/test_news_service.py
@@ -1,10 +1,15 @@
 from datetime import datetime, timedelta
+from freezegun import freeze_time
+
 from tests.base import ApiDBTestCase
 
 from zou.app.models.news import News
 from zou.app.services import comments_service, news_service
 
 
+# Frozen mid-day time: these tests build date-boundary filters (before/
+# after) from now(), which flakes around midnight otherwise.
+@freeze_time("2026-07-06T12:00:00")
 class NewsServiceTestCase(ApiDBTestCase):
     def setUp(self):
         super(NewsServiceTestCase, self).setUp()

--- a/tests/shots/test_episodes.py
+++ b/tests/shots/test_episodes.py
@@ -175,4 +175,14 @@ class EpisodeTestCase(ApiDBTestCase):
         self.delete(f"data/episodes/{self.episode_id}", 400)
 
     def test_episode_stats(self):
-        pass
+        self.generate_fixture_department()
+        self.generate_fixture_shot_task()
+        stats = self.get(f"data/projects/{self.project_id}/episodes/stats")
+        task_type_id = str(self.task_type_animation.id)
+        task_status_id = str(self.task_status.id)
+        episode_stats = stats[self.episode_id]
+        self.assertEqual(
+            episode_stats[task_type_id][task_status_id]["count"], 1
+        )
+        self.assertEqual(episode_stats["all"][task_status_id]["count"], 1)
+        self.assertIn("all", stats)

--- a/zou/app/blueprints/auth/schemas.py
+++ b/zou/app/blueprints/auth/schemas.py
@@ -70,7 +70,7 @@ class TwoFactorAuthSchema(BaseSchema):
 
     totp: Optional[str] = None
     email_otp: Optional[str] = None
-    fido_authentication_response: Optional[dict] = Field(default={})
+    fido_authentication_response: Optional[dict] = None
     recovery_code: Optional[str] = None
 
 
@@ -107,5 +107,5 @@ class FidoUnregisterSchema(BaseSchema):
     )
     totp: Optional[str] = None
     email_otp: Optional[str] = None
-    fido_authentication_response: Optional[dict] = Field(default={})
+    fido_authentication_response: Optional[dict] = None
     recovery_code: Optional[str] = None

--- a/zou/app/blueprints/crud/base.py
+++ b/zou/app/blueprints/crud/base.py
@@ -1,3 +1,28 @@
+"""
+Generic CRUD resources shared by every model exposed under /data.
+
+BaseModelsResource handles the collection (GET list, POST create) and
+BaseModelResource the single instance (GET, PUT, DELETE). Per-model
+subclasses in this package customize behaviour through overridable hooks
+rather than by reimplementing the HTTP methods:
+
+- check_read_permissions / check_create_permissions(data) /
+  check_update_permissions(instance, data) / check_delete_permissions
+  (instance): raise permissions.PermissionDenied to forbid; the default
+  requires admin.
+- add_project_permission_filter(query): narrow a list query to the
+  projects the caller may see.
+- update_data(data[, instance_id]): last chance to clean or complete the
+  payload before it hits the model (protected fields are already
+  stripped and dates validated).
+- pre/post_create, pre/post_update, pre/post_delete: side effects around
+  the mutation (events are emitted by emit_*_event).
+
+Hooks run inside the request; raising a domain exception maps to the
+matching error handler. Integrity/statement errors are caught here and
+returned as sanitized 400s (see build_db_error_message).
+"""
+
 import datetime
 import math
 import orjson as json

--- a/zou/app/models/entity.py
+++ b/zou/app/models/entity.py
@@ -1,3 +1,16 @@
+"""
+The Entity model is polymorphic: assets, shots, sequences, episodes,
+scenes, edits and concepts are all rows in the entity table,
+distinguished by entity_type_id (there is no per-type table). Parenting
+is done through parent_id (e.g. shot -> sequence -> episode) and
+source_id (the "main" episode of an asset), while EntityLink models
+many-to-many casting relations between entities.
+
+Because there is no ORM subclass per type, "is this a shot?" style
+questions live in the services (shots_service, entities_service...) and
+compare entity_type_id against the cached type ids, not in this model.
+"""
+
 from sqlalchemy_utils import UUIDType, ChoiceType
 
 from zou.app import db

--- a/zou/app/services/sync_service.py
+++ b/zou/app/services/sync_service.py
@@ -1,3 +1,15 @@
+"""
+Pull-based synchronization from another Kitsu instance through gazu.
+
+The service logs in to a remote instance and mirrors its data locally,
+model by model, following the API event log to fetch only what changed
+since the last run (see _fetch_events / cursor_event_id). It is meant
+for one-way replication (a studio mirror, a backup instance); it never
+pushes local changes back. File synchronization (previews, thumbnails)
+downloads to a temporary path first and cleans it up on failure so a
+partial download never lands in the store.
+"""
+
 import datetime
 import logging
 import os

--- a/zou/app/services/tasks_service.py
+++ b/zou/app/services/tasks_service.py
@@ -1,3 +1,16 @@
+"""
+Business logic for tasks: assignation, status changes, comments, time
+spent and the aggregated "todos"/"open tasks" views.
+
+Two conventions matter when editing this module:
+- get_task()/get_task_status()/... return serialized dicts and are
+  memoized; every mutation must invalidate its entry (clear_task_cache
+  and friends) or clients keep reading stale data.
+- Several imports of other services are done lazily inside functions to
+  break import cycles (tasks <-> shots <-> entities). Keep them local
+  when adding cross-service calls.
+"""
+
 import collections
 import uuid
 

--- a/zou/app/utils/date_helpers.py
+++ b/zou/app/utils/date_helpers.py
@@ -1,4 +1,3 @@
-import isoweek
 import datetime
 
 from babel.dates import format_datetime
@@ -122,7 +121,7 @@ def get_week_interval(year, week):
         or week > 52
     ):
         raise WrongDateFormatException
-    start = isoweek.Week(year, week).monday()
+    start = datetime.date.fromisocalendar(year, week, 1)
     end = start + relativedelta.relativedelta(days=7)
     return start, end
 


### PR DESCRIPTION
**Problem**
- FIDO/WebAuthn and SAML SSO login paths had no test coverage
- Tests leaked state: real mail enabled, module-level fakeredis stores and pushed app contexts never reset between tests; a few stubbed/duplicated tests; time-dependent tests could flake around midnight
- FIDO/2FA users could not fall back to a recovery code (the auth check always took the FIDO branch)
- isoweek (micro-package) and the psycopg binary wheel pinned for production; the hardest modules had no module docstring

**Solution**
- Add tests/auth/test_fido.py and test_saml.py, mocking only the hardware attestation and the pysaml2 client; test_fido.py runs with real bcrypt so recovery codes are actually verified
- Force MAIL_ENABLED off, flush the fakeredis stores and pop the app context via addCleanup in tests/base.py; implement the remaining stubs, drop a shadowed duplicate, freeze time on date-boundary tests
- Default fido_authentication_response to None so the recovery_code fallback is reachable
- Replace isoweek with date.fromisocalendar, add a prodpg extra (psycopg[c]), document crud/base hooks, tasks_service, sync_service and entity