### PR TITLE
[audit] Pydantic validation, lazy Redis clients, event-stream docs

### DIFF
--- a/zou/app/blueprints/project_templates/resources.py
+++ b/zou/app/blueprints/project_templates/resources.py
@@ -2,21 +2,30 @@ from flask import request
 from flask_jwt_extended import jwt_required
 from flask.views import MethodView
 
-from zou.app.mixin import ArgsMixin
 from zou.app.services import project_templates_service
 from zou.app.services.exception import (
     ProjectNotFoundException,
     ProjectTemplateNotFoundException,
     WrongParameterException,
 )
-from zou.app.utils import permissions
+from zou.app.utils import permissions, validation
+from zou.app.blueprints.project_templates.schemas import (
+    SetDefaultBackgroundSchema,
+    AddAssetTypeSchema,
+    AddBackgroundSchema,
+    AddStatusAutomationSchema,
+    AddTaskStatusSchema,
+    AddTaskTypeSchema,
+    CreateTemplateFromProjectSchema,
+    SetMetadataDescriptorsSchema,
+)
 
 # ---------------------------------------------------------------------------
 # Link management
 # ---------------------------------------------------------------------------
 
 
-class ProjectTemplateTaskTypesResource(MethodView, ArgsMixin):
+class ProjectTemplateTaskTypesResource(MethodView):
     @jwt_required()
     def get(self, template_id):
         """
@@ -42,17 +51,12 @@ class ProjectTemplateTaskTypesResource(MethodView, ArgsMixin):
           - Project Templates
         """
         permissions.check_admin_permissions()
-        args = self.get_args(
-            [
-                ("task_type_id", "", True),
-                ("priority", None, False, int),
-            ]
-        )
+        data = validation.validate_request_body(AddTaskTypeSchema)
         try:
             link = project_templates_service.add_task_type_to_template(
                 template_id,
-                args["task_type_id"],
-                args["priority"],
+                data.task_type_id,
+                data.priority,
             )
         except ProjectTemplateNotFoundException:
             return {"message": "Project template not found"}, 404
@@ -80,7 +84,7 @@ class ProjectTemplateTaskTypeResource(MethodView):
         return "", 204
 
 
-class ProjectTemplateTaskStatusesResource(MethodView, ArgsMixin):
+class ProjectTemplateTaskStatusesResource(MethodView):
     @jwt_required()
     def get(self, template_id):
         """
@@ -106,19 +110,13 @@ class ProjectTemplateTaskStatusesResource(MethodView, ArgsMixin):
           - Project Templates
         """
         permissions.check_admin_permissions()
-        args = self.get_args(
-            [
-                ("task_status_id", "", True),
-                ("priority", None, False, int),
-                ("roles_for_board", [], False, str, "append"),
-            ]
-        )
+        data = validation.validate_request_body(AddTaskStatusSchema)
         try:
             link = project_templates_service.add_task_status_to_template(
                 template_id,
-                args["task_status_id"],
-                args["priority"],
-                args["roles_for_board"] or None,
+                data.task_status_id,
+                data.priority,
+                data.roles_for_board or None,
             )
         except ProjectTemplateNotFoundException:
             return {"message": "Project template not found"}, 404
@@ -146,7 +144,7 @@ class ProjectTemplateTaskStatusResource(MethodView):
         return "", 204
 
 
-class ProjectTemplateAssetTypesResource(MethodView, ArgsMixin):
+class ProjectTemplateAssetTypesResource(MethodView):
     @jwt_required()
     def get(self, template_id):
         """
@@ -172,10 +170,10 @@ class ProjectTemplateAssetTypesResource(MethodView, ArgsMixin):
           - Project Templates
         """
         permissions.check_admin_permissions()
-        args = self.get_args([("asset_type_id", "", True)])
+        data = validation.validate_request_body(AddAssetTypeSchema)
         try:
             entry = project_templates_service.add_asset_type_to_template(
-                template_id, args["asset_type_id"]
+                template_id, data.asset_type_id
             )
         except ProjectTemplateNotFoundException:
             return {"message": "Project template not found"}, 404
