### PR TITLE
[various] CRUD response shape, task/person fixes and frame_in option

### DIFF
--- a/tests/fixtures/csv/shots_frame_range.csv
+++ b/tests/fixtures/csv/shots_frame_range.csv
@@ -1,0 +1,3 @@
+Episode,Sequence,Name,Description,FPS,In,Out
+FE01,FSE01,FS01,Empty range,25,,
+FE01,FSE01,FS02,Filled range,25,1001,1100

--- a/tests/models/test_crud_create_relations.py
+++ b/tests/models/test_crud_create_relations.py
@@ -1,0 +1,27 @@
+from tests.base import ApiDBTestCase
+
+
+class CrudCreateRelationsTestCase(ApiDBTestCase):
+    """
+    A freshly created entry must have the same shape as the same entry
+    fetched back from the single-instance GET route: relation keys are
+    included in the creation response (see cgwire/gazu#385).
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.generate_fixture_project_status()
+        self.generate_fixture_project()
+
+    def test_create_response_includes_relations(self):
+        playlist = self.post(
+            "data/playlists",
+            {
+                "name": "created-with-relations",
+                "project_id": str(self.project.id),
+                "for_entity": "shot",
+            },
+        )
+        self.assertIn("build_jobs", playlist)
+        fetched = self.get(f"data/playlists/{playlist['id']}")
+        self.assertEqual(set(playlist.keys()), set(fetched.keys()))

--- a/tests/models/test_person.py
+++ b/tests/models/test_person.py
@@ -212,6 +212,45 @@ class PersonTestCase(ApiDBTestCase):
         self.assertEqual(bot_again["first_name"], "Renamed Bot")
         self.assertEqual(bot_again["email"], "ema.doe@gmail.com")
 
+    def test_update_expired_person_keeps_its_own_expiration_date(self):
+        import datetime
+
+        yesterday = datetime.date.today() - datetime.timedelta(days=2)
+        bot = Person.create(
+            first_name="Expired",
+            last_name="Bot",
+            email="expired.bot@gmail.com",
+            is_bot=True,
+            expiration_date=yesterday,
+        )
+        bot_id = str(bot.id)
+
+        # Re-submitting the already-expired date (e.g. to disable the bot)
+        # must work: it is unchanged, not a new past date.
+        self.put(
+            f"data/persons/{bot_id}",
+            {"expiration_date": yesterday.isoformat(), "active": False},
+        )
+        bot_again = self.get(f"data/persons/{bot_id}")
+        self.assertFalse(bot_again["active"])
+
+        # Moving the expiration to a different past date is still rejected.
+        other_past = (yesterday - datetime.timedelta(days=1)).isoformat()
+        self.put(
+            f"data/persons/{bot_id}",
+            {"expiration_date": other_past},
+            400,
+        )
+
+        # Renewing to a future date still works and issues a fresh token.
+        future = (
+            datetime.date.today() + datetime.timedelta(days=30)
+        ).isoformat()
+        renewed = self.put(
+            f"data/persons/{bot_id}", {"expiration_date": future}
+        )
+        self.assertIn("access_token", renewed)
+
     def test_update_person(self):
         person = self.get_first("data/persons")
         data = {

--- a/tests/models/test_task.py
+++ b/tests/models/test_task.py
@@ -63,6 +63,17 @@ class TaskTestCase(ApiDBTestCase):
         self.task = self.post("data/tasks", data)
         self.assertEqual(len(tasks), 4)
 
+    def test_create_task_without_name_defaults_to_main(self):
+        data = {
+            "project_id": self.project.id,
+            "task_type_id": self.task_type.id,
+            "task_status_id": self.task_status.id,
+            "entity_id": self.asset.id,
+            "assigner_id": self.assigner.id,
+        }
+        task = self.post("data/tasks", data)
+        self.assertEqual(task["name"], "main")
+
     def test_update_task(self):
         task = self.get_first("data/tasks")
         data = {"name": "Modeling arbre 2"}

--- a/tests/services/test_tasks_service.py
+++ b/tests/services/test_tasks_service.py
@@ -422,6 +422,26 @@ class TaskServiceTestCase(ApiDBTestCase):
         task = tasks_service.get_task(task_id, relations=True)
         self.assertEqual(len(task["assignees"]), 0)
 
+    def test_clear_assignation_swallows_stale_data_error(self):
+        from unittest import mock
+        from sqlalchemy.orm.exc import StaleDataError
+
+        task_id = str(self.task.id)
+        tasks_service.assign_task(self.task.id, self.person.id)
+        task = tasks_service.get_task_raw(task_id)
+
+        # A concurrent unassign makes the assignees flush delete a link that is
+        # already gone, which SQLAlchemy reports as StaleDataError. clear_
+        # assignation must treat that as already-cleared, not raise. (The real
+        # rollback path can't be exercised here: the test harness keeps every
+        # fixture in one uncommitted transaction, so any rollback wipes them.)
+        with mock.patch.object(
+            type(task), "update", side_effect=StaleDataError("stale link")
+        ), mock.patch.object(tasks_service, "get_task_raw", return_value=task):
+            result = tasks_service.clear_assignation(task_id)
+
+        self.assertEqual(result["id"], task_id)
+
     def test_get_tasks_for_person(self):
         projects = [self.project.serialize()]
         tasks = tasks_service.get_person_tasks(self.user["id"], projects)

--- a/tests/source/csv/test_import_shots.py
+++ b/tests/source/csv/test_import_shots.py
@@ -80,3 +80,27 @@ class ImportCsvShotsTestCase(ApiDBTestCase):
 
         shot = shots[0]
         self.assertEqual(shot["data"].get("contractor", None), "contractor 1")
+
+    def test_import_shots_frame_range_is_normalized(self):
+        path = f"/import/csv/projects/{self.project.id}/shots"
+        self.project.update({"production_type": "tvshow"})
+
+        file_path_fixture = self.get_fixture_file_path(
+            os.path.join("csv", "shots_frame_range.csv")
+        )
+        self.upload_file(path, file_path_fixture)
+
+        shots = {s["name"]: s for s in shots_service.get_shots()}
+
+        # An empty frame value must not be stored as "": the key stays absent
+        # so it reads as None, consistently with a shot never given one.
+        empty = shots["FS01"]
+        self.assertNotIn("frame_in", empty["data"])
+        self.assertNotIn("frame_out", empty["data"])
+
+        # A provided frame value is stored as an int, not the raw CSV string.
+        filled = shots["FS02"]
+        self.assertEqual(filled["data"]["frame_in"], 1001)
+        self.assertEqual(filled["data"]["frame_out"], 1100)
+        self.assertIsInstance(filled["data"]["frame_in"], int)
+        self.assertIsInstance(filled["data"]["frame_out"], int)

--- a/tests/tasks/test_preview_revision.py
+++ b/tests/tasks/test_preview_revision.py
@@ -77,6 +77,18 @@ class PreviewRevisionTestCase(ApiDBTestCase):
         self.assertIn("auto-increment", message)
         self.assertNotIn("ormaliz", message)
 
+    def test_add_preview_response_includes_relations(self):
+        """
+        The add-preview response must have the same shape as a later GET
+        on the preview file: the comments relation is included
+        (see cgwire/gazu#385).
+        """
+        comment = self.create_comment()
+        preview = self.add_preview(comment["id"])
+        self.assertEqual(preview["comments"], [comment["id"]])
+        fetched = self.get(f"data/preview-files/{preview['id']}")
+        self.assertEqual(set(preview.keys()), set(fetched.keys()))
+
     def test_extra_preview_same_revision_allowed(self):
         """
         Extra previews should be allowed to share the same revision.

--- a/zou/app/blueprints/crud/base.py
+++ b/zou/app/blueprints/crud/base.py
@@ -216,7 +216,9 @@ class BaseModelsResource(MethodView, ArgsMixin):
         return data
 
     def post_creation(self, instance):
-        return instance.serialize()
+        # relations=True so a freshly created entry has the same shape as
+        # the single-instance GET (relations are empty lists at this point).
+        return instance.serialize(relations=True)
 
     @jwt_required()
     def get(self):

--- a/zou/app/blueprints/crud/base.py
+++ b/zou/app/blueprints/crud/base.py
@@ -216,8 +216,6 @@ class BaseModelsResource(MethodView, ArgsMixin):
         return data
 
     def post_creation(self, instance):
-        # relations=True so a freshly created entry has the same shape as
-        # the single-instance GET (relations are empty lists at this point).
         return instance.serialize(relations=True)
 
     @jwt_required()

--- a/zou/app/blueprints/crud/custom_action.py
+++ b/zou/app/blueprints/crud/custom_action.py
@@ -152,7 +152,7 @@ class CustomActionsResource(BaseModelsResource):
 
     def post_creation(self, custom_action):
         custom_actions_service.clear_custom_action_cache()
-        return custom_action.serialize()
+        return custom_action.serialize(relations=True)
 
 
 class CustomActionResource(BaseModelResource):

--- a/zou/app/blueprints/crud/day_off.py
+++ b/zou/app/blueprints/crud/day_off.py
@@ -173,7 +173,7 @@ class DayOffsResource(BaseModelsResource):
             instance.end_date <= TimeSpent.date,
             person_id=instance.person_id,
         )
