### PR TITLE
[core] Build the default application lazily

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -49,10 +49,15 @@ def _skip_bcrypt_check(request, monkeypatch):
 
 def pytest_configure(config):
     """
-    Create database schema once for the entire test session.
+    Build the application explicitly and create the database schema once
+    for the entire test session. Importing zou.app no longer builds the
+    app as a side effect: the suite owns the moment (and the config
+    environment) the app is wired with.
     """
-    from zou.app import app
+    from zou.app import create_app
     from zou.app.utils import dbhelpers
+
+    app = create_app()
 
     # Register the admin blueprint so it can be tested.
     from zou.app.blueprints.admin import blueprint as admin_blueprint

--- a/tests/misc/test_lazy_app.py
+++ b/tests/misc/test_lazy_app.py
@@ -1,0 +1,25 @@
+import os
+import subprocess
+import sys
+import unittest
+
+
+class LazyAppTestCase(unittest.TestCase):
+    """
+    The default application must be built lazily: importing zou.app (or
+    any submodule) stays side-effect free, and the first access to
+    `zou.app.app` builds and caches it. Observed from a fresh
+    interpreter because the suite's conftest already built the app in
+    this process.
+    """
+
+    def test_importing_zou_app_does_not_build_the_app(self):
+        code = (
+            "import zou.app; "
+            "assert 'app' not in vars(zou.app), 'import built the app'; "
+            "from flask import Flask; "
+            "assert isinstance(zou.app.app, Flask); "
+            "assert 'app' in vars(zou.app), 'lazy build was not cached'"
+        )
+        env = dict(os.environ, SECRET_KEY="test-only")
+        subprocess.run([sys.executable, "-c", code], check=True, env=env)

--- a/zou/app/__init__.py
+++ b/zou/app/__init__.py
@@ -60,10 +60,11 @@ migrate = Migrate()
 jwt = JWTManager()
 mail = Mail()
 swagger = None
-# Set by create_app(). Kept as a module global because much of the code
-# base imports `from zou.app import app` at import time, including modules
-# loaded while the API is being wired.
-app = None
+# The module-level `app` is NOT created at import time: it is built
+# lazily by __getattr__ (bottom of this module) on first access, so
+# importing zou.app or any submodule stays side-effect free. Entry
+# points (wsgi, debug, event_stream, tests) either access `zou.app.app`
+# or call create_app() explicitly.
 
 
 def shutdown_session(exception=None):
