### PR TITLE
[previews] Harden upload pipeline against stuck previews and silent corruption

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ install_requires =
     flask_mail==0.10.0
     flask_principal==0.4.0
     flask_sqlalchemy==3.1.1
-    flask-fs2[swift, s3]==0.8.1
+    flask-fs2[swift, s3]==0.8.2
     flask-jwt-extended==4.7.3
     flask-migrate==4.1.0
     flask-socketio==5.6.1

--- a/tests/services/test_chats_service.py
+++ b/tests/services/test_chats_service.py
@@ -1,7 +1,15 @@
+import io
+import os
+
+from unittest.mock import patch
+
+from werkzeug.datastructures import FileStorage
+
 from tests.base import ApiDBTestCase
 
+from zou.app import config
+from zou.app.models.attachment_file import AttachmentFile
 from zou.app.models.chat import Chat
-from zou.app.models.chat_message import ChatMessage
 
 from zou.app.services import chats_service
 
@@ -93,6 +101,45 @@ class ChatsServiceTestCase(ApiDBTestCase):
         self.assertEqual(result["id"], message["id"])
         messages = chats_service.get_chat_messages(chat.id)
         self.assertEqual(len(messages), 0)
+
+    def _create_message(self):
+        chat = chats_service.get_chat_raw(self.asset.id)
+        return chats_service.create_chat_message(
+            chat.id, str(self.person.id), "with attachment"
+        )
+
+    def test_create_attachment_non_image_removes_temp_file(self):
+        message = self._create_message()
+        uploaded_file = FileStorage(
+            stream=io.BytesIO(b"%PDF-1.4 fake content"),
+            filename="notes.pdf",
+            content_type="application/pdf",
+        )
+
+        attachment = chats_service._create_attachment(message, uploaded_file)
+
+        tmp_file_path = os.path.join(config.TMP_DIR, f"{attachment['id']}.pdf")
+        self.assertFalse(os.path.exists(tmp_file_path))
+
+    def test_create_attachment_failure_cleans_up(self):
+        message = self._create_message()
+        uploaded_file = FileStorage(
+            stream=io.BytesIO(b"%PDF-1.4 fake content"),
+            filename="notes.pdf",
+            content_type="application/pdf",
+        )
+        os.makedirs(config.TMP_DIR, exist_ok=True)
+        tmp_files_before = set(os.listdir(config.TMP_DIR))
+
+        with patch(
+            "zou.app.services.chats_service.file_store.add_file",
+            side_effect=OSError("storage down"),
+        ):
+            with self.assertRaises(OSError):
+                chats_service._create_attachment(message, uploaded_file)
+
+        self.assertEqual(AttachmentFile.query.count(), 0)
+        self.assertEqual(set(os.listdir(config.TMP_DIR)), tmp_files_before)
 
     def test_get_chat_message_raw(self):
         chat = chats_service.get_chat_raw(self.asset.id)

--- a/tests/services/test_comments_service.py
+++ b/tests/services/test_comments_service.py
@@ -1,8 +1,14 @@
 import io
+import os
+
+from unittest.mock import patch
 
 from werkzeug.datastructures import FileStorage
 
 from tests.base import ApiDBTestCase
