### PR TITLE
[tasks] Return 400 when setting main preview without a preview

### DIFF
--- a/tests/tasks/test_task_routes.py
+++ b/tests/tasks/test_task_routes.py
@@ -256,6 +256,14 @@ class TaskRoutesTestCase(ApiDBTestCase):
         entity = self.get(f"/data/entities/{task['entity_id']}")
         self.assertIsNotNone(entity.get("preview_file_id"))
 
+    def test_set_main_preview_without_preview(self):
+        result = self.put(
+            f"/actions/tasks/{self.task.id}/set-main-preview",
+            {},
+            400,
+        )
+        self.assertIn("no preview file", result["message"])
+
     def test_set_main_preview_as_client(self):
         # A client can review but must not redefine the entity thumbnail.
         self.generate_fixture_preview_file()

--- a/zou/app/blueprints/tasks/resources.py
+++ b/zou/app/blueprints/tasks/resources.py
@@ -2688,6 +2688,8 @@ class SetTaskMainPreviewResource(MethodView):
         responses:
             200:
                 description: Preview set as main preview
+            400:
+                description: The task has no preview file
                 content:
                   application/json:
                     schema:
@@ -2731,12 +2733,13 @@ class SetTaskMainPreviewResource(MethodView):
         preview_file = preview_files_service.get_last_preview_file_for_task(
             task_id
         )
-        entity = None
-        if preview_file is not None:
-            entity = entities_service.update_entity_preview(
-                task["entity_id"], preview_file["id"]
+        if preview_file is None:
+            raise WrongParameterException(
+                "This task has no preview file to set as the main preview."
             )
-        return entity
+        return entities_service.update_entity_preview(
+            task["entity_id"], preview_file["id"]
+        )
 
 
 class PersonsTasksDatesResource(MethodView, ArgsMixin):


### PR DESCRIPTION
## Problems

- PUT /actions/tasks/<id>/set-main-preview fell through to return None (Flask 500) when the task had no preview file to promote.

## Solutions

- Answer with a 400 and an explicit message telling the task has no preview file to set as main preview.