### PR TITLE
[previews] Missing-file 404 and batch route hardening

### DIFF
--- a/tests/entities/test_route_entities.py
+++ b/tests/entities/test_route_entities.py
@@ -1,6 +1,7 @@
 from tests.base import ApiDBTestCase
 
 from zou.app.models.time_spent import TimeSpent
+from zou.app.utils import fields
 from zou.app.models.entity import EntityConceptLink
 from zou.app.services import (
     comments_service,
@@ -102,6 +103,17 @@ class EntityRoutesTestCase(ApiDBTestCase):
         asset_id = str(self.asset.id)
         path = f"/actions/projects/{self.project.id}/delete-entities"
         self.post(path, [asset_id], 200)
+        self.get(f"/data/assets/{asset_id}", 404)
+
+    def test_delete_entities_ignores_absent_entities(self):
+        # An id that no longer exists (e.g. deleted by someone else) must not
+        # fail the whole batch: it is skipped and the others are processed.
+        self.asset.update({"canceled": True})
+        asset_id = str(self.asset.id)
+        missing_id = str(fields.gen_uuid())
+        path = f"/actions/projects/{self.project.id}/delete-entities"
+        result = self.post(path, [missing_id, asset_id], 200)
+        self.assertEqual(result, [asset_id])
         self.get(f"/data/assets/{asset_id}", 404)
 
     def test_delete_entities_skips_unsupported_entity_type(self):

--- a/tests/utils/test_fs.py
+++ b/tests/utils/test_fs.py
@@ -1,0 +1,35 @@
+import tempfile
+import unittest
+from unittest import mock
+
+import pytest
+from flask_fs.errors import FileNotFound
+
+from zou.app.utils import fs
+
+
+class FakeConfig:
+    FS_BACKEND = "s3"
+
+    def __init__(self, tmp_dir):
+        self.TMP_DIR = tmp_dir
+
+
+class GetFilePathAndFileTestCase(unittest.TestCase):
+    def test_missing_remote_file_raises_file_not_found(self):
+        # A remote download that "succeeds" but yields an empty file must be
+        # reported as absent (FileNotFound -> 404), not an unhandled 500.
+        def open_file(prefix, instance_id):
+            yield from ()
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with mock.patch("zou.app.utils.fs.time.sleep"):
+                with pytest.raises(FileNotFound):
+                    fs.get_file_path_and_file(
+                        FakeConfig(tmp_dir),
+                        get_local_path=lambda prefix, instance_id: "",
+                        open_file=open_file,
+                        prefix="previews",
+                        instance_id="does-not-exist",
+                        extension="png",
+                    )

--- a/zou/app/blueprints/entities/resources.py
+++ b/zou/app/blueprints/entities/resources.py
@@ -3,6 +3,7 @@ from flask.views import MethodView
 from flask_jwt_extended import jwt_required
 
 from zou.app.blueprints.entities.schemas import CreateEntityTasksSchema
+from zou.app.services.exception import EntityNotFoundException
 from zou.app.services import (
     deletion_service,
     entities_service,
@@ -423,7 +424,11 @@ class ProjectDeleteEntitiesResource(MethodView):
         # Authorization stays in the resource: creators may delete their own
         # entities, otherwise project-manager access is required.
         for entity_id in entity_ids:
-            entity = entities_service.get_entity(entity_id)
+            try:
+                entity = entities_service.get_entity(entity_id)
+            except EntityNotFoundException:
+                # Nothing to authorize for an entity that is already gone.
+                continue
             if entity["created_by"] == current_user_id:
                 user_service.check_belong_to_project(project_id)
             else:

--- a/zou/app/services/deletion_service.py
+++ b/zou/app/services/deletion_service.py
@@ -44,6 +44,7 @@ from zou.app import config
 from zou.app.services.exception import (
     AttachmentFileNotFoundException,
     CommentNotFoundException,
+    EntityNotFoundException,
     ModelWithRelationsDeletionException,
     PersonInProtectedAccounts,
     PreviewBackgroundFileNotFoundException,
@@ -388,9 +389,9 @@ def remove_entities(project_id, entity_ids):
     Delete a list of a project's entities, dispatching each to the right
     removal by its type (asset, shot, edit, concept). Entities with tasks are
     canceled on first deletion, then removed for real when already canceled;
-    concepts are always removed. Entities that do not belong to the project
-    or are not one of those types are skipped. Returns the ids of the
-    entities that were removed.
+    concepts are always removed. Absent entities and entities that do not
+    belong to the project or are not one of those types are skipped.
+    Returns the ids of the entities that were removed.
     """
     from zou.app.services import (
         assets_service,
@@ -406,7 +407,12 @@ def remove_entities(project_id, entity_ids):
 
     to_remove = []
     for entity_id in entity_ids:
-        entity = entities_service.get_entity(entity_id)
+        try:
+            entity = entities_service.get_entity(entity_id)
+        except EntityNotFoundException:
+            # Already gone (e.g. deleted by someone else): the deletion is
+            # idempotent, skip it like remove_tasks ignores unknown ids.
+            continue
         if entity["project_id"] != project_id:
             continue
         entity_type_id = entity["entity_type_id"]

--- a/zou/app/utils/fs.py
+++ b/zou/app/utils/fs.py
@@ -4,10 +4,6 @@ import time
 from flask_fs.errors import FileNotFound
 
 
-class DownloadFromStorageFailedException(Exception):
-    pass
-
-
 def mkdir_p(path):
     os.makedirs(path, exist_ok=True)
 
@@ -85,7 +81,10 @@ def get_file_path_and_file(
                             f"{prefix}-{instance_id}"
                         ) from exception
                     else:
-                        raise DownloadFromStorageFailedException
+                        # The download reported success but the file is still
+                        # missing or empty: treat it as absent (404) like the
+                        # local backend does, not an unhandled 500.
+                        raise FileNotFound(f"{prefix}-{instance_id}")
 
     return file_path
 


### PR DESCRIPTION
## Problems

- On S3/Swift backends, a download that reported success but produced an empty or missing file raised an uncaught DownloadFromStorageFailedException, so preview/thumbnail requests 500ed.
- The batch delete-entities route fetched every entity in its authorization loop and in remove_entities, so an id already deleted by someone else raised EntityNotFoundException and failed the whole batch.

## Solutions

- Raise FileNotFound (404) instead, matching the local backend; the now-unused exception class is removed.
- Skip absent entities in both loops, keeping the deletion idempotent like remove_tasks.