### PR TITLE
[plugins] Keep existing loggers enabled during migrations

### DIFF
--- a/tests/services/test_plugins_service.py
+++ b/tests/services/test_plugins_service.py
@@ -70,6 +70,13 @@ class PluginsServiceTestCase(ApiDBTestCase):
         self.assertTrue(installed_path.exists())
         self.assertTrue((installed_path / "manifest.toml").exists())
 
+    def test_install_plugin_keeps_existing_loggers_enabled(self):
+        from zou.app import app
+
+        plugin_path = self._create_test_plugin("test_plugin", "0.1.0")
+        plugins_service.install_plugin(str(plugin_path))
+        self.assertFalse(app.logger.disabled)
+
     def test_install_plugin_upgrade(self):
         existing_plugin = Plugin.create(
             plugin_id="test_plugin",

--- a/zou/app/utils/plugin_alembic_template/env.py
+++ b/zou/app/utils/plugin_alembic_template/env.py
@@ -55,7 +55,10 @@ if not already_loaded:
 
 
 if config.config_file_name:
-    fileConfig(config.config_file_name)
+    # disable_existing_loggers defaults to True and would silence every
+    # logger created before the migration runs (including Flask's
+    # app.logger, since plugin installs happen in-process).
+    fileConfig(config.config_file_name, disable_existing_loggers=False)
 logger = logging.getLogger("alembic.env")
 
 

--- a/zou/migrations/env.py
+++ b/zou/migrations/env.py
@@ -24,7 +24,10 @@ except RuntimeError:
     migrate_args = {}
 
 if config.config_file_name:
-    fileConfig(config.config_file_name)
+    # disable_existing_loggers defaults to True and would silence every
+    # logger created before the migration runs (e.g. Flask's app.logger
+    # when upgrade-db is invoked in-process).
+    fileConfig(config.config_file_name, disable_existing_loggers=False)
 logger = logging.getLogger("alembic.env")
 
 


### PR DESCRIPTION
**Problem**
- In-process Alembic runs (plugin install, `upgrade-db`) called `fileConfig()` with its default `disable_existing_loggers=True`, silencing every logger created earlier, including Flask's `app.logger`.
- On CI, any test running after the plugin service tests could no longer capture `app.logger` output: `test_smtp_failure_is_logged_as_error` failed on main.

**Solution**
- Pass `disable_existing_loggers=False` to `fileConfig()` in the plugin Alembic template and in `zou/migrations/env.py`.
- Add a regression test checking `app.logger` stays enabled after a plugin install.
