### PR TITLE
[shots] Return 404 on a malformed shot id

### DIFF
--- a/tests/shots/test_shots.py
+++ b/tests/shots/test_shots.py
@@ -65,6 +65,9 @@ class ShotTestCase(ApiDBTestCase):
         self.assertEqual(shot["project_name"], self.serialized_project["name"])
         self.assertEqual(len(shot["tasks"]), 1)
 
+    def test_get_shot_with_invalid_id(self):
+        self.get_404("data/shots/undefined")
+
     def test_get_shot_by_name(self):
         shots = self.get(f"data/shots/all?name={self.shot.name.lower()}")
         self.assertEqual(shots[0]["id"], str(self.shot.id))

--- a/zou/app/services/shots_service.py
+++ b/zou/app/services/shots_service.py
@@ -580,6 +580,8 @@ def get_full_shot(shot_id):
     Return given shot as a dictionary with extra data like project and
     sequence names.
     """
+    if not fields.is_valid_id(shot_id):
+        raise ShotNotFoundException
     shots = get_shots_and_tasks({"id": shot_id})
     if len(shots) > 0:
         shot = shots[0]


### PR DESCRIPTION
## Problems

- GET /data/shots/<non-uuid> (e.g. /data/shots/undefined) reached the database and raised StatementError as an unhandled 500.

## Solutions

- Validate the id in get_full_shot and raise ShotNotFoundException (404), matching get_shot_raw.