### PR TITLE
Fix preview delete crash, pip-audit gate and CLI SECRET_KEY guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,7 @@ jobs:
           --ignore-vuln CVE-2026-26007
           --ignore-vuln GHSA-537c-gmf6-5ccf
           --ignore-vuln CVE-2026-27448
+          --ignore-vuln PYSEC-2026-2269
           --ignore-vuln CVE-2026-27459
 
   publish-test:

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,7 +61,7 @@ install_requires =
     OpenTimelineIO-Plugins==0.18.1
     orjson==3.11.9
     pydantic==2.13.4
-    pillow==12.2.0
+    pillow==12.3.0
     psutil==7.2.2
     psycopg[binary]==3.3.4
     PyJWT==2.13.0

--- a/tests/services/test_preview_files_service.py
+++ b/tests/services/test_preview_files_service.py
@@ -411,6 +411,46 @@ class PlaylistTestCase(ApiDBTestCase):
                 )
         self.assertEqual(os.listdir(folder), [])
 
+    def test_update_preview_file_raw_deleted_midflight_raises_not_found(self):
+        """
+        When the row is deleted by another process mid-update, base.update()
+        raises StaleDataError then rolls back, which expires the instance.
+        Reading preview_file.id in the error handler would then reload the
+        deleted row and raise ObjectDeletedError, masking the real error.
+        The id must be captured before update() so the handler never touches
+        the ORM instance again.
+
+        Modelled with a fake: the test DB harness runs each test in a single
+        rolled-back transaction, so a committed cross-process delete (the only
+        thing that makes .id reload fail) cannot be reproduced against a real
+        row.
+        """
+        from sqlalchemy.orm.exc import StaleDataError
+
+        from zou.app.services.exception import PreviewFileNotFoundException
+
+        class _VanishingPreviewFile:
+            def __init__(self):
+                self._live = True
+
+            @property
+            def id(self):
+                if not self._live:
+                    raise AssertionError(
+                        "id read after failed update reloads the deleted row"
+                    )
+                return "50aa09cb-3f13-4c12-8669-e3fb8f0d0ac7"
+
+            def update(self, data):
+                # A failed commit rolls back and expires the instance.
+                self._live = False
+                raise StaleDataError("0 rows matched")
+
+        with self.assertRaises(PreviewFileNotFoundException):
+            preview_files_service.update_preview_file_raw(
+                _VanishingPreviewFile(), {"status": "broken"}
+            )
+
     def test_get_preview_file_dimensions(self):
         self.assertFalse(_is_valid_resolution(""))
         self.assertFalse(_is_valid_resolution(None))

--- a/zou/app/services/preview_files_service.py
+++ b/zou/app/services/preview_files_service.py
@@ -182,11 +182,14 @@ def update_preview_file(preview_file_id, data, silent=False):
 
 
 def update_preview_file_raw(preview_file, data, silent=False):
+    # Read the id while the instance is still live: on StaleDataError,
+    # base.update() rolls the session back, which expires every attribute.
+    # Reading preview_file.id afterwards reloads the (now deleted) row and
+    # raises ObjectDeletedError, masking the real error.
+    preview_file_id = str(preview_file.id)
     try:
         preview_file.update(data)
     except StaleDataError:
-        # Preview file was deleted by another process during update
-        preview_file_id = str(preview_file.id)
         from zou.app import app as current_app
 
         current_app.logger.warning(
@@ -196,12 +199,12 @@ def update_preview_file_raw(preview_file, data, silent=False):
             f"Preview file {preview_file_id} was deleted"
         )
 
-    files_service.clear_preview_file_cache(str(preview_file.id))
+    files_service.clear_preview_file_cache(preview_file_id)
     if not silent:
         task = Task.get(preview_file.task_id)
         events.emit(
             "preview-file:update",
-            {"preview_file_id": str(preview_file.id)},
+            {"preview_file_id": preview_file_id},
             project_id=str(task.project_id),
         )
     return preview_file.serialize()


### PR DESCRIPTION
**Problem**
- `update_preview_file_raw` reads `preview_file.id` in its `StaleDataError` handler after the failed commit expired the instance, raising an unhandled `ObjectDeletedError` instead of a clean 404 when a preview is deleted mid-update.
- The pip-audit CI gate fails on new pillow (PYSEC-2026-2253 through 2257) and pyopenssl (PYSEC-2026-2269) advisories.
- The default-SECRET_KEY guard only exempts the CLI when launched via the `zou` console script, so `python zou/cli.py` and `python -m zou.cli` are wrongly blocked.

**Solution**
- Capture the preview file id before `update()` so the handler never re-touches the expired ORM instance.
- Bump pillow to 12.3.0; ignore PYSEC-2026-2269, blocked by pysaml2 7.5.4's `pyopenssl<24.3` cap.
- Also exempt the guard when the `__main__` module is `cli.py`.
