### PR TITLE
[perf] Rework the with-tasks views: flat queries, stream and compact options

### DIFF
--- a/tests/assets/test_asset_tasks.py
+++ b/tests/assets/test_asset_tasks.py
@@ -1,3 +1,5 @@
+import orjson
+
 from tests.base import ApiDBTestCase
 
 from zou.app.models.entity import EntityLink
@@ -7,6 +9,21 @@ from zou.app.services import (
     assets_service,
     persons_service,
 )
+
+
+def rebuild_from_compact(asset_fields, task_fields, rows):
+    """
+    Reverse the compact encoding by mapping positional values back to
+    field names, as a client is expected to do.
+    """
+    assets = []
+    for row in rows:
+        asset = dict(zip(asset_fields, row))
+        asset["tasks"] = [
+            dict(zip(task_fields, task_row)) for task_row in asset["tasks"]
+        ]
+        assets.append(asset)
+    return assets
 
 
 class AssetTasksTestCase(ApiDBTestCase):
@@ -45,6 +62,48 @@ class AssetTasksTestCase(ApiDBTestCase):
         self.assertEqual(
             assets[0]["tasks"][0]["assignees"][0], str(self.person_id)
         )
+
+    def test_get_assets_and_tasks_compact(self):
+        self.generate_fixture_task(name="Secondary")
+        reference = self.get("data/assets/with-tasks")
+        payload = self.get("data/assets/with-tasks?compact=true")
+        self.assertTrue(payload["compact"])
+        rebuilt = rebuild_from_compact(
+            payload["asset_fields"], payload["task_fields"], payload["rows"]
+        )
+        self.assertEqual(rebuilt, reference)
+
+    def test_get_assets_and_tasks_stream(self):
+        self.generate_fixture_task(name="Secondary")
+        reference = self.get("data/assets/with-tasks")
+        response = self.app.get(
+            "data/assets/with-tasks?stream=true", headers=self.base_headers
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.mimetype, "application/x-ndjson")
+        lines = response.data.decode("utf-8").strip().split("\n")
+        header = orjson.loads(lines[0])
+        self.assertFalse(header["compact"])
+        assets = [orjson.loads(line) for line in lines[1:]]
+        self.assertEqual(assets, reference)
+
+    def test_get_assets_and_tasks_stream_compact(self):
+        self.generate_fixture_task(name="Secondary")
+        reference = self.get("data/assets/with-tasks")
+        response = self.app.get(
+            "data/assets/with-tasks?stream=true&compact=true",
+            headers=self.base_headers,
+        )
+        self.assertEqual(response.status_code, 200)
+        lines = response.data.decode("utf-8").strip().split("\n")
+        header = orjson.loads(lines[0])
+        self.assertTrue(header["compact"])
+        rebuilt = rebuild_from_compact(
+            header["asset_fields"],
+            header["task_fields"],
+            [orjson.loads(line) for line in lines[1:]],
+        )
+        self.assertEqual(rebuilt, reference)
 
     def test_get_assets_and_tasks_episode_filter(self):
         """

--- a/tests/assets/test_asset_tasks.py
+++ b/tests/assets/test_asset_tasks.py
@@ -1,5 +1,6 @@
 from tests.base import ApiDBTestCase
 
+from zou.app.models.entity import EntityLink
 from zou.app.services import (
     projects_service,
     tasks_service,
@@ -44,6 +45,36 @@ class AssetTasksTestCase(ApiDBTestCase):
         self.assertEqual(
             assets[0]["tasks"][0]["assignees"][0], str(self.person_id)
         )
+
+    def test_get_assets_and_tasks_episode_filter(self):
+        """
+        An asset both sourced from an episode and cast in it through an
+        entity link must come back exactly once with its tasks, and an
+        asset unrelated to the episode must not come back at all.
+        """
+        self.generate_fixture_episode("E01")
+        episode_id = str(self.episode.id)
+        self.asset.update({"source_id": self.episode.id})
+        EntityLink.create(
+            entity_in_id=self.episode.id, entity_out_id=self.asset.id
+        )
+        self.generate_fixture_asset_character()
+
+        assets = assets_service.get_assets_and_tasks(
+            {"episode_id": episode_id}
+        )
+        self.assertEqual(len(assets), 1)
+        self.assertEqual(assets[0]["id"], str(self.asset_id))
+        self.assertEqual(len(assets[0]["tasks"]), 1)
+        self.assertEqual(
+            assets[0]["tasks"][0]["assignees"], [str(self.person_id)]
+        )
+
+        main_assets = assets_service.get_assets_and_tasks(
+            {"episode_id": "main"}
+        )
+        self.assertEqual(len(main_assets), 1)
+        self.assertEqual(main_assets[0]["id"], str(self.asset_character.id))
 
     def test_get_assets_and_tasks_vendor(self):
         self.generate_fixture_task(name="Secondary")

--- a/tests/shots/test_shot_tasks.py
+++ b/tests/shots/test_shot_tasks.py
@@ -1,3 +1,5 @@
+import orjson
+
 from tests.base import ApiDBTestCase
 
 from zou.app.services import (
@@ -6,6 +8,21 @@ from zou.app.services import (
     tasks_service,
     shots_service,
 )
+
+
+def rebuild_from_compact(shot_fields, task_fields, rows):
+    """
+    Reverse the compact encoding by mapping positional values back to
+    field names, as a client is expected to do.
+    """
+    shots = []
+    for row in rows:
+        shot = dict(zip(shot_fields, row))
+        shot["tasks"] = [
+            dict(zip(task_fields, task_row)) for task_row in shot["tasks"]
+        ]
+        shots.append(shot)
+    return shots
 
 
 class ShotTasksTestCase(ApiDBTestCase):
@@ -43,6 +60,48 @@ class ShotTasksTestCase(ApiDBTestCase):
         self.assertEqual(shots[0]["tasks"][0]["assignees"][0], self.person_id)
         self.assertEqual(shots[0]["episode_name"], "E01")
         self.assertEqual(shots[0]["sequence_name"], "S01")
+
+    def test_get_shots_and_tasks_compact(self):
+        self.generate_fixture_shot_task(name="Secondary")
+        reference = self.get("data/shots/with-tasks")
+        payload = self.get("data/shots/with-tasks?compact=true")
+        self.assertTrue(payload["compact"])
+        rebuilt = rebuild_from_compact(
+            payload["shot_fields"], payload["task_fields"], payload["rows"]
+        )
+        self.assertEqual(rebuilt, reference)
+
+    def test_get_shots_and_tasks_stream(self):
+        self.generate_fixture_shot_task(name="Secondary")
+        reference = self.get("data/shots/with-tasks")
+        response = self.app.get(
+            "data/shots/with-tasks?stream=true", headers=self.base_headers
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.mimetype, "application/x-ndjson")
+        lines = response.data.decode("utf-8").strip().split("\n")
+        header = orjson.loads(lines[0])
+        self.assertFalse(header["compact"])
+        shots = [orjson.loads(line) for line in lines[1:]]
+        self.assertEqual(shots, reference)
+
+    def test_get_shots_and_tasks_stream_compact(self):
+        self.generate_fixture_shot_task(name="Secondary")
+        reference = self.get("data/shots/with-tasks")
+        response = self.app.get(
+            "data/shots/with-tasks?stream=true&compact=true",
+            headers=self.base_headers,
+        )
+        self.assertEqual(response.status_code, 200)
+        lines = response.data.decode("utf-8").strip().split("\n")
+        header = orjson.loads(lines[0])
+        self.assertTrue(header["compact"])
+        rebuilt = rebuild_from_compact(
+            header["shot_fields"],
+            header["task_fields"],
+            [orjson.loads(line) for line in lines[1:]],
+        )
+        self.assertEqual(rebuilt, reference)
 
     def test_get_shots_and_tasks_vendor(self):
         self.generate_fixture_shot_task(name="Secondary")

--- a/zou/app/blueprints/assets/resources.py
+++ b/zou/app/blueprints/assets/resources.py
@@ -1,4 +1,6 @@
-from flask import request
+import orjson
+
+from flask import request, Response
 from flask.views import MethodView
 from flask_jwt_extended import jwt_required
 
@@ -242,6 +244,21 @@ class AssetsAndTasksResource(MethodView, ArgsMixin):
             description: Filter assets by episode (returns assets not linked to episode and assets linked to given episode)
             example: a24a6ea4-ce75-4665-a070-57453082c25
           - in: query
+            name: compact
+            type: boolean
+            default: false
+            description: Encode assets and tasks as positional value arrays
+              (halves the payload). Field names are given by the
+              asset_fields and task_fields entries of the response, map
+              values by name, never by hardcoded position.
+          - in: query
+            name: stream
+            type: boolean
+            default: false
+            description: Stream the response as NDJSON (one header line,
+              then one asset per line) instead of a single JSON document,
+              to keep server memory flat on large productions.
+          - in: query
             name: asset_type_id
             type: string
             format: uuid
@@ -291,6 +308,13 @@ class AssetsAndTasksResource(MethodView, ArgsMixin):
                         description: Array of related tasks
         """
         criterions = query.get_query_criterions_from_request(request)
+        # Kitsu-oriented options for full-project views: compact halves
+        # the payload (positional rows, field names in the header) and
+        # stream sends NDJSON without holding the response in memory.
+        # They are response options, not filters: pop them before the
+        # criterions reach the service.
+        stream = criterions.pop("stream", "false") == "true"
+        compact = criterions.pop("compact", "false") == "true"
         query.check_criterion_id_format(criterions)
         check_criterion_access(criterions)
         if permissions.has_vendor_permissions():
@@ -301,7 +325,29 @@ class AssetsAndTasksResource(MethodView, ArgsMixin):
                 str(department.id)
                 for department in persons_service.get_current_user_raw().departments
             ]
-        return assets_service.get_assets_and_tasks(criterions)
+        if not stream and not compact:
+            return assets_service.get_assets_and_tasks(criterions)
+
+        rows = assets_service.prepare_assets_and_tasks(
+            criterions, compact=compact
+        )
+        header = {"compact": compact}
+        if compact:
+            header["asset_fields"] = (
+                assets_service.ASSETS_AND_TASKS_ASSET_FIELDS
+            )
+            header["task_fields"] = assets_service.ASSETS_AND_TASKS_TASK_FIELDS
+
+        if not stream:
+            header["rows"] = list(rows)
+            return header
+
+        def generate():
+            yield orjson.dumps(header) + b"\n"
+            for item in rows:
+                yield orjson.dumps(item) + b"\n"
+
+        return Response(generate(), mimetype="application/x-ndjson")
 
 
 class AssetTypeResource(MethodView):

--- a/zou/app/blueprints/shots/resources.py
+++ b/zou/app/blueprints/shots/resources.py
@@ -1,4 +1,6 @@
-from flask import request
+import orjson
+
+from flask import request, Response
 from flask.views import MethodView
 from flask_jwt_extended import jwt_required
 
@@ -1006,6 +1008,21 @@ class ShotsAndTasksResource(MethodView):
             type: string
             format: uuid
             example: a24a6ea4-ce75-4665-a070-57453082c25
