### PR TITLE
Batch production settings, descriptor copy at creation and assignee update events

### DIFF
--- a/tests/projects/test_route_metadata.py
+++ b/tests/projects/test_route_metadata.py
@@ -104,6 +104,33 @@ class ProjectMetadataRouteTestCase(ApiDBTestCase):
                 any(d["field_name"] == "ship_code" for d in descriptors)
             )
 
+    def test_new_project_copies_project_descriptors(self):
+        # A Project descriptor on an open project and one on a closed
+        # project: only the open one is copied onto a new project.
+        self.post(
+            f"data/projects/{self.project_id}/metadata-descriptors",
+            {
+                "entity_type": "Project",
+                "name": "Delivery code",
+                "data_type": "string",
+            },
+        )
+        projects_service.add_metadata_descriptor(
+            str(self.project_closed.id),
+            "Project",
+            "Closed only",
+            "string",
+            [],
+            False,
+        )
+        project = self.post("data/projects", {"name": "Fresh Project"}, 201)
+        descriptors = self.get(
+            f"data/projects/{project['id']}/metadata-descriptors"
+        )
+        field_names = [d["field_name"] for d in descriptors]
+        self.assertIn("delivery_code", field_names)
+        self.assertNotIn("closed_only", field_names)
+
     def test_add_asset_metadata_descriptor(self):
         descriptor = self.post(
             f"data/projects/{self.project_id}/metadata-descriptors",

--- a/tests/projects/test_route_project_settings.py
+++ b/tests/projects/test_route_project_settings.py
@@ -1,6 +1,8 @@
 from tests.base import ApiDBTestCase
 
+from zou.app.models.project import ProjectTaskTypeLink
 from zou.app.services import budget_service
+from zou.app.utils import fields
 
 
 class ProjectSettingsRoutesTestCase(ApiDBTestCase):
@@ -96,6 +98,126 @@ class ProjectSettingsRoutesTestCase(ApiDBTestCase):
         )
         status_ids = [s["id"] for s in statuses]
         self.assertNotIn(str(self.task_status.id), status_ids)