@@ -203,7 +201,7 @@ class ProjectTemplateAssetTypeResource(MethodView):
         return "", 204
 
 
-class ProjectTemplateStatusAutomationsResource(MethodView, ArgsMixin):
+class ProjectTemplateStatusAutomationsResource(MethodView):
     @jwt_required()
     def get(self, template_id):
         """
@@ -229,11 +227,11 @@ class ProjectTemplateStatusAutomationsResource(MethodView, ArgsMixin):
           - Project Templates
         """
         permissions.check_admin_permissions()
-        args = self.get_args([("status_automation_id", "", True)])
+        data = validation.validate_request_body(AddStatusAutomationSchema)
         try:
             entry = (
                 project_templates_service.add_status_automation_to_template(
-                    template_id, args["status_automation_id"]
+                    template_id, data.status_automation_id
                 )
             )
         except ProjectTemplateNotFoundException:
@@ -262,7 +260,7 @@ class ProjectTemplateStatusAutomationResource(MethodView):
         return "", 204
 
 
-class ProjectTemplateBackgroundsResource(MethodView, ArgsMixin):
+class ProjectTemplateBackgroundsResource(MethodView):
     @jwt_required()
     def get(self, template_id):
         """
@@ -288,10 +286,10 @@ class ProjectTemplateBackgroundsResource(MethodView, ArgsMixin):
           - Project Templates
         """
         permissions.check_admin_permissions()
-        args = self.get_args([("preview_background_file_id", "", True)])
+        data = validation.validate_request_body(AddBackgroundSchema)
         try:
             entry = project_templates_service.add_preview_background_file_to_template(
-                template_id, args["preview_background_file_id"]
+                template_id, data.preview_background_file_id
             )
         except ProjectTemplateNotFoundException:
             return {"message": "Project template not found"}, 404
@@ -329,11 +327,10 @@ class ProjectTemplateDefaultBackgroundResource(MethodView):
           - Project Templates
         """
         permissions.check_admin_permissions()
-        data = request.json or {}
-        background_id = data.get("default_preview_background_file_id")
+        data = validation.validate_request_body(SetDefaultBackgroundSchema)
         try:
             template = project_templates_service.set_template_default_preview_background_file(
-                template_id, background_id
+                template_id, data.default_preview_background_file_id
             )
         except ProjectTemplateNotFoundException:
             return {"message": "Project template not found"}, 404
@@ -353,10 +350,14 @@ class ProjectTemplateMetadataDescriptorsResource(MethodView):
           - Project Templates
         """
         permissions.check_admin_permissions()