+
+from zou.app import config
+from zou.app.models.attachment_file import AttachmentFile
 
 from zou.app.services import (
     comments_service,
@@ -194,6 +200,26 @@ class CommentsServiceTestCase(ApiDBTestCase):
             self.assertFalse(
                 comments_service.is_inline_safe_mimetype(mimetype), mimetype
             )
+
+    def test_create_attachment_failure_cleans_up(self):
+        comment = comments_service.new_comment(
+            self.task.id, self.task_status.id, self.user["id"], "comment"
+        )
+        uploaded_file = FileStorage(
+            stream=io.BytesIO(b"attachment content"), filename="notes.txt"
+        )
+        os.makedirs(config.TMP_DIR, exist_ok=True)
+        tmp_files_before = set(os.listdir(config.TMP_DIR))
+
+        with patch(
+            "zou.app.services.comments_service.file_store.add_file",
+            side_effect=OSError("storage down"),
+        ):
+            with self.assertRaises(OSError):
+                comments_service.create_attachment(comment, uploaded_file)
+
+        self.assertEqual(AttachmentFile.query.count(), 0)
+        self.assertEqual(set(os.listdir(config.TMP_DIR)), tmp_files_before)
 
     def test_get_attachment_file_path(self):
         comment = comments_service.new_comment(

--- a/tests/services/test_preview_files_service.py
+++ b/tests/services/test_preview_files_service.py
@@ -1,5 +1,6 @@
 import os
 import tempfile
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from tests.base import ApiDBTestCase
@@ -600,6 +601,67 @@ class PlaylistTestCase(ApiDBTestCase):
         for p in (uploaded_path, norm_path, norm_low_path):
             if os.path.exists(p):
                 os.remove(p)
+
+    @patch("zou.app.services.preview_files_service.movie.generate_thumbnail")
+    @patch("zou.app.services.preview_files_service.movie.get_movie_duration")
+    @patch("zou.app.services.preview_files_service.movie.get_movie_size")
+    @patch("zou.app.services.preview_files_service.movie.normalize_movie")
+    @patch("zou.app.services.preview_files_service.file_store.add_movie")
+    def test_prepare_and_store_movie_thumbnail_failure_marks_broken(
+        self,
+        mock_add_movie,
+        mock_normalize,
+        mock_size,
+        mock_duration,
+        mock_gen_thumbnail,
+    ):
+        preview_file = self.generate_fixture_preview_file(status="processing")
+        preview_file_id = str(preview_file.id)
+
+        tmp = tempfile.NamedTemporaryFile(suffix=".mp4", delete=False)
+        tmp.write(b"\x00" * 1024)
+        tmp.close()
+        uploaded_path = tmp.name
+        norm_path = uploaded_path + "_norm.mp4"
+        norm_low_path = uploaded_path + "_norm_low.mp4"
+        for p in (norm_path, norm_low_path):
+            with open(p, "wb") as f:
+                f.write(b"\x00" * 512)
+
+        mock_normalize.return_value = (norm_path, norm_low_path, None)
+        mock_size.return_value = (1920, 1080)
+        mock_duration.return_value = 10.0
+        mock_gen_thumbnail.side_effect = OSError("ffmpeg thumbnail crashed")
+
+        result = preview_files_service.prepare_and_store_movie(
+            preview_file_id,
+            uploaded_path,
+            normalize=True,
+            add_source_to_file_store=False,
+        )
+
+        self.assertEqual(result["status"], "broken")
+        persisted = files_service.get_preview_file(preview_file_id)
+        self.assertEqual(persisted["status"], "broken")
+        for p in (uploaded_path, norm_path, norm_low_path):
+            self.assertFalse(os.path.exists(p))
+
+    def test_mark_broken_on_job_failure(self):
+        preview_file = self.generate_fixture_preview_file(status="processing")
+        preview_file_id = str(preview_file.id)
+
+        tmp = tempfile.NamedTemporaryFile(suffix=".mp4", delete=False)
+        tmp.write(b"\x00" * 8)
+        tmp.close()
+
+        job = SimpleNamespace(args=(preview_file_id, tmp.name, True, False))
+        preview_files_service.mark_broken_on_job_failure(
+            job, None, Exception, Exception("worker killed"), None
+        )
+
+        persisted = files_service.get_preview_file(preview_file_id)
+        self.assertEqual(persisted["status"], "broken")
+        self.assertFalse(os.path.exists(tmp.name))
 
     def test_extract_skips_metadata_only_previews(self):
         """

--- a/tests/tasks/test_preview_processing_failure.py
+++ b/tests/tasks/test_preview_processing_failure.py
@@ -4,6 +4,8 @@ from unittest import mock
 
 from tests.base import ApiDBTestCase
 
+from zou.app.services import preview_files_service
+
 
 class PreviewProcessingFailureTestCase(ApiDBTestCase):
     """
@@ -66,4 +68,24 @@ class PreviewProcessingFailureTestCase(ApiDBTestCase):
         self.assertIn("normalization disabled", message)
         self.assertEqual(
             response.get("data", {}).get("reason"), "ffmpeg exploded"
+        )
+
+    @mock.patch("zou.app.config.ENABLE_JOB_QUEUE", True)
+    @mock.patch("zou.app.stores.queue_store.job_queue")
+    def test_movie_upload_enqueues_with_failure_callback(self, mock_queue):
+        """
+        The movie normalization job must carry an on_failure callback so a
+        killed worker cannot leave the preview file stuck in "processing".
+        """
+        preview_file_id, movie_path = self.add_movie_preview()
+
+        self.upload_file(
+            f"/pictures/preview-files/{preview_file_id}", movie_path
+        )
+
+        self.assertTrue(mock_queue.enqueue.called)
+        kwargs = mock_queue.enqueue.call_args.kwargs
+        self.assertEqual(
+            kwargs.get("on_failure"),
+            preview_files_service.mark_broken_on_job_failure,
         )

--- a/tests/tasks/test_preview_processing_failure.py
+++ b/tests/tasks/test_preview_processing_failure.py
@@ -70,6 +70,37 @@ class PreviewProcessingFailureTestCase(ApiDBTestCase):
             response.get("data", {}).get("reason"), "ffmpeg exploded"
         )
 
+    @mock.patch("zou.app.blueprints.previews.resources.movie.save_file")
+    def test_truncated_upload_is_rejected_and_cleaned_up(self, mock_save):
+        """
+        A movie spooled to a truncated (but non-empty) temporary file —
+        typically a full temp disk — must be rejected right away with a
+        clear error instead of reaching normalization, and the partial
+        file must be removed.
+        """
+        saved = {}
+
+        def save_truncated(tmp_folder, instance_id, file_to_save):
+            file_path = os.path.join(tmp_folder, f"{instance_id}.mp4.tmp")
+            os.makedirs(tmp_folder, exist_ok=True)
+            with open(file_path, "wb") as truncated_file:
+                truncated_file.write(b"\x00" * 10)
+            saved["path"] = file_path
+            return file_path
+
+        mock_save.side_effect = save_truncated
+        preview_file_id, movie_path = self.add_movie_preview()
+
+        response = self.upload_file(
+            f"/pictures/preview-files/{preview_file_id}",
+            movie_path,
+            code=500,
+        )
+
+        reason = response.get("data", {}).get("reason", "")
+        self.assertIn("partially written", reason)
+        self.assertFalse(os.path.exists(saved["path"]))
+
     @mock.patch("zou.app.config.ENABLE_JOB_QUEUE", True)
     @mock.patch("zou.app.stores.queue_store.job_queue")
     def test_movie_upload_enqueues_with_failure_callback(self, mock_queue):

--- a/zou/app/blueprints/previews/resources.py
+++ b/zou/app/blueprints/previews/resources.py
@@ -286,6 +286,7 @@ class BaseNewPreviewFilePicture:
                     save_source_file,
                 ),
                 job_timeout=int(config.JOB_QUEUE_TIMEOUT),
