### PR TITLE
[persons] Add display preference fields to the person model

### DIFF
--- a/tests/models/test_person.py
+++ b/tests/models/test_person.py
@@ -260,6 +260,38 @@ class PersonTestCase(ApiDBTestCase):
         person_again = self.get(f"data/persons/{person['id']}")
         self.assertIsNone(person_again["country"])
 
+    def test_person_display_preferences_round_trip(self):
+        person = self.get_first("data/persons")
+        self.put(
+            f"data/persons/{person['id']}",
+            {"use_12_hour_clock": True, "display_date_format": "DD/MM/YYYY"},
+        )
+        person_again = self.get(f"data/persons/{person['id']}")
+        self.assertTrue(person_again["use_12_hour_clock"])
+        self.assertEqual(person_again["display_date_format"], "DD/MM/YYYY")
+
+        self.put(f"data/persons/{person['id']}", {"display_date_format": None})
+        person_again = self.get(f"data/persons/{person['id']}")
+        self.assertIsNone(person_again["display_date_format"])
+
+    def test_person_invalid_display_date_format(self):
+        person = self.get_first("data/persons")
+        self.put(
+            f"data/persons/{person['id']}",
+            {"display_date_format": "DD-MM-YYYY"},
+            400,
+        )
+        self.post(
+            "data/persons",
+            {
+                "first_name": "Bad",
+                "last_name": "Format",
+                "email": "bad.format@gmail.com",
+                "display_date_format": "MM-DD",
+            },
+            400,
+        )
+
     def test_create_person_without_country(self):
         data = {
             "first_name": "NoCountry",
@@ -355,7 +387,14 @@ class PersonTestCase(ApiDBTestCase):
         # (never a 500 and never a poisoned entry): unknown locales, wrong
         # separators, malformed identifiers and non-string bodies.
         person = self.get_first("data/persons")
-        for value in ["zz_ZZ", "notlocale", "en-US", "fr_FR_x", 123, ["fr_FR"]]:
+        for value in [
+            "zz_ZZ",
+            "notlocale",
+            "en-US",
+            "fr_FR_x",
+            123,
+            ["fr_FR"],
+        ]:
             self.put(f"data/persons/{person['id']}", {"locale": value}, 400)
 
     def test_locale_validator_never_raises_on_direct_write(self):

--- a/zou/app/blueprints/crud/person.py
+++ b/zou/app/blueprints/crud/person.py
@@ -7,6 +7,7 @@ from zou.app.models.person import (
     Person,
     ROLE_TYPES,
     CONTRACT_TYPES,
+    DISPLAY_DATE_FORMATS,
     TWO_FACTOR_AUTHENTICATION_TYPES,
     normalize_country,
     normalize_locale,
@@ -56,6 +57,20 @@ def check_locale(data):
         raise WrongParameterException(
             "Invalid locale, expected a name available in Python Babel "
             "(e.g. en_US, fr_FR)."
+        )
+
+
+def check_display_date_format(data):
+    """
+    Reject a display date format outside the supported list with a clean
+    400. A missing or null value is treated as "use the default" and
+    accepted.
+    """
+    value = data.get("display_date_format")
+    if value is not None and value not in DISPLAY_DATE_FORMATS:
+        raise WrongParameterException(
+            "Invalid display_date_format, expected one of: "
+            f"{', '.join(DISPLAY_DATE_FORMATS)}."
         )
 
 
@@ -317,6 +332,7 @@ class PersonsResource(BaseModelsResource):
             raise WrongParameterException("Invalid contract_type")
         check_country(data)
         check_locale(data)
+        check_display_date_format(data)
         if "two_factor_authentication" in data and data[
             "two_factor_authentication"
         ] not in [
@@ -625,6 +641,7 @@ class PersonResource(BaseModelResource, ArgsMixin):
             raise WrongParameterException("Invalid contract_type")
         check_country(data)
         check_locale(data)
+        check_display_date_format(data)
         if "two_factor_authentication" in data and data[
             "two_factor_authentication"
         ] not in [

--- a/zou/app/models/person.py
+++ b/zou/app/models/person.py
@@ -61,6 +61,12 @@ SENIORITY_TYPES = [
     ("junior", "Junior"),
 ]
 
+DISPLAY_DATE_FORMATS = [
+    "YYYY-MM-DD",
+    "DD/MM/YYYY",
+    "MM/DD/YYYY",
+]
+
 
 def normalize_country(value):
     """
@@ -195,6 +201,8 @@ class Person(db.Model, BaseMixin, SerializerMixin):
         LocaleType,
         default=lambda: Locale(config_store.get_default_locale()),
     )
+    use_12_hour_clock = db.Column(db.Boolean(), default=False)
+    display_date_format = db.Column(db.String(20), default="YYYY-MM-DD")
     data = db.Column(JSONB)
     role = db.Column(ChoiceType(ROLE_TYPES), default="user", nullable=False)
     position = db.Column(ChoiceType(POSITION_TYPES), default="artist")

--- a/zou/app/models/person.py
+++ b/zou/app/models/person.py
@@ -193,6 +193,7 @@ class Person(db.Model, BaseMixin, SerializerMixin):
     )
 
     shotgun_id = db.Column(db.Integer, unique=True)
+
     timezone = db.Column(
         TimezoneType(backend="pytz"),
         default=lambda: pytz_timezone(config_store.get_default_timezone()),
@@ -204,6 +205,7 @@ class Person(db.Model, BaseMixin, SerializerMixin):
     use_12_hour_clock = db.Column(db.Boolean(), default=False)
     display_date_format = db.Column(db.String(20), default="YYYY-MM-DD")
     data = db.Column(JSONB)
+
     role = db.Column(ChoiceType(ROLE_TYPES), default="user", nullable=False)
     position = db.Column(ChoiceType(POSITION_TYPES), default="artist")
     seniority = db.Column(ChoiceType(SENIORITY_TYPES), default="mid")
@@ -223,6 +225,8 @@ class Person(db.Model, BaseMixin, SerializerMixin):
     is_guest = db.Column(db.Boolean(), default=False, nullable=False)
     jti = db.Column(db.String(60), nullable=True, unique=True)
     expiration_date = db.Column(db.Date(), nullable=True)
+    is_generated_from_ldap = db.Column(db.Boolean(), default=False)
+    ldap_uid = db.Column(db.String(60), unique=True, default=None)
 
     departments = db.relationship(
         "Department",
@@ -231,9 +235,6 @@ class Person(db.Model, BaseMixin, SerializerMixin):
     studio_id = db.Column(
         UUIDType(binary=False), db.ForeignKey("studio.id"), index=True
     )
-
-    is_generated_from_ldap = db.Column(db.Boolean(), default=False)
-    ldap_uid = db.Column(db.String(60), unique=True, default=None)
 
     __table_args__ = (
         Index(

--- a/zou/migrations/versions/c7d3f9b2a1e4_add_person_display_preferences.py
+++ b/zou/migrations/versions/c7d3f9b2a1e4_add_person_display_preferences.py
@@ -1,0 +1,37 @@
+"""add person display preferences
+
+Two per-user display preferences surfaced in the Kitsu profile page: an
+opt-in 12-hour clock and the date format used for displayed dates. Both
+columns are nullable so existing rows keep working; the read paths fall
+back to the 24-hour clock and the ISO date format.
+
+Revision ID: c7d3f9b2a1e4
+Revises: f2c9a1b7e4d8
+Create Date: 2026-07-11 10:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "c7d3f9b2a1e4"
+down_revision = "f2c9a1b7e4d8"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "person",
+        sa.Column("use_12_hour_clock", sa.Boolean(), nullable=True),
+    )
+    op.add_column(
+        "person",
+        sa.Column("display_date_format", sa.String(length=20), nullable=True),
+    )
+
+
+def downgrade():
+    op.drop_column("person", "display_date_format")
+    op.drop_column("person", "use_12_hour_clock")


### PR DESCRIPTION
**Problem**
- The Kitsu 12-hour clock (cgwire/kitsu#2105) and date format (cgwire/kitsu#2110) profile preferences had no proper storage: they rode the generic person `data` JSONB blob, unvalidated and clobber-prone

**Solution**
- Add `use_12_hour_clock` (boolean, default false) and `display_date_format` (string, default `YYYY-MM-DD`) to the person model, editable by each person on their own profile
- Reject unsupported `display_date_format` values (outside `YYYY-MM-DD`, `DD/MM/YYYY`, `MM/DD/YYYY`) with a 400 on creation and update
- Nullable migration so existing rows keep working; clients fall back to the 24-hour clock and the ISO format