### PR TITLE
[crud] Allow requesting specific fields on list routes

### DIFF
--- a/tests/models/test_crud_fields.py
+++ b/tests/models/test_crud_fields.py
@@ -1,0 +1,37 @@
+from tests.base import ApiDBTestCase
+
+from zou.app.models.department import Department
+
+
+class CrudFieldsParamTestCase(ApiDBTestCase):
+    def setUp(self):
+        super().setUp()
+        self.generate_data(Department, 3)
+
+    def test_fields_param_trims_entries(self):
+        departments = self.get("data/departments?fields=name")
+        self.assertEqual(len(departments), 3)
+        for department in departments:
+            self.assertIn("name", department)
+            self.assertIn("id", department)
+            self.assertNotIn("color", department)
+
+    def test_fields_param_paginated(self):
+        result = self.get("data/departments?page=1&fields=name")
+        self.assertEqual(result["total"], 3)
+        for department in result["data"]:
+            self.assertIn("name", department)
+            self.assertIn("id", department)
+            self.assertNotIn("color", department)
+
+    def test_fields_param_unknown_field_is_ignored(self):
+        departments = self.get("data/departments?fields=name,nonexistent")
+        for department in departments:
+            self.assertIn("name", department)
+            self.assertNotIn("nonexistent", department)
+            self.assertNotIn("color", department)
+
+    def test_no_fields_param_returns_everything(self):
+        departments = self.get("data/departments")
+        for department in departments:
+            self.assertIn("color", department)

--- a/zou/app/blueprints/crud/base.py
+++ b/zou/app/blueprints/crud/base.py
@@ -133,7 +133,10 @@ class BaseModelsResource(MethodView, ArgsMixin):
 
         column_names = inspect(self.model).all_orm_descriptors.keys()
         for key, value in options.items():
-            if key not in ["page", "relations"] and key in column_names:
+            if (
+                key not in ["page", "relations", "fields"]
+                and key in column_names
+            ):
                 field_key = getattr(self.model, key)
 
                 is_many_to_many_field = hasattr(
@@ -247,6 +250,15 @@ class BaseModelsResource(MethodView, ArgsMixin):
             default: false
             example: false
             description: Whether to include relations
+          - in: query
+            name: fields
+            required: false
+            schema:
+              type: string
+            example: first_name,last_name
+            description: Comma-separated list of attributes to return for
+              each entry (id and type are always included). Unknown names
+              are ignored.
         responses:
             200:
               description: Models retrieved successfully
@@ -296,14 +308,27 @@ class BaseModelsResource(MethodView, ArgsMixin):
                 page = self.get_page()
                 limit = self.get_limit()
                 relations = self.get_bool_parameter("relations")
+                field_names = self.get_text_parameter("fields")
+                if field_names:
+                    field_names = [
+                        name.strip() for name in field_names.split(",")
+                    ]
                 is_paginated = page > -1
 
                 if is_paginated:
-                    return self.paginated_entries(
+                    result = self.paginated_entries(
                         query, page, limit=limit, relations=relations
                     )
+                    if field_names:
+                        result["data"] = fields.pick_fields(
+                            result["data"], field_names
+                        )
+                    return result
                 else:
-                    return self.all_entries(query, relations=relations)
+                    result = self.all_entries(query, relations=relations)
+                    if field_names:
+                        result = fields.pick_fields(result, field_names)
+                    return result
         except StatementError as exception:
             if hasattr(exception, "message"):
                 return (

--- a/zou/app/utils/fields.py
+++ b/zou/app/utils/fields.py
@@ -151,6 +151,20 @@ def serialize_datetime(value):
     return value.replace(microsecond=0).isoformat()
 
 
+def pick_fields(entries, field_names):
+    """
+    Keep only the given field names in each serialized entry (id and type
+    are always kept). Runs after full serialization on purpose: any
+    permission-based field masking has already been applied, so picking
+    can only remove data, never expose it. Unknown names are ignored.
+    """
+    kept = set(field_names) | {"id", "type"}
+    return [
+        {key: value for key, value in entry.items() if key in kept}
+        for entry in entries
+    ]
+
+
 def boolean(value):
     """
     Parse "true"/"false" (case insensitive, also "1"/"0"/"on") as a boolean.


### PR DESCRIPTION
**Problem**
- List routes always return every attribute, which is wasteful when a script only needs a couple of fields.

**Solution**
- Add a `fields` query parameter to the generic `/data/<model>` list routes, e.g. `?fields=first_name,last_name` (`id` and `type` always included, unknown names ignored).
- Trim entries after full serialization so permission-based field masking still applies, on both paginated and plain listings.

Fix #611
