### PR TITLE
[tasks] Task metadata descriptors scoped per task type

### DIFF
--- a/tests/assets/test_asset_tasks.py
+++ b/tests/assets/test_asset_tasks.py
@@ -63,6 +63,11 @@ class AssetTasksTestCase(ApiDBTestCase):
             assets[0]["tasks"][0]["assignees"][0], str(self.person_id)
         )
 
+    def test_get_assets_and_tasks_include_task_data(self):
+        self.task.update({"data": {"render_layer": "bg"}})
+        assets = self.get("data/assets/with-tasks")
+        self.assertEqual(assets[0]["tasks"][0]["data"], {"render_layer": "bg"})
+
     def test_get_assets_and_tasks_compact(self):
         self.generate_fixture_task(name="Secondary")
         reference = self.get("data/assets/with-tasks")

--- a/tests/edits/test_edit_routes.py
+++ b/tests/edits/test_edit_routes.py
@@ -27,6 +27,16 @@ class EditRoutesTestCase(BaseEditTestCase):
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0]["name"], "Edit")
 
+    def test_get_edits_with_tasks_include_task_data(self):
+        self.task.update({"data": {"render_layer": "bg"}})
+        result = self.get("/data/edits/with-tasks")
+        task = next(
+            task
+            for task in result[0]["tasks"]
+            if task["id"] == str(self.task.id)
+        )
+        self.assertEqual(task["data"], {"render_layer": "bg"})
+
     def test_get_edits_with_tasks_wrong_id_format(self):
         self.get("/data/edits/with-tasks?project_id=not-a-uuid", 400)
         self.get("/data/edits/with-tasks?episode_id=not-a-uuid", 400)

--- a/tests/projects/test_route_metadata.py
+++ b/tests/projects/test_route_metadata.py
@@ -45,6 +45,17 @@ class ProjectMetadataRouteTestCase(ApiDBTestCase):
         project = self.get(f"data/projects/{self.project_id}")
         self.assertIsNone((project.get("data") or {}).get("ship_code"))
 
+    def test_add_date_metadata_descriptor(self):
+        descriptor = self.post(
+            f"data/projects/{self.project_id}/metadata-descriptors",
+            {
+                "entity_type": "Asset",
+                "name": "Due date",
+                "data_type": "date",
+            },
+        )
+        self.assertEqual(descriptor["data_type"], "date")
+
     def test_all_projects_metadata_descriptor(self):
         first_project_id = str(self.project_id)
         second_project = self.generate_fixture_project(name="Second Project")

--- a/tests/projects/test_route_metadata.py
+++ b/tests/projects/test_route_metadata.py
@@ -1,6 +1,7 @@
 from tests.base import ApiDBTestCase
 
 from zou.app.services import projects_service
+from zou.app.utils import fields
 
 
 class ProjectMetadataRouteTestCase(ApiDBTestCase):
@@ -242,3 +243,116 @@ class ProjectMetadataRouteTestCase(ApiDBTestCase):
             f"data/projects/{self.project_id}/metadata-descriptors/{descriptor['id']}",
             403,
         )