-        return instance.serialize()
+        return instance.serialize(relations=True)
 
 
 class DayOffResource(BaseModelResource):

--- a/zou/app/blueprints/crud/department.py
+++ b/zou/app/blueprints/crud/department.py
@@ -140,7 +140,7 @@ class DepartmentsResource(BaseModelsResource):
 
     def post_creation(self, instance):
         tasks_service.clear_department_cache(str(instance.id))
-        return instance.serialize()
+        return instance.serialize(relations=True)
 
 
 class DepartmentResource(BaseModelResource):

--- a/zou/app/blueprints/crud/person.py
+++ b/zou/app/blueprints/crud/person.py
@@ -652,19 +652,23 @@ class PersonResource(BaseModelResource, ArgsMixin):
 
         if "expiration_date" in data and data["expiration_date"] is not None:
             try:
-                if (
-                    datetime.datetime.strptime(
-                        data["expiration_date"], "%Y-%m-%d"
-                    ).date()
-                    < datetime.date.today()
-                ):
-                    raise WrongParameterException(
-                        "Expiration date can't be in the past."
-                    )
-            except WrongParameterException:
-                raise
+                new_expiration_date = datetime.datetime.strptime(
+                    data["expiration_date"], "%Y-%m-%d"
+                ).date()
             except Exception:
                 raise WrongParameterException("Expiration date is not valid.")
