### PR TITLE
[shots] Answer 400 without error log on bad OTIO import files

### DIFF
--- a/tests/source/test_import_otio.py
+++ b/tests/source/test_import_otio.py
@@ -1,4 +1,5 @@
 import os
+import tempfile
 
 from tests.base import ApiDBTestCase
 
@@ -67,6 +68,28 @@ class ImportOTIOEdlTestCase(ApiDBTestCase):
         sequences = shots_service.get_sequences()
         sequence_names = {s["name"] for s in sequences}
         self.assertEqual(sequence_names, {"SQ010", "SQ020"})
+
+    def _upload_bad_file(self, suffix, content):
+        path = f"/import/otio/projects/{self.project.id}"
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=suffix, delete=False
+        ) as bad_file:
+            bad_file.write(content)
+        try:
+            return self.upload_file(path, bad_file.name, code=400)
+        finally:
+            os.remove(bad_file.name)
+
+    def test_import_unsupported_file_type(self):
+        # A file OTIO has no adapter for (e.g. a csv) is a user error: clean
+        # 400 with an explicit message, not a logged server error.
+        result = self._upload_bad_file(".csv", "shot;frame_in;frame_out\n")
+        self.assertIn("Unsupported file type '.csv'", result["message"])
+        self.assertIn("edl", result["message"])
+
+    def test_import_unparseable_file(self):
+        result = self._upload_bad_file(".edl", "this is not an edl\n")
+        self.assertIn("Failed to parse OTIO file", result["message"])
 
     def test_import_edl_updates_existing_shots(self):
         self.import_edl("no_offset.edl")

--- a/zou/app/blueprints/source/otio.py
+++ b/zou/app/blueprints/source/otio.py
@@ -11,6 +11,7 @@ from flask_jwt_extended import jwt_required
 from zou.app import config
 
 from zou.app.mixin import ArgsMixin
+from zou.app.services.exception import WrongParameterException
 from zou.app.utils import fields
 from zou.app.services import (
     shots_service,
@@ -88,6 +89,10 @@ class OTIOBaseResource(MethodView, ArgsMixin):
                 args["naming_convention"],
                 args["match_case"],
             )
+        except WrongParameterException:
+            # User input error (unsupported or unparseable file): the global
+            # handler answers 400, no server-error log.
+            raise
         except Exception as e:
             current_app.logger.error(
                 f"Import OTIO failed: {type(e).__name__}: {str(e)}"
@@ -161,17 +166,25 @@ class OTIOBaseResource(MethodView, ArgsMixin):
         match_case,
     ):
         result = {"updated_shots": [], "created_shots": []}
-        try:
-            import opentimelineio as otio
+        import opentimelineio as otio
 
+        suffix = pathlib.Path(file_path).suffix.lstrip(".").lower()
+        supported = otio.adapters.suffixes_with_defined_adapters(read=True)
+        if suffix not in supported:
+            raise WrongParameterException(
+                f"Unsupported file type '.{suffix}'. Supported formats: "
+                f"{', '.join(sorted(supported))}."
+            )
+        try:
             kwargs = {}
-            extension = pathlib.Path(file_path).suffix
-            if extension == ".edl":
+            if suffix == "edl":
                 kwargs["rate"] = projects_service.get_project_fps(project_id)
                 kwargs["ignore_timecode_mismatch"] = True
             timeline = otio.adapters.read_from_file(file_path, **kwargs)
         except Exception as e:
-            raise Exception(f"Failed to parse OTIO file: {str(e)}")
+            raise WrongParameterException(
+                f"Failed to parse OTIO file: {str(e)}"
+            )
 
         self.prepare_import(
             project_id,


### PR DESCRIPTION
## Problems

- Uploading a file OTIO cannot read (e.g. a csv) on /import/otio answered 400 through a catch-all that logged every user mistake as a server error, flooding Sentry.

## Solutions

- Validate the suffix against the OTIO adapters up front and raise WrongParameterException for unsupported or unparseable files: clean 400 with an explicit message, no error log; the catch-all stays for genuine internal failures.