+
+    def post_task_descriptor(self, task_type_id, name="Render layer"):
+        return self.post(
+            f"data/projects/{self.project_id}/metadata-descriptors",
+            {
+                "entity_type": "Task",
+                "task_type_id": task_type_id,
+                "name": name,
+                "data_type": "string",
+            },
+        )
+
+    def test_add_task_metadata_descriptor(self):
+        self.generate_fixture_task()
+        task_type_id = str(self.task_type.id)
+        descriptor = self.post_task_descriptor(task_type_id)
+        self.assertEqual(descriptor["entity_type"], "Task")
+        self.assertEqual(descriptor["task_type_id"], task_type_id)
+        self.assertEqual(descriptor["field_name"], "render_layer")
+        # The same field name is allowed on another task type but not
+        # twice on the same one.
+        other = self.post_task_descriptor(str(self.task_type_modeling.id))
+        self.assertEqual(other["field_name"], "render_layer")
+        self.post(
+            f"data/projects/{self.project_id}/metadata-descriptors",
+            {
+                "entity_type": "Task",
+                "task_type_id": task_type_id,
+                "name": "Render layer",
+                "data_type": "string",
+            },
+            400,
+        )
+
+    def test_task_metadata_descriptor_in_open_projects_payload(self):
+        self.generate_fixture_task()
+        task_type_id = str(self.task_type.id)
+        self.post_task_descriptor(task_type_id)
+        projects = self.get("data/projects/open")
+        descriptor = projects[0]["descriptors"][0]
+        self.assertEqual(descriptor["task_type_id"], task_type_id)
+
+    def test_task_metadata_descriptor_requires_valid_task_type(self):
+        self.generate_fixture_task()
+        self.post(
+            f"data/projects/{self.project_id}/metadata-descriptors",
+            {
+                "entity_type": "Task",
+                "name": "Render layer",
+                "data_type": "string",
+            },
+            400,
+        )
+        self.post(
+            f"data/projects/{self.project_id}/metadata-descriptors",
+            {
+                "entity_type": "Task",
+                "task_type_id": str(fields.gen_uuid()),
+                "name": "Render layer",
+                "data_type": "string",
+            },
+            400,
+        )
+        self.post(
+            f"data/projects/{self.project_id}/metadata-descriptors",
+            {
+                "entity_type": "Asset",
+                "task_type_id": str(self.task_type.id),
+                "name": "Render layer",
+                "data_type": "string",
+            },
+            400,
+        )
+
+    def test_update_task_data_merges_metadata(self):
+        self.generate_fixture_task()
+        task_id = str(self.task.id)
+        self.put(f"data/tasks/{task_id}", {"data": {"render_layer": "bg"}})
+        self.put(f"data/tasks/{task_id}", {"data": {"note": "wip"}})
+        task = self.get(f"data/tasks/{task_id}")
+        self.assertEqual(task["data"].get("render_layer"), "bg")
+        self.assertEqual(task["data"].get("note"), "wip")
+
+    def test_rename_and_delete_task_metadata_descriptor(self):
+        self.generate_fixture_task()
+        task_id = str(self.task.id)
+        descriptor = self.post_task_descriptor(str(self.task_type.id))
+        self.post_task_descriptor(str(self.task_type_modeling.id))
+        other_task = self.generate_fixture_task(
+            name="Second", task_type_id=self.task_type_modeling.id
+        )
+        other_task_id = str(other_task.id)
+        self.put(f"data/tasks/{task_id}", {"data": {"render_layer": "bg"}})
+        self.put(
+            f"data/tasks/{other_task_id}", {"data": {"render_layer": "fg"}}
+        )
+        self.put(
+            f"data/projects/{self.project_id}/metadata-descriptors/{descriptor['id']}",
+            {"name": "Layer", "data_type": "string"},
+        )
+        task = self.get(f"data/tasks/{task_id}")
+        self.assertEqual(task["data"].get("layer"), "bg")
+        self.assertNotIn("render_layer", task["data"])
+        # The same field on another task type is left untouched.
+        other_task_data = self.get(f"data/tasks/{other_task_id}")["data"]
+        self.assertEqual(other_task_data.get("render_layer"), "fg")
+        self.delete(
+            f"data/projects/{self.project_id}/metadata-descriptors/{descriptor['id']}"
+        )
+        task = self.get(f"data/tasks/{task_id}")
+        self.assertNotIn("layer", task["data"] or {})
+        other_task_data = self.get(f"data/tasks/{other_task_id}")["data"]
+        self.assertEqual(other_task_data.get("render_layer"), "fg")

--- a/tests/projects/test_route_metadata.py
+++ b/tests/projects/test_route_metadata.py
@@ -56,6 +56,17 @@ class ProjectMetadataRouteTestCase(ApiDBTestCase):
         )
         self.assertEqual(descriptor["data_type"], "date")
 
+    def test_add_url_metadata_descriptor(self):
+        descriptor = self.post(
+            f"data/projects/{self.project_id}/metadata-descriptors",
+            {
+                "entity_type": "Asset",
+                "name": "Brief link",
+                "data_type": "url",
+            },
+        )
+        self.assertEqual(descriptor["data_type"], "url")
+
     def test_all_projects_metadata_descriptor(self):
         first_project_id = str(self.project_id)
         second_project = self.generate_fixture_project(name="Second Project")

--- a/tests/projects/test_route_metadata.py
+++ b/tests/projects/test_route_metadata.py
@@ -67,6 +67,17 @@ class ProjectMetadataRouteTestCase(ApiDBTestCase):
         )
         self.assertEqual(descriptor["data_type"], "url")
 
+    def test_add_person_metadata_descriptor(self):
+        descriptor = self.post(
+            f"data/projects/{self.project_id}/metadata-descriptors",
+            {
+                "entity_type": "Asset",
+                "name": "Reviewer",
+                "data_type": "person",
+            },
+        )
+        self.assertEqual(descriptor["data_type"], "person")
+
     def test_all_projects_metadata_descriptor(self):
         first_project_id = str(self.project_id)
         second_project = self.generate_fixture_project(name="Second Project")

