### PR TITLE
[plugins] Ship plugin_template data files in wheel

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -85,7 +85,7 @@ install_requires =
     werkzeug==3.1.8
 
 [options.package_data]
-* = app/*.json,app/file_trees/*.json,migrations/*,migrations/versions/*.py,app/utils/plugin_alembic_template/*
+* = app/*.json,app/file_trees/*.json,migrations/*,migrations/versions/*.py,app/utils/plugin_alembic_template/*,plugin_template/*,plugin_template/frontend/*/dist/*
 
 [options.packages.find]
 # ignore tests and build directories


### PR DESCRIPTION
**Problem**
- `zou create-plugin-skeleton` crashes with `FileNotFoundError` on `manifest.toml`: the `package_data` glob omitted `zou/plugin_template/`, so the published wheel shipped only its `.py` modules.

**Solution**
- Add `plugin_template/*` and `plugin_template/frontend/*/dist/*` to `package_data` so the manifest, `models.py.template`, logo and placeholder frontends ship in the wheel.

Fix #1171