@@ -343,8 +344,10 @@ def load_api(app):
 def create_app(config_object=config):
     """
     Build and wire a Zou Flask application: extensions, JSON provider,
-    error handlers, auth, storages and API routes. The module-level `app`
-    below is one instance of it; the CLI and tests can build their own.
+    error handlers, auth, storages and API routes. Nothing is built at
+    import time: entry points call this explicitly, and legacy
+    `from zou.app import app` imports get the same instance lazily via
+    the module __getattr__ below.
 
     Assigns the module-level `app` early (before the API is loaded)
     because blueprints and services imported during load_api still do
@@ -405,4 +408,15 @@ def create_app(config_object=config):
     return app
 
 
-app = create_app()
+def __getattr__(name):
+    """
+    Build the default application on first access to `zou.app.app`
+    (PEP 562). Keeps `from zou.app import app` and the gunicorn
+    `zou.app:app` entry point working while making the boot lazy:
+    importing zou.app or its submodules no longer wires the whole API.
+    Once built, create_app() assigns the module global, so this hook
+    only ever fires once per process.
+    """
+    if name == "app":
+        return create_app()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/zou/app/services/backup_service.py
+++ b/zou/app/services/backup_service.py
@@ -12,9 +12,9 @@ from zou.app.utils import date_helpers
 
 from flask_fs.backends.local import LocalBackend
 
-from zou.app import app
+from zou.app import config
 
-preview_folder = app.config["PREVIEW_FOLDER"]
+preview_folder = config.PREVIEW_FOLDER
 local_picture = LocalBackend(
     "local", {"root": os.path.join(preview_folder, "pictures")}
 )

--- a/zou/app/services/file_tree_service.py
+++ b/zou/app/services/file_tree_service.py
@@ -5,8 +5,6 @@ import orjson as json
 from collections import OrderedDict
 from slugify import slugify
 
-from zou.app import app
-
 from zou.app.models.asset_instance import AssetInstance
 from zou.app.models.entity import Entity
 from zou.app.models.entity_type import EntityType
@@ -298,6 +296,8 @@ _file_tree_cache = {}
 
 
 def get_tree_from_file(tree_name):
+    from zou.app import app
+
     if tree_name in _file_tree_cache:
         return _file_tree_cache[tree_name]
     try:

--- a/zou/app/services/files_service.py
+++ b/zou/app/services/files_service.py
@@ -2,7 +2,7 @@ import itertools
 from operator import itemgetter
 
 from zou.app.models.file_status import FileStatus
-from zou.app import app
+from zou.app import config
 
 from zou.app.models.entity import Entity
 from zou.app.models.output_file import OutputFile
@@ -71,10 +71,10 @@ def get_default_status():
     """
     Return default file status to set on a file when it is created.
     """
-    default_status = FileStatus.get_by(name=app.config["DEFAULT_FILE_STATUS"])
+    default_status = FileStatus.get_by(name=config.DEFAULT_FILE_STATUS)
     if default_status is None:
         default_status = FileStatus(
-            name=app.config["DEFAULT_FILE_STATUS"], color="#FFFFFF"
+            name=config.DEFAULT_FILE_STATUS, color="#FFFFFF"
         )
         default_status.save()
     return default_status.serialize()

--- a/zou/app/services/index_service.py
+++ b/zou/app/services/index_service.py
@@ -1,4 +1,5 @@
-from zou.app import app
+from flask import current_app
+
 from zou.app.indexer import indexing
 
 from zou.app.models.entity import Entity
@@ -332,7 +333,9 @@ def index_asset(asset):
     except indexing.IndexerNotInitializedError:
         pass
     except Exception:
-        app.logger.error("Indexer is not reachable, indexation failed.")
+        current_app.logger.error(
+            "Indexer is not reachable, indexation failed."
+        )
     return {}
 
 
@@ -348,7 +351,9 @@ def index_person(person):
     except indexing.IndexerNotInitializedError:
         pass
     except Exception:
-        app.logger.error("Indexer is not reachable, indexation failed.")
+        current_app.logger.error(
+            "Indexer is not reachable, indexation failed."
+        )
     return {}
 
 
@@ -364,7 +369,9 @@ def index_shot(shot):
     except indexing.IndexerNotInitializedError:
         pass
     except Exception:
-        app.logger.error("Indexer is not reachable, indexation failed.")
+        current_app.logger.error(
+            "Indexer is not reachable, indexation failed."
+        )
     return {}
 
 
@@ -473,7 +480,9 @@ def remove_asset_index(asset_id):
     except indexing.IndexerNotInitializedError:
         pass
     except Exception:
-        app.logger.error("Indexer is not reachable, indexation failed.")
+        current_app.logger.error(
+            "Indexer is not reachable, indexation failed."
+        )
     return {}
 
 
@@ -486,7 +495,9 @@ def remove_person_index(person_id):
     except indexing.IndexerNotInitializedError:
         pass
     except Exception:
-        app.logger.error("Indexer is not reachable, indexation failed.")
+        current_app.logger.error(
+            "Indexer is not reachable, indexation failed."
+        )
     return {}
 
 
@@ -499,5 +510,7 @@ def remove_shot_index(shot_id):
     except indexing.IndexerNotInitializedError:
         pass
     except Exception:
-        app.logger.error("Indexer is not reachable, indexation failed.")
+        current_app.logger.error(
+            "Indexer is not reachable, indexation failed."
+        )
     return {}

--- a/zou/app/services/sync_service.py
+++ b/zou/app/services/sync_service.py
@@ -70,7 +70,7 @@ from zou.app.models.working_file import WorkingFile
 from zou.app.services import deletion_service, tasks_service, projects_service
 from zou.app.stores import file_store
 from zou.app.utils import events, date_helpers
-from zou.app import app
+from zou.app import config
 
 logger = logging.getLogger()
 logger.setLevel(os.environ.get("LOGLEVEL", "INFO").upper())
@@ -81,7 +81,7 @@ logger.addHandler(console_handler)
 lock = RLock()
 
 
-preview_folder = app.config["PREVIEW_FOLDER"]
+preview_folder = config.PREVIEW_FOLDER
 local_picture = LocalBackend(
     "local", {"root": os.path.join(preview_folder, "pictures")}
 )
@@ -1583,6 +1583,8 @@ def download_file_from_another_instance(
     force=False,
     dict_errors={},
 ):
+    from zou.app import app
+
     with app.app_context():
         if force or not exist_func(prefix, id):
             for attemps_count in range(0, number_attemps):

--- a/zou/app/services/tasks_service.py
+++ b/zou/app/services/tasks_service.py
@@ -19,7 +19,7 @@ from sqlalchemy.sql import func
 from sqlalchemy.sql.expression import case
 from sqlalchemy.orm import aliased, selectinload
 
-from zou.app import app, db
+from zou.app import config, db
 from zou.app.utils import events
 
 from zou.app.models.attachment_file import AttachmentFile
@@ -135,7 +135,7 @@ def get_task_statuses():
 
 @cache.memoize_function(120)
 def get_to_review_status():
-    return get_or_create_status(app.config["TO_REVIEW_TASK_STATUS"], "pndng")
+    return get_or_create_status(config.TO_REVIEW_TASK_STATUS, "pndng")
 
 
 @cache.memoize_function(120)

--- a/zou/app/utils/emails.py
+++ b/zou/app/utils/emails.py
@@ -5,7 +5,7 @@ from io import StringIO
 from html.parser import HTMLParser
 from flask_mail import Message
 
-from zou.app import mail, app
+from zou.app import mail
 
 # Force quoted-printable encoding for utf-8 message bodies so that the
 # Python email module wraps lines at 76 chars. Without this, long HTML
@@ -26,6 +26,8 @@ def send_email(subject, html, recipient_email, body=None, locale=None):
     If locale is provided (e.g. "en_US", "fr_FR"), the Content-Language
     header is set so the recipient's client can use the correct language.
     """