--- a/tests/projects/test_route_metadata.py
+++ b/tests/projects/test_route_metadata.py
@@ -67,6 +67,17 @@ class ProjectMetadataRouteTestCase(ApiDBTestCase):
         )
         self.assertEqual(descriptor["data_type"], "url")
 
+    def test_add_textarea_metadata_descriptor(self):
+        descriptor = self.post(
+            f"data/projects/{self.project_id}/metadata-descriptors",
+            {
+                "entity_type": "Asset",
+                "name": "Notes",
+                "data_type": "textarea",
+            },
+        )
+        self.assertEqual(descriptor["data_type"], "textarea")
+
     def test_add_person_metadata_descriptor(self):
         descriptor = self.post(
             f"data/projects/{self.project_id}/metadata-descriptors",

--- a/tests/services/test_project_templates_service.py
+++ b/tests/services/test_project_templates_service.py
@@ -298,6 +298,35 @@ class ProjectTemplateServiceTestCase(ApiDBTestCase):
             descriptors[0]["departments"], [str(self.department.id)]
         )
 
+    def test_task_metadata_descriptor_round_trip(self):
+        projects_service.add_metadata_descriptor(
+            project_id=str(self.project.id),
+            entity_type="Task",
+            name="Render layer",
+            data_type="string",
+            choices=[],
+            for_client=False,
+            task_type_id=str(self.task_type.id),
+        )
+        template = project_templates_service.create_template_from_project(
+            str(self.project.id), name="From production"
+        )
+        snapshot = template["metadata_descriptors"]
+        self.assertEqual(len(snapshot), 1)
+        self.assertEqual(snapshot[0]["task_type_id"], str(self.task_type.id))
+
+        project = self.generate_fixture_project(name="Fresh Project")
+        project_templates_service.apply_template_to_project(
+            str(project.id), template["id"]
+        )
+        descriptors = MetadataDescriptor.query.filter_by(
+            project_id=project.id, entity_type="Task"
+        ).all()
+        self.assertEqual(len(descriptors), 1)
+        self.assertEqual(
+            str(descriptors[0].task_type_id), str(self.task_type.id)
+        )
+
     def test_create_template_from_project_does_not_copy_team(self):
         self.generate_fixture_person()
         projects_service.add_team_member(self.project_id, self.person.id)

--- a/tests/shots/test_sequence_tasks.py
+++ b/tests/shots/test_sequence_tasks.py
@@ -33,6 +33,13 @@ class SequenceTasksTestCase(ApiDBTestCase):
         )
         self.assertEqual(sequences[0]["name"], "S01")
 
+    def test_get_sequences_and_tasks_include_task_data(self):
+        self.sequence_task.update({"data": {"render_layer": "bg"}})
+        sequences = self.get("data/sequences/with-tasks")
+        self.assertEqual(
+            sequences[0]["tasks"][0]["data"], {"render_layer": "bg"}
+        )
+
     def test_get_task_types_for_sequence(self):
         self.generate_fixture_shot()
         self.generate_fixture_shot_task()

--- a/tests/shots/test_shot_tasks.py
+++ b/tests/shots/test_shot_tasks.py
@@ -61,6 +61,11 @@ class ShotTasksTestCase(ApiDBTestCase):
         self.assertEqual(shots[0]["episode_name"], "E01")
         self.assertEqual(shots[0]["sequence_name"], "S01")
 
+    def test_get_shots_and_tasks_include_task_data(self):
+        self.shot_task.update({"data": {"render_layer": "bg"}})
+        shots = self.get("data/shots/with-tasks")
+        self.assertEqual(shots[0]["tasks"][0]["data"], {"render_layer": "bg"})
+
     def test_get_shots_and_tasks_compact(self):
         self.generate_fixture_shot_task(name="Secondary")
         reference = self.get("data/shots/with-tasks")

--- a/tests/tasks/test_task_routes.py
+++ b/tests/tasks/test_task_routes.py
@@ -4,6 +4,7 @@ from zou.app.models.person import Person
 from zou.app.models.task import Task
 from zou.app.services import (
     concepts_service,
+    persons_service,
     projects_service,
     tasks_service,
 )
@@ -196,6 +197,39 @@ class TaskRoutesTestCase(ApiDBTestCase):
         self.generate_fixture_user_vendor()
         self.log_in_vendor()
         self.get("/data/persons/task-dates", 403)
