### PR TITLE
Serve safe image attachments inline again

### DIFF
--- a/tests/services/test_comments_service.py
+++ b/tests/services/test_comments_service.py
@@ -171,6 +171,30 @@ class CommentsServiceTestCase(ApiDBTestCase):
         self.assertEqual(attachment["extension"], "txt")
         self.assertGreater(attachment["size"], 0)
 
+    def test_is_inline_safe_mimetype(self):
+        for mimetype in [
+            "image/jpeg",
+            "image/png",
+            "image/gif",
+            "image/webp",
+            "IMAGE/PNG",
+            "image/jpeg; charset=binary",
+        ]:
+            self.assertTrue(
+                comments_service.is_inline_safe_mimetype(mimetype), mimetype
+            )
+        for mimetype in [
+            "image/svg+xml",
+            "text/html",
+            "application/pdf",
+            "application/octet-stream",
+            "",
+            None,
+        ]:
+            self.assertFalse(
+                comments_service.is_inline_safe_mimetype(mimetype), mimetype
+            )
+
     def test_get_attachment_file_path(self):
         comment = comments_service.new_comment(
             self.task.id, self.task_status.id, self.user["id"], "comment"

--- a/zou/app/blueprints/comments/resources.py
+++ b/zou/app/blueprints/comments/resources.py
@@ -90,10 +90,14 @@ class DownloadAttachmentResource(MethodView):
                 file_path,
                 conditional=True,
                 mimetype=attachment_file["mimetype"],
-                # Force download: the mimetype comes verbatim from the
-                # uploader, so serving inline would let an attacker run
-                # HTML/SVG in Kitsu's origin (stored XSS).
-                as_attachment=True,
+                # Serve safe raster images inline so they display in the
+                # browser; force download for everything else. The mimetype
+                # comes verbatim from the uploader, so serving e.g. HTML/SVG
+                # inline would let an attacker run code in Kitsu's origin
+                # (stored XSS).
+                as_attachment=not comments_service.is_inline_safe_mimetype(
+                    attachment_file["mimetype"]
+                ),
                 download_name=attachment_file["name"],
                 max_age=config.CLIENT_CACHE_MAX_AGE,
                 last_modified=date_helpers.get_datetime_from_string(

--- a/zou/app/services/comments_service.py
+++ b/zou/app/services/comments_service.py
@@ -77,6 +77,31 @@ def get_attachment_file_path(attachment_file):
     )
 
 
+# Raster image types that are safe to display inline. Paired with the global
+# X-Content-Type-Options: nosniff header, the browser honors the declared type
+# and will not sniff a disguised HTML payload into an executable document.
+# image/svg+xml is deliberately excluded: SVG can embed scripts and would run
+# in Kitsu's origin (stored XSS).
+INLINE_SAFE_MIMETYPES = {
+    "image/jpeg",
+    "image/png",
+    "image/gif",
+    "image/webp",
+    "image/bmp",
+    "image/avif",
+}
+
+
+def is_inline_safe_mimetype(mimetype):
+    """
+    Return True when an attachment with this mimetype may be served inline
+    (displayed in the browser) instead of forced as a download.
+    """
+    if not mimetype:
+        return False
+    return mimetype.split(";")[0].strip().lower() in INLINE_SAFE_MIMETYPES
+
+
 def create_comment(
     person_id,
     task_id,

--- a/zou/app/services/playlist_sharing_service.py
+++ b/zou/app/services/playlist_sharing_service.py
@@ -443,10 +443,13 @@ def download_shared_attachment(token, attachment_id, file_name):
         file_path,
         conditional=True,
         mimetype=attachment["mimetype"],
-        # Force download: this path is unauthenticated (share link) and the
-        # mimetype is attacker-controlled, so inline serving would allow a
+        # Serve safe raster images inline; force download for everything else.
+        # This path is unauthenticated (share link) and the mimetype is
+        # attacker-controlled, so serving e.g. HTML/SVG inline would allow a
         # stored XSS in Kitsu's origin.
-        as_attachment=True,
+        as_attachment=not comments_service.is_inline_safe_mimetype(
+            attachment["mimetype"]
+        ),
         download_name=attachment["name"],
     )
 


### PR DESCRIPTION
**Problem**
- Since the stored-XSS fix, every comment/playlist attachment is forced as a download, so legitimate images (jpeg, png…) no longer preview in a new tab of the browser.

Related to https://github.com/cgwire/kitsu/issues/2139

**Solution**
- Serve an allowlist of safe raster image mimetypes (jpeg, png, gif, webp, bmp, avif) inline on both the authenticated and shared-playlist routes, keeping the forced download for everything else (SVG included, as it can carry scripts); the global nosniff header keeps a disguised HTML payload from executing.