-        data = request.json or {}
-        descriptors = data.get("metadata_descriptors")
-        if descriptors is None and isinstance(data, list):
-            descriptors = data
+        body = request.get_json(silent=True)
+        if isinstance(body, list):
+            # Legacy shape: the descriptors sent as a bare JSON array.
+            descriptors = body
+        else:
+            descriptors = validation.validate_request_body(
+                SetMetadataDescriptorsSchema
+            ).metadata_descriptors
         try:
             template = (
                 project_templates_service.set_template_metadata_descriptors(
@@ -375,7 +376,7 @@ class ProjectTemplateMetadataDescriptorsResource(MethodView):
 # ---------------------------------------------------------------------------
 
 
-class ProjectTemplateFromProjectResource(MethodView, ArgsMixin):
+class ProjectTemplateFromProjectResource(MethodView):
     @jwt_required()
     def post(self, project_id):
         """
@@ -386,17 +387,14 @@ class ProjectTemplateFromProjectResource(MethodView, ArgsMixin):
           - Project Templates
         """
         permissions.check_admin_permissions()
-        args = self.get_args(
-            [
-                ("name", "", True),
-                ("description", None, False),
-            ]
+        data = validation.validate_request_body(
+            CreateTemplateFromProjectSchema
         )
         try:
             template = project_templates_service.create_template_from_project(
                 project_id,
-                args["name"],
-                description=args["description"],
+                data.name,
+                description=data.description,
             )
         except ProjectNotFoundException:
             return {"message": "Project not found"}, 404

--- a/zou/app/blueprints/project_templates/schemas.py
+++ b/zou/app/blueprints/project_templates/schemas.py
@@ -1,0 +1,86 @@
+"""
+Pydantic schemas for request body validation in the project templates
+blueprint.
+"""
+
+from typing import List, Optional
+
+from pydantic import Field
+
+from zou.app.utils.validation import BaseSchema
+
+
+class AddTaskTypeSchema(BaseSchema):
+    """
+    Body for attaching a task type to a project template.
+    """
+
+    task_type_id: str = Field(..., min_length=1, description="Task type UUID")
+    priority: Optional[int] = None
+
+
+class AddTaskStatusSchema(BaseSchema):
+    """
+    Body for attaching a task status to a project template.
+    """
+
+    task_status_id: str = Field(
+        ..., min_length=1, description="Task status UUID"
+    )
+    priority: Optional[int] = None
+    roles_for_board: List[str] = Field(default_factory=list)
+
+
+class AddAssetTypeSchema(BaseSchema):
+    """
+    Body for attaching an asset type to a project template.
+    """
+
+    asset_type_id: str = Field(
+        ..., min_length=1, description="Asset type UUID"
+    )
+
+
+class AddStatusAutomationSchema(BaseSchema):
+    """
+    Body for attaching a status automation to a project template.
+    """
+
+    status_automation_id: str = Field(
+        ..., min_length=1, description="Status automation UUID"
+    )
+
+
+class AddBackgroundSchema(BaseSchema):
+    """
+    Body for attaching a preview background to a project template.
+    """
+
+    preview_background_file_id: str = Field(
+        ..., min_length=1, description="Preview background file UUID"
+    )
+
+
+class SetMetadataDescriptorsSchema(BaseSchema):
+    """
+    Body for replacing the metadata descriptors snapshot on a template.
+    """
+
+    metadata_descriptors: Optional[list] = None
+
+
+class SetDefaultBackgroundSchema(BaseSchema):
+    """
+    Body for setting the default preview background of a template.
+    """
+
+    default_preview_background_file_id: Optional[str] = None
+
+
+class CreateTemplateFromProjectSchema(BaseSchema):
+    """
+    Body for creating a template from an existing project.
+    """
+
+    name: str = Field(..., min_length=1, description="Template name")
+    description: Optional[str] = None

--- a/zou/app/stores/auth_tokens_store.py
+++ b/zou/app/stores/auth_tokens_store.py
@@ -1,25 +1,14 @@
 import logging
-import sys
-
-import redis
 
 from zou.app import config
+from zou.app.stores import redis_client
 
 logger = logging.getLogger(__name__)
 
-try:
-    revoked_tokens_store = redis.StrictRedis(
-        host=config.KEY_VALUE_STORE["host"],
-        port=config.KEY_VALUE_STORE["port"],
-        db=config.AUTH_TOKEN_BLACKLIST_KV_INDEX,
-        password=config.KEY_VALUE_STORE["password"],
-        decode_responses=True,
-    )
-    revoked_tokens_store.ping()
-except redis.ConnectionError:
-    revoked_tokens_store = None
-    if "pytest" not in sys.modules:
-        logger.error("Cannot access to the required Redis instance")
+# Lazily connected: the pool opens on the first command, not at import.
+revoked_tokens_store = redis_client.get_client(
+    config.AUTH_TOKEN_BLACKLIST_KV_INDEX
+)
 
 
 def add(key, token, ttl=None):

--- a/zou/app/stores/config_store.py
+++ b/zou/app/stores/config_store.py
@@ -1,9 +1,9 @@
 import logging
-import sys
 
 import redis
 
 from zou.app import config
+from zou.app.stores import redis_client
 
 logger = logging.getLogger(__name__)
 
@@ -14,19 +14,8 @@ NOMAD_HOST_KEY = "config:nomad_host"
 NOMAD_NORMALIZE_JOB_KEY = "config:nomad_normalize_job"
 NOMAD_PLAYLIST_JOB_KEY = "config:nomad_playlist_job"
 
-try:
-    config_store = redis.StrictRedis(
-        host=config.KEY_VALUE_STORE["host"],
-        port=config.KEY_VALUE_STORE["port"],
-        db=config.KV_CONFIG_DB_INDEX,
-        password=config.KEY_VALUE_STORE["password"],
-        decode_responses=True,
-    )
-    config_store.ping()
-except redis.ConnectionError:
-    config_store = None
-    if "pytest" not in sys.modules:
-        logger.error("Cannot access to the required Redis instance")
+# Lazily connected: the pool opens on the first command, not at import.
+config_store = redis_client.get_client(config.KV_CONFIG_DB_INDEX)
 
 
 def _get_redis_raw(key):

--- a/zou/app/stores/redis_client.py
+++ b/zou/app/stores/redis_client.py
@@ -1,0 +1,37 @@
+"""
+Lazy, shared Redis client factory.
+
+redis.StrictRedis only opens a connection on the first command, so
+building a client is cheap and non-blocking; the stores used to force a
+connection at import time with a ping, which slowed startup and made the
+whole process fail when Redis was momentarily unreachable.
+
+Clients are memoized per (db index, decode_responses): a given logical
+store reuses the same client and its connection pool instead of opening
+a new one on every call.
+"""
+
+import redis
+
+from zou.app import config
+
+_clients = {}
+
+
+def get_client(db_index, decode_responses=True):
+    """
+    Return a memoized Redis client for the given db index. The connection
+    is opened lazily on the first command, not here.
+    """
+    key = (db_index, decode_responses)
+    client = _clients.get(key)
+    if client is None:
+        client = redis.StrictRedis(
+            host=config.KEY_VALUE_STORE["host"],
+            port=config.KEY_VALUE_STORE["port"],
+            db=db_index,
+            password=config.KEY_VALUE_STORE["password"],
+            decode_responses=decode_responses,
+        )
+        _clients[key] = client
+    return client

--- a/zou/event_stream.py
+++ b/zou/event_stream.py
@@ -1,3 +1,18 @@
+"""
+Realtime event stream (WebSocket) server.
+
+This process fans out Zou events and hosts the collaborative "preview
+rooms". SocketIO message delivery is shared across processes through the
+Redis message_queue, BUT the presence state below (rooms_data,
+user_rooms, server_stats) lives in this process's memory.
+
+Consequence: run the event stream as a SINGLE process. It uses gevent
+(one process, many greenlets) and is meant to be deployed that way; do
+NOT put it behind several gunicorn workers or the room playback state
+and connection counts diverge per worker. Horizontal scaling would
+require moving that presence state into Redis (see ARCH-12 / MEM-8).
+"""
+
 from gevent import monkey
 
 monkey.patch_all()


### PR DESCRIPTION
**Problem**
- project_templates parsed its 8 request bodies through ArgsMixin.get_args and raw request.json with no schema (worst legacy file)
- auth and config stores opened a Redis connection and pinged it at import, blocking startup and failing the process when Redis was momentarily down
- Running several event-stream workers silently diverges the in-process preview-room state

**Solution**
- Add a schemas.py to project_templates and validate all 8 bodies with Pydantic (the metadata-descriptors route still accepts a bare JSON array for compatibility)
- Build the auth/config Redis clients through a shared lazy factory (redis_client.get_client) that connects on first use and memoizes one client per db index
- Document the single-process requirement of the event stream and the Redis externalization needed to scale it