+
+    def test_supervisor_in_department_can_update_task_data(self):
+        # A supervisor may write task metadata (task.data) when the task
+        # type's department is one of theirs.
+        self.generate_fixture_user_supervisor()
+        supervisor_id = self.user_supervisor["id"]
+        projects_service.add_team_member(self.project_id, supervisor_id)
+        persons_service.add_to_department(
+            str(self.department.id), supervisor_id
+        )
+        self.log_in_supervisor()
+        self.put(
+            f"/data/tasks/{self.task.id}",
+            {"data": {"render_engine": "cycles"}},
+        )
+        task = tasks_service.get_task(str(self.task.id))
+        self.assertEqual(task["data"]["render_engine"], "cycles")
+
+    def test_supervisor_outside_department_cannot_update_task_data(self):
+        # A supervisor whose departments do not include the task type's
+        # department is denied.
+        self.generate_fixture_user_supervisor()
+        supervisor_id = self.user_supervisor["id"]
+        projects_service.add_team_member(self.project_id, supervisor_id)
+        persons_service.add_to_department(
+            str(self.department_animation.id), supervisor_id
+        )
+        self.log_in_supervisor()
+        self.put(
+            f"/data/tasks/{self.task.id}",
+            {"data": {"render_engine": "cycles"}},
+            403,
+        )
 
     def test_assign_person_to_tasks(self):
         result = self.put(

--- a/zou/app/blueprints/crud/task.py
+++ b/zou/app/blueprints/crud/task.py
@@ -450,6 +450,10 @@ class TaskResource(BaseModelResource, ArgsMixin):
             self._previous_assignees = {
                 str(person.id) for person in self.instance.assignees
             }
+        # Metadata values pile up in the JSONB bag: merge the incoming
+        # dict instead of replacing the whole field, like entities do.
+        if data.get("data"):
+            data["data"] = {**(self.instance.data or {}), **data["data"]}
         return instance_dict
 
     def post_update(self, instance_dict, data):

--- a/zou/app/blueprints/projects/resources.py
+++ b/zou/app/blueprints/projects/resources.py
@@ -35,6 +35,7 @@ from zou.app.blueprints.projects.schemas import (
 )
 from zou.app.services.exception import (
     BudgetNotFoundException,
+    TaskTypeNotFoundException,
     WrongDateFormatException,
     WrongParameterException,
 )
@@ -1114,8 +1115,15 @@ class ProductionMetadataDescriptorsResource(MethodView, ArgsMixin):
                       - Episode
                       - Sequence
                       - Project
+                      - Task
                     default: "Asset"
                     example: "Asset"
+                  task_type_id:
+                    type: string
+                    format: uuid
+                    description: Task type the descriptor is scoped to.
+                      Required for Task descriptors, forbidden otherwise.
+                    example: a24a6ea4-ce75-4665-a070-57453082c25
                   name:
                     type: string
                     description: Name of the metadata descriptor
@@ -1176,10 +1184,25 @@ class ProductionMetadataDescriptorsResource(MethodView, ArgsMixin):
             "Episode",
             "Sequence",
             "Project",
+            "Task",
         ]:
             raise WrongParameterException(
                 "Wrong entity type. Please select Asset, Shot, Sequence, "
-                "Episode, Edit, or Project."
+                "Episode, Edit, Project, or Task."
+            )
+
+        if body.entity_type == "Task":
+            if body.task_type_id is None:
+                raise WrongParameterException(
+                    "Task metadata descriptors require a task_type_id."
+                )
+            try:
+                tasks_service.get_task_type(body.task_type_id)
+            except TaskTypeNotFoundException:
+                raise WrongParameterException("Task type not found.")
+        elif body.task_type_id is not None:
+            raise WrongParameterException(
+                "task_type_id only applies to Task metadata descriptors."
             )
 
         types = [type_name for type_name, _ in METADATA_DESCRIPTOR_TYPES]
@@ -1195,6 +1218,7 @@ class ProductionMetadataDescriptorsResource(MethodView, ArgsMixin):
                 body.choices,
                 body.for_client,
                 body.departments,
+                task_type_id=body.task_type_id,
             ),
             201,
         )
@@ -1458,10 +1482,11 @@ class ProductionMetadataDescriptorsReorderResource(MethodView, ArgsMixin):
             "Episode",
             "Sequence",
             "Project",