+    from zou.app import app
+
     if body is None:
         body = strip_html_tags(html)
     if app.config["MAIL_DEBUG_BODY"]:

--- a/zou/app/utils/plugins.py
+++ b/zou/app/utils/plugins.py
@@ -22,7 +22,7 @@ from pathlib import Path
 from sqlalchemy import MetaData
 from sqlalchemy.util import FacadeDict
 
-from zou.app import db, app
+from zou.app import db
 from zou.app.utils.api import configure_api_from_blueprint
 
 
@@ -504,6 +504,8 @@ def create_plugin_metadata(plugin_id):
     their tables fresh, and Alembic won't try to create/drop Zou's
     core tables.
     """
+    from zou.app import app
+
     plugin_metadata = MetaData()
     with app.app_context():
         plugin_metadata.reflect(bind=db.engine)

--- a/zou/app/utils/query.py
+++ b/zou/app/utils/query.py
@@ -4,7 +4,7 @@ import uuid
 import orjson as json
 import sqlalchemy.orm as orm
 
-from zou.app import app
+from zou.app import config
 from zou.app.utils import fields, string
 from zou.app.services.exception import WrongParameterException
 from sqlalchemy import func
@@ -115,7 +115,7 @@ def get_paginated_results(query, page, limit=None, relations=False):
         entries = query.all()
         return fields.serialize_models(entries, relations=relations)
     else:
-        limit = limit or app.config["NB_RECORDS_PER_PAGE"]
+        limit = limit or config.NB_RECORDS_PER_PAGE
         total = query.count()
         offset = (page - 1) * limit
 
@@ -153,7 +153,7 @@ def get_cursor_results(
     relations=False,
 ):
     """ """
-    limit = limit or app.config["NB_RECORDS_PER_PAGE"]
+    limit = limit or config.NB_RECORDS_PER_PAGE
     total = query.count()
     query = (
         query.filter(model.created_at > cursor_created_at)

--- a/zou/debug.py
+++ b/zou/debug.py
@@ -2,9 +2,11 @@ from gevent import monkey
 
 monkey.patch_all()
 
-from zou.app import app, config
+from zou.app import config, create_app
 from flask_socketio import SocketIO
 import logging
+
+app = create_app()
 
 FORMAT = "%(message)s"
 logging.basicConfig(level=logging.INFO, format=FORMAT)

--- a/zou/event_stream.py
+++ b/zou/event_stream.py
@@ -25,8 +25,11 @@ from flask_jwt_extended import (
 )
 from flask_socketio import SocketIO, disconnect, join_room, leave_room, emit
 
-from zou.app import config, app
+from zou.app import config, create_app
 from zou.app.utils.redis import get_redis_url
+
+app = create_app()
+
 from zou.app.services.playlists_service import get_playlist
 from zou.app.services.user_service import check_project_access
 


### PR DESCRIPTION
**Problem**
- Importing zou.app or any submodule built the whole application as a side effect: CLI commands, RQ worker settings and remote runners paid the full boot (Redis config sync, 592 routes, plugins) even when they only needed helpers or config
- create_app() existed but nothing could skip the import-time build, and the test suite received an app it never explicitly constructed

**Solution**
- Build the module-level app lazily through a PEP 562 __getattr__ on first access: from zou.app import app and the gunicorn zou.app:app entry point keep working unchanged, while importing zou.app becomes side-effect free
- Stop importing app at module scope in services and utils (constants read from the config module, runtime access through a local import or current_app), so a service imported first can no longer trigger the build mid-import
- Make entry points (debug server, event stream, test conftest) call create_app() explicitly, and add a fresh-interpreter test asserting imports stay build-free