+
+    # --- Batch settings ---
+
+    def test_add_project_settings_batch(self):
+        result = self.post(
+            f"/data/projects/{self.project_id}/settings/batch",
+            {
+                "task_types": [
+                    {"task_type_id": str(self.task_type.id), "priority": 1},
+                    {
+                        "task_type_id": str(self.task_type_modeling.id),
+                        "priority": 2,
+                    },
+                ],
+                "task_status_ids": [str(self.task_status.id)],
+                "asset_type_ids": [str(self.asset_type.id)],
+            },
+            200,
+        )
+        self.assertIsNotNone(result.get("id"))
+        project = self.get(f"/data/projects/{self.project_id}")
+        self.assertIn(str(self.task_type.id), project["task_types"])
+        self.assertIn(str(self.task_type_modeling.id), project["task_types"])
+        self.assertIn(str(self.asset_type.id), project["asset_types"])
+        statuses = self.get(
+            f"/data/projects/{self.project_id}/settings/task-status"
+        )
+        self.assertIn(str(self.task_status.id), [s["id"] for s in statuses])
+        link = ProjectTaskTypeLink.get_by(
+            project_id=self.project_id, task_type_id=str(self.task_type.id)
+        )
+        self.assertEqual(link.priority, 1)
+
+    def test_project_settings_batch_is_idempotent(self):
+        data = {
+            "task_types": [{"task_type_id": str(self.task_type.id)}],
+            "task_status_ids": [
+                str(self.task_status.id),
+                str(self.task_status.id),
+            ],
+            "asset_type_ids": [str(self.asset_type.id)],
+        }
+        self.post(
+            f"/data/projects/{self.project_id}/settings/batch", data, 200
+        )
+        self.post(
+            f"/data/projects/{self.project_id}/settings/batch", data, 200
+        )
+        project = self.get(f"/data/projects/{self.project_id}")
+        self.assertEqual(
+            project["task_types"].count(str(self.task_type.id)), 1
+        )
+        self.assertEqual(
+            project["asset_types"].count(str(self.asset_type.id)), 1
+        )
+        statuses = self.get(
+            f"/data/projects/{self.project_id}/settings/task-status"
+        )
+        status_ids = [s["id"] for s in statuses]
+        self.assertEqual(status_ids.count(str(self.task_status.id)), 1)
+
+    def test_project_settings_batch_replace_task_types(self):
+        self.post(
+            f"/data/projects/{self.project_id}/settings/batch",
+            {
+                "task_types": [
+                    {"task_type_id": str(self.task_type.id), "priority": 1},
+                    {
+                        "task_type_id": str(self.task_type_concept.id),
+                        "priority": 2,
+                    },
+                ]
+            },
+            200,
+        )
+        self.post(
+            f"/data/projects/{self.project_id}/settings/batch",
+            {
+                "task_types": [
+                    {"task_type_id": str(self.task_type.id), "priority": 2},
+                    {
+                        "task_type_id": str(self.task_type_modeling.id),
+                        "priority": 1,
+                    },
+                ],
+                "replace_task_types": True,
+            },
+            200,
+        )
+        project = self.get(f"/data/projects/{self.project_id}")
+        self.assertIn(str(self.task_type.id), project["task_types"])
+        self.assertIn(str(self.task_type_modeling.id), project["task_types"])
+        self.assertNotIn(str(self.task_type_concept.id), project["task_types"])
+        link = ProjectTaskTypeLink.get_by(
+            project_id=self.project_id, task_type_id=str(self.task_type.id)
+        )
+        self.assertEqual(link.priority, 2)
+
+    def test_project_settings_batch_skips_unknown_ids(self):
+        self.post(
+            f"/data/projects/{self.project_id}/settings/batch",
+            {
+                "task_types": [{"task_type_id": fields.gen_uuid()}],
+                "task_status_ids": [fields.gen_uuid()],
+                "asset_type_ids": [fields.gen_uuid()],
+            },
+            200,
+        )
+        project = self.get(f"/data/projects/{self.project_id}")
+        self.assertEqual(project["task_types"], [])
+        self.assertEqual(project["asset_types"], [])
+
+    def test_project_settings_batch_as_artist_is_forbidden(self):
+        self.generate_fixture_user_cg_artist()
+        self.log_in_cg_artist()
+        self.post(
+            f"/data/projects/{self.project_id}/settings/batch",
+            {"task_types": [{"task_type_id": str(self.task_type.id)}]},
+            403,
+        )
 
     # --- Status automations settings ---
 

--- a/tests/tasks/test_route_tasks.py
+++ b/tests/tasks/test_route_tasks.py
@@ -279,6 +279,25 @@ class TaskRoutesTestCase(ApiDBTestCase):
         task = tasks_service.get_task(shot_task_id, relations=True)
         self.assertEqual(len(task["assignees"]), 0)
 
+    def test_update_task_assignees(self):
+        # The fixture task starts assigned to self.person.
+        self.generate_fixture_task()
+        task_id = str(self.task.id)
+        person_id = str(self.person.id)
+        self.put(f"data/tasks/{task_id}", {"assignees": []}, 200)
+        task = tasks_service.get_task(task_id, relations=True)
+        self.assertEqual(task["assignees"], [])
+        self.put(f"data/tasks/{task_id}", {"assignees": [person_id]}, 200)
+        task = tasks_service.get_task(task_id, relations=True)
+        self.assertEqual(task["assignees"], [person_id])
+        # The generic update emits the same task:assign event as the assign
+        # route, so the assignation notification is created too.
+        notifications = notifications_service.get_last_notifications(
+            "assignation"
+        )
+        self.assertEqual(len(notifications), 1)
+        self.assertEqual(str(notifications[0]["person_id"]), person_id)
+
     def test_set_tasks_priority(self):
         self.generate_fixture_task()
         self.generate_fixture_shot_task()