+            "Task",
         ]:
             raise WrongParameterException(
                 "Wrong entity type. Please select Asset, Shot, Sequence, "
-                "Episode, Edit, or Project."
+                "Episode, Edit, Project, or Task."
             )
 
         return projects_service.reorder_metadata_descriptors(

--- a/zou/app/blueprints/projects/schemas.py
+++ b/zou/app/blueprints/projects/schemas.py
@@ -79,6 +79,7 @@ class MetadataDescriptorSchema(BaseSchema):
     """
 
     entity_type: str = "Asset"
+    task_type_id: Optional[str] = None
     name: str = Field(..., min_length=1)
     data_type: str = Field("string", min_length=1)
     for_client: Optional[bool] = False

--- a/zou/app/models/metadata_descriptor.py
+++ b/zou/app/models/metadata_descriptor.py
@@ -38,6 +38,7 @@ METADATA_DESCRIPTOR_TYPES = [
     ("boolean", "Boolean"),
     ("checklist", "Checklist"),
     ("date", "Date"),
+    ("url", "URL"),
 ]
 
 

--- a/zou/app/models/metadata_descriptor.py
+++ b/zou/app/models/metadata_descriptor.py
@@ -53,6 +53,13 @@ class MetadataDescriptor(db.Model, BaseMixin, SerializerMixin):
         index=True,
     )
     entity_type = db.Column(db.String(60), nullable=False, index=True)
+    # Only set for "Task" descriptors: scopes the field to one task type.
+    task_type_id = db.Column(
+        UUIDType(binary=False),
+        db.ForeignKey("task_type.id"),
+        nullable=True,
+        index=True,
+    )
     name = db.Column(db.String(120), nullable=False)
     data_type = db.Column(ChoiceType(METADATA_DESCRIPTOR_TYPES))
     field_name = db.Column(db.String(120), nullable=False)
@@ -64,15 +71,44 @@ class MetadataDescriptor(db.Model, BaseMixin, SerializerMixin):
         secondary=DepartmentMetadataDescriptorLink.__table__,
     )
 
+    # Partial indexes instead of plain unique constraints: NULLs are
+    # distinct in Postgres unique constraints, so task_type_id could not
+    # be part of a single constraint without weakening uniqueness for
+    # non-Task descriptors.
     __table_args__ = (
-        db.UniqueConstraint(
-            "project_id", "entity_type", "name", name="metadata_descriptor_uc"
+        db.Index(
+            "metadata_descriptor_uc",
+            "project_id",
+            "entity_type",
+            "name",
+            unique=True,
+            postgresql_where=db.text("task_type_id IS NULL"),
         ),
-        db.UniqueConstraint(
+        db.Index(
+            "metadata_descriptor_uc2",
             "project_id",
             "entity_type",
             "field_name",
-            name="metadata_descriptor_uc2",
+            unique=True,
+            postgresql_where=db.text("task_type_id IS NULL"),
+        ),
+        db.Index(
+            "metadata_descriptor_task_type_uc",
+            "project_id",
+            "entity_type",
+            "task_type_id",
+            "name",
+            unique=True,
+            postgresql_where=db.text("task_type_id IS NOT NULL"),
+        ),
+        db.Index(
+            "metadata_descriptor_task_type_uc2",
+            "project_id",
+            "entity_type",
+            "task_type_id",
+            "field_name",
+            unique=True,
+            postgresql_where=db.text("task_type_id IS NOT NULL"),
         ),
     )
 

--- a/zou/app/models/metadata_descriptor.py
+++ b/zou/app/models/metadata_descriptor.py
@@ -39,6 +39,7 @@ METADATA_DESCRIPTOR_TYPES = [
     ("checklist", "Checklist"),
     ("date", "Date"),
     ("url", "URL"),
+    ("person", "Person"),
 ]
 
 

--- a/zou/app/models/metadata_descriptor.py
+++ b/zou/app/models/metadata_descriptor.py
@@ -37,6 +37,7 @@ METADATA_DESCRIPTOR_TYPES = [
     ("taglist", "Taglist"),
     ("boolean", "Boolean"),
     ("checklist", "Checklist"),
+    ("date", "Date"),
 ]
 
 

--- a/zou/app/models/metadata_descriptor.py
+++ b/zou/app/models/metadata_descriptor.py
@@ -39,6 +39,7 @@ METADATA_DESCRIPTOR_TYPES = [
     ("checklist", "Checklist"),
     ("date", "Date"),
     ("url", "URL"),
+    ("textarea", "Textarea"),
     ("person", "Person"),
 ]
 

--- a/zou/app/services/assets_service.py
+++ b/zou/app/services/assets_service.py
@@ -254,6 +254,7 @@ ASSETS_AND_TASKS_TASK_FIELDS = [
     "task_status_id",
     "task_type_id",
     "assignees",
+    "data",
 ]
 
 
@@ -340,6 +341,7 @@ def prepare_assets_and_tasks(
         Task.last_comment_date,
         cast(Task.last_preview_file_id, Text).label("last_preview_file_id"),
         Task.difficulty,
+        Task.data,
     )
     if assigned_to:
         task_query = task_query.filter(user_service.build_assignee_filter())
@@ -434,6 +436,7 @@ def prepare_assets_and_tasks(
                 row.task_status_id,
                 row.task_type_id,
                 assignees_by_task.get(row.id, []),
+                fields.serialize_value(row.data),
             ]
 
     else:
@@ -462,6 +465,7 @@ def prepare_assets_and_tasks(
                 "task_status_id": row.task_status_id,
                 "task_type_id": row.task_type_id,
                 "assignees": assignees_by_task.get(row.id, []),
+                "data": fields.serialize_value(row.data),
             }
 
     def iterate():

--- a/zou/app/services/concepts_service.py
+++ b/zou/app/services/concepts_service.py
@@ -182,6 +182,7 @@ CONCEPTS_AND_TASKS_TASK_FIELDS = [
     "start_date",
     "task_status_id",
     "task_type_id",
+    "data",
 ]
 
 

--- a/zou/app/services/edits_service.py
+++ b/zou/app/services/edits_service.py
@@ -94,6 +94,7 @@ EDITS_AND_TASKS_TASK_FIELDS = [
     "start_date",
     "task_status_id",
     "task_type_id",
+    "data",
 ]
 
 

--- a/zou/app/services/entities_service.py
+++ b/zou/app/services/entities_service.py
@@ -285,6 +285,7 @@ _TASK_FIELD_BUILDERS = {
     "nb_assets_ready": lambda row: row.nb_assets_ready,
     "difficulty": lambda row: row.difficulty,
     "nb_drawings": lambda row: row.nb_drawings,
+    "data": lambda row: fields.serialize_value(row.data),
 }
 
 ENTITIES_AND_TASKS_TASK_FIELDS = [
@@ -304,6 +305,7 @@ ENTITIES_AND_TASKS_TASK_FIELDS = [
     "difficulty",
     "task_status_id",
     "task_type_id",
+    "data",
 ]
 
 
@@ -347,6 +349,7 @@ def fetch_entity_task_map(
         Task.nb_assets_ready,
         Task.difficulty,
         Task.nb_drawings,
+        Task.data,
     )
     if assigned_to:
         task_query = task_query.filter(user_service.build_assignee_filter())

--- a/zou/app/services/project_templates_service.py
+++ b/zou/app/services/project_templates_service.py
@@ -559,10 +559,12 @@ def _clean_descriptor_dict(descriptor):
     field_name = descriptor.get("field_name") or slugify.slugify(
         name, separator="_"
     )
+    task_type_id = descriptor.get("task_type_id")
     return {
         "name": name,
         "field_name": field_name,
         "entity_type": descriptor.get("entity_type"),
+        "task_type_id": str(task_type_id) if task_type_id else None,
         "data_type": descriptor.get("data_type"),
         "choices": descriptor.get("choices") or [],
         "for_client": bool(descriptor.get("for_client", False)),
@@ -687,6 +689,11 @@ def _snapshot_descriptors(project_id):
                 "name": descriptor.name,
                 "field_name": descriptor.field_name,
                 "entity_type": descriptor.entity_type,
+                "task_type_id": (
+                    str(descriptor.task_type_id)
+                    if descriptor.task_type_id is not None
+                    else None
+                ),
                 "data_type": (
                     descriptor.data_type.code
                     if descriptor.data_type is not None
@@ -860,9 +867,15 @@ def _create_descriptor_from_snapshot(project_id, descriptor):
     entity_type = descriptor.get("entity_type")
     if not name or not entity_type:
         return None
+    task_type_id = descriptor.get("task_type_id")
+    if entity_type == "Task" and task_type_id is None:
+        return None
 
     existing = MetadataDescriptor.query.filter_by(
-        project_id=project_id, entity_type=entity_type, name=name
+        project_id=project_id,
+        entity_type=entity_type,
+        name=name,
+        task_type_id=task_type_id,
     ).first()
     if existing is not None:
         return existing
@@ -876,6 +889,7 @@ def _create_descriptor_from_snapshot(project_id, descriptor):
             choices=descriptor.get("choices") or [],
             for_client=bool(descriptor.get("for_client", False)),
             departments=descriptor.get("departments") or [],
+            task_type_id=task_type_id,
         )
     except WrongParameterException:
         return None

--- a/zou/app/services/projects_service.py
+++ b/zou/app/services/projects_service.py
@@ -16,6 +16,7 @@ from zou.app.models.project import (
 )
 from zou.app.models.project_status import ProjectStatus
 from zou.app.models.status_automation import StatusAutomation
+from zou.app.models.task import Task
 from zou.app.models.task_type import TaskType
 from zou.app.models.task_status import TaskStatus
 from zou.app.models.department import Department
@@ -222,6 +223,7 @@ def _serialize_descriptor(descriptor):
         "choices": descriptor.choices,
         "for_client": descriptor.for_client or False,
         "entity_type": descriptor.entity_type,
+        "task_type_id": fields.serialize_value(descriptor.task_type_id),
         "position": descriptor.position,
         "departments": [
             str(department.id) for department in descriptor.departments
@@ -688,6 +690,16 @@ def _entity_query_for_descriptor_entity_type(descriptor):
     return query
 
 
+def _task_query_for_descriptor(descriptor):
+    """
+    Tasks whose `data` may hold values for this Task descriptor.
+    """
+    return Task.query.filter(
+        Task.project_id == descriptor.project_id,
+        Task.task_type_id == descriptor.task_type_id,
+    )
+
+
 def _strip_metadata_field_from_model_data(model, field_name):
     """
     Remove field_name from model.data when `data` is not null.
@@ -711,6 +723,16 @@ def _migrate_descriptor_field_rename(descriptor, new_field_name):
             use_no_commit=False,
         )
         return
