### PR TITLE
Add episode filtering and an edits endpoint to schedule items

### DIFF
--- a/tests/projects/test_route_schedule_items.py
+++ b/tests/projects/test_route_schedule_items.py
@@ -31,6 +31,24 @@ class ProjectScheduleRouteTestCase(ApiDBTestCase):
         self.assertEqual(items[0]["task_type_id"], self.task_type_id)
         self.assertEqual(items[0]["project_id"], self.project_id)
 
+    def test_get_schedule_sequence_items_for_episode(self):
+        episode_2 = self.generate_fixture_episode(name="E02")
+        sequence_2 = self.generate_fixture_sequence(
+            name="S02", episode_id=episode_2.id
+        )
+        sequence_2_id = str(sequence_2.id)
+        base_path = f"/data/projects/{self.project_id}/schedule-items/{self.task_type_id}/sequences"
+
+        # Without episode filter, both sequences are returned.
+        items = self.get(base_path)
+        object_ids = {item["object_id"] for item in items}
+        self.assertEqual(object_ids, {self.sequence_id, sequence_2_id})
+
+        # Filtered on an episode, only its sequence is returned.
+        items = self.get(f"{base_path}?episode_id={self.episode_id}")
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0]["object_id"], self.sequence_id)
+
     def test_get_schedule_episode_items(self):
         path = f"/data/projects/{self.project_id}/schedule-items/{self.task_type_id}/episodes"
         items = self.get(path)

--- a/tests/projects/test_route_schedule_items.py
+++ b/tests/projects/test_route_schedule_items.py
@@ -74,6 +74,38 @@ class ProjectScheduleRouteTestCase(ApiDBTestCase):
         self.assertEqual(len(items), 1)
         self.assertEqual(items[0]["object_id"], self.episode_id)
 
+    def test_get_schedule_edit_items(self):
+        edit = self.generate_fixture_edit()
+        edit_id = str(edit.id)
+        path = f"/data/projects/{self.project_id}/schedule-items/{self.task_type_id}/edits"
+        items = self.get(path)
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0]["object_id"], edit_id)
+        self.assertEqual(items[0]["task_type_id"], self.task_type_id)
+        self.assertEqual(items[0]["project_id"], self.project_id)
+
+    def test_get_schedule_edit_items_for_episode(self):
+        edit_1 = self.generate_fixture_edit(
+            name="Edit E01", parent_id=self.episode.id
+        )
+        edit_1_id = str(edit_1.id)
+        episode_2 = self.generate_fixture_episode(name="E02")
+        edit_2 = self.generate_fixture_edit(
+            name="Edit E02", parent_id=episode_2.id
+        )
+        edit_2_id = str(edit_2.id)
+        base_path = f"/data/projects/{self.project_id}/schedule-items/{self.task_type_id}/edits"
+
+        # Without episode filter, both edits are returned.
+        items = self.get(base_path)
+        object_ids = {item["object_id"] for item in items}
+        self.assertEqual(object_ids, {edit_1_id, edit_2_id})
+
+        # Filtered on an episode, only its edit is returned.
+        items = self.get(f"{base_path}?episode_id={self.episode_id}")
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0]["object_id"], edit_1_id)
+
     def test_get_schedule_asset_type_items(self):
         path = f"/data/projects/{self.project_id}/schedule-items/{self.task_type_id}/asset-types"
         items = self.get(path)

--- a/tests/projects/test_route_schedule_items.py
+++ b/tests/projects/test_route_schedule_items.py
@@ -59,6 +59,21 @@ class ProjectScheduleRouteTestCase(ApiDBTestCase):
         self.assertEqual(items[0]["task_type_id"], self.task_type_id)
         self.assertEqual(items[0]["project_id"], self.project_id)
 