--- a/zou/app/blueprints/crud/project.py
+++ b/zou/app/blueprints/crud/project.py
@@ -268,6 +268,11 @@ class ProjectsResource(BaseModelsResource):
             project_dict["first_episode_id"] = fields.serialize_value(
                 episode["id"]
             )
+        # The all-projects metadata columns are one Project descriptor row
+        # per project: copy them onto the new project so its cells are
+        # editable right away, instead of one create request per descriptor
+        # from the client.
+        projects_service.copy_project_metadata_descriptors(str(project.id))
         user_service.clear_project_cache()
         projects_service.clear_project_cache("")
         return project_dict

--- a/zou/app/blueprints/crud/task.py
+++ b/zou/app/blueprints/crud/task.py
@@ -16,8 +16,10 @@ from zou.app.services import (
     deletion_service,
     entities_service,
     assets_service,
+    notifications_service,
+    persons_service,
 )
-from zou.app.utils import permissions
+from zou.app.utils import events, permissions
 
 from zou.app.services.exception import WrongTaskTypeForEntityException
 
@@ -440,8 +442,40 @@ class TaskResource(BaseModelResource, ArgsMixin):
     def check_delete_permissions(self, task):
         user_service.check_manager_project_access(task["project_id"])
 
+    def pre_update(self, instance_dict, data):
+        if "assignees" in data:
+            self._previous_assignees = {
+                str(person.id) for person in self.instance.assignees
+            }
+        return instance_dict
+
     def post_update(self, instance_dict, data):
         tasks_service.clear_task_cache(instance_dict["id"])
+        # Assignees set through the generic update emit the same events and
+        # assignation notifications as the assign/clear-assignation routes
+        # so that listeners and assignees stay in sync.
+        if "assignees" in data:
+            new_assignees = {
+                str(person.id) for person in self.instance.assignees
+            }
+            previous_assignees = getattr(self, "_previous_assignees", set())
+            project_id = instance_dict["project_id"]
+            current_user_id = persons_service.get_current_user()["id"]
+            for person_id in new_assignees - previous_assignees:
+                events.emit(
+                    "task:assign",
+                    {"task_id": instance_dict["id"], "person_id": person_id},
+                    project_id=project_id,
+                )
+                notifications_service.create_assignation_notification(
+                    instance_dict["id"], person_id, current_user_id
+                )
+            for person_id in previous_assignees - new_assignees:
+                events.emit(
+                    "task:unassign",
+                    {"task_id": instance_dict["id"], "person_id": person_id},
+                    project_id=project_id,
+                )
         return instance_dict
 
     @jwt_required()

