### PR TITLE
[emails] Log email sending failures at error level

### DIFF
--- a/tests/utils/test_emails.py
+++ b/tests/utils/test_emails.py
@@ -59,3 +59,21 @@ class EmailsLineLengthTestCase(ApiDBTestCase):
         html = "<p>" + ("é" * 2000) + "</p>"
         raw = self._get_message_bytes("Sujet avec accents é", html)
         self._assert_lines_within_rfc5322(raw)
+
+
+class EmailsSendFailureTestCase(ApiDBTestCase):
+    def test_smtp_failure_is_logged_as_error(self):
+        from unittest.mock import patch
+
+        with patch.dict(app.config, {"MAIL_ENABLED": True}):
+            with patch(
+                "zou.app.utils.emails.mail.send",
+                side_effect=Exception("SMTP down"),
+            ):
+                with self.assertLogs(app.logger, level="ERROR") as logs:
+                    emails.send_email(
+                        "Subject", "<p>Hello</p>", "recipient@example.com"
+                    )
+        self.assertTrue(
+            any("recipient@example.com" in line for line in logs.output)
+        )

--- a/zou/app/utils/emails.py
+++ b/zou/app/utils/emails.py
@@ -53,8 +53,15 @@ def send_email(subject, html, recipient_email, body=None, locale=None):
                         pass
                 mail.send(message)
             except Exception:
-                app.logger.info("Exception when sending a mail notification:")
-                app.logger.info(traceback.format_exc())
+                # Log at error level so failures show up in production and
+                # RQ worker logs: the default Flask logger drops info
+                # messages, which made SMTP errors invisible while the
+                # email job was still reported as successful.
+                app.logger.error(
+                    f"Failed to send email to {recipient_email} "
+                    f"(subject: {subject}):"
+                )
+                app.logger.error(traceback.format_exc())
 
 
 class HTMLStripper(HTMLParser):


### PR DESCRIPTION
**Problem**
- When SMTP delivery fails, `send_email` swallows the exception and logs it at info level, which the default Flask logger drops: RQ marks the email job as successful (`Job OK`) while nothing was delivered, leaving no trace to diagnose (as in the playlist share reports).
- The `send_email() got an unexpected keyword argument 'locale'` error from the issue is a stale RQ worker running a pre-i18n zou after upgrade: restarting the worker fixes it, no code change needed.

**Solution**
- Log email sending failures at error level, including the recipient and subject, so they show up in production and RQ worker logs.
- Add a test checking that an SMTP failure is logged as an error and does not raise.

Fix #1074