### PR TITLE
[user] Fix 500 on subscription-check routes

### DIFF
--- a/tests/user/test_route_user.py
+++ b/tests/user/test_route_user.py
@@ -30,6 +30,12 @@ class UserRoutesTestCase(ApiDBTestCase):
         self.assertIsInstance(result, list)
         self.assertTrue(len(result) > 0)
 
+    def test_task_subscription(self):
+        path = f"/data/user/tasks/{self.task.id}/subscribed"
+        self.assertFalse(self.get(path))
+        self.post(f"/actions/user/tasks/{self.task.id}/subscribe", {}, 201)
+        self.assertTrue(self.get(path))
+
     def test_join_and_leave_chat(self):
         self.post(f"/actions/user/chats/{self.asset.id}/join", {}, 200)
         chat = self.get(f"/data/entities/{self.asset.id}/chat")

--- a/zou/app/blueprints/user/resources.py
+++ b/zou/app/blueprints/user/resources.py
@@ -1,4 +1,4 @@
-from flask import abort, request
+from flask import abort, jsonify, request
 from flask.views import MethodView
 
 from zou.app.mixin import ArgsMixin
@@ -2440,7 +2440,7 @@ class HasTaskSubscribedResource(MethodView):
                     type: boolean
                     example: true
         """
-        return user_service.has_task_subscription(task_id)
+        return jsonify(user_service.has_task_subscription(task_id))
 
 
 class TaskSubscribeResource(MethodView):
@@ -2564,8 +2564,10 @@ class HasSequenceSubscribedResource(MethodView):
                     type: boolean
                     example: true
         """
-        return user_service.has_sequence_subscription(
-            sequence_id, task_type_id
+        return jsonify(
+            user_service.has_sequence_subscription(
+                sequence_id, task_type_id
+            )
         )
 
 


### PR DESCRIPTION
## Problems

- GET on the subscription-check routes (task and sequence `.../subscribed`)
  returned a bare bool, which plain Flask MethodView cannot serialize,
  raising a 500 (TypeError, "it was a bool").
- Only the service layer was tested; no HTTP test covered these routes.

## Solutions

- Wrap the boolean in jsonify in HasTaskSubscribedResource and
  HasSequenceSubscribedResource, restoring the true/false JSON response.
- Add an HTTP test exercising the subscribe then subscribed flow.