### PR TITLE
[plugins] Escape percent signs in Alembic database URL

### DIFF
--- a/tests/misc/test_utils_plugins.py
+++ b/tests/misc/test_utils_plugins.py
@@ -11,6 +11,7 @@ from tests.base import ApiDBTestCase
 
 from zou.app.utils.plugins import (
     PluginManifest,
+    _build_plugin_alembic_config,
     install_plugin_files,
     uninstall_plugin_files,
     create_plugin_package,
@@ -431,3 +432,28 @@ class PluginStaticRoutesTestCase(ApiDBTestCase):
         add_static_routes(manifest, routes)
 
         self.assertEqual(len(routes), 0)
+
+
+class PluginAlembicConfigTestCase(ApiDBTestCase):
+
+    def setUp(self):
+        super(PluginAlembicConfigTestCase, self).setUp()
+        self.temp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        super(PluginAlembicConfigTestCase, self).tearDown()
+        if os.path.exists(self.temp_dir):
+            shutil.rmtree(self.temp_dir)
+
+    def test_build_config_with_percent_in_db_uri(self):
+        from zou.app import app
+
+        uri = "postgresql://user:i4xVGz%2189Dsoi@localhost:5432/zoudb"
+        with app.app_context():
+            with patch.dict(
+                app.config, {"SQLALCHEMY_DATABASE_URI": uri}
+            ):
+                alembic_cfg = _build_plugin_alembic_config(self.temp_dir)
+        self.assertEqual(
+            alembic_cfg.get_main_option("sqlalchemy.url"), uri
+        )

--- a/zou/app/utils/plugins.py
+++ b/zou/app/utils/plugins.py
@@ -216,8 +216,12 @@ def _build_plugin_alembic_config(plugin_path):
         "script_location", str(PLUGIN_ALEMBIC_TEMPLATE_DIR)
     )
     alembic_cfg.set_main_option("version_locations", str(versions_dir))
+    # Escape % for configparser, which Alembic uses internally and would
+    # otherwise treat percent-encoded characters in the URI (e.g. a "!" in
+    # the DB password rendered as "%21") as interpolation tokens.
     alembic_cfg.set_main_option(
-        "sqlalchemy.url", current_app.config["SQLALCHEMY_DATABASE_URI"]
+        "sqlalchemy.url",
+        current_app.config["SQLALCHEMY_DATABASE_URI"].replace("%", "%%"),
     )
     alembic_cfg.attributes["plugin_path"] = str(plugin_path)
     return alembic_cfg


### PR DESCRIPTION
**Problem**
- `zou install-plugin` crashes when the PostgreSQL password contains special characters (e.g. `!`): the password is percent-encoded in the SQLAlchemy URL and configparser, used internally by Alembic, rejects the resulting `%` sequences as invalid interpolation tokens.

**Solution**
- Escape `%` as `%%` when setting `sqlalchemy.url` in the plugin Alembic config, exactly like the core migration config already does in `cli.py`. The value is unescaped back by configparser when env.py reads it.
- Add a test checking the config round-trips a percent-encoded database URI.

Fix #1117