+                on_failure=preview_files_service.mark_broken_on_job_failure,
             )
         else:
             preview_files_service.prepare_and_store_movie(

--- a/zou/app/blueprints/previews/resources.py
+++ b/zou/app/blueprints/previews/resources.py
@@ -255,6 +255,22 @@ class BaseNewPreviewFilePicture:
             "height": height,
         }
 
+    @staticmethod
+    def _get_upload_stream_size(uploaded_file):
+        """
+        Return the byte size of the uploaded file stream, or None when the
+        stream is not seekable.
+        """
+        try:
+            stream = uploaded_file.stream
+            position = stream.tell()
+            stream.seek(0, os.SEEK_END)
+            size = stream.tell()
+            stream.seek(position)
+            return size
+        except (AttributeError, OSError, ValueError):
+            return None
+
     def save_movie_preview(
         self, preview_file_id, uploaded_file, normalize=True
     ):
@@ -274,6 +290,15 @@ class BaseNewPreviewFilePicture:
             raise WrongParameterException(
                 "Uploaded movie could not be written to temporary storage "
                 "or is empty; aborting before dispatching normalization."
+            )
+        expected_size = self._get_upload_stream_size(uploaded_file)
+        written_size = os.path.getsize(uploaded_movie_path)
+        if expected_size is not None and written_size != expected_size:
+            fs.rm_file(uploaded_movie_path)
+            raise PreviewProcessingFailedException(
+                f"Uploaded movie was only partially written to temporary "
+                f"storage ({written_size}/{expected_size} bytes); the "
+                f"temporary disk may be full."
             )
         save_source_file = config.PREVIEW_SAVE_SOURCE_FILE
         if normalize and config.ENABLE_JOB_QUEUE and not no_job:

--- a/zou/app/services/chats_service.py
+++ b/zou/app/services/chats_service.py
@@ -261,20 +261,38 @@ def _create_attachment(message, uploaded_file, randomize=False):
         chat_message_id=message["id"],
     )
 
-    # Store attachment file
+    # Store attachment file. On failure, drop the database entry to avoid
+    # a ghost attachment pointing to a missing object; the temporary file
+    # is removed in every case (it used to leak for non-image files).
     attachment_file_id = str(attachment_file.id)
     tmp_file_path = fs.save_file(tmp_folder, attachment_file_id, uploaded_file)
-    size = fs.get_file_size(tmp_file_path)
-    attachment_file.update({"size": size})
-    file_store.add_file("attachments", attachment_file_id, tmp_file_path)
+    image_path = None
+    try:
+        size = fs.get_file_size(tmp_file_path)
+        attachment_file.update({"size": size})
+        file_store.add_file("attachments", attachment_file_id, tmp_file_path)
 
-    # Create thumbnail for pictures
-    if "png" in mimetype or "jpg" in mimetype:
-        image_path = tmp_file_path
-        if "jpg" in mimetype:
-            image_path = thumbnail.convert_jpg_to_png(tmp_file_path)
-        thumbnail.resize(image_path, (150, 150), True)
-        file_store.add_picture("thumbnails", attachment_file_id, image_path)
-        fs.rm_file(image_path)
+        # Create thumbnail for pictures
+        if "png" in mimetype or "jpg" in mimetype:
+            image_path = tmp_file_path
+            if "jpg" in mimetype:
+                image_path = thumbnail.convert_jpg_to_png(tmp_file_path)
+            thumbnail.resize(image_path, (150, 150), True)
+            file_store.add_picture(
+                "thumbnails", attachment_file_id, image_path
+            )
+        return attachment_file.present()
+    except Exception:
+        try:
+            attachment_file.delete()
+        except Exception:
+            current_app.logger.error(
+                f"Failed to delete attachment file {attachment_file_id} "
+                f"after a storage failure",
+                exc_info=1,
+            )
+        raise
+    finally:
+        if image_path is not None and image_path != tmp_file_path:
+            fs.rm_file(image_path)
         fs.rm_file(tmp_file_path)
-    return attachment_file.present()

--- a/zou/app/services/comments_service.py
+++ b/zou/app/services/comments_service.py
@@ -1,5 +1,4 @@
 import datetime
-import os
 import re
 import random
 import string