+    def test_get_schedule_episode_items_for_episode(self):
+        episode_2 = self.generate_fixture_episode(name="E02")
+        episode_2_id = str(episode_2.id)
+        base_path = f"/data/projects/{self.project_id}/schedule-items/{self.task_type_id}/episodes"
+
+        # Without episode filter, both episodes are returned.
+        items = self.get(base_path)
+        object_ids = {item["object_id"] for item in items}
+        self.assertEqual(object_ids, {self.episode_id, episode_2_id})
+
+        # Filtered on an episode, only that episode is returned.
+        items = self.get(f"{base_path}?episode_id={self.episode_id}")
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0]["object_id"], self.episode_id)
+
     def test_get_schedule_asset_type_items(self):
         path = f"/data/projects/{self.project_id}/schedule-items/{self.task_type_id}/asset-types"
         items = self.get(path)

--- a/tests/projects/test_route_schedule_items.py
+++ b/tests/projects/test_route_schedule_items.py
@@ -1,5 +1,7 @@
 from tests.base import ApiDBTestCase
 
+from zou.app.models.entity import Entity
+
 
 class ProjectScheduleRouteTestCase(ApiDBTestCase):
     def setUp(self):
@@ -64,3 +66,34 @@ class ProjectScheduleRouteTestCase(ApiDBTestCase):
         self.assertEqual(items[0]["object_id"], self.asset_type_id)
         self.assertEqual(items[0]["task_type_id"], self.task_type_id)
         self.assertEqual(items[0]["project_id"], self.project_id)
+
+    def test_get_schedule_asset_type_items_for_episode(self):
+        self.generate_fixture_asset_types()
+        episode_1 = self.episode
+        episode_2 = self.generate_fixture_episode(name="E02")
+        episode_2_id = str(episode_2.id)
+        asset_type_character_id = str(self.asset_type_character.id)
+
+        Entity.create(
+            name="Tree E01",
+            project_id=self.project.id,
+            entity_type_id=self.asset_type.id,
+            source_id=episode_1.id,
+        )
+        Entity.create(
+            name="Rabbit E02",
+            project_id=self.project.id,
+            entity_type_id=self.asset_type_character.id,
+            source_id=episode_2.id,
+        )
+        base_path = f"/data/projects/{self.project_id}/schedule-items/{self.task_type_id}/asset-types"
+
+        # Filtered on the first episode, only its asset type is returned.
+        items = self.get(f"{base_path}?episode_id={self.episode_id}")
+        object_ids = {item["object_id"] for item in items}
+        self.assertEqual(object_ids, {self.asset_type_id})
+
+        # Filtered on the second episode, only its asset type is returned.
+        items = self.get(f"{base_path}?episode_id={episode_2_id}")
+        object_ids = {item["object_id"] for item in items}
+        self.assertEqual(object_ids, {asset_type_character_id})

--- a/tests/services/test_edits_service.py
+++ b/tests/services/test_edits_service.py
@@ -2,6 +2,7 @@ import pytest
 
 from tests.base import ApiDBTestCase
 
+from zou.app.models.schedule_item import ScheduleItem
 from zou.app.services import edits_service, shots_service
 from zou.app.services.exception import EditNotFoundException
 
@@ -105,3 +106,16 @@ class EditUtilsTestCase(ApiDBTestCase):
         edits_service.remove_edit(edit_id)
         with pytest.raises(EditNotFoundException):
             edits_service.get_edit(edit_id)
+
+    def test_remove_edit_deletes_schedule_items(self):
+        self.generate_fixture_task_type()
+        edit_id = str(self.edit.id)
+        schedule_item = ScheduleItem.create(
+            project_id=self.project.id,
+            task_type_id=self.task_type.id,
+            object_id=self.edit.id,
+        )
+        schedule_item_id = schedule_item.id
+
+        edits_service.remove_edit(edit_id)
+        self.assertIsNone(ScheduleItem.get(schedule_item_id))

--- a/tests/services/test_schedule_service.py
+++ b/tests/services/test_schedule_service.py
@@ -108,6 +108,62 @@ class ScheduleServiceTestCase(ApiDBTestCase):
         self.assertEqual(len(items), 1)
         self.assertEqual(items[0]["object_id"], episode_2_id)
 
