### PR TITLE
[persons] Let datetime validate interval helper inputs

### DIFF
--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -118,6 +118,24 @@ class UtilsTestCase(unittest.TestCase):
         self.assertEqual(start.strftime("%Y-%m-%d"), "2021-02-10")
         self.assertEqual(end.strftime("%Y-%m-%d"), "2021-02-11")
 
+    def test_interval_allows_future_years(self):
+        from zou.app.services.exception import WrongDateFormatException
+
+        next_year = date_helpers.get_utc_now_datetime().year + 1
+        start, _ = date_helpers.get_month_interval(next_year, 1)
+        self.assertEqual(start.year, next_year)
+        start, _ = date_helpers.get_month_interval(2500, 12)
+        self.assertEqual(start.year, 2500)
+
+        with pytest.raises(WrongDateFormatException):
+            date_helpers.get_month_interval(2026, 13)
+        with pytest.raises(WrongDateFormatException):
+            date_helpers.get_day_interval(2026, 2, 30)
+        with pytest.raises(WrongDateFormatException):
+            date_helpers.get_week_interval(2026, 60)
+        with pytest.raises(WrongDateFormatException):
+            date_helpers.get_month_interval("abc", 1)
+
     def test_get_redis_url(self):
         db_index = 0
         self.assertEqual(

--- a/zou/app/utils/date_helpers.py
+++ b/zou/app/utils/date_helpers.py
@@ -80,12 +80,11 @@ def get_year_interval(year):
     """
     Get a tuple containing start date and end date for given year.
     """
-    year = int(year)
-    if year > get_utc_now_datetime().year or year < 2010:
+    try:
+        start = datetime.datetime(int(year), 1, 1)
+        end = start + relativedelta.relativedelta(years=1)
+    except (ValueError, OverflowError):
         raise WrongDateFormatException
-
-    start = datetime.datetime(year, 1, 1)
-    end = start + relativedelta.relativedelta(years=1)
     return start, end
 
 
@@ -93,18 +92,11 @@ def get_month_interval(year, month):
     """
     Get a tuple containing start date and end date for given year and month.
     """
-    year = int(year)
-    month = int(month)
-    if (
-        year > get_utc_now_datetime().year
-        or year < 2010
-        or month < 1
-        or month > 12
-    ):
+    try:
+        start = datetime.datetime(int(year), int(month), 1)
+        end = start + relativedelta.relativedelta(months=1)
+    except (ValueError, OverflowError):
         raise WrongDateFormatException
-
-    start = datetime.datetime(year, month, 1)
-    end = start + relativedelta.relativedelta(months=1)
     return start, end
 
 
@@ -112,17 +104,11 @@ def get_week_interval(year, week):
     """
     Get a tuple containing start date and end date for given year and week.
     """
-    year = int(year)
-    week = int(week)
-    if (
-        year > get_utc_now_datetime().year
-        or year < 2010
-        or week < 1
-        or week > 52
-    ):
+    try:
+        start = datetime.date.fromisocalendar(int(year), int(week), 1)
+        end = start + relativedelta.relativedelta(days=7)
+    except (ValueError, OverflowError):
         raise WrongDateFormatException
-    start = datetime.date.fromisocalendar(year, week, 1)
-    end = start + relativedelta.relativedelta(days=7)
     return start, end
 
 
@@ -130,20 +116,11 @@ def get_day_interval(year, month, day):
     """
     Get a tuple containing start date and end date for given day.
     """
-    year = int(year)
-    month = int(month)
-    day = int(day)
-    if (
-        year > get_utc_now_datetime().year
-        or year < 2010
-        or month < 1
-        or month > 12
-        or day < 1
-        or day > 31
-    ):
+    try:
+        start = datetime.datetime(int(year), int(month), int(day))
+        end = start + relativedelta.relativedelta(days=1)
+    except (ValueError, OverflowError):
         raise WrongDateFormatException
-    start = datetime.datetime(year, month, day)
-    end = start + relativedelta.relativedelta(days=1)
     return start, end
 
 


### PR DESCRIPTION
## Problems

- The date interval helpers enforced an arbitrary year range (2010 to the current year), so viewing a future month (e.g. day offs for 2027/01 while in 2026) raised WrongDateFormatException and a 500.
- The manual bounds let impossible dates through (Feb 30, non-numeric input, ISO week 53 wrongly rejected), which crashed later with unhandled errors.

## Solutions

- Drop the year-range policy from the interval helpers: build the interval and let datetime validate, converting ValueError into WrongDateFormatException (400 in the routes that catch it).