@@ -567,12 +566,27 @@ def create_attachment(comment, uploaded_file, randomize=False, reply_id=None):
     )
     attachment_file_id = str(attachment_file.id)
 
+    # On storage failure, drop the database entry to avoid a ghost
+    # attachment pointing to a missing object; the temporary file is
+    # removed in every case.
     tmp_file_path = fs.save_file(tmp_folder, attachment_file_id, uploaded_file)
-    size = fs.get_file_size(tmp_file_path)
-    attachment_file.update({"size": size})
-    file_store.add_file("attachments", attachment_file_id, tmp_file_path)
-    os.remove(tmp_file_path)
-    return attachment_file.present()
+    try:
+        size = fs.get_file_size(tmp_file_path)
+        attachment_file.update({"size": size})
+        file_store.add_file("attachments", attachment_file_id, tmp_file_path)
+        return attachment_file.present()
+    except Exception:
+        try:
+            attachment_file.delete()
+        except Exception:
+            current_app.logger.error(
+                f"Failed to delete attachment file {attachment_file_id} "
+                f"after a storage failure",
+                exc_info=1,
+            )
+        raise
+    finally:
+        fs.rm_file(tmp_file_path)
 
 
 def get_all_attachment_files_for_project(project_id):

--- a/zou/app/services/preview_files_service.py
+++ b/zou/app/services/preview_files_service.py
@@ -255,6 +255,35 @@ def _abort_on_storage_failure(preview_file_id, operation, exc):
     return set_preview_file_as_broken(preview_file_id)
 
 