+    if descriptor.entity_type == "Task":
+        for task in _task_query_for_descriptor(descriptor).all():
+            _migrate_metadata_field_name(
+                task,
+                descriptor.field_name,
+                new_field_name,
+                use_no_commit=True,
+            )
+        Task.commit()
+        return
     entities = _entity_query_for_descriptor_entity_type(descriptor).all()
     for entity in entities:
         _migrate_metadata_field_name(
@@ -731,6 +753,10 @@ def _remove_stored_values_for_metadata_descriptor(descriptor):
         project = get_project_raw(descriptor.project_id)
         _strip_metadata_field_from_model_data(project, descriptor.field_name)
         return
+    if descriptor.entity_type == "Task":
+        for task in _task_query_for_descriptor(descriptor).all():
+            _strip_metadata_field_from_model_data(task, descriptor.field_name)
+        return
     for entity in Entity.get_all_by(project_id=descriptor.project_id):
         _strip_metadata_field_from_model_data(entity, descriptor.field_name)
 
@@ -743,11 +769,13 @@ def add_metadata_descriptor(
     choices,
     for_client,
     departments=None,
+    task_type_id=None,
 ):
     """
     Register a custom field for the given `entity_type` in this project.
-    Values are stored in `Entity.data` (Asset, Shot, …) or in `Project.data`
-    when `entity_type` is ``Project``.
+    Values are stored in `Entity.data` (Asset, Shot, …), in `Project.data`
+    when `entity_type` is ``Project`` or in `Task.data` when it is
+    ``Task`` (scoped to `task_type_id`).
     """
     if not departments:
         departments = []
@@ -765,6 +793,7 @@ def add_metadata_descriptor(
         descriptor = MetadataDescriptor.create(
             project_id=project_id,
             entity_type=entity_type,
+            task_type_id=task_type_id,
             name=name,
             data_type=data_type,
             choices=choices,

--- a/zou/app/services/shots_service.py
+++ b/zou/app/services/shots_service.py
@@ -268,6 +268,7 @@ SHOTS_AND_TASKS_TASK_FIELDS = [
     "task_status_id",
     "task_type_id",
     "assignees",
+    "data",
 ]
 
 
@@ -378,6 +379,7 @@ def prepare_shots_and_tasks(criterions=None, compact=False):
         Task.nb_assets_ready,
         Task.difficulty,
         Task.nb_drawings,
+        Task.data,
     )
     if assigned_to:
         task_query = task_query.filter(user_service.build_assignee_filter())
@@ -439,6 +441,7 @@ def prepare_shots_and_tasks(criterions=None, compact=False):
                 row.task_status_id,
                 row.task_type_id,
                 assignees_by_task.get(row.id, []),
+                fields.serialize_value(row.data),
             ]
 
     else:
@@ -469,6 +472,7 @@ def prepare_shots_and_tasks(criterions=None, compact=False):
                 "task_status_id": row.task_status_id,
                 "task_type_id": row.task_type_id,
                 "assignees": assignees_by_task.get(row.id, []),
+                "data": fields.serialize_value(row.data),
             }
 
     def iterate():