+          - in: query
+            name: compact
+            type: boolean
+            default: false
+            description: Encode shots and tasks as positional value arrays
+              (halves the payload). Field names are given by the
+              shot_fields and task_fields entries of the response, map
+              values by name, never by hardcoded position.
+          - in: query
+            name: stream
+            type: boolean
+            default: false
+            description: Stream the response as NDJSON (one header line,
+              then one shot per line) instead of a single JSON document,
+              to keep server memory flat on large productions.
         responses:
             200:
                 description: All shots
@@ -1041,6 +1058,13 @@ class ShotsAndTasksResource(MethodView):
                                   example: SH010 Animation
         """
         criterions = query.get_query_criterions_from_request(request)
+        # Kitsu-oriented options for full-project views: compact halves
+        # the payload (positional rows, field names in the header) and
+        # stream sends NDJSON without holding the response in memory.
+        # They are response options, not filters: pop them before the
+        # criterions reach the service.
+        stream = criterions.pop("stream", "false") == "true"
+        compact = criterions.pop("compact", "false") == "true"
         query.check_criterion_id_format(criterions)
         user_service.check_project_access(criterions.get("project_id", None))
         if permissions.has_vendor_permissions():
@@ -1051,7 +1075,27 @@ class ShotsAndTasksResource(MethodView):
                 str(department.id)
                 for department in persons_service.get_current_user_raw().departments
             ]
-        return shots_service.get_shots_and_tasks(criterions)
+        if not stream and not compact:
+            return shots_service.get_shots_and_tasks(criterions)
+
+        rows = shots_service.prepare_shots_and_tasks(
+            criterions, compact=compact
+        )
+        header = {"compact": compact}
+        if compact:
+            header["shot_fields"] = shots_service.SHOTS_AND_TASKS_SHOT_FIELDS
+            header["task_fields"] = shots_service.SHOTS_AND_TASKS_TASK_FIELDS
+
+        if not stream:
+            header["rows"] = list(rows)
+            return header
+
+        def generate():
+            yield orjson.dumps(header) + b"\n"
+            for item in rows:
+                yield orjson.dumps(item) + b"\n"
+
+        return Response(generate(), mimetype="application/x-ndjson")
 
 
 class SceneAndTasksResource(MethodView):

--- a/zou/app/services/assets_service.py
+++ b/zou/app/services/assets_service.py
@@ -2,6 +2,7 @@ from sqlalchemy import or_
 from sqlalchemy.exc import StatementError
 from sqlalchemy.orm import aliased
 
+from zou.app import db
 from zou.app.utils import events, fields, cache
 from zou.app.utils import query as query_utils
 
@@ -173,9 +174,57 @@ def get_full_assets(criterions=None):
     return assets
 
 
+def _apply_asset_and_tasks_criterions(query, criterions, assigned_to):
+    """
+    Apply the with-tasks asset filters (asset types only, id, project,
+    episode casting, assigned to current user) on a query that has Entity
+    in its FROM clause. Episode casting and assignation are expressed as
+    EXISTS subqueries so no filter ever multiplies the result rows.
+    """
+    query = query.filter(build_asset_type_filter())
+
+    if "id" in criterions:
+        query = query.filter(Entity.id == criterions["id"])
+
+    if "project_id" in criterions:
+        query = query.filter(Entity.project_id == criterions["project_id"])
+
+    if "episode_id" in criterions:
+        episode_id = criterions["episode_id"]
+        if episode_id == "main":
+            query = query.filter(Entity.source_id == None)
+        elif episode_id != "all":
+            cast_in_episode = (
+                db.session.query(EntityLink.entity_out_id)
+                .filter(EntityLink.entity_out_id == Entity.id)
+                .filter(EntityLink.entity_in_id == episode_id)
+                .exists()
+            )
+            query = query.filter(
+                or_(Entity.source_id == episode_id, cast_in_episode)
+            )
+
+    if assigned_to:
+        has_assigned_task = (
+            db.session.query(Task.id)
+            .filter(Task.entity_id == Entity.id)
+            .filter(user_service.build_assignee_filter())
+            .exists()
+        )
+        query = query.filter(has_assigned_task)
+
+    return query
+
+
 def get_assets_and_tasks(criterions=None, with_episode_ids=False):
     """
     Get all assets for given criterions with related tasks for each asset.