+    def test_get_schedule_edit_items(self):
+        edit = self.generate_fixture_edit(parent_id=self.episode.id)
+        edit_id = str(edit.id)
+        items = schedule_service.get_edits_schedule_items(
+            self.project.id, self.task_type_id
+        )
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0]["object_id"], edit_id)
+        self.assertEqual(items[0]["task_type_id"], self.task_type_id)
+        self.assertEqual(items[0]["project_id"], self.project_id)
+
+    def test_get_schedule_edit_items_for_episode(self):
+        edit_1 = self.generate_fixture_edit(
+            name="Edit E01", parent_id=self.episode.id
+        )
+        edit_1_id = str(edit_1.id)
+        episode_2 = self.generate_fixture_episode(name="E02")
+        episode_2_id = str(episode_2.id)
+        edit_2 = self.generate_fixture_edit(
+            name="Edit E02", parent_id=episode_2.id
+        )
+        edit_2_id = str(edit_2.id)
+
+        # Without episode filter, both edits are returned.
+        items = schedule_service.get_edits_schedule_items(
+            self.project.id, self.task_type_id
+        )
+        object_ids = {item["object_id"] for item in items}
+        self.assertEqual(object_ids, {edit_1_id, edit_2_id})
+
+        # Filtered on the first episode, only its edit is returned.
+        items = schedule_service.get_edits_schedule_items(
+            self.project.id, self.task_type_id, self.episode_id
+        )
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0]["object_id"], edit_1_id)
+
+        # Filtered on the second episode, only its edit is returned.
+        items = schedule_service.get_edits_schedule_items(
+            self.project.id, self.task_type_id, episode_2_id
+        )
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0]["object_id"], edit_2_id)
+
+    def test_get_schedule_edit_items_ignores_canceled(self):
+        edit = self.generate_fixture_edit()
+        edit_id = str(edit.id)
+        canceled_edit = self.generate_fixture_edit(name="Canceled Edit")
+        canceled_edit.update({"canceled": True})
+
+        items = schedule_service.get_edits_schedule_items(
+            self.project.id, self.task_type_id
+        )
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0]["object_id"], edit_id)
+
     def test_get_schedule_asset_type_items(self):
         items = schedule_service.get_asset_types_schedule_items(
             self.project.id, self.task_type_id

--- a/tests/services/test_schedule_service.py
+++ b/tests/services/test_schedule_service.py
@@ -44,6 +44,35 @@ class ScheduleServiceTestCase(ApiDBTestCase):
         self.assertEqual(items[0]["task_type_id"], self.task_type_id)
         self.assertEqual(items[0]["project_id"], self.project_id)
 
+    def test_get_schedule_sequence_items_for_episode(self):
+        episode_2 = self.generate_fixture_episode(name="E02")
+        sequence_2 = self.generate_fixture_sequence(
+            name="S02", episode_id=episode_2.id
+        )
+        sequence_2_id = str(sequence_2.id)
+        episode_2_id = str(episode_2.id)
+
+        # Without episode filter, both sequences are returned.
+        items = schedule_service.get_sequences_schedule_items(
+            self.project.id, self.task_type_id
+        )
+        object_ids = {item["object_id"] for item in items}
+        self.assertEqual(object_ids, {self.sequence_id, sequence_2_id})
+
+        # Filtered on the first episode, only its sequence is returned.
+        items = schedule_service.get_sequences_schedule_items(
+            self.project.id, self.task_type_id, self.episode_id
+        )
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0]["object_id"], self.sequence_id)
+
+        # Filtered on the second episode, only its sequence is returned.
+        items = schedule_service.get_sequences_schedule_items(
+            self.project.id, self.task_type_id, episode_2_id
+        )
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0]["object_id"], sequence_2_id)
+
     def test_get_schedule_episode_items(self):
         items = schedule_service.get_episodes_schedule_items(
             self.project.id, self.task_type_id

--- a/tests/services/test_schedule_service.py
+++ b/tests/services/test_schedule_service.py
@@ -1,5 +1,6 @@
 from tests.base import ApiDBTestCase
 
+from zou.app.models.entity import Entity
 from zou.app.models.milestone import Milestone
 from zou.app.models.production_schedule_version import (
     ProductionScheduleVersion,
@@ -88,6 +89,42 @@ class ScheduleServiceTestCase(ApiDBTestCase):
         self.assertEqual(items[0]["object_id"], self.asset_type_id)
         self.assertEqual(items[0]["task_type_id"], self.task_type_id)
         self.assertEqual(items[0]["project_id"], self.project_id)
+
+    def test_get_schedule_asset_type_items_for_episode(self):
+        self.generate_fixture_asset_types()
+        episode_1 = self.episode
+        episode_2 = self.generate_fixture_episode(name="E02")
+        episode_2_id = str(episode_2.id)
+        asset_type_character_id = str(self.asset_type_character.id)
+
+        # An asset natively belonging to the first episode...
+        Entity.create(
+            name="Tree E01",
+            project_id=self.project.id,
+            entity_type_id=self.asset_type.id,
+            source_id=episode_1.id,
+        )
+        # ...and one of a different type belonging to the second episode.
+        Entity.create(
+            name="Rabbit E02",
+            project_id=self.project.id,
+            entity_type_id=self.asset_type_character.id,
+            source_id=episode_2.id,
+        )
+
+        # Filtered on the first episode, only its asset type is returned.
+        items = schedule_service.get_asset_types_schedule_items(
+            self.project.id, self.task_type_id, self.episode_id
+        )
+        object_ids = {item["object_id"] for item in items}
+        self.assertEqual(object_ids, {self.asset_type_id})
+
+        # Filtered on the second episode, only its asset type is returned.
+        items = schedule_service.get_asset_types_schedule_items(
+            self.project.id, self.task_type_id, episode_2_id
+        )
+        object_ids = {item["object_id"] for item in items}
+        self.assertEqual(object_ids, {asset_type_character_id})
 
     def test_get_all_schedule_items(self):
         schedule_service.get_task_types_schedule_items(self.project.id)

--- a/tests/services/test_schedule_service.py
+++ b/tests/services/test_schedule_service.py
@@ -82,6 +82,32 @@ class ScheduleServiceTestCase(ApiDBTestCase):
         self.assertEqual(items[0]["task_type_id"], self.task_type_id)
         self.assertEqual(items[0]["project_id"], self.project_id)
 
+    def test_get_schedule_episode_items_for_episode(self):
+        episode_1_id = self.episode_id
+        episode_2 = self.generate_fixture_episode(name="E02")
+        episode_2_id = str(episode_2.id)
+
+        # Without episode filter, both episodes are returned.
+        items = schedule_service.get_episodes_schedule_items(
+            self.project.id, self.task_type_id
+        )
+        object_ids = {item["object_id"] for item in items}
+        self.assertEqual(object_ids, {episode_1_id, episode_2_id})
+
+        # Filtered on the first episode, only that episode is returned.
+        items = schedule_service.get_episodes_schedule_items(
+            self.project.id, self.task_type_id, episode_1_id
+        )
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0]["object_id"], episode_1_id)
+
+        # Filtered on the second episode, only that episode is returned.
+        items = schedule_service.get_episodes_schedule_items(
+            self.project.id, self.task_type_id, episode_2_id
+        )
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0]["object_id"], episode_2_id)
+
     def test_get_schedule_asset_type_items(self):
         items = schedule_service.get_asset_types_schedule_items(
             self.project.id, self.task_type_id

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -51,6 +51,13 @@ class UtilsTestCase(unittest.TestCase):
         self.assertEqual(fields.serialize_dict(data), result)
         self.assertEqual(fields.serialize_value(data), result)
 
+    def test_is_valid_id(self):
+        unique_id = uuid.uuid4()
+        self.assertTrue(fields.is_valid_id(str(unique_id)))
+        self.assertTrue(fields.is_valid_id(unique_id))
+        self.assertFalse(fields.is_valid_id("undefined"))
+        self.assertFalse(fields.is_valid_id(None))
+
     def test_serialize_orm_array(self):
         person = Person(id=uuid.uuid4(), first_name="Jhon", last_name="Doe")
         person2 = Person(id=uuid.uuid4(), first_name="Emma", last_name="Peel")

--- a/zou/app/blueprints/projects/__init__.py
+++ b/zou/app/blueprints/projects/__init__.py
@@ -28,6 +28,7 @@ from zou.app.blueprints.projects.resources import (
     ProductionScheduleItemsResource,
     ProductionTaskTypeScheduleItemsResource,
     ProductionAssetTypesScheduleItemsResource,
+    ProductionEditsScheduleItemsResource,
     ProductionEpisodesScheduleItemsResource,
     ProductionSequencesScheduleItemsResource,
     ProductionTimeSpentsResource,
@@ -141,6 +142,10 @@ routes = [
     (
         "/data/projects/<project_id>/schedule-items/<task_type_id>/asset-types",
         ProductionAssetTypesScheduleItemsResource,
+    ),
+    (
+        "/data/projects/<project_id>/schedule-items/<task_type_id>/edits",
+        ProductionEditsScheduleItemsResource,
     ),
     (
         "/data/projects/<project_id>/schedule-items/<task_type_id>/episodes",

--- a/zou/app/blueprints/projects/resources.py
+++ b/zou/app/blueprints/projects/resources.py
@@ -1900,6 +1900,13 @@ class ProductionEpisodesScheduleItemsResource(MethodView, ArgsMixin):
         tags:
           - Projects
         parameters:
+          - in: query
+            name: episode_id
+            required: false
+            schema:
+              type: string
+              format: uuid
+            description: Restrict results to the given episode
           - in: path
             name: project_id
             required: true
@@ -1930,8 +1937,9 @@ class ProductionEpisodesScheduleItemsResource(MethodView, ArgsMixin):
         user_service.block_access_to_vendor()
         self.check_id_parameter(project_id)
         self.check_id_parameter(task_type_id)
+        episode_id = self.get_id_parameter("episode") or None
         return schedule_service.get_episodes_schedule_items(
-            project_id, task_type_id
+            project_id, task_type_id, episode_id
         )
 
 

--- a/zou/app/blueprints/projects/resources.py
+++ b/zou/app/blueprints/projects/resources.py
@@ -1829,7 +1829,7 @@ class ProductionTaskTypeScheduleItemsResource(MethodView):
         return schedule_service.get_task_types_schedule_items(project_id)
 
 
-class ProductionAssetTypesScheduleItemsResource(MethodView):
+class ProductionAssetTypesScheduleItemsResource(MethodView, ArgsMixin):
     """
     Resource to retrieve asset types schedule items for given task type.
     """
@@ -1843,6 +1843,13 @@ class ProductionAssetTypesScheduleItemsResource(MethodView):
         tags:
           - Projects
         parameters:
+          - in: query
+            name: episode_id
+            required: false
+            schema:
+              type: string
+              format: uuid
+            description: Restrict results to asset types of the given episode
           - in: path
             name: project_id
             required: true
@@ -1871,8 +1878,11 @@ class ProductionAssetTypesScheduleItemsResource(MethodView):
         """
         user_service.check_project_access(project_id)
         user_service.block_access_to_vendor()
+        self.check_id_parameter(project_id)
+        self.check_id_parameter(task_type_id)
+        episode_id = self.get_id_parameter("episode") or None
         return schedule_service.get_asset_types_schedule_items(
-            project_id, task_type_id
+            project_id, task_type_id, episode_id
         )
 
 

--- a/zou/app/blueprints/projects/resources.py
+++ b/zou/app/blueprints/projects/resources.py
@@ -1925,7 +1925,7 @@ class ProductionEpisodesScheduleItemsResource(MethodView, ArgsMixin):
         )
 
 
-class ProductionSequencesScheduleItemsResource(MethodView):
+class ProductionSequencesScheduleItemsResource(MethodView, ArgsMixin):
     """
     Resource to retrieve sequences schedule items for given task type.
     """
@@ -1939,6 +1939,13 @@ class ProductionSequencesScheduleItemsResource(MethodView):
         tags:
           - Projects
         parameters:
+          - in: query
+            name: episode_id
+            required: false
+            schema:
+              type: string
+              format: uuid
+            description: Restrict results to sequences of the given episode
           - in: path
             name: project_id
             required: true
@@ -1967,8 +1974,11 @@ class ProductionSequencesScheduleItemsResource(MethodView):
         """
         user_service.check_project_access(project_id)
         user_service.block_access_to_vendor()
+        self.check_id_parameter(project_id)
+        self.check_id_parameter(task_type_id)
+        episode_id = self.get_id_parameter("episode") or None
         return schedule_service.get_sequences_schedule_items(
-            project_id, task_type_id
+            project_id, task_type_id, episode_id
         )
 
 

--- a/zou/app/blueprints/projects/resources.py
+++ b/zou/app/blueprints/projects/resources.py
@@ -2000,6 +2000,63 @@ class ProductionSequencesScheduleItemsResource(MethodView, ArgsMixin):
         )
 
 
+class ProductionEditsScheduleItemsResource(MethodView, ArgsMixin):
+    """
+    Resource to retrieve edits schedule items for given task type.
+    """
+
+    @jwt_required()
+    def get(self, project_id, task_type_id):
+        """
+        Get edits schedule items
+        ---
+        description: Retrieve edits schedule items for given task type.
+        tags:
+          - Projects
+        parameters:
+          - in: query
+            name: episode_id
+            required: false
+            schema:
+              type: string
+              format: uuid
+            description: Restrict results to edits of the given episode
+          - in: path
+            name: project_id
+            required: true
+            schema:
+              type: string
+              format: uuid
+            description: Project unique identifier
+            example: a24a6ea4-ce75-4665-a070-57453082c25
+          - in: path
+            name: task_type_id
+            required: true
+            schema:
+              type: string
+              format: uuid
+            description: Task type unique identifier
+            example: b35b7fb5-df86-5776-b181-68564193d36
+        responses:
+          200:
+            description: All edits schedule items for given task type
+            content:
+              application/json:
+                schema:
+                  type: array
+                  items:
+                    type: object
+        """
+        user_service.check_project_access(project_id)
+        user_service.block_access_to_vendor()
+        self.check_id_parameter(project_id)
+        self.check_id_parameter(task_type_id)
+        episode_id = self.get_id_parameter("episode") or None
+        return schedule_service.get_edits_schedule_items(
+            project_id, task_type_id, episode_id
+        )
+
+
 class ProductionBudgetsResource(MethodView, ArgsMixin):
 
     @jwt_required()

--- a/zou/app/services/assets_service.py
+++ b/zou/app/services/assets_service.py
@@ -569,6 +569,28 @@ def get_asset_types_for_project(project_id):
     return EntityType.serialize_list(result, obj_type="AssetType")
 
 
+def get_asset_types_for_episode(project_id, episode_id):
+    """
+    Retrieve all asset types related to assets natively belonging to a given
+    episode (shared/casted assets excluded, to match the schedule scope).
+    """
+    asset_type_ids = {
+        asset.entity_type_id
+        for asset in Entity.query.filter(build_asset_type_filter())
+        .filter(Entity.project_id == project_id)
+        .filter(Entity.source_id == episode_id)
+        .all()
+    }
+
+    if len(asset_type_ids) > 0:
+        result = EntityType.query.filter(
+            EntityType.id.in_(list(asset_type_ids))
+        ).all()
+    else:
+        result = []
+    return EntityType.serialize_list(result, obj_type="AssetType")
+
+
 def get_asset_types_for_shot(shot_id):
     """
     Retrieve all asset types related to asset casted in a given shot.

--- a/zou/app/services/edits_service.py
+++ b/zou/app/services/edits_service.py
@@ -17,6 +17,7 @@ from zou.app.models.entity import (
     EntityConceptLink,
 )
 from zou.app.models.project import Project
+from zou.app.models.schedule_item import ScheduleItem
 from zou.app.models.subscription import Subscription
 from zou.app.models.task import Task
 
@@ -302,6 +303,7 @@ def remove_edit(edit_id, force=False):
 
         EntityVersion.delete_all_by(entity_id=edit_id)
         Subscription.delete_all_by(entity_id=edit_id)
+        ScheduleItem.delete_all_by(object_id=edit_id)
         EntityLink.delete_all_by(entity_in_id=edit_id)
         EntityLink.delete_all_by(entity_out_id=edit_id)
         EntityConceptLink.delete_all_by(entity_in_id=edit_id)

--- a/zou/app/services/schedule_service.py
+++ b/zou/app/services/schedule_service.py
@@ -19,6 +19,7 @@ from zou.app.utils import events, fields, cache
 from zou.app.services import (
     assets_service,
     base_service,
+    edits_service,
     shots_service,
     tasks_service,
     projects_service,
@@ -201,6 +202,41 @@ def get_sequences_schedule_items(project_id, task_type_id, episode_id=None):
         task_type_id,
         sequences,
         sequence_map,
+        existing_schedule_items,
+    )
+
+
+def get_edits_schedule_items(project_id, task_type_id, episode_id=None):
+    """
+    Return all edit schedule items for given project. If no schedule item
+    exists for a given edit, it creates one. Canceled edits are ignored.
+    When an episode is given, results are restricted to the edits of that
+    episode.
+    """
+    edits = edits_service.get_edits_for_project(project_id)
+    edits = [edit for edit in edits if not edit["canceled"]]
+    if episode_id is not None:
+        edits = [
+            edit for edit in edits if edit["parent_id"] == str(episode_id)
+        ]
+    edit_map = base_service.get_model_map_from_array(edits)
+    edit_type = edits_service.get_edit_type()
+
+    query = (
+        ScheduleItem.query.join(Entity, ScheduleItem.object_id == Entity.id)
+        .filter(ScheduleItem.project_id == project_id)
+        .filter(Entity.entity_type_id == edit_type["id"])
+        .filter(ScheduleItem.task_type_id == task_type_id)
+    )
+    if episode_id is not None:
+        query = query.filter(Entity.parent_id == episode_id)
+    existing_schedule_items = set(query.all())
+
+    return get_entity_schedule_items(
+        project_id,
+        task_type_id,
+        edits,
+        edit_map,
         existing_schedule_items,
     )
 

--- a/zou/app/services/schedule_service.py
+++ b/zou/app/services/schedule_service.py
@@ -151,13 +151,17 @@ def get_episodes_schedule_items(project_id, task_type_id):
 
 def get_sequences_schedule_items(project_id, task_type_id, episode_id=None):
     """
-    Return all asset type schedule items for given project. If no schedule item
-    exists for a given asset type, it creates one.
+    Return all sequence schedule items for given project. If no schedule item
+    exists for a given sequence, it creates one. When an episode is given,
+    results are restricted to the sequences of that episode.
     """
+    sequences = shots_service.get_sequences_for_project(project_id)
     if episode_id is not None:
-        sequences = shots_service.get_sequences_for_episode(episode_id)
-    else:
-        sequences = shots_service.get_sequences_for_project(project_id)
+        sequences = [
+            sequence
+            for sequence in sequences
+            if sequence["parent_id"] == str(episode_id)
+        ]
     sequence_map = base_service.get_model_map_from_array(sequences)
     sequence_type = shots_service.get_sequence_type()
 

--- a/zou/app/services/schedule_service.py
+++ b/zou/app/services/schedule_service.py
@@ -137,21 +137,30 @@ def get_asset_types_schedule_items(project_id, task_type_id, episode_id=None):
     )
 
 
-def get_episodes_schedule_items(project_id, task_type_id):
+def get_episodes_schedule_items(project_id, task_type_id, episode_id=None):
     """
     Return all episode schedule items for given project. If no schedule item
-    exists for a given asset type, it creates one.
+    exists for a given episode, it creates one. When an episode is given,
+    results are restricted to that episode.
     """
     episode_type = shots_service.get_episode_type()
     episodes = shots_service.get_episodes_for_project(project_id)
+    if episode_id is not None:
+        episodes = [
+            episode for episode in episodes if episode["id"] == str(episode_id)
+        ]
     episodes_map = base_service.get_model_map_from_array(episodes)
-    existing_schedule_items = set(
+
+    query = (
         ScheduleItem.query.join(Entity, ScheduleItem.object_id == Entity.id)
         .filter(ScheduleItem.project_id == project_id)
         .filter(Entity.entity_type_id == episode_type["id"])
         .filter(ScheduleItem.task_type_id == task_type_id)
-        .all()
     )
+    if episode_id is not None:
+        query = query.filter(ScheduleItem.object_id == episode_id)
+    existing_schedule_items = set(query.all())
+
     return get_entity_schedule_items(
         project_id,
         task_type_id,

--- a/zou/app/services/schedule_service.py
+++ b/zou/app/services/schedule_service.py
@@ -101,21 +101,33 @@ def get_task_types_schedule_items(project_id):
     )
 
 
-def get_asset_types_schedule_items(project_id, task_type_id):
+def get_asset_types_schedule_items(project_id, task_type_id, episode_id=None):
     """
     Return all asset type schedule items for given project. If no schedule item
-    exists for a given asset type, it creates one.
+    exists for a given asset type, it creates one. When an episode is given,
+    results are restricted to the asset types having assets in that episode.
     """
-    asset_types = assets_service.get_asset_types_for_project(project_id)
+    if episode_id is not None:
+        asset_types = assets_service.get_asset_types_for_episode(
+            project_id, episode_id
+        )
+    else:
+        asset_types = assets_service.get_asset_types_for_project(project_id)
     asset_type_map = base_service.get_model_map_from_array(asset_types)
-    existing_schedule_items = set(
+
+    query = (
         ScheduleItem.query.join(
             EntityType, ScheduleItem.object_id == EntityType.id
         )
         .filter(ScheduleItem.project_id == project_id)
         .filter(ScheduleItem.task_type_id == task_type_id)
-        .all()
     )
+    if episode_id is not None:
+        query = query.filter(
+            ScheduleItem.object_id.in_(list(asset_type_map.keys()))
+        )
+    existing_schedule_items = set(query.all())
+
     return get_entity_schedule_items(
         project_id,
         task_type_id,

--- a/zou/app/utils/fields.py
+++ b/zou/app/utils/fields.py
@@ -136,9 +136,9 @@ def get_default_date_object(date_string):
 
 def is_valid_id(value):
     """
-    Check if a given string is a valid UUID.
+    Check if a given value is a valid UUID or its string representation.
     """
-    return _UUID_RE.match(value)
+    return _UUID_RE.match(str(value))
 
 
 def serialize_datetime(value):


### PR DESCRIPTION
**Problem**
- The sequences, asset types, and episodes schedule-items endpoints always return the whole production, with no way to scope them to a single episode.
- There is no schedule-items endpoint for edits, so Edit task types cannot be drilled down in the production schedule.
- CI broken since ddc4fe9c6: `is_valid_id` rejects the `uuid.UUID` objects passed to `get_full_shot`, raising a `TypeError`.

**Solution**
- Add an optional `episode_id` query parameter to the three endpoints, restricting results to the sequences / asset types / episode belonging to the given episode; the filter is project-scoped, so an `episode_id` from another project returns nothing.
- Add an edits schedule-items endpoint with the same optional `episode_id` filter; deleted edits no longer appear in the schedule, and their schedule items are cleaned up.
- Cast the value to `str` in `is_valid_id`, so UUID objects are accepted again.