--- a/zou/app/blueprints/projects/__init__.py
+++ b/zou/app/blueprints/projects/__init__.py
@@ -15,6 +15,7 @@ from zou.app.blueprints.projects.resources import (
     ProductionTaskTypesResource,
     ProductionTaskStatusResource,
     ProductionTaskStatusRemoveResource,
+    ProductionSettingsBatchResource,
     ProductionStatusAutomationResource,
     ProductionStatusAutomationRemoveResource,
     ProductionMetadataDescriptorResource,
@@ -83,6 +84,10 @@ routes = [
     (
         "/data/projects/<project_id>/settings/task-status/<task_status_id>",
         ProductionTaskStatusRemoveResource,
+    ),
+    (
+        "/data/projects/<project_id>/settings/batch",
+        ProductionSettingsBatchResource,
     ),
     (
         "/data/projects/<project_id>/settings/status-automations",

--- a/zou/app/blueprints/projects/resources.py
+++ b/zou/app/blueprints/projects/resources.py
@@ -19,6 +19,7 @@ from zou.app.blueprints.projects.schemas import (
     ProjectAssetTypeSchema,
     ProjectTaskTypeSchema,
     ProjectTaskStatusSchema,
+    ProjectSettingsBatchSchema,
     ProjectStatusAutomationSchema,
     ProjectPreviewBackgroundSchema,
     MetadataDescriptorSchema,
@@ -691,6 +692,78 @@ class ProductionTaskStatusRemoveResource(MethodView):
         user_service.check_manager_project_access(project_id)
         projects_service.remove_task_status_setting(project_id, task_status_id)
         return "", 204
+
+
+class ProductionSettingsBatchResource(MethodView):
+    """
+    Allow to add several task types, task statuses and asset types to a
+    production in a single request.
+    """
+
+    @jwt_required()
+    def post(self, project_id):
+        """
+        Add settings to production batch
+        ---
+        description: Add several task types (with their priority), task
+          statuses and asset types to a production in a single request,
+          replacing one link request per item. Unknown ids are skipped.
+          When replace_task_types is set, the task type list is the full
+          wanted set and existing links absent from it are removed.
+        tags:
+          - Projects
+        parameters:
+          - in: path
+            name: project_id
+            required: true
+            schema:
+              type: string
+              format: uuid
+            description: Project unique identifier
+            example: a24a6ea4-ce75-4665-a070-57453082c25
+        requestBody:
+          required: true
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  task_types:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        task_type_id:
+                          type: string
+                          format: uuid
+                        priority:
+                          type: integer
+                  task_status_ids:
+                    type: array
+                    items:
+                      type: string
+                      format: uuid
+                  asset_type_ids:
+                    type: array
+                    items:
+                      type: string
+                      format: uuid
+                  replace_task_types:
+                    type: boolean
+                    default: false
+        responses:
+          200:
+            description: Updated project
+        """
+        body = validation.validate_request_body(ProjectSettingsBatchSchema)
+        user_service.check_manager_project_access(project_id)
+        return projects_service.update_project_settings(
+            project_id,
+            task_types=[entry.model_dump() for entry in body.task_types],
+            task_status_ids=body.task_status_ids,
+            asset_type_ids=body.asset_type_ids,
+            replace_task_types=body.replace_task_types,
+        )
 
 
 class ProductionStatusAutomationResource(MethodView, ArgsMixin):

--- a/zou/app/blueprints/projects/schemas.py
+++ b/zou/app/blueprints/projects/schemas.py
@@ -43,6 +43,20 @@ class ProjectTaskStatusSchema(BaseSchema):
     task_status_id: str = Field(..., min_length=1)
 
 
+class ProjectSettingsBatchSchema(BaseSchema):
+    """
+    Body for adding several task types, task statuses and asset types to a
+    project in a single request.
+    """
+
+    task_types: List[ProjectTaskTypeSchema] = Field(default=[])
+    task_status_ids: List[str] = Field(default=[])
+    asset_type_ids: List[str] = Field(default=[])
+    # When set, task_types is the full wanted set: existing task type links
+    # absent from it are removed (used by the import-from-production flow).
+    replace_task_types: bool = False
+
+
 class ProjectStatusAutomationSchema(BaseSchema):
     """
     Body for adding a status automation to a project.

--- a/zou/app/services/projects_service.py
+++ b/zou/app/services/projects_service.py
@@ -497,6 +497,72 @@ def remove_task_status_setting(project_id, task_status_id):
     )
 
 
+def update_project_settings(
+    project_id,
+    task_types=None,
+    task_status_ids=None,
+    asset_type_ids=None,
+    replace_task_types=False,
+):
+    """
+    Add several task types (with their priority), task statuses and asset
+    types to the project settings in a single operation. Unknown ids are
+    skipped. When replace_task_types is set, the given task type list is the
+    full wanted set: existing links absent from it are removed.
+    """
+    project = get_project_raw(project_id)
+    project_id = str(project.id)
+
+    wanted_task_types = {}
+    for entry in task_types or []:
+        wanted_task_types[str(entry["task_type_id"])] = entry.get("priority")
+
+    existing_links = {
+        str(link.task_type_id): link
+        for link in ProjectTaskTypeLink.query.filter_by(project_id=project_id)
+    }
+    for task_type_id, priority in wanted_task_types.items():
+        link = existing_links.get(task_type_id)
+        if link is None:
+            if TaskType.get(task_type_id) is not None:
+                ProjectTaskTypeLink.create(
+                    task_type_id=task_type_id,
+                    project_id=project_id,
+                    priority=priority,
+                )
+        elif priority is not None and link.priority != priority:
+            link.update({"priority": priority})
+    if replace_task_types:
+        for task_type_id, link in existing_links.items():
+            if task_type_id not in wanted_task_types:
+                task_type = TaskType.get(task_type_id)
+                if task_type is not None:
+                    project.task_types.remove(task_type)
+
+    task_status_map = {
+        str(status.id): status for status in project.task_statuses
+    }
+    for task_status_id in task_status_ids or []:
+        task_status = TaskStatus.get(task_status_id)
+        if (
+            task_status is not None
+            and str(task_status.id) not in task_status_map
+        ):
+            project.task_statuses.append(task_status)
+            task_status_map[str(task_status.id)] = task_status
+
+    asset_type_map = {
+        str(asset_type.id): asset_type for asset_type in project.asset_types
+    }
+    for asset_type_id in asset_type_ids or []:
+        asset_type = EntityType.get(asset_type_id)
+        if asset_type is not None and str(asset_type.id) not in asset_type_map:
+            project.asset_types.append(asset_type)
+            asset_type_map[str(asset_type.id)] = asset_type
+
+    return _save_project(project)
+
+
 def add_status_automation_setting(project_id, status_automation_id):
     """
     Add a status automation listed in database to the project status automations.

--- a/zou/app/services/projects_service.py
+++ b/zou/app/services/projects_service.py
@@ -956,6 +956,50 @@ def add_metadata_descriptor_to_projects(
     return created
 
 
+def copy_project_metadata_descriptors(project_id):
+    """
+    Copy the Project-scoped metadata descriptors (the all-projects columns)
+    owned by open projects onto the given project so that its cells are
+    editable right away. One copy per distinct field name; field names the
+    project already owns are left untouched. Returns the created descriptors.
+    """
+    descriptors = (
+        MetadataDescriptor.query.join(
+            Project, MetadataDescriptor.project_id == Project.id
+        )
+        .join(ProjectStatus, Project.project_status_id == ProjectStatus.id)
+        .filter(ProjectStatus.name.in_(("Active", "open", "Open")))
+        .filter(MetadataDescriptor.entity_type == "Project")
+        .filter(MetadataDescriptor.project_id != project_id)
+        .order_by(MetadataDescriptor.position, MetadataDescriptor.name)
+        .all()
+    )
+    owned_field_names = {
+        descriptor.field_name
+        for descriptor in MetadataDescriptor.query.filter(
+            MetadataDescriptor.project_id == project_id,
+            MetadataDescriptor.entity_type == "Project",
+        )
+    }
+    created = []
+    for descriptor in descriptors:
+        if descriptor.field_name in owned_field_names:
+            continue
+        owned_field_names.add(descriptor.field_name)
+        created.append(
+            add_metadata_descriptor(
+                project_id,
+                "Project",
+                descriptor.name,
+                descriptor.data_type,
+                descriptor.choices,
+                descriptor.for_client,
+                [str(department.id) for department in descriptor.departments],
+            )
+        )
+    return created
+
+
 def update_metadata_descriptor_on_projects(
     project_ids, entity_type, field_name, changes
 ):


### PR DESCRIPTION
**Problem**
- Attaching task types, task statuses and asset types to a production takes one request per item: production creation and the import-from-production flows fire dozens of requests (the task type import even relies on a client-side timer between removals and additions).
- Creating a production requires the web client to copy every all-projects metadata descriptor onto it, one create request per descriptor, and API-created projects miss those columns entirely.
- Updating a task's assignee list in one PUT works but emits no task:assign/task:unassign events and creates no assignation notification, so it cannot replace the one-request-per-person assign flow.

**Solution**
- Add POST /data/projects/<id>/settings/batch: attaches task types (with priorities), task statuses and asset types in one request, skips unknown ids, and supports replace_task_types so an import expresses the full wanted set in a single call.
- Copy Project-scoped metadata descriptors from open projects onto new projects at creation, server-side.
- Emit task:assign/task:unassign and create assignation notifications from the task update resource when the assignees list changes.