--- a/zou/app/services/user_service.py
+++ b/zou/app/services/user_service.py
@@ -697,6 +697,7 @@ def check_supervisor_task_access(task, new_data=None):
             "due_date",
             "estimation",
             "difficulty",
+            "data",
         }
         if len(set(new_data.keys()) - allowed_columns) == 0:
             user_departments = persons_service.get_current_user(

--- a/zou/migrations/versions/f3a7c1e9b5d2_add_task_metadata_descriptors.py
+++ b/zou/migrations/versions/f3a7c1e9b5d2_add_task_metadata_descriptors.py
@@ -1,0 +1,92 @@
+"""Add task_type_id to metadata_descriptor for task metadata
+
+Revision ID: f3a7c1e9b5d2
+Revises: e8b2c4d6f1a3
+Create Date: 2026-07-20 10:00:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+import sqlalchemy_utils
+
+revision = "f3a7c1e9b5d2"
+down_revision = "e8b2c4d6f1a3"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("metadata_descriptor", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "task_type_id",
+                sqlalchemy_utils.types.uuid.UUIDType(binary=False),
+                nullable=True,
+            )
+        )
+        batch_op.create_index(
+            batch_op.f("ix_metadata_descriptor_task_type_id"),
+            ["task_type_id"],
+            unique=False,
+        )
+        batch_op.create_foreign_key(
+            "fk_metadata_descriptor_task_type_id",
+            "task_type",
+            ["task_type_id"],
+            ["id"],
+        )
+        # The plain unique constraints become partial unique indexes:
+        # NULLs are distinct in Postgres unique constraints, so a single
+        # constraint including task_type_id would stop protecting
+        # non-Task descriptors from duplicates.
+        batch_op.drop_constraint("metadata_descriptor_uc", type_="unique")
+        batch_op.drop_constraint("metadata_descriptor_uc2", type_="unique")
+    op.create_index(
+        "metadata_descriptor_uc",
+        "metadata_descriptor",
+        ["project_id", "entity_type", "name"],
+        unique=True,
+        postgresql_where=sa.text("task_type_id IS NULL"),
+    )
+    op.create_index(
+        "metadata_descriptor_uc2",
+        "metadata_descriptor",
+        ["project_id", "entity_type", "field_name"],
+        unique=True,
+        postgresql_where=sa.text("task_type_id IS NULL"),
+    )
+    op.create_index(
+        "metadata_descriptor_task_type_uc",
+        "metadata_descriptor",
+        ["project_id", "entity_type", "task_type_id", "name"],
+        unique=True,
+        postgresql_where=sa.text("task_type_id IS NOT NULL"),
+    )
+    op.create_index(
+        "metadata_descriptor_task_type_uc2",
+        "metadata_descriptor",
+        ["project_id", "entity_type", "task_type_id", "field_name"],
+        unique=True,
+        postgresql_where=sa.text("task_type_id IS NOT NULL"),
+    )
+
+
+def downgrade():
+    op.drop_index("metadata_descriptor_task_type_uc2", "metadata_descriptor")
+    op.drop_index("metadata_descriptor_task_type_uc", "metadata_descriptor")
+    op.drop_index("metadata_descriptor_uc2", "metadata_descriptor")
+    op.drop_index("metadata_descriptor_uc", "metadata_descriptor")
+    with op.batch_alter_table("metadata_descriptor", schema=None) as batch_op:
+        batch_op.drop_constraint(
+            "fk_metadata_descriptor_task_type_id", type_="foreignkey"
+        )
+        batch_op.drop_index(batch_op.f("ix_metadata_descriptor_task_type_id"))
+        batch_op.drop_column("task_type_id")
+        batch_op.create_unique_constraint(
+            "metadata_descriptor_uc", ["project_id", "entity_type", "name"]
+        )
+        batch_op.create_unique_constraint(
+            "metadata_descriptor_uc2",
+            ["project_id", "entity_type", "field_name"],
+        )


### PR DESCRIPTION
**Problem**
- Task types could not carry their own production metadata: descriptors were entity-only (asset/shot/edit), leaving nowhere to store per-task-type fields.
- Task metadata (task.data) could only be written by admins and project managers.

**Solution**
- Add metadata descriptors scoped per task type, with new date, url, textarea and person descriptor types, and carry them through project templates.
- Include task data in the with-tasks payloads so clients can display it.
- Let supervisors edit task metadata when the task type's department is one of theirs.