### PR TITLE
[auth] Allow a full bind DN as LDAP_USER for LDAP sync

### DIFF
--- a/zou/app/utils/commands.py
+++ b/zou/app/utils/commands.py
@@ -530,6 +530,12 @@ def sync_with_ldap_server():
         elif LDAP_IS_AD:
             user = f"{LDAP_DOMAIN}\\{LDAP_USER}"
             authentication = NTLM
+        elif "=" in LDAP_USER:
+            # LDAP_USER is already a full bind DN, use it as is. OpenLDAP
+            # admin accounts often live outside the users base DN
+            # (e.g. cn=admin,dc=studio,dc=local).
+            user = LDAP_USER
+            authentication = SIMPLE
         else:
             user = f"uid={LDAP_USER},{LDAP_BASE_DN}"
             authentication = SIMPLE


### PR DESCRIPTION
**Problem**
- `zou sync-with-ldap-server` fails with `LDAPInvalidCredentialsResult` on OpenLDAP servers: the bind user is always built as `uid=<LDAP_USER>,<LDAP_BASE_DN>`, but OpenLDAP admin accounts usually live outside the users base DN (e.g. `cn=admin,dc=studio,dc=local`), so there is no way to provide a working bind identity.

**Solution**
- When `LDAP_USER` contains a `=`, treat it as a full bind DN and pass it to the LDAP bind untouched; plain usernames keep the existing `uid=...,<base DN>` behavior.

Fix #1070