+
+    Runs three flat queries (assets, tasks, assignee links) instead of a
+    single Entity x Task x TaskPersonLink join: the joined form returned
+    one row per (asset, task, assignee) with every asset column repeated
+    on each row, which dominated the payload, the sort and the Python
+    dedup on large productions.
     """
     if criterions is None:
         criterions = {}
@@ -186,16 +235,44 @@ def get_assets_and_tasks(criterions=None, with_episode_ids=False):
         criterions.get("project_id", None), None
     )
 
-    query = (
-        Entity.query.filter(build_asset_type_filter())
-        .join(EntityType, Entity.entity_type_id == EntityType.id)
-        .outerjoin(Task)
-        .outerjoin(TaskPersonLink)
+    assigned_to = "assigned_to" in criterions
+    if assigned_to:
+        del criterions["assigned_to"]
+
+    asset_rows = (
+        _apply_asset_and_tasks_criterions(
+            Entity.query.join(
+                EntityType, Entity.entity_type_id == EntityType.id
+            ),
+            criterions,
+            assigned_to,
+        )
+        .with_entities(
+            Entity.id,
+            Entity.name,
+            Entity.description,
+            Entity.data,
+            Entity.preview_file_id,
+            Entity.entity_type_id,
+            Entity.canceled,
+            Entity.ready_for,
+            Entity.source_id,
+            Entity.is_casting_standby,
+            Entity.is_shared,
+            Entity.project_id,
+            EntityType.name.label("asset_type_name"),
+        )
+        .order_by(EntityType.name, Entity.name)
+        .all()
     )
 
-    tasks_query = query.add_columns(
-        EntityType.name,
+    task_query = _apply_asset_and_tasks_criterions(
+        Task.query.join(Entity, Task.entity_id == Entity.id),
+        criterions,
+        assigned_to,
+    ).with_entities(
         Task.id,
+        Task.entity_id,
         Task.task_type_id,
         Task.task_status_id,
         Task.priority,
@@ -210,35 +287,21 @@ def get_assets_and_tasks(criterions=None, with_episode_ids=False):
         Task.last_comment_date,
         Task.last_preview_file_id,
         Task.difficulty,
-        TaskPersonLink.person_id,
-    ).order_by(EntityType.name, Entity.name)
+    )
+    if assigned_to:
+        task_query = task_query.filter(user_service.build_assignee_filter())
+    task_rows = task_query.all()
 
-    if "id" in criterions:
-        tasks_query = tasks_query.filter(Entity.id == criterions["id"])
-
-    if "project_id" in criterions:
-        tasks_query = tasks_query.filter(
-            Entity.project_id == criterions["project_id"]
-        )
-
-    if "episode_id" in criterions:
-        episode_id = criterions["episode_id"]
-        if episode_id == "main":
-            tasks_query = tasks_query.filter(Entity.source_id == None)
-        elif episode_id != "all":
-            tasks_query = tasks_query.outerjoin(
-                EntityLink, EntityLink.entity_out_id == Entity.id
-            )
-            tasks_query = tasks_query.filter(
-                or_(
-                    Entity.source_id == episode_id,
-                    EntityLink.entity_in_id == episode_id,
-                )
-            )
-
-    if "assigned_to" in criterions:
-        tasks_query = tasks_query.filter(user_service.build_assignee_filter())
-        del criterions["assigned_to"]
+    link_query = _apply_asset_and_tasks_criterions(
+        db.session.query(TaskPersonLink)
+        .join(Task, TaskPersonLink.task_id == Task.id)
+        .join(Entity, Task.entity_id == Entity.id),
+        criterions,
+        assigned_to,
+    ).with_entities(TaskPersonLink.task_id, TaskPersonLink.person_id)
+    if assigned_to:
+        link_query = link_query.filter(user_service.build_assignee_filter())
+    link_rows = link_query.all()
 
     cast_in_episode_ids = {}
     if "project_id" in criterions or with_episode_ids:
@@ -274,106 +337,73 @@ def get_assets_and_tasks(criterions=None, with_episode_ids=False):
                 str(link.entity_in_id)
             )
 
-    query_result = tasks_query.all()
-
     if "vendor_departments" in criterions:
         not_allowed_descriptors_field_names = (
             entities_service.get_not_allowed_descriptors_fields_for_vendor(
                 "Asset",
                 criterions["vendor_departments"],
-                set(asset[0].project_id for asset in query_result),
+                set(row.project_id for row in asset_rows),
             )
         )
 
-    for (
-        asset,
-        entity_type_name,
-        task_id,
-        task_type_id,
-        task_status_id,
-        task_priority,
-        task_estimation,
-        task_duration,
-        task_retake_count,
-        task_real_start_date,
-        task_end_date,
-        task_start_date,
-        task_due_date,
-        task_done_date,
-        task_last_comment_date,
-        task_last_preview_file_id,
-        task_difficulty,
-        person_id,
-    ) in query_result:
-        if asset.source_id is None:
-            source_id = ""
-        else:
-            source_id = str(asset.source_id)
+    for row in asset_rows:
+        asset_id = str(row.id)
+        data = fields.serialize_value(row.data or {})
+        if "vendor_departments" in criterions:
+            data = entities_service.remove_not_allowed_fields_from_metadata(
+                not_allowed_descriptors_field_names[row.project_id],
+                data,
+            )
 
-        asset_id = str(asset.id)
+        asset_map[asset_id] = {
+            "id": asset_id,
+            "name": row.name,
+            "preview_file_id": str(row.preview_file_id or ""),
+            "description": row.description,
+            "asset_type_name": row.asset_type_name,
+            "asset_type_id": str(row.entity_type_id),
+            "canceled": row.canceled,
+            "ready_for": str(row.ready_for),
+            "episode_id": str(row.source_id) if row.source_id else "",
+            "casting_episode_ids": cast_in_episode_ids.get(asset_id, []),
+            "is_casting_standby": row.is_casting_standby,
+            "is_shared": row.is_shared,
+            "data": data,
+            "tasks": [],
+        }
 
-        if asset_id not in asset_map:
-            data = fields.serialize_value(asset.data or {})
-            if "vendor_departments" in criterions:
-                data = (
-                    entities_service.remove_not_allowed_fields_from_metadata(
-                        not_allowed_descriptors_field_names[asset.project_id],
-                        data,
-                    )
-                )
+    for row in task_rows:
+        task_id = str(row.id)
+        asset_dict = asset_map.get(str(row.entity_id))
+        if asset_dict is None:
+            continue
+        task_dict = {
+            "id": task_id,
+            "due_date": fields.serialize_value(row.due_date),
+            "done_date": fields.serialize_value(row.done_date),
+            "duration": row.duration,
+            "entity_id": str(row.entity_id),
+            "estimation": row.estimation,
+            "end_date": fields.serialize_value(row.end_date),
+            "is_subscribed": subscription_map.get(task_id, False),
+            "last_comment_date": fields.serialize_value(row.last_comment_date),
+            "last_preview_file_id": str(row.last_preview_file_id or ""),
+            "priority": row.priority or 0,
+            "real_start_date": fields.serialize_value(row.real_start_date),
+            "retake_count": row.retake_count,
+            "start_date": fields.serialize_value(row.start_date),
+            "difficulty": row.difficulty,
+            "task_status_id": str(row.task_status_id),
+            "task_type_id": str(row.task_type_id),
+            "assignees": [],
+        }
+        task_map[task_id] = task_dict
+        asset_dict["tasks"].append(task_dict)
 
-            asset_map[asset_id] = {
-                "id": asset_id,
-                "name": asset.name,
-                "preview_file_id": str(asset.preview_file_id or ""),
-                "description": asset.description,
-                "asset_type_name": entity_type_name,
-                "asset_type_id": str(asset.entity_type_id),
-                "canceled": asset.canceled,
-                "ready_for": str(asset.ready_for),
-                "episode_id": source_id,
-                "casting_episode_ids": cast_in_episode_ids.get(asset_id, []),
-                "is_casting_standby": asset.is_casting_standby,
-                "is_shared": asset.is_shared,
-                "data": data,
-                "tasks": [],
-            }
-
-        if task_id is not None:
-            task_id = str(task_id)
-            if task_id not in task_map:
-                task_dict = {
-                    "id": task_id,
-                    "due_date": fields.serialize_value(task_due_date),
-                    "done_date": fields.serialize_value(task_done_date),
-                    "duration": task_duration,
-                    "entity_id": asset_id,
-                    "estimation": task_estimation,
-                    "end_date": fields.serialize_value(task_end_date),
-                    "is_subscribed": subscription_map.get(task_id, False),
-                    "last_comment_date": fields.serialize_value(
-                        task_last_comment_date
-                    ),
-                    "last_preview_file_id": str(
-                        task_last_preview_file_id or ""
-                    ),
-                    "priority": task_priority or 0,
-                    "real_start_date": fields.serialize_value(
-                        task_real_start_date
-                    ),
-                    "retake_count": task_retake_count,
-                    "start_date": fields.serialize_value(task_start_date),
-                    "difficulty": task_difficulty,
-                    "task_status_id": str(task_status_id),
-                    "task_type_id": str(task_type_id),
-                    "assignees": [],
-                }
-                task_map[task_id] = task_dict
-                asset_dict = asset_map[asset_id]
-                asset_dict["tasks"].append(task_dict)
-
-            if person_id:
-                task_map[task_id]["assignees"].append(str(person_id))
+    for task_id, person_id in link_rows:
+        task_dict = task_map.get(str(task_id))
+        if task_dict is not None and person_id:
+            task_dict["assignees"].append(str(person_id))
 
     return list(asset_map.values())
 

--- a/zou/app/services/assets_service.py
+++ b/zou/app/services/assets_service.py
@@ -174,17 +174,6 @@ def get_full_assets(criterions=None):
     return assets
 
 
-def _serialize_datetime(value):
-    """
-    Specialized serializer for the with-tasks hot loop: the task date
-    columns are all DateTime, so the type-dispatch of
-    fields.serialize_value (6 calls per task) is pure overhead there.
-    """
-    if value is None:
-        return None
-    return value.replace(microsecond=0).isoformat()
-
-
 def _apply_asset_and_tasks_criterions(query, criterions, assigned_to):
     """
     Apply the with-tasks asset filters (asset types only, id, project,
@@ -428,19 +417,19 @@ def prepare_assets_and_tasks(
         def build_task(row):
             return [
                 row.id,
-                _serialize_datetime(row.due_date),
-                _serialize_datetime(row.done_date),
+                fields.serialize_datetime(row.due_date),
+                fields.serialize_datetime(row.done_date),
                 row.duration,
                 row.entity_id,
                 row.estimation,
-                _serialize_datetime(row.end_date),
+                fields.serialize_datetime(row.end_date),
                 subscription_map.get(row.id, False),
-                _serialize_datetime(row.last_comment_date),
+                fields.serialize_datetime(row.last_comment_date),
                 row.last_preview_file_id or "",
                 row.priority or 0,
-                _serialize_datetime(row.real_start_date),
+                fields.serialize_datetime(row.real_start_date),
                 row.retake_count,
-                _serialize_datetime(row.start_date),
+                fields.serialize_datetime(row.start_date),
                 row.difficulty,
                 row.task_status_id,
                 row.task_type_id,
@@ -452,21 +441,23 @@ def prepare_assets_and_tasks(
         def build_task(row):
             return {
                 "id": row.id,
-                "due_date": _serialize_datetime(row.due_date),
-                "done_date": _serialize_datetime(row.done_date),
+                "due_date": fields.serialize_datetime(row.due_date),
+                "done_date": fields.serialize_datetime(row.done_date),
                 "duration": row.duration,
                 "entity_id": row.entity_id,
                 "estimation": row.estimation,
-                "end_date": _serialize_datetime(row.end_date),
+                "end_date": fields.serialize_datetime(row.end_date),
                 "is_subscribed": subscription_map.get(row.id, False),
-                "last_comment_date": _serialize_datetime(
+                "last_comment_date": fields.serialize_datetime(
                     row.last_comment_date
                 ),
                 "last_preview_file_id": row.last_preview_file_id or "",
                 "priority": row.priority or 0,
-                "real_start_date": _serialize_datetime(row.real_start_date),
+                "real_start_date": fields.serialize_datetime(
+                    row.real_start_date
+                ),
                 "retake_count": row.retake_count,
-                "start_date": _serialize_datetime(row.start_date),
+                "start_date": fields.serialize_datetime(row.start_date),
                 "difficulty": row.difficulty,
                 "task_status_id": row.task_status_id,
                 "task_type_id": row.task_type_id,

--- a/zou/app/services/assets_service.py
+++ b/zou/app/services/assets_service.py
@@ -1,4 +1,4 @@
-from sqlalchemy import or_
+from sqlalchemy import cast, or_, Text
 from sqlalchemy.exc import StatementError
 from sqlalchemy.orm import aliased
 
@@ -174,6 +174,17 @@ def get_full_assets(criterions=None):
     return assets
 
 
+def _serialize_datetime(value):
+    """
+    Specialized serializer for the with-tasks hot loop: the task date
+    columns are all DateTime, so the type-dispatch of
+    fields.serialize_value (6 calls per task) is pure overhead there.
+    """
+    if value is None:
+        return None
+    return value.replace(microsecond=0).isoformat()
+
+
 def _apply_asset_and_tasks_criterions(query, criterions, assigned_to):
     """
     Apply the with-tasks asset filters (asset types only, id, project,
@@ -271,10 +282,13 @@ def get_assets_and_tasks(criterions=None, with_episode_ids=False):
         criterions,
         assigned_to,
     ).with_entities(
-        Task.id,
-        Task.entity_id,
-        Task.task_type_id,
-        Task.task_status_id,
+        # uuid::text in SQL: casting 4-5 uuids per task row in Python
+        # (uuid.__str__ + the UUID result processor) shows up in profiles
+        # at 75k tasks.
+        cast(Task.id, Text).label("id"),
+        cast(Task.entity_id, Text).label("entity_id"),
+        cast(Task.task_type_id, Text).label("task_type_id"),
+        cast(Task.task_status_id, Text).label("task_status_id"),
         Task.priority,
         Task.estimation,
         Task.duration,
@@ -285,7 +299,7 @@ def get_assets_and_tasks(criterions=None, with_episode_ids=False):
         Task.due_date,
         Task.done_date,
         Task.last_comment_date,
-        Task.last_preview_file_id,
+        cast(Task.last_preview_file_id, Text).label("last_preview_file_id"),
         Task.difficulty,
     )
     if assigned_to:
@@ -298,7 +312,10 @@ def get_assets_and_tasks(criterions=None, with_episode_ids=False):
         .join(Entity, Task.entity_id == Entity.id),
         criterions,
         assigned_to,
-    ).with_entities(TaskPersonLink.task_id, TaskPersonLink.person_id)
+    ).with_entities(
+        cast(TaskPersonLink.task_id, Text),
+        cast(TaskPersonLink.person_id, Text),
+    )
     if assigned_to:
         link_query = link_query.filter(user_service.build_assignee_filter())
     link_rows = link_query.all()
@@ -373,37 +390,37 @@ def get_assets_and_tasks(criterions=None, with_episode_ids=False):
         }
 
     for row in task_rows:
-        task_id = str(row.id)
-        asset_dict = asset_map.get(str(row.entity_id))
+        task_id = row.id
+        asset_dict = asset_map.get(row.entity_id)
         if asset_dict is None:
             continue
         task_dict = {
             "id": task_id,
-            "due_date": fields.serialize_value(row.due_date),
-            "done_date": fields.serialize_value(row.done_date),
+            "due_date": _serialize_datetime(row.due_date),
+            "done_date": _serialize_datetime(row.done_date),
             "duration": row.duration,
-            "entity_id": str(row.entity_id),
+            "entity_id": row.entity_id,
             "estimation": row.estimation,
-            "end_date": fields.serialize_value(row.end_date),
+            "end_date": _serialize_datetime(row.end_date),
             "is_subscribed": subscription_map.get(task_id, False),
-            "last_comment_date": fields.serialize_value(row.last_comment_date),
-            "last_preview_file_id": str(row.last_preview_file_id or ""),
+            "last_comment_date": _serialize_datetime(row.last_comment_date),
+            "last_preview_file_id": row.last_preview_file_id or "",
             "priority": row.priority or 0,
-            "real_start_date": fields.serialize_value(row.real_start_date),
+            "real_start_date": _serialize_datetime(row.real_start_date),
             "retake_count": row.retake_count,
-            "start_date": fields.serialize_value(row.start_date),
+            "start_date": _serialize_datetime(row.start_date),
             "difficulty": row.difficulty,
-            "task_status_id": str(row.task_status_id),
-            "task_type_id": str(row.task_type_id),
+            "task_status_id": row.task_status_id,
+            "task_type_id": row.task_type_id,
             "assignees": [],
         }
         task_map[task_id] = task_dict
         asset_dict["tasks"].append(task_dict)
 
     for task_id, person_id in link_rows:
-        task_dict = task_map.get(str(task_id))
+        task_dict = task_map.get(task_id)
         if task_dict is not None and person_id:
-            task_dict["assignees"].append(str(person_id))
+            task_dict["assignees"].append(person_id)
 
     return list(asset_map.values())
 

--- a/zou/app/services/assets_service.py
+++ b/zou/app/services/assets_service.py
@@ -227,20 +227,70 @@ def _apply_asset_and_tasks_criterions(query, criterions, assigned_to):
     return query
 
 
-def get_assets_and_tasks(criterions=None, with_episode_ids=False):
-    """
-    Get all assets for given criterions with related tasks for each asset.
+# Field orders of the compact encoding of the with-tasks views. Clients
+# must map values by reading these names from the response header, never
+# by hardcoding positions.
+ASSETS_AND_TASKS_ASSET_FIELDS = [
+    "id",
+    "name",
+    "preview_file_id",
+    "description",
+    "asset_type_name",
+    "asset_type_id",
+    "canceled",
+    "ready_for",
+    "episode_id",
+    "casting_episode_ids",
+    "is_casting_standby",
+    "is_shared",
+    "data",
+    "tasks",
+]
+ASSETS_AND_TASKS_TASK_FIELDS = [
+    "id",
+    "due_date",
+    "done_date",
+    "duration",
+    "entity_id",
+    "estimation",
+    "end_date",
+    "is_subscribed",
+    "last_comment_date",
+    "last_preview_file_id",
+    "priority",
+    "real_start_date",
+    "retake_count",
+    "start_date",
+    "difficulty",
+    "task_status_id",
+    "task_type_id",
+    "assignees",
+]
 
-    Runs three flat queries (assets, tasks, assignee links) instead of a
+
+def prepare_assets_and_tasks(
+    criterions=None, with_episode_ids=False, compact=False
+):
+    """
+    Run the with-tasks queries and return a generator yielding one asset
+    at a time, in display order. With compact=True each item is a list of
+    values aligned on ASSETS_AND_TASKS_ASSET_FIELDS (tasks aligned on
+    ASSETS_AND_TASKS_TASK_FIELDS) instead of a dict, which halves the
+    payload of task-heavy views.
+
+    Three flat queries (assets, tasks, assignee links) instead of a
     single Entity x Task x TaskPersonLink join: the joined form returned
     one row per (asset, task, assignee) with every asset column repeated
     on each row, which dominated the payload, the sort and the Python
     dedup on large productions.
+
+    All database and request-dependent work happens before this function
+    returns: the generator is pure formatting, so a streaming response
+    can consume it after the request context is gone, without the whole
+    response ever being held in memory.
     """
     if criterions is None:
         criterions = {}
-    asset_map = {}
-    task_map = {}
     Episode = aliased(Entity, name="episode")
     subscription_map = notifications_service.get_subscriptions_for_user(
         criterions.get("project_id", None), None
@@ -354,8 +404,9 @@ def get_assets_and_tasks(criterions=None, with_episode_ids=False):
                 str(link.entity_in_id)
             )
 
+    not_allowed_map = None
     if "vendor_departments" in criterions:
-        not_allowed_descriptors_field_names = (
+        not_allowed_map = (
             entities_service.get_not_allowed_descriptors_fields_for_vendor(
                 "Asset",
                 criterions["vendor_departments"],
@@ -363,66 +414,125 @@ def get_assets_and_tasks(criterions=None, with_episode_ids=False):
             )
         )
 
-    for row in asset_rows:
-        asset_id = str(row.id)
-        data = fields.serialize_value(row.data or {})
-        if "vendor_departments" in criterions:
-            data = entities_service.remove_not_allowed_fields_from_metadata(
-                not_allowed_descriptors_field_names[row.project_id],
-                data,
-            )
-
-        asset_map[asset_id] = {
-            "id": asset_id,
-            "name": row.name,
-            "preview_file_id": str(row.preview_file_id or ""),
-            "description": row.description,
-            "asset_type_name": row.asset_type_name,
-            "asset_type_id": str(row.entity_type_id),
-            "canceled": row.canceled,
-            "ready_for": str(row.ready_for),
-            "episode_id": str(row.source_id) if row.source_id else "",
-            "casting_episode_ids": cast_in_episode_ids.get(asset_id, []),
-            "is_casting_standby": row.is_casting_standby,
-            "is_shared": row.is_shared,
-            "data": data,
-            "tasks": [],
-        }
-
-    for row in task_rows:
-        task_id = row.id
-        asset_dict = asset_map.get(row.entity_id)
-        if asset_dict is None:
-            continue
-        task_dict = {
-            "id": task_id,
-            "due_date": _serialize_datetime(row.due_date),
-            "done_date": _serialize_datetime(row.done_date),
-            "duration": row.duration,
-            "entity_id": row.entity_id,
-            "estimation": row.estimation,
-            "end_date": _serialize_datetime(row.end_date),
-            "is_subscribed": subscription_map.get(task_id, False),
-            "last_comment_date": _serialize_datetime(row.last_comment_date),
-            "last_preview_file_id": row.last_preview_file_id or "",
-            "priority": row.priority or 0,
-            "real_start_date": _serialize_datetime(row.real_start_date),
-            "retake_count": row.retake_count,
-            "start_date": _serialize_datetime(row.start_date),
-            "difficulty": row.difficulty,
-            "task_status_id": row.task_status_id,
-            "task_type_id": row.task_type_id,
-            "assignees": [],
-        }
-        task_map[task_id] = task_dict
-        asset_dict["tasks"].append(task_dict)
-
+    assignees_by_task = {}
     for task_id, person_id in link_rows:
-        task_dict = task_map.get(task_id)
-        if task_dict is not None and person_id:
-            task_dict["assignees"].append(person_id)
+        if person_id:
+            assignees_by_task.setdefault(task_id, []).append(person_id)
 
-    return list(asset_map.values())
+    tasks_by_entity = {}
+    for row in task_rows:
+        tasks_by_entity.setdefault(row.entity_id, []).append(row)
+
+    if compact:
+
+        def build_task(row):
+            return [
+                row.id,
+                _serialize_datetime(row.due_date),
+                _serialize_datetime(row.done_date),
+                row.duration,
+                row.entity_id,
+                row.estimation,
+                _serialize_datetime(row.end_date),
+                subscription_map.get(row.id, False),
+                _serialize_datetime(row.last_comment_date),
+                row.last_preview_file_id or "",
+                row.priority or 0,
+                _serialize_datetime(row.real_start_date),
+                row.retake_count,
+                _serialize_datetime(row.start_date),
+                row.difficulty,
+                row.task_status_id,
+                row.task_type_id,
+                assignees_by_task.get(row.id, []),
+            ]
+
+    else:
+
+        def build_task(row):
+            return {
+                "id": row.id,
+                "due_date": _serialize_datetime(row.due_date),
+                "done_date": _serialize_datetime(row.done_date),
+                "duration": row.duration,
+                "entity_id": row.entity_id,
+                "estimation": row.estimation,
+                "end_date": _serialize_datetime(row.end_date),
+                "is_subscribed": subscription_map.get(row.id, False),
+                "last_comment_date": _serialize_datetime(
+                    row.last_comment_date
+                ),
+                "last_preview_file_id": row.last_preview_file_id or "",
+                "priority": row.priority or 0,
+                "real_start_date": _serialize_datetime(row.real_start_date),
+                "retake_count": row.retake_count,
+                "start_date": _serialize_datetime(row.start_date),
+                "difficulty": row.difficulty,
+                "task_status_id": row.task_status_id,
+                "task_type_id": row.task_type_id,
+                "assignees": assignees_by_task.get(row.id, []),
+            }
+
+    def iterate():
+        for row in asset_rows:
+            asset_id = str(row.id)
+            data = fields.serialize_value(row.data or {})
+            if not_allowed_map is not None:
+                data = (
+                    entities_service.remove_not_allowed_fields_from_metadata(
+                        not_allowed_map[row.project_id], data
+                    )
+                )
+            tasks = [
+                build_task(task_row)
+                for task_row in tasks_by_entity.get(asset_id, ())
+            ]
+            if compact:
+                yield [
+                    asset_id,
+                    row.name,
+                    str(row.preview_file_id or ""),
+                    row.description,
+                    row.asset_type_name,
+                    str(row.entity_type_id),
+                    row.canceled,
+                    str(row.ready_for),
+                    str(row.source_id) if row.source_id else "",
+                    cast_in_episode_ids.get(asset_id, []),
+                    row.is_casting_standby,
+                    row.is_shared,
+                    data,
+                    tasks,
+                ]
+            else:
+                yield {
+                    "id": asset_id,
+                    "name": row.name,
+                    "preview_file_id": str(row.preview_file_id or ""),
+                    "description": row.description,
+                    "asset_type_name": row.asset_type_name,
+                    "asset_type_id": str(row.entity_type_id),
+                    "canceled": row.canceled,
+                    "ready_for": str(row.ready_for),
+                    "episode_id": str(row.source_id) if row.source_id else "",
+                    "casting_episode_ids": cast_in_episode_ids.get(
+                        asset_id, []
+                    ),
+                    "is_casting_standby": row.is_casting_standby,
+                    "is_shared": row.is_shared,
+                    "data": data,
+                    "tasks": tasks,
+                }
+
+    return iterate()
+
+
+def get_assets_and_tasks(criterions=None, with_episode_ids=False):
+    """
+    Get all assets for given criterions with related tasks for each
+    asset, as a list of dicts.
+    """
+    return list(prepare_assets_and_tasks(criterions, with_episode_ids))
 
 
 def get_asset_types(criterions=None):

--- a/zou/app/services/concepts_service.py
+++ b/zou/app/services/concepts_service.py
@@ -1,3 +1,4 @@
+from sqlalchemy import cast, Text
 from sqlalchemy.exc import StatementError
 from sqlalchemy.orm import selectinload
 
@@ -8,6 +9,7 @@ from zou.app.utils import (
     query as query_utils,
 )
 
+from zou.app import db
 from zou.app.models.entity import (
     Entity,
     EntityLink,
@@ -16,7 +18,7 @@ from zou.app.models.entity import (
 )
 from zou.app.models.project import Project
 from zou.app.models.subscription import Subscription
-from zou.app.models.task import Task, TaskPersonLink
+from zou.app.models.task import Task
 
 from zou.app.services import (
     deletion_service,
@@ -165,138 +167,137 @@ def get_concepts(criterions=None):
     return concepts
 
 
+CONCEPTS_AND_TASKS_TASK_FIELDS = [
+    "id",
+    "duration",
+    "due_date",
+    "end_date",
+    "entity_id",
+    "estimation",
+    "last_comment_date",
+    "nb_assets_ready",
+    "priority",
+    "real_start_date",
+    "retake_count",
+    "start_date",
+    "task_status_id",
+    "task_type_id",
+]
+
+
 def get_concepts_and_tasks(criterions=None):
     """
-    Get all concepts for given criterions with related tasks for each concept.
+    Get all concepts for given criterions with related tasks for each
+    concept, as a list of dicts. Flat narrow queries through
+    entities_service.fetch_entity_task_map instead of a row-multiplying
+    join; response shape unchanged.
     """
     if criterions is None:
         criterions = {}
     concept_type = get_concept_type()
-    concept_map = {}
-    task_map = {}
     subscription_map = notifications_service.get_subscriptions_for_user(
-        criterions.get("project_id", None), get_concept_type()["id"]
+        criterions.get("project_id", None), concept_type["id"]
     )
 
-    query = (
-        Entity.query.join(Project, Project.id == Entity.project_id)
-        .outerjoin(Task, Task.entity_id == Entity.id)
-        .outerjoin(TaskPersonLink)
-        .add_columns(
-            Task.id,
-            Task.task_type_id,
-            Task.task_status_id,
-            Task.priority,
-            Task.estimation,
-            Task.duration,
-            Task.retake_count,
-            Task.real_start_date,
-            Task.end_date,
-            Task.start_date,
-            Task.due_date,
-            Task.last_comment_date,
-            Task.nb_assets_ready,
-            TaskPersonLink.person_id,
-            Project.id,
-            Project.name,
-        )
-        .filter(Entity.entity_type_id == concept_type["id"])
-    )
-    if "id" in criterions:
-        query = query.filter(Entity.id == criterions["id"])
-
-    if "project_id" in criterions:
-        query = query.filter(Entity.project_id == criterions["project_id"])
-
-    if "assigned_to" in criterions:
-        query = query.filter(user_service.build_assignee_filter())
+    assigned_to = "assigned_to" in criterions
+    if assigned_to:
         del criterions["assigned_to"]
 
-    query_result = query.all()
-
-    for (
-        concept,
-        task_id,
-        task_type_id,
-        task_status_id,
-        task_priority,
-        task_estimation,
-        task_duration,
-        task_retake_count,
-        task_real_start_date,
-        task_end_date,
-        task_start_date,
-        task_due_date,
-        task_last_comment_date,
-        task_nb_assets_ready,
-        person_id,
-        project_id,
-        project_name,
-    ) in query_result:
-        concept_id = str(concept.id)
-
-        if concept_id not in concept_map:
-            data = fields.serialize_value(concept.data or {})
-
-            concept_map[concept_id] = fields.serialize_dict(
-                {
-                    "canceled": concept.canceled,
-                    "data": data,
-                    "description": concept.description,
-                    "entity_type_id": concept.entity_type_id,
-                    "fps": data.get("fps", None),
-                    "frame_in": data.get("frame_in", None),
-                    "frame_out": data.get("frame_out", None),
-                    "id": concept.id,
-                    "name": concept.name,
-                    "nb_frames": concept.nb_frames,
-                    "parent_id": concept.parent_id,
-                    "preview_file_id": concept.preview_file_id or None,
-                    "project_id": project_id,
-                    "project_name": project_name,
-                    "source_id": concept.source_id,
-                    "nb_entities_out": concept.nb_entities_out,
-                    "is_casting_standby": concept.is_casting_standby,
-                    "tasks": [],
-                    "entity_concept_links": concept.entity_concept_links,
-                    "type": "Concept",
-                    "updated_at": concept.updated_at,
-                    "created_at": concept.created_at,
-                    "created_by": concept.created_by,
-                }
+    def apply_filters(query):
+        query = query.filter(Entity.entity_type_id == concept_type["id"])
+        if "id" in criterions:
+            query = query.filter(Entity.id == criterions["id"])
+        if "project_id" in criterions:
+            query = query.filter(Entity.project_id == criterions["project_id"])
+        if assigned_to:
+            has_assigned_task = (
+                db.session.query(Task.id)
+                .filter(Task.entity_id == Entity.id)
+                .filter(user_service.build_assignee_filter())
+                .exists()
             )
+            query = query.filter(has_assigned_task)
+        return query
 
-        if task_id is not None:
-            task_id = str(task_id)
-            if task_id not in task_map:
-                task_dict = fields.serialize_dict(
-                    {
-                        "id": task_id,
-                        "duration": task_duration,
-                        "due_date": task_due_date,
-                        "end_date": task_end_date,
-                        "entity_id": concept_id,
-                        "estimation": task_estimation,
-                        "is_subscribed": subscription_map.get(task_id, False),
-                        "last_comment_date": task_last_comment_date,
-                        "nb_assets_ready": task_nb_assets_ready,
-                        "priority": task_priority or 0,
-                        "real_start_date": task_real_start_date,
-                        "retake_count": task_retake_count,
-                        "start_date": task_start_date,
-                        "task_status_id": task_status_id,
-                        "task_type_id": task_type_id,
-                        "assignees": [],
-                    }
-                )
-                task_map[task_id] = task_dict
-                concept_dict = concept_map[concept_id]
-                concept_dict["tasks"].append(task_dict)
+    concept_rows = (
+        apply_filters(
+            Entity.query.join(Project, Project.id == Entity.project_id)
+        )
+        .with_entities(
+            cast(Entity.id, Text).label("id"),
+            Entity.name,
+            Entity.description,
+            Entity.data,
+            Entity.canceled,
+            cast(Entity.entity_type_id, Text).label("entity_type_id"),
+            cast(Entity.parent_id, Text).label("parent_id"),
+            cast(Entity.preview_file_id, Text).label("preview_file_id"),
+            cast(Entity.source_id, Text).label("source_id"),
+            Entity.nb_frames,
+            Entity.nb_entities_out,
+            Entity.is_casting_standby,
+            cast(Entity.created_by, Text).label("created_by"),
+            Entity.created_at,
+            Entity.updated_at,
+            cast(Entity.project_id, Text).label("project_id"),
+            Project.name.label("project_name"),
+        )
+        .all()
+    )
 
-            if person_id:
-                task_map[task_id]["assignees"].append(str(person_id))
+    tasks_by_entity, build_task = entities_service.fetch_entity_task_map(
+        apply_filters,
+        subscription_map,
+        CONCEPTS_AND_TASKS_TASK_FIELDS,
+        assigned_to=assigned_to,
+    )
 
-    return list(concept_map.values())
+    concept_links = apply_filters(
+        db.session.query(EntityConceptLink).join(
+            Entity, EntityConceptLink.entity_in_id == Entity.id
+        )
+    ).with_entities(
+        cast(EntityConceptLink.entity_in_id, Text),
+        cast(EntityConceptLink.entity_out_id, Text),
+    )
+    links_by_concept = {}
+    for entity_in_id, entity_out_id in concept_links.all():
+        links_by_concept.setdefault(entity_in_id, []).append(entity_out_id)
+
+    concepts = []
+    for row in concept_rows:
+        data = fields.serialize_value(row.data or {})
+        concepts.append(
+            {
+                "canceled": row.canceled,
+                "data": data,
+                "description": row.description,
+                "entity_type_id": row.entity_type_id,
+                "fps": data.get("fps", None),
+                "frame_in": data.get("frame_in", None),
+                "frame_out": data.get("frame_out", None),
+                "id": row.id,
+                "name": row.name,
+                "nb_frames": row.nb_frames,
+                "parent_id": row.parent_id,
+                "preview_file_id": row.preview_file_id,
+                "project_id": row.project_id,
+                "project_name": row.project_name,
+                "source_id": row.source_id,
+                "nb_entities_out": row.nb_entities_out,
+                "is_casting_standby": row.is_casting_standby,
+                "tasks": [
+                    build_task(task_row)
+                    for task_row in tasks_by_entity.get(row.id, ())
+                ],
+                "entity_concept_links": links_by_concept.get(row.id, []),
+                "type": "Concept",
+                "updated_at": fields.serialize_datetime(row.updated_at),
+                "created_at": fields.serialize_datetime(row.created_at),
+                "created_by": row.created_by,
+            }
+        )
+    return concepts
 
 
 def get_concepts_for_project(project_id, only_assigned=False):

--- a/zou/app/services/edits_service.py
+++ b/zou/app/services/edits_service.py
@@ -1,3 +1,4 @@
+from sqlalchemy import cast, Text
 from sqlalchemy.orm import aliased
 from sqlalchemy.exc import StatementError
 
@@ -8,6 +9,7 @@ from zou.app.utils import (
     query as query_utils,
 )
 
+from zou.app import db
 from zou.app.models.entity import (
     Entity,
     EntityLink,
@@ -16,7 +18,7 @@ from zou.app.models.entity import (
 )
 from zou.app.models.project import Project
 from zou.app.models.subscription import Subscription
-from zou.app.models.task import Task, TaskPersonLink
+from zou.app.models.task import Task
 
 from zou.app.services import (
     deletion_service,
@@ -75,159 +77,136 @@ def get_edits(criterions=None):
     return edits
 
 
+EDITS_AND_TASKS_TASK_FIELDS = [
+    "id",
+    "duration",
+    "due_date",
+    "entity_id",
+    "end_date",
+    "estimation",
+    "last_comment_date",
+    "last_preview_file_id",
+    "nb_assets_ready",
+    "priority",
+    "real_start_date",
+    "retake_count",
+    "start_date",
+    "task_status_id",
+    "task_type_id",
+]
+
+
 def get_edits_and_tasks(criterions=None):
     """
-    Get all edits for given criterions with related tasks for each edit.
+    Get all edits for given criterions with related tasks for each edit,
+    as a list of dicts. Flat narrow queries through
+    entities_service.fetch_entity_task_map instead of a row-multiplying
+    join; response shape unchanged.
     """
     if criterions is None:
         criterions = {}
     edit_type = get_edit_type()
-    edit_map = {}
-    task_map = {}
-    Episode = aliased(Entity, name="episode")
     subscription_map = notifications_service.get_subscriptions_for_user(
-        criterions.get("project_id", None), get_edit_type()["id"]
+        criterions.get("project_id", None), edit_type["id"]
     )
 
-    query = (
-        Entity.query.join(Project, Entity.project_id == Project.id)
-        .outerjoin(Episode, Episode.id == Entity.parent_id)
-        .outerjoin(Task, Task.entity_id == Entity.id)
-        .outerjoin(TaskPersonLink)
-        .add_columns(
-            Episode.id,
-            Episode.name,
-            Task.id,
-            Task.task_type_id,
-            Task.task_status_id,
-            Task.priority,
-            Task.estimation,
-            Task.duration,
-            Task.retake_count,
-            Task.real_start_date,
-            Task.end_date,
-            Task.start_date,
-            Task.due_date,
-            Task.last_comment_date,
-            Task.last_preview_file_id,
-            Task.nb_assets_ready,
-            TaskPersonLink.person_id,
-            Project.id,
-            Project.name,
-        )
-        .filter(Entity.entity_type_id == edit_type["id"])
-    )
-    if "id" in criterions:
-        query = query.filter(Entity.id == criterions["id"])
-
-    if "project_id" in criterions:
-        query = query.filter(Entity.project_id == criterions["project_id"])
-
-    if "episode_id" in criterions:
-        query = query.filter(Entity.parent_id == criterions["episode_id"])
-
-    if "assigned_to" in criterions:
-        query = query.filter(user_service.build_assignee_filter())
+    assigned_to = "assigned_to" in criterions
+    if assigned_to:
         del criterions["assigned_to"]
 
-    query_result = query.all()
+    Episode = aliased(Entity, name="episode")
 
+    def apply_filters(query):
+        query = query.filter(Entity.entity_type_id == edit_type["id"])
+        if "id" in criterions:
+            query = query.filter(Entity.id == criterions["id"])
+        if "project_id" in criterions:
+            query = query.filter(Entity.project_id == criterions["project_id"])
+        if "episode_id" in criterions:
+            query = query.filter(Entity.parent_id == criterions["episode_id"])
+        if assigned_to:
+            has_assigned_task = (
+                db.session.query(Task.id)
+                .filter(Task.entity_id == Entity.id)
+                .filter(user_service.build_assignee_filter())
+                .exists()
+            )
+            query = query.filter(has_assigned_task)
+        return query
+
+    edit_rows = (
+        apply_filters(
+            Entity.query.join(
+                Project, Entity.project_id == Project.id
+            ).outerjoin(Episode, Episode.id == Entity.parent_id)
+        )
+        .with_entities(
+            cast(Entity.id, Text).label("id"),
+            Entity.name,
+            Entity.description,
+            Entity.data,
+            Entity.canceled,
+            cast(Entity.entity_type_id, Text).label("entity_type_id"),
+            cast(Entity.parent_id, Text).label("parent_id"),
+            cast(Entity.preview_file_id, Text).label("preview_file_id"),
+            cast(Entity.source_id, Text).label("source_id"),
+            Entity.nb_entities_out,
+            cast(Entity.project_id, Text).label("project_id"),
+            cast(Episode.id, Text).label("episode_id"),
+            Episode.name.label("episode_name"),
+            Project.name.label("project_name"),
+        )
+        .all()
+    )
+
+    tasks_by_entity, build_task = entities_service.fetch_entity_task_map(
+        apply_filters,
+        subscription_map,
+        EDITS_AND_TASKS_TASK_FIELDS,
+        assigned_to=assigned_to,
+    )
+
+    not_allowed_map = None
     if "vendor_departments" in criterions:
-        not_allowed_descriptors_field_names = (
+        not_allowed_map = (
             entities_service.get_not_allowed_descriptors_fields_for_vendor(
                 "Edit",
                 criterions["vendor_departments"],
-                set(edit[0].project_id for edit in query_result),
+                set(row.project_id for row in edit_rows),
             )
         )
 
-    for (
-        edit,
-        episode_id,
-        episode_name,
-        task_id,
-        task_type_id,
-        task_status_id,
-        task_priority,
-        task_estimation,
-        task_duration,
-        task_retake_count,
-        task_real_start_date,
-        task_end_date,
-        task_start_date,
-        task_due_date,
-        task_last_comment_date,
-        task_last_preview_file_id,
-        task_nb_assets_ready,
-        person_id,
-        project_id,
-        project_name,
-    ) in query.all():
-        edit_id = str(edit.id)
-
-        if edit_id not in edit_map:
-            data = fields.serialize_value(edit.data or {})
-            if "vendor_departments" in criterions:
-                data = (
-                    entities_service.remove_not_allowed_fields_from_metadata(
-                        not_allowed_descriptors_field_names[edit.project_id],
-                        data,
-                    )
-                )
-
-            edit_map[edit_id] = fields.serialize_dict(
-                {
-                    "canceled": edit.canceled,
-                    "data": data,
-                    "description": edit.description,
-                    "entity_type_id": edit.entity_type_id,
-                    "episode_id": episode_id,
-                    "episode_name": episode_name or "",
-                    "id": edit.id,
-                    "name": edit.name,
-                    "parent_id": edit.parent_id,
-                    "preview_file_id": edit.preview_file_id or None,
-                    "project_id": project_id,
-                    "project_name": project_name,
-                    "source_id": edit.source_id,
-                    "nb_entities_out": edit.nb_entities_out,
-                    "tasks": [],
-                    "type": "Edit",
-                }
+    edits = []
+    for row in edit_rows:
+        data = fields.serialize_value(row.data or {})
+        if not_allowed_map is not None:
+            data = entities_service.remove_not_allowed_fields_from_metadata(
+                not_allowed_map[row.project_id], data
             )
-
-        if task_id is not None:
-            task_id = str(task_id)
-            if task_id not in task_map:
-                task_dict = fields.serialize_dict(
-                    {
-                        "id": task_id,
-                        "duration": task_duration,
-                        "due_date": task_due_date,
-                        "entity_id": edit_id,
-                        "end_date": task_end_date,
-                        "estimation": task_estimation,
-                        "last_comment_date": task_last_comment_date,
-                        "last_preview_file_id": task_last_preview_file_id,
-                        "is_subscribed": subscription_map.get(task_id, False),
-                        "nb_assets_ready": task_nb_assets_ready,
-                        "priority": task_priority or 0,
-                        "real_start_date": task_real_start_date,
-                        "retake_count": task_retake_count,
-                        "start_date": task_start_date,
-                        "task_status_id": task_status_id,
-                        "task_type_id": task_type_id,
-                        "assignees": [],
-                    }
-                )
-                task_map[task_id] = task_dict
-                edit_dict = edit_map[edit_id]
-                edit_dict["tasks"].append(task_dict)
-
-            if person_id:
-                task_map[task_id]["assignees"].append(str(person_id))
-
-    return list(edit_map.values())
+        edits.append(
+            {
+                "canceled": row.canceled,
+                "data": data,
+                "description": row.description,
+                "entity_type_id": row.entity_type_id,
+                "episode_id": row.episode_id,
+                "episode_name": row.episode_name or "",
+                "id": row.id,
+                "name": row.name,
+                "parent_id": row.parent_id,
+                "preview_file_id": row.preview_file_id,
+                "project_id": row.project_id,
+                "project_name": row.project_name,
+                "source_id": row.source_id,
+                "nb_entities_out": row.nb_entities_out,
+                "tasks": [
+                    build_task(task_row)
+                    for task_row in tasks_by_entity.get(row.id, ())
+                ],
+                "type": "Edit",
+            }
+        )
+    return edits
 
 
 def get_edit_raw(edit_id):

--- a/zou/app/services/entities_service.py
+++ b/zou/app/services/entities_service.py
@@ -1,3 +1,4 @@
+from sqlalchemy import cast, Text
 from sqlalchemy.exc import IntegrityError
 
 from zou.app.services import (
@@ -258,142 +259,208 @@ def get_entity_links_for_project(
     return results
 
 
+# Builders for each task field of the with-tasks views. Every view picks
+# its exact field list so its response shape stays unchanged; is_subscribed
+# and assignees are always added by build_task.
+_TASK_FIELD_BUILDERS = {
+    "id": lambda row: row.id,
+    "entity_id": lambda row: row.entity_id,
+    "task_type_id": lambda row: row.task_type_id,
+    "task_status_id": lambda row: row.task_status_id,
+    "priority": lambda row: row.priority or 0,
+    "estimation": lambda row: row.estimation,
+    "duration": lambda row: row.duration,
+    "retake_count": lambda row: row.retake_count,
+    "real_start_date": lambda row: fields.serialize_datetime(
+        row.real_start_date
+    ),
+    "end_date": lambda row: fields.serialize_datetime(row.end_date),
+    "start_date": lambda row: fields.serialize_datetime(row.start_date),
+    "due_date": lambda row: fields.serialize_datetime(row.due_date),
+    "done_date": lambda row: fields.serialize_datetime(row.done_date),
+    "last_comment_date": lambda row: fields.serialize_datetime(
+        row.last_comment_date
+    ),
+    "last_preview_file_id": lambda row: row.last_preview_file_id,
+    "nb_assets_ready": lambda row: row.nb_assets_ready,
+    "difficulty": lambda row: row.difficulty,
+    "nb_drawings": lambda row: row.nb_drawings,
+}
+
+ENTITIES_AND_TASKS_TASK_FIELDS = [
+    "id",
+    "estimation",
+    "entity_id",
+    "end_date",
+    "due_date",
+    "done_date",
+    "duration",
+    "last_comment_date",
+    "last_preview_file_id",
+    "priority",
+    "real_start_date",
+    "retake_count",
+    "start_date",
+    "difficulty",
+    "task_status_id",
+    "task_type_id",
+]
+
+
+def fetch_entity_task_map(
+    apply_filters, subscription_map, task_fields, assigned_to=False
+):
+    """
+    Shared core of the get_*_and_tasks views: fetch the tasks and the
+    assignee links of the entities selected by apply_filters (a callable
+    adding entity-scoped filters and joins to a query whose FROM clause
+    contains Entity) with two narrow flat queries, then group them.
+
+    Returns (tasks_by_entity, build_task): task rows grouped by entity id
+    (uuid as text) and a builder producing task dicts restricted to
+    task_fields, so every view keeps its exact response shape. With
+    assigned_to=True only the tasks assigned to the current user are
+    fetched.
+    """
+    from zou.app.services import user_service
+
+    task_query = apply_filters(
+        Task.query.join(Entity, Task.entity_id == Entity.id)
+    ).with_entities(
+        # uuid::text in SQL: casting uuids per task row in Python shows
+        # up in profiles on task-heavy productions.
+        cast(Task.id, Text).label("id"),
+        cast(Task.entity_id, Text).label("entity_id"),
+        cast(Task.task_type_id, Text).label("task_type_id"),
+        cast(Task.task_status_id, Text).label("task_status_id"),
+        Task.priority,
+        Task.estimation,
+        Task.duration,
+        Task.retake_count,
+        Task.real_start_date,
+        Task.end_date,
+        Task.start_date,
+        Task.due_date,
+        Task.done_date,
+        Task.last_comment_date,
+        cast(Task.last_preview_file_id, Text).label("last_preview_file_id"),
+        Task.nb_assets_ready,
+        Task.difficulty,
+        Task.nb_drawings,
+    )
+    if assigned_to:
+        task_query = task_query.filter(user_service.build_assignee_filter())
+    task_rows = task_query.all()
+
+    link_query = apply_filters(
+        db.session.query(TaskPersonLink)
+        .join(Task, TaskPersonLink.task_id == Task.id)
+        .join(Entity, Task.entity_id == Entity.id)
+    ).with_entities(
+        cast(TaskPersonLink.task_id, Text),
+        cast(TaskPersonLink.person_id, Text),
+    )
+    if assigned_to:
+        link_query = link_query.filter(user_service.build_assignee_filter())
+
+    assignees_by_task = {}
+    for task_id, person_id in link_query.all():
+        if person_id:
+            assignees_by_task.setdefault(task_id, []).append(person_id)
+
+    tasks_by_entity = {}
+    for row in task_rows:
+        tasks_by_entity.setdefault(row.entity_id, []).append(row)
+
+    builders = [(name, _TASK_FIELD_BUILDERS[name]) for name in task_fields]
+
+    def build_task(row):
+        task = {name: builder(row) for name, builder in builders}
+        task["is_subscribed"] = subscription_map.get(row.id, False)
+        task["assignees"] = assignees_by_task.get(row.id, [])
+        return task
+
+    return tasks_by_entity, build_task
+
+
 def get_entities_and_tasks(criterions=None):
     """
-    Get all entities for given criterions with related tasks for each entity.
+    Get all entities for given criterions with related tasks for each
+    entity, as a list of dicts.
     """
     if criterions is None:
         criterions = {}
     if "episode_id" in criterions and criterions["episode_id"] == "all":
         return []
 
-    entity_map = {}
-    task_map = {}
     subscription_map = notifications_service.get_subscriptions_for_user(
         criterions.get("project_id", None),
         criterions.get("entity_type_id", None),
     )
 
-    query = (
-        Entity.query.outerjoin(Task, Task.entity_id == Entity.id)
-        .outerjoin(TaskPersonLink)
-        .add_columns(
-            Task.id,
-            Task.task_type_id,
-            Task.task_status_id,
-            Task.priority,
-            Task.estimation,
-            Task.duration,
-            Task.retake_count,
-            Task.real_start_date,
-            Task.end_date,
-            Task.start_date,
-            Task.due_date,
-            Task.done_date,
-            Task.last_comment_date,
-            Task.last_preview_file_id,
-            Task.difficulty,
-            TaskPersonLink.person_id,
+    def apply_filters(query):
+        if "entity_type_id" in criterions:
+            query = query.filter(
+                Entity.entity_type_id == criterions["entity_type_id"]
+            )
+        if "project_id" in criterions:
+            query = query.filter(Entity.project_id == criterions["project_id"])
+        if "episode_id" in criterions:
+            query = query.filter(Entity.parent_id == criterions["episode_id"])
+        if "entity_ids" in criterions:
+            query = query.filter(Entity.id.in_(criterions["entity_ids"]))
+        return query
+
+    entity_rows = (
+        apply_filters(Entity.query)
+        .with_entities(
+            cast(Entity.id, Text).label("id"),
+            Entity.name,
+            Entity.status,
+            cast(Entity.parent_id, Text).label("parent_id"),
+            Entity.description,
+            Entity.data,
+            cast(Entity.preview_file_id, Text).label("preview_file_id"),
+            Entity.canceled,
         )
+        .all()
     )
 
-    if "entity_type_id" in criterions:
-        query = query.filter(
-            Entity.entity_type_id == criterions["entity_type_id"]
-        )
+    tasks_by_entity, build_task = fetch_entity_task_map(
+        apply_filters, subscription_map, ENTITIES_AND_TASKS_TASK_FIELDS
+    )
 
-    if "project_id" in criterions:
-        query = query.filter(Entity.project_id == criterions["project_id"])
-
-    if "episode_id" in criterions:
-        query = query.filter(Entity.parent_id == criterions["episode_id"])
-
-    if "entity_ids" in criterions:
-        query = query.filter(Entity.id.in_(criterions["entity_ids"]))
-
-    for (
-        entity,
-        task_id,
-        task_type_id,
-        task_status_id,
-        task_priority,
-        task_estimation,
-        task_duration,
-        task_retake_count,
-        task_real_start_date,
-        task_end_date,
-        task_start_date,
-        task_due_date,
-        task_done_date,
-        task_last_comment_date,
-        task_last_preview_file_id,
-        task_difficulty,
-        person_id,
-    ) in query.all():
-        entity_id = str(entity.id)
-
-        entity.data = entity.data or {}
-
-        if entity_id not in entity_map:
-            status = "running"
-            if entity.status is not None:
-                status = str(entity.status.code)
-            entity_map[entity_id] = {
-                "id": str(entity.id),
-                "name": entity.name,
-                "status": status,
-                "episode_id": str(entity.parent_id),
-                "description": entity.description,
-                "frame_in": entity.data.get("frame_in", None),
-                "frame_out": entity.data.get("frame_out", None),
-                "fps": entity.data.get("fps", None),
-                "preview_file_id": str(entity.preview_file_id or ""),
-                "canceled": entity.canceled,
-                "data": fields.serialize_value(entity.data),
-                "tasks": [],
-            }
-
-        if task_id is not None:
-            task_id = str(task_id)
-            if task_id not in task_map:
-                task_dict = fields.serialize_dict(
-                    {
-                        "id": task_id,
-                        "estimation": task_estimation,
-                        "entity_id": entity_id,
-                        "end_date": task_end_date,
-                        "due_date": task_due_date,
-                        "done_date": task_done_date,
-                        "duration": task_duration,
-                        "is_subscribed": subscription_map.get(task_id, False),
-                        "last_comment_date": task_last_comment_date,
-                        "last_preview_file_id": task_last_preview_file_id,
-                        "priority": task_priority or 0,
-                        "real_start_date": task_real_start_date,
-                        "retake_count": task_retake_count,
-                        "start_date": task_start_date,
-                        "difficulty": task_difficulty,
-                        "task_status_id": str(task_status_id),
-                        "task_type_id": str(task_type_id),
-                        "assignees": [],
-                    }
-                )
-                task_map[task_id] = task_dict
-                entity_dict = entity_map[entity_id]
-                entity_dict["tasks"].append(task_dict)
-
-            if person_id:
-                task_map[task_id]["assignees"].append(str(person_id))
-
-    entities = list(entity_map.values())
     assigned_to = criterions.get("assigned_to")
-    if assigned_to is not None:
-        for entity in entities:
-            entity["tasks"] = [
-                task
-                for task in entity["tasks"]
-                if assigned_to in task["assignees"]
+    entities = []
+    for row in entity_rows:
+        data = row.data or {}
+        status = "running"
+        if row.status is not None:
+            status = str(row.status.code)
+        tasks = [
+            build_task(task_row)
+            for task_row in tasks_by_entity.get(row.id, ())
+        ]
+        if assigned_to is not None:
+            tasks = [
+                task for task in tasks if assigned_to in task["assignees"]
             ]
+        entities.append(
+            {
+                "id": row.id,
+                "name": row.name,
+                "status": status,
+                "episode_id": str(row.parent_id),
+                "description": row.description,
+                "frame_in": data.get("frame_in", None),
+                "frame_out": data.get("frame_out", None),
+                "fps": data.get("fps", None),
+                "preview_file_id": row.preview_file_id or "",
+                "canceled": row.canceled,
+                "data": fields.serialize_value(data),
+                "tasks": tasks,
+            }
+        )
     return entities
 
 

--- a/zou/app/services/shots_service.py
+++ b/zou/app/services/shots_service.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 from operator import itemgetter
 from sqlalchemy.orm import aliased
 from sqlalchemy.exc import IntegrityError, StatementError
-from sqlalchemy import func, or_
+from sqlalchemy import cast, func, or_, Text
 
 from zou.app.utils import (
     cache,
@@ -219,182 +219,333 @@ def get_episode_map(criterions=None):
     return episode_map
 
 
-def get_shots_and_tasks(criterions=None):
+# Field orders of the compact encoding of the with-tasks view. Clients
+# must map values by reading these names from the response header, never
+# by hardcoding positions.
+SHOTS_AND_TASKS_SHOT_FIELDS = [
+    "canceled",
+    "data",
+    "description",
+    "entity_type_id",
+    "episode_id",
+    "episode_name",
+    "fps",
+    "frame_in",
+    "frame_out",
+    "id",
+    "name",
+    "nb_frames",
+    "parent_id",
+    "preview_file_id",
+    "project_id",
+    "project_name",
+    "sequence_id",
+    "sequence_name",
+    "source_id",
+    "nb_entities_out",
+    "is_casting_standby",
+    "type",
+    "tasks",
+]
+SHOTS_AND_TASKS_TASK_FIELDS = [
+    "id",
+    "duration",
+    "due_date",
+    "end_date",
+    "done_date",
+    "entity_id",
+    "estimation",
+    "is_subscribed",
+    "last_comment_date",
+    "last_preview_file_id",
+    "nb_assets_ready",
+    "priority",
+    "real_start_date",
+    "retake_count",
+    "start_date",
+    "difficulty",
+    "nb_drawings",
+    "task_status_id",
+    "task_type_id",
+    "assignees",
+]
+
+
+def prepare_shots_and_tasks(criterions=None, compact=False):
     """
-    Get all shots for given criterions with related tasks for each shot.
+    Run the with-tasks queries and return a generator yielding one shot
+    at a time. With compact=True each item is a list of values aligned on
+    SHOTS_AND_TASKS_SHOT_FIELDS (tasks aligned on
+    SHOTS_AND_TASKS_TASK_FIELDS) instead of a dict.
+
+    Three flat queries (shots, tasks, assignee links) instead of a single
+    Entity x Task x TaskPersonLink join, and no per-row ORM
+    materialization: the joined form dominated payload and memory on
+    large productions (10k shots for series).
+
+    All database and request-dependent work happens before this function
+    returns: the generator is pure formatting, so a streaming response
+    can consume it after the request context is gone, without the whole
+    response ever being held in memory.
     """
+    from zou.app import db
+
     if criterions is None:
         criterions = {}
     shot_type = get_shot_type()
-    shot_map = {}
-    task_map = {}
     subscription_map = notifications_service.get_subscriptions_for_user(
-        criterions.get("project_id", None), get_shot_type()["id"]
+        criterions.get("project_id", None), shot_type["id"]
     )
+
+    assigned_to = "assigned_to" in criterions
+    if assigned_to:
+        del criterions["assigned_to"]
 
     Sequence = aliased(Entity, name="sequence")
     Episode = aliased(Entity, name="episode")
 
-    query = (
-        Entity.query.join(Project, Project.id == Entity.project_id)
-        .join(Sequence, Sequence.id == Entity.parent_id)
-        .outerjoin(Episode, Episode.id == Sequence.parent_id)
-        .outerjoin(Task, Task.entity_id == Entity.id)
-        .outerjoin(TaskPersonLink)
-        .add_columns(
-            Episode.name,
-            Episode.id,
-            Sequence.name,
-            Sequence.id,
-            Task.id,
-            Task.task_type_id,
-            Task.task_status_id,
-            Task.priority,
-            Task.estimation,
-            Task.duration,
-            Task.retake_count,
-            Task.real_start_date,
-            Task.end_date,
-            Task.start_date,
-            Task.due_date,
-            Task.done_date,
-            Task.last_comment_date,
-            Task.last_preview_file_id,
-            Task.nb_assets_ready,
-            Task.difficulty,
-            Task.nb_drawings,
-            TaskPersonLink.person_id,
-            Project.id,
-            Project.name,
+    def apply_filters(query):
+        query = query.filter(Entity.entity_type_id == shot_type["id"])
+        if "id" in criterions:
+            query = query.filter(Entity.id == criterions["id"])
+        if "project_id" in criterions:
+            query = query.filter(Entity.project_id == criterions["project_id"])
+        if "episode_id" in criterions and criterions["episode_id"] != "all":
+            query = query.filter(
+                Sequence.parent_id == criterions["episode_id"]
+            )
+        if assigned_to:
+            has_assigned_task = (
+                db.session.query(Task.id)
+                .filter(Task.entity_id == Entity.id)
+                .filter(user_service.build_assignee_filter())
+                .exists()
+            )
+            query = query.filter(has_assigned_task)
+        return query
+
+    shot_rows = (
+        apply_filters(
+            Entity.query.join(Project, Project.id == Entity.project_id)
+            .join(Sequence, Sequence.id == Entity.parent_id)
+            .outerjoin(Episode, Episode.id == Sequence.parent_id)
         )
-        .filter(Entity.entity_type_id == shot_type["id"])
+        .with_entities(
+            cast(Entity.id, Text).label("id"),
+            Entity.name,
+            Entity.description,
+            Entity.data,
+            Entity.canceled,
+            cast(Entity.entity_type_id, Text).label("entity_type_id"),
+            cast(Entity.parent_id, Text).label("parent_id"),
+            cast(Entity.preview_file_id, Text).label("preview_file_id"),
+            cast(Entity.source_id, Text).label("source_id"),
+            Entity.nb_frames,
+            Entity.nb_entities_out,
+            Entity.is_casting_standby,
+            cast(Entity.project_id, Text).label("project_id"),
+            cast(Episode.id, Text).label("episode_id"),
+            Episode.name.label("episode_name"),
+            cast(Sequence.id, Text).label("sequence_id"),
+            Sequence.name.label("sequence_name"),
+            Project.name.label("project_name"),
+        )
+        .all()
     )
-    if "id" in criterions:
-        query = query.filter(Entity.id == criterions["id"])
 
-    if "project_id" in criterions:
-        query = query.filter(Entity.project_id == criterions["project_id"])
+    task_query = apply_filters(
+        Task.query.join(Entity, Task.entity_id == Entity.id).join(
+            Sequence, Sequence.id == Entity.parent_id
+        )
+    ).with_entities(
+        # uuid::text in SQL: casting uuids per task row in Python shows
+        # up in profiles on task-heavy productions.
+        cast(Task.id, Text).label("id"),
+        cast(Task.entity_id, Text).label("entity_id"),
+        cast(Task.task_type_id, Text).label("task_type_id"),
+        cast(Task.task_status_id, Text).label("task_status_id"),
+        Task.priority,
+        Task.estimation,
+        Task.duration,
+        Task.retake_count,
+        Task.real_start_date,
+        Task.end_date,
+        Task.start_date,
+        Task.due_date,
+        Task.done_date,
+        Task.last_comment_date,
+        cast(Task.last_preview_file_id, Text).label("last_preview_file_id"),
+        Task.nb_assets_ready,
+        Task.difficulty,
+        Task.nb_drawings,
+    )
+    if assigned_to:
+        task_query = task_query.filter(user_service.build_assignee_filter())
+    task_rows = task_query.all()
 
-    if "episode_id" in criterions and criterions["episode_id"] != "all":
-        query = query.filter(Sequence.parent_id == criterions["episode_id"])
+    link_query = apply_filters(
+        db.session.query(TaskPersonLink)
+        .join(Task, TaskPersonLink.task_id == Task.id)
+        .join(Entity, Task.entity_id == Entity.id)
+        .join(Sequence, Sequence.id == Entity.parent_id)
+    ).with_entities(
+        cast(TaskPersonLink.task_id, Text),
+        cast(TaskPersonLink.person_id, Text),
+    )
+    if assigned_to:
+        link_query = link_query.filter(user_service.build_assignee_filter())
+    link_rows = link_query.all()
 
-    if "assigned_to" in criterions:
-        query = query.filter(user_service.build_assignee_filter())
-        del criterions["assigned_to"]
-
-    query_result = query.all()
-
+    not_allowed_map = None
     if "vendor_departments" in criterions:
-        not_allowed_descriptors_field_names = (
+        not_allowed_map = (
             entities_service.get_not_allowed_descriptors_fields_for_vendor(
                 "Shot",
                 criterions["vendor_departments"],
-                set(shot[0].project_id for shot in query_result),
+                set(row.project_id for row in shot_rows),
             )
         )
 
-    for (
-        shot,
-        episode_name,
-        episode_id,
-        sequence_name,
-        sequence_id,
-        task_id,
-        task_type_id,
-        task_status_id,
-        task_priority,
-        task_estimation,
-        task_duration,
-        task_retake_count,
-        task_real_start_date,
-        task_end_date,
-        task_start_date,
-        task_due_date,
-        task_done_date,
-        task_last_comment_date,
-        task_last_preview_file_id,
-        task_nb_assets_ready,
-        task_difficulty,
-        task_nb_drawings,
-        person_id,
-        project_id,
-        project_name,
-    ) in query_result:
-        shot_id = str(shot.id)
+    assignees_by_task = {}
+    for task_id, person_id in link_rows:
+        if person_id:
+            assignees_by_task.setdefault(task_id, []).append(person_id)
 
-        if shot_id not in shot_map:
-            data = fields.serialize_value(shot.data or {})
-            if "vendor_departments" in criterions:
+    tasks_by_entity = {}
+    for row in task_rows:
+        tasks_by_entity.setdefault(row.entity_id, []).append(row)
+
+    if compact:
+
+        def build_task(row):
+            return [
+                row.id,
+                row.duration,
+                fields.serialize_datetime(row.due_date),
+                fields.serialize_datetime(row.end_date),
+                fields.serialize_datetime(row.done_date),
+                row.entity_id,
+                row.estimation,
+                subscription_map.get(row.id, False),
+                fields.serialize_datetime(row.last_comment_date),
+                row.last_preview_file_id,
+                row.nb_assets_ready,
+                row.priority or 0,
+                fields.serialize_datetime(row.real_start_date),
+                row.retake_count,
+                fields.serialize_datetime(row.start_date),
+                row.difficulty,
+                row.nb_drawings,
+                row.task_status_id,
+                row.task_type_id,
+                assignees_by_task.get(row.id, []),
+            ]
+
+    else:
+
+        def build_task(row):
+            return {
+                "id": row.id,
+                "duration": row.duration,
+                "due_date": fields.serialize_datetime(row.due_date),
+                "end_date": fields.serialize_datetime(row.end_date),
+                "done_date": fields.serialize_datetime(row.done_date),
+                "entity_id": row.entity_id,
+                "estimation": row.estimation,
+                "is_subscribed": subscription_map.get(row.id, False),
+                "last_comment_date": fields.serialize_datetime(
+                    row.last_comment_date
+                ),
+                "last_preview_file_id": row.last_preview_file_id,
+                "nb_assets_ready": row.nb_assets_ready,
+                "priority": row.priority or 0,
+                "real_start_date": fields.serialize_datetime(
+                    row.real_start_date
+                ),
+                "retake_count": row.retake_count,
+                "start_date": fields.serialize_datetime(row.start_date),
+                "difficulty": row.difficulty,
+                "nb_drawings": row.nb_drawings,
+                "task_status_id": row.task_status_id,
+                "task_type_id": row.task_type_id,
+                "assignees": assignees_by_task.get(row.id, []),
+            }
+
+    def iterate():
+        for row in shot_rows:
+            data = fields.serialize_value(row.data or {})
+            if not_allowed_map is not None:
                 data = (
                     entities_service.remove_not_allowed_fields_from_metadata(
-                        not_allowed_descriptors_field_names[shot.project_id],
-                        data,
+                        not_allowed_map[row.project_id], data
                     )
                 )
-
-            shot_map[shot_id] = fields.serialize_dict(
-                {
-                    "canceled": shot.canceled,
+            tasks = [
+                build_task(task_row)
+                for task_row in tasks_by_entity.get(row.id, ())
+            ]
+            if compact:
+                yield [
+                    row.canceled,
+                    data,
+                    row.description,
+                    row.entity_type_id,
+                    row.episode_id,
+                    row.episode_name or "",
+                    data.get("fps", None),
+                    data.get("frame_in", None),
+                    data.get("frame_out", None),
+                    row.id,
+                    row.name,
+                    row.nb_frames,
+                    row.parent_id,
+                    row.preview_file_id,
+                    row.project_id,
+                    row.project_name,
+                    row.sequence_id,
+                    row.sequence_name,
+                    row.source_id,
+                    row.nb_entities_out,
+                    row.is_casting_standby,
+                    "Shot",
+                    tasks,
+                ]
+            else:
+                yield {
+                    "canceled": row.canceled,
                     "data": data,
-                    "description": shot.description,
-                    "entity_type_id": shot.entity_type_id,
-                    "episode_id": episode_id,
-                    "episode_name": episode_name or "",
+                    "description": row.description,
+                    "entity_type_id": row.entity_type_id,
+                    "episode_id": row.episode_id,
+                    "episode_name": row.episode_name or "",
                     "fps": data.get("fps", None),
                     "frame_in": data.get("frame_in", None),
                     "frame_out": data.get("frame_out", None),
-                    "id": shot.id,
-                    "name": shot.name,
-                    "nb_frames": shot.nb_frames,
-                    "parent_id": shot.parent_id,
-                    "preview_file_id": shot.preview_file_id or None,
-                    "project_id": project_id,
-                    "project_name": project_name,
-                    "sequence_id": sequence_id,
-                    "sequence_name": sequence_name,
-                    "source_id": shot.source_id,
-                    "nb_entities_out": shot.nb_entities_out,
-                    "is_casting_standby": shot.is_casting_standby,
-                    "tasks": [],
+                    "id": row.id,
+                    "name": row.name,
+                    "nb_frames": row.nb_frames,
+                    "parent_id": row.parent_id,
+                    "preview_file_id": row.preview_file_id,
+                    "project_id": row.project_id,
+                    "project_name": row.project_name,
+                    "sequence_id": row.sequence_id,
+                    "sequence_name": row.sequence_name,
+                    "source_id": row.source_id,
+                    "nb_entities_out": row.nb_entities_out,
+                    "is_casting_standby": row.is_casting_standby,
+                    "tasks": tasks,
                     "type": "Shot",
                 }
-            )
 
-        if task_id is not None:
-            task_id = str(task_id)
-            if task_id not in task_map:
-                task_dict = fields.serialize_dict(
-                    {
-                        "id": task_id,
-                        "duration": task_duration,
-                        "due_date": task_due_date,
-                        "end_date": task_end_date,
-                        "done_date": task_done_date,
-                        "entity_id": shot_id,
-                        "estimation": task_estimation,
-                        "is_subscribed": subscription_map.get(task_id, False),
-                        "last_comment_date": task_last_comment_date,
-                        "last_preview_file_id": task_last_preview_file_id,
-                        "nb_assets_ready": task_nb_assets_ready,
-                        "priority": task_priority or 0,
-                        "real_start_date": task_real_start_date,
-                        "retake_count": task_retake_count,
-                        "start_date": task_start_date,
-                        "difficulty": task_difficulty,
-                        "nb_drawings": task_nb_drawings,
-                        "task_status_id": task_status_id,
-                        "task_type_id": task_type_id,
-                        "assignees": [],
-                    }
-                )
-                task_map[task_id] = task_dict
-                shot_dict = shot_map[shot_id]
-                shot_dict["tasks"].append(task_dict)
+    return iterate()
 
-            if person_id:
-                task_map[task_id]["assignees"].append(str(person_id))
 
-    return list(shot_map.values())
+def get_shots_and_tasks(criterions=None):
+    """
+    Get all shots for given criterions with related tasks for each shot,
+    as a list of dicts.
+    """
+    return list(prepare_shots_and_tasks(criterions))
 
 
 def get_shot_raw(shot_id):

--- a/zou/app/utils/fields.py
+++ b/zou/app/utils/fields.py
@@ -141,6 +141,16 @@ def is_valid_id(value):
     return _UUID_RE.match(value)
 
 
+def serialize_datetime(value):
+    """
+    Serialize a DateTime column value (or None) without the type dispatch
+    of serialize_value: meant for hot loops over known column types.
+    """
+    if value is None:
+        return None
+    return value.replace(microsecond=0).isoformat()
+
+
 def boolean(value):
     """
     Parse "true"/"false" (case insensitive, also "1"/"0"/"on") as a boolean.


### PR DESCRIPTION
**Problem**
- The with-tasks builders joined Entity x Task x TaskPersonLink: one row per (entity, task, assignee) carrying the full entity columns each time, materialized and sorted before a Python dedup (measured on a 5k assets / 75k tasks project: 2.0s and 132MB peak per request; shots: 1.7s and 100MB)
- These full-project views are fetched constantly by Kitsu and cannot be paginated (the client operates on the whole list), so concurrent requests saturate server memory
- The five smaller with-tasks builders (episodes/sequences/scenes, edits, concepts) were near-identical copies of the same pattern

**Solution**
- Split assets and shots with-tasks into three narrow flat queries (entities, tasks, assignee links) with EXISTS filters, no per-row ORM or generic serialization, uuid::text cast in SQL: assets 2.03s -> 1.13s, shots 1.68s -> 0.59s, byte-identical default output
- Add Kitsu-only response options on those two routes: compact=true (self-describing positional arrays, field names in the header, raw payload halved) and stream=true (NDJSON generator, response never held in memory: 132MB -> 58MB and 100MB -> 33MB peak); without these options nothing changes for existing clients
- Factor the task fetching of the five smaller views into entities_service.fetch_entity_task_map with explicit per-view field lists, keeping each response shape unchanged

Six roundtrip tests assert stream/compact reassemble exactly to the default output; all existing suites pass unchanged.