### PR TITLE
Skip invalid entities in the batch delete instead of failing

### DIFF
--- a/tests/entities/test_route_entities.py
+++ b/tests/entities/test_route_entities.py
@@ -104,10 +104,23 @@ class EntityRoutesTestCase(ApiDBTestCase):
         self.post(path, [asset_id], 200)
         self.get(f"/data/assets/{asset_id}", 404)
 
-    def test_delete_entities_rejects_unsupported_entity_type(self):
+    def test_delete_entities_skips_unsupported_entity_type(self):
         self.generate_fixture_sequence()
+        sequence_id = str(self.sequence.id)
         path = f"/actions/projects/{self.project.id}/delete-entities"
-        self.post(path, [str(self.sequence.id)], 400)
+        result = self.post(path, [sequence_id], 200)
+        # A sequence is not a deletable type: it is skipped, not deleted.
+        self.assertEqual(result, [])
+        self.get(f"/data/entities/{sequence_id}")
+
+    def test_delete_entities_skips_entity_from_other_project(self):
+        asset_id = str(self.asset.id)
+        other_project = self.generate_fixture_project(name="Other Project")
+        path = f"/actions/projects/{other_project.id}/delete-entities"
+        result = self.post(path, [asset_id], 200)
+        # The asset belongs to another project: it is skipped, not deleted.
+        self.assertEqual(result, [])
+        self.get(f"/data/assets/{asset_id}")
 
     def test_delete_entities_as_artist_is_forbidden(self):
         self.generate_fixture_user_cg_artist()

--- a/zou/app/blueprints/entities/resources.py
+++ b/zou/app/blueprints/entities/resources.py
@@ -405,7 +405,9 @@ class ProjectDeleteEntitiesResource(MethodView):
                 description: Entity unique identifiers to delete
         responses:
           200:
-            description: Deleted entity ids
+            description: Ids of the entities that were deleted. Entities that
+              do not belong to the project or are not an asset, a shot, an
+              edit or a concept are skipped.
             content:
               application/json:
                 schema:
@@ -413,9 +415,6 @@ class ProjectDeleteEntitiesResource(MethodView):
                   items:
                     type: string
                     format: uuid
-          400:
-            description: An entity does not belong to the project or is
-              not an asset, a shot, an edit or a concept
         """
         projects_service.get_project(project_id)
         entity_ids = validation.validate_id_list()

--- a/zou/app/services/deletion_service.py
+++ b/zou/app/services/deletion_service.py
@@ -48,7 +48,6 @@ from zou.app.services.exception import (
     PersonInProtectedAccounts,
     PreviewBackgroundFileNotFoundException,
     PreviewFileNotFoundException,
-    WrongParameterException,
 )
 
 
@@ -389,9 +388,9 @@ def remove_entities(project_id, entity_ids):
     Delete a list of a project's entities, dispatching each to the right
     removal by its type (asset, shot, edit, concept). Entities with tasks are
     canceled on first deletion, then removed for real when already canceled;
-    concepts are always removed. Every entity is validated to belong to the
-    project and to be a supported type before anything is removed. Returns
-    the removed entity ids.
+    concepts are always removed. Entities that do not belong to the project
+    or are not one of those types are skipped. Returns the ids of the
+    entities that were removed.
     """
     from zou.app.services import (
         assets_service,
@@ -409,9 +408,7 @@ def remove_entities(project_id, entity_ids):
     for entity_id in entity_ids:
         entity = entities_service.get_entity(entity_id)
         if entity["project_id"] != project_id:
-            raise WrongParameterException(
-                f"Entity {entity_id} does not belong to project {project_id}."
-            )
+            continue
         entity_type_id = entity["entity_type_id"]
         if entity_type_id == shot_type_id:
             remove = shots_service.remove_shot
@@ -426,15 +423,12 @@ def remove_entities(project_id, entity_ids):
             remove = assets_service.remove_asset
             force = entity["canceled"]
         else:
-            raise WrongParameterException(
-                f"Entity {entity_id} is not an asset, a shot, an edit "
-                f"or a concept."
-            )
+            continue
         to_remove.append((entity_id, remove, force))
 
     for entity_id, remove, force in to_remove:
         remove(entity_id, force=force)
-    return entity_ids
+    return [entity_id for entity_id, _, _ in to_remove]
 
 
 def remove_tasks_for_project_and_task_type(project_id, task_type_id):


### PR DESCRIPTION
**Problem**
- `deletion_service.remove_entities` (batch delete-entities route, merged in #1145) raised a `WrongParameterException` as soon as one id did not belong to the project or was not a deletable type, aborting the whole batch.
- A selection containing a single stray entity (wrong project, or a sequence) therefore deleted nothing.

**Solution**
- Skip entities that do not belong to the project or are not an asset, shot, edit or concept, and return the ids actually removed.
- Update the tests accordingly (skip unsupported type, skip entity from another project) and drop the now-unused exception and the 400 response from the route doc.

Follow-up to #1145 (merged before this change landed).