+
+            # Reject a past date only when it actually changes. Re-submitting an
+            # already-expired person's own date (e.g. to disable a bot) must
+            # keep working, otherwise expired accounts can never be edited.
+            current_expiration_date = Person.get(instance_id).expiration_date
+            if (
+                new_expiration_date != current_expiration_date
+                and new_expiration_date < datetime.date.today()
+            ):
+                raise WrongParameterException(
+                    "Expiration date can't be in the past."
+                )
 
         if "email" in data:
             try:
@@ -730,7 +734,18 @@ class PersonResource(BaseModelResource, ArgsMixin):
         instance_dict["departments"] = [
             str(department.id) for department in self.instance.departments
         ]
-        if "expiration_date" in data:
+        regenerate_token = "expiration_date" in data
+        if regenerate_token and data["expiration_date"] is not None:
+            # A past date only yields an already-expired token that get_jti()
+            # then rejects (500/401). Skip regeneration so an expired bot
+            # keeps a stable token and stays editable.
+            regenerate_token = (
+                datetime.datetime.strptime(
+                    data["expiration_date"], "%Y-%m-%d"
+                ).date()
+                >= datetime.date.today()
+            )
+        if regenerate_token:
             instance_dict["access_token"] = (
                 persons_service.create_access_token_for_raw_person(
                     self.instance

--- a/zou/app/blueprints/crud/preview_background_file.py
+++ b/zou/app/blueprints/crud/preview_background_file.py
@@ -155,7 +155,7 @@ class PreviewBackgroundFilesResource(BaseModelsResource):
         if instance.is_default:
             files_service.reset_default_preview_background_files(instance.id)
         files_service.clear_preview_background_file_cache(str(instance.id))
-        return instance.serialize()
+        return instance.serialize(relations=True)
 
 
 class PreviewBackgroundFileResource(BaseModelResource):

--- a/zou/app/blueprints/crud/project.py
+++ b/zou/app/blueprints/crud/project.py
@@ -251,14 +251,14 @@ class ProjectsResource(BaseModelsResource):
         return data
 
     def post_creation(self, project):
-        project_dict = project.serialize()
+        project_dict = project.serialize(relations=True)
         if self._template_id_to_apply is not None:
             project_templates_service.apply_template_to_project(
                 str(project.id),
                 self._template_id_to_apply,
                 override_settings=self._template_overrides,
             )
-            project_dict = project.serialize()
+            project_dict = project.serialize(relations=True)
         if project.production_type == "tvshow":
             episode = shots_service.create_episode(
                 project.id,

--- a/zou/app/blueprints/crud/status_automation.py
+++ b/zou/app/blueprints/crud/status_automation.py
@@ -162,7 +162,7 @@ class StatusAutomationsResource(BaseModelsResource):
 
     def post_creation(self, status_automation):
         status_automations_service.clear_status_automation_cache()
-        return status_automation.serialize()
+        return status_automation.serialize(relations=True)
 
 
 class StatusAutomationResource(BaseModelResource):

--- a/zou/app/blueprints/crud/studio.py
+++ b/zou/app/blueprints/crud/studio.py
@@ -140,7 +140,7 @@ class StudiosResource(BaseModelsResource):
 
     def post_creation(self, instance):
         tasks_service.clear_studio_cache(str(instance.id))
-        return instance.serialize()
+        return instance.serialize(relations=True)
 
 
 class StudioResource(BaseModelResource):

--- a/zou/app/blueprints/crud/task.py
+++ b/zou/app/blueprints/crud/task.py
@@ -223,6 +223,9 @@ class TasksResource(BaseModelsResource, ArgsMixin):
         """
         try:
             data = request.json
+            # task.name is NOT NULL; default it like create_task() does so a
+            # client omitting it gets a task instead of an IntegrityError.
+            data["name"] = data.get("name") or "main"
             is_assignees = "assignees" in data
             assignees = None
 

--- a/zou/app/blueprints/crud/task_status.py
+++ b/zou/app/blueprints/crud/task_status.py
@@ -152,7 +152,7 @@ class TaskStatusesResource(BaseModelsResource):
 
     def post_creation(self, instance):
         tasks_service.clear_task_status_cache(str(instance.id))
-        return instance.serialize()
+        return instance.serialize(relations=True)
 
     def check_creation_integrity(self, data):
         if data.get("is_default", False):

--- a/zou/app/blueprints/crud/task_type.py
+++ b/zou/app/blueprints/crud/task_type.py
@@ -163,7 +163,7 @@ class TaskTypesResource(BaseModelsResource):
 
     def post_creation(self, instance):
         tasks_service.clear_task_type_cache(str(instance.id))
-        return instance.serialize()
+        return instance.serialize(relations=True)
 
 
 class TaskTypeResource(BaseModelResource):

--- a/zou/app/blueprints/crud/time_spent.py
+++ b/zou/app/blueprints/crud/time_spent.py
@@ -213,7 +213,7 @@ class TimeSpentsResource(BaseModelsResource):
             {"task_id": task_id},
             project_id=str(task.project_id),
         )
-        return instance.serialize()
+        return instance.serialize(relations=True)
 
 
 class TimeSpentResource(BaseModelResource):

--- a/zou/app/blueprints/source/csv/shots.py
+++ b/zou/app/blueprints/source/csv/shots.py
@@ -258,12 +258,22 @@ class ShotsCsvImportResource(BaseCsvProjectImportResource):
             shot_new_values["data"] = entity.data.copy()
 
         frame_in = row.get("Frame In", None) or row.get("In", None)
-        if frame_in is not None:
-            shot_new_values["data"]["frame_in"] = frame_in
+        if frame_in is not None and frame_in != "":
+            try:
+                shot_new_values["data"]["frame_in"] = int(frame_in)
+            except (ValueError, TypeError):
+                raise RowException(
+                    f"frame_in must be an integer, got '{frame_in}'"
+                )
 
         frame_out = row.get("Frame Out", None) or row.get("Out", None)
-        if frame_out is not None:
-            shot_new_values["data"]["frame_out"] = frame_out
+        if frame_out is not None and frame_out != "":
+            try:
+                shot_new_values["data"]["frame_out"] = int(frame_out)
+            except (ValueError, TypeError):
+                raise RowException(
+                    f"frame_out must be an integer, got '{frame_out}'"
+                )
 
         # Keep the frame count consistent with an imported frame range when
         # the CSV doesn't provide it explicitly.

--- a/zou/app/models/project.py
+++ b/zou/app/models/project.py
@@ -174,6 +174,7 @@ class Project(db.Model, BaseMixin, SerializerMixin):
     is_publish_default_for_artists = db.Column(db.Boolean(), default=False)
     is_bot_collaboration_enabled = db.Column(db.Boolean(), default=False)
     is_single_preview_per_revision = db.Column(db.Boolean(), default=False)
+    is_frame_in_numbering = db.Column(db.Boolean(), default=False)
     revision_padding = db.Column(db.Integer, default=0, nullable=False)
     hd_bitrate_compression = db.Column(db.Integer, default=28)
     ld_bitrate_compression = db.Column(db.Integer, default=6)

--- a/zou/app/models/project_template.py
+++ b/zou/app/models/project_template.py
@@ -137,6 +137,7 @@ class ProjectTemplate(db.Model, BaseMixin, SerializerMixin):
     is_set_preview_automated = db.Column(db.Boolean(), default=False)
     is_publish_default_for_artists = db.Column(db.Boolean(), default=False)
     is_single_preview_per_revision = db.Column(db.Boolean(), default=False)
+    is_frame_in_numbering = db.Column(db.Boolean(), default=False)
     revision_padding = db.Column(db.Integer, default=0, nullable=False)
     homepage = db.Column(db.String(80), default="assets")
     hd_bitrate_compression = db.Column(db.Integer, default=28)

--- a/zou/app/services/tasks_service.py
+++ b/zou/app/services/tasks_service.py
@@ -1842,7 +1842,10 @@ def add_preview_file_to_comment(comment_id, person_id, task_id, revision=None):
     events.emit(
         "comment:update", {"comment_id": comment.id}, project_id=project_id
     )
-    return preview_file.serialize()
+    # relations=True so the response has the same shape as a later GET on
+    # data/preview-files/<id> (it includes the comment the preview belongs
+    # to). See cgwire/gazu#385.
+    return preview_file.serialize(relations=True)
 
 
 def update_preview_file_info(preview_file):
@@ -1890,9 +1893,7 @@ def get_tasks_for_project(
     Return all tasks for given project.
     """
     query = (
-        Task.query.options(
-            selectinload(Task.assignees).load_only(Person.id)
-        )
+        Task.query.options(selectinload(Task.assignees).load_only(Person.id))
         .filter(Task.project_id == project_id)
         .order_by(Task.updated_at.desc())
     )

--- a/zou/app/services/tasks_service.py
+++ b/zou/app/services/tasks_service.py
@@ -18,6 +18,7 @@ from sqlalchemy.exc import StatementError, IntegrityError, DataError
 from sqlalchemy.sql import func
 from sqlalchemy.sql.expression import case
 from sqlalchemy.orm import aliased, load_only, selectinload
+from sqlalchemy.orm.exc import StaleDataError
 
 from zou.app import config, db
 from zou.app.utils import events
@@ -1676,16 +1677,22 @@ def clear_assignation(task_id, person_id=None):
     task = get_task_raw(task_id)
     project_id = str(task.project_id)
 
-    removed_assignments = []
     if person_id is None:
         removed_assignments = [person.serialize() for person in task.assignees]
-        task.update({"assignees": []})
+        new_assignees = []
     else:
-        assignees = [
+        removed_assignments = [{"id": person_id}]
+        new_assignees = [
             person for person in task.assignees if str(person.id) != person_id
         ]
-        task.update({"assignees": assignees})
-        removed_assignments = [{"id": person_id}]
+
+    try:
+        task.update({"assignees": new_assignees})
+    except StaleDataError:
+        # A concurrent unassign already removed the link, so the desired state
+        # is already reached. task.update() has rolled back its own failed
+        # transaction, so there is nothing left to delete: treat it as cleared.
+        pass
 
     clear_task_cache(task_id)
     task_dict = task.serialize()

--- a/zou/app/services/tasks_service.py
+++ b/zou/app/services/tasks_service.py
@@ -1849,9 +1849,6 @@ def add_preview_file_to_comment(comment_id, person_id, task_id, revision=None):
     events.emit(
         "comment:update", {"comment_id": comment.id}, project_id=project_id
     )
-    # relations=True so the response has the same shape as a later GET on
-    # data/preview-files/<id> (it includes the comment the preview belongs
-    # to). See cgwire/gazu#385.
     return preview_file.serialize(relations=True)
 
 

--- a/zou/migrations/versions/e8b2c4d6f1a3_add_frame_in_numbering.py
+++ b/zou/migrations/versions/e8b2c4d6f1a3_add_frame_in_numbering.py
@@ -1,0 +1,36 @@
+"""Add is_frame_in_numbering to project and project_template
+
+Revision ID: e8b2c4d6f1a3
+Revises: c7d3f9b2a1e4
+Create Date: 2026-07-17 10:00:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "e8b2c4d6f1a3"
+down_revision = "c7d3f9b2a1e4"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Default false: the frame counter keeps its classic numbering
+    # unless the production opts in.
+    for table in ("project", "project_template"):
+        with op.batch_alter_table(table, schema=None) as batch_op:
+            batch_op.add_column(
+                sa.Column(
+                    "is_frame_in_numbering",
+                    sa.Boolean(),
+                    nullable=True,
+                    server_default=sa.text("false"),
+                )
+            )
+
+
+def downgrade():
+    for table in ("project", "project_template"):
+        with op.batch_alter_table(table, schema=None) as batch_op:
+            batch_op.drop_column("is_frame_in_numbering")


### PR DESCRIPTION
**Problem**
- A freshly created entry has a different shape from the same entry fetched back: relation keys (a playlist's `build_jobs`, a preview file's `comments`) only appear on the single-instance GET
- CSV shot import stored empty or raw-string frame ranges, so `frame_in` mixed None, `''` and `"1001"` across shots
- POST /data/tasks without a name inserted NULL and surfaced as "Task already exists."
- Clearing an assignation already removed by a concurrent request raised StaleDataError
- A person with a past expiration_date could no longer be edited or disabled
- The Kitsu player frame counter always uses shot frame_in numbering; productions cannot opt out

**Solution**
- Serialize creation responses with `relations=True` in the generic CRUD POST, its `post_creation` overrides, and the add-preview action
- Treat empty frame cells as absent and coerce provided values to int on CSV import
- Default the task name to "main" on direct CRUD creation, like `create_task()`
- Catch the stale-link case and report the assignation as cleared
- Reject a past expiration_date only when it changes, and skip token regeneration for past dates
- Add an `is_frame_in_numbering` boolean (default false, opt-in) to project and project_template with the migration

Fix cgwire/gazu#385