+def mark_broken_on_job_failure(
+    job, connection, exc_type, exc_value, traceback
+):
+    """
+    RQ failure callback for the movie normalization job: mark the preview
+    file as broken and drop its temporary file. Without it, a job killed by
+    timeout or a dead worker leaves the preview file stuck on "processing"
+    forever.
+    """
+    from zou.app import app as current_app
+
+    preview_file_id = job.args[0]
+    uploaded_movie_path = job.args[1] if len(job.args) > 1 else None
+    with current_app.app_context():
+        current_app.logger.error(
+            f"Normalization job failed for preview file {preview_file_id}: "
+            f"{exc_value}"
+        )
+        if uploaded_movie_path is not None:
+            _remove_temp_files(uploaded_movie_path)
+        try:
+            set_preview_file_as_broken(preview_file_id)
+        except PreviewFileNotFoundException:
+            current_app.logger.warning(
+                f"Preview file {preview_file_id} was deleted before its "
+                f"failed job could mark it as broken"
+            )
+
+
 def prepare_and_store_movie(
     preview_file_id,
     uploaded_movie_path,
@@ -415,42 +444,66 @@ def prepare_and_store_movie(
                 )
             normalized_movie_path = uploaded_movie_path
 
-        # Build thumbnails (skipped when remote v2+, done by Nomad job)
-        size = movie.get_movie_size(normalized_movie_path)
-        width, height = size
-        file_size = os.path.getsize(normalized_movie_path)
-        duration = movie.get_movie_duration(normalized_movie_path)
+        # Build thumbnails (skipped when remote v2+, done by Nomad job).
+        # Any failure here must mark the preview file as broken: an
+        # uncaught exception would kill the job and leave the status
+        # stuck on "processing" forever.
+        try:
+            size = movie.get_movie_size(normalized_movie_path)
+            width, height = size
+            file_size = os.path.getsize(normalized_movie_path)
+            duration = movie.get_movie_duration(normalized_movie_path)
 
-        remote_handles_thumbnails = is_remote and REMOTE_NORMALIZE_VERSION >= 2
-        if not remote_handles_thumbnails:
-            original_picture_path = movie.generate_thumbnail(
-                normalized_movie_path
+            remote_handles_thumbnails = (
+                is_remote and REMOTE_NORMALIZE_VERSION >= 2
             )
-            thumbnail_utils.turn_into_thumbnail(original_picture_path, size)
-            try:
-                save_variants(preview_file_id, original_picture_path)
-            except Exception as exc:
-                _remove_temp_files(
-                    uploaded_movie_path,
-                    normalized_movie_path,
-                    normalized_movie_low_path,
-                    original_picture_path,
+            if not remote_handles_thumbnails:
+                original_picture_path = movie.generate_thumbnail(
+                    normalized_movie_path
                 )
-                return _abort_on_storage_failure(
-                    preview_file_id, "thumbnail variants upload", exc
+                thumbnail_utils.turn_into_thumbnail(
+                    original_picture_path, size
                 )
-            current_app.logger.info(
-                f"thumbnail created {original_picture_path}"
-            )
+                try:
+                    save_variants(preview_file_id, original_picture_path)
+                except Exception as exc:
+                    _remove_temp_files(
+                        uploaded_movie_path,
+                        normalized_movie_path,
+                        normalized_movie_low_path,
+                        original_picture_path,
+                    )
+                    return _abort_on_storage_failure(
+                        preview_file_id, "thumbnail variants upload", exc
+                    )
+                current_app.logger.info(
+                    f"thumbnail created {original_picture_path}"
+                )
 
-            # Build tiles
-            try:
-                tile_path = movie.generate_tile(normalized_movie_path)
-                file_store.add_picture("tiles", preview_file_id, tile_path)
-                os.remove(tile_path)
-                current_app.logger.info(f"tile created {tile_path}")
-            except Exception:
-                current_app.logger.error("Failed to create tile", exc_info=1)
+                # Build tiles
+                try:
+                    tile_path = movie.generate_tile(normalized_movie_path)
+                    file_store.add_picture("tiles", preview_file_id, tile_path)
+                    os.remove(tile_path)
+                    current_app.logger.info(f"tile created {tile_path}")
+                except Exception:
+                    current_app.logger.error(
+                        "Failed to create tile", exc_info=1
+                    )
+        except Exception:
+            current_app.logger.error(
+                f"Failed to build thumbnails for preview file "
+                f"{preview_file_id}",
+                exc_info=1,
+            )
+            preview_file = set_preview_file_as_broken(preview_file_id)
+            _remove_temp_files(
+                uploaded_movie_path,
+                normalized_movie_path,
+                normalized_movie_low_path,
+                original_picture_path,
+            )
+            return preview_file
 
         # Remove files and update status
         try:


### PR DESCRIPTION
**Problem**
  - An uncaught exception in the thumbnail build step of prepare_and_store_movie kills the RQ job and leaves the preview file stuck on "processing" forever
  - The movie normalization job has no failure callback: a worker killed by timeout, OOM or redeploy also leaves the preview stuck on "processing"
  - A movie spooled to a truncated temporary file (full temp disk) is accepted, then fails later in normalization with the preview marked broken
  - Chat attachment temporary files are never removed for non-image files, slowly filling the temp directory
  - When the file store upload fails, chats and comments keep an orphan AttachmentFile row pointing to a missing object, and leak the temporary file
  - Swift uploads from file objects were sent chunked without Content-Length nor ETag, so a corrupted transfer was stored silently; dropped read_chunks() streams leaked connection pool slots until PoolExhaustedError


**Solution**
  - Wrap the thumbnail build step in a try/except that marks the preview file as broken and removes temporary files
  - Add mark_broken_on_job_failure and pass it as RQ on_failure callback when enqueuing the movie normalization job
  - Compare the spooled file size against the uploaded stream size in save_movie_preview and reject mismatches immediately with a 500 carrying both sizes
  - Rework chats_service._create_attachment and comments_service.create_attachment with try/except/finally: temporary files are always removed, and the AttachmentFile row is deleted when the storage upload fails
  - Bump flask-fs2 to 0.8.2, which precomputes Content-Length/ETag for seekable file uploads (server-side integrity check on every PUT) and recycles pool slots of streams dropped without close()