### PR TITLE
[crud] Avoid 500 when filtering a list on a ChoiceType column

### DIFF
--- a/tests/persons/test_person_routes.py
+++ b/tests/persons/test_person_routes.py
@@ -39,6 +39,13 @@ class PersonRoutesTestCase(ApiDBTestCase):
             {"duration": 300},
         )
 
+    def test_get_persons_filtered_by_choice_field(self):
+        # Filtering on a ChoiceType column (role) used to 500: its SQLAlchemy
+        # type raises NotImplementedError for python_type.
+        persons = self.get("data/persons?role=admin")
+        self.assertTrue(len(persons) >= 1)
+        self.assertTrue(all(p["role"] == "admin" for p in persons))
+
     # --- Time spents ---
 
     def test_get_person_time_spents(self):

--- a/zou/app/utils/query.py
+++ b/zou/app/utils/query.py
@@ -185,12 +185,19 @@ def apply_sort_by(model, query, sort_by):
 
 
 def cast_value(value, field_key):
-    if field_key.type.python_type is bool:
+    # Some column types (ChoiceType, LocaleType, TimezoneType, ...) do not
+    # implement python_type and raise NotImplementedError; they just fall
+    # through to the generic cast below instead of crashing the request.
+    try:
+        python_type = field_key.type.python_type
+    except NotImplementedError:
+        python_type = None
+    if python_type is bool:
         try:
             return string.strtobool(value)
         except ValueError:
             raise WrongParameterException(f"Invalid boolean value: {value}")
-    elif field_key.type.python_type is uuid.UUID:
+    elif python_type is uuid.UUID:
         if (
             value
             and not isinstance(value, uuid.UUID)


### PR DESCRIPTION
## Problems

- A CRUD list filter on a ChoiceType/LocaleType/TimezoneType column (e.g. GET /data/persons?role=admin) crashed with a 500 because those types raise NotImplementedError for python_type.

## Solutions

- Treat a missing python_type as the generic case and fall through to the default cast.