### PR TITLE
[projects] Allow a different role per project for team members

### DIFF
--- a/tests/services/test_project_roles.py
+++ b/tests/services/test_project_roles.py
@@ -278,6 +278,17 @@ class TeamRoleServiceTestCase(ApiDBTestCase):
             "admin",
         )
 
+    def test_add_team_member_rejects_admin_without_partial_state(self):
+        self.assertRaises(
+            WrongParameterException,
+            projects_service.add_team_member,
+            str(self.project.id),
+            str(self.person.id),
+            "admin",
+        )
+        project = projects_service.get_project_raw(str(self.project.id))
+        self.assertEqual(len(project.team), 0)
+
 
 class TeamRoleApiTestCase(ApiDBTestCase):
     def setUp(self):

--- a/tests/services/test_project_roles.py
+++ b/tests/services/test_project_roles.py
@@ -1,12 +1,15 @@
 from flask import g
+from flask_jwt_extended import verify_jwt_in_request
 
 from tests.base import ApiDBTestCase
 
 from zou.app import app, db
 from zou.app.models.person import Person
 from zou.app.models.project import ProjectPersonLink
+from zou.app.models.studio import Studio
 from zou.app.services import (
     comments_service,
+    entities_service,
     projects_service,
     tasks_service,
     user_service,
@@ -311,3 +314,372 @@ class DirectRoleReadTestCase(ApiDBTestCase):
         self.make_comment(str(self.person.id))
         comment_map = tasks_service.get_last_comment_map([str(self.task.id)])
         self.assertEqual(comment_map, {})
+
+
+class AllShotsRoleTestCase(ApiDBTestCase):
+    """
+    Coverage audit fix: shots/resources.py AllShotsResource.get moves
+    check_project_access above the vendor filter so a project-scoped
+    vendor demotion is honored.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.generate_base_context()
+        self.generate_fixture_episode()
+        self.generate_fixture_sequence()
+        self.generate_fixture_shot()
+        self.generate_fixture_shot_task()
+        self.generate_fixture_user_manager()
+
+    def test_demoted_vendor_scoped_to_assigned_shots(self):
+        manager_id = str(self.user_manager["id"])
+        projects_service.add_team_member(
+            str(self.project.id), manager_id, role="vendor"
+        )
+        self.log_in_manager()
+        shots = self.get(f"data/shots?project_id={self.project.id}")
+        self.assertEqual(len(shots), 0)
+        tasks_service.assign_task(str(self.shot_task.id), manager_id)
+        shots = self.get(f"data/shots?project_id={self.project.id}")
+        self.assertEqual(len(shots), 1)
+
+
+class ProjectPersonQuotasRoleTestCase(ApiDBTestCase):
+    """
+    Coverage audit fix: shots/resources.py ProjectPersonQuotasResource.get
+    resolves the project role before branching, so a demoted manager falls
+    to the person-access branch instead of the project-wide one.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.generate_base_context()
+        self.generate_fixture_user_manager()
+        self.generate_fixture_person()
+
+    def test_demoted_manager_cannot_view_other_person_quotas(self):
+        manager_id = str(self.user_manager["id"])
+        projects_service.add_team_member(
+            str(self.project.id), manager_id, role="user"
+        )
+        self.log_in_manager()
+        self.get(
+            f"data/projects/{self.project.id}/quotas/persons/"
+            f"{self.person.id}",
+            403,
+        )
+
+
+class TaskCommentDeleteRoleTestCase(ApiDBTestCase):
+    """
+    Coverage audit fix: tasks/resources.py TaskCommentResource.delete
+    resolves the project role before branching, so a demoted manager
+    cannot delete another person's comment.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.generate_base_context()
+        self.generate_fixture_asset()
+        self.generate_fixture_task()
+        self.generate_fixture_comment()
+        self.generate_fixture_user_manager()
+
+    def test_demoted_manager_cannot_delete_others_comment(self):
+        manager_id = str(self.user_manager["id"])
+        projects_service.add_team_member(
+            str(self.project.id), manager_id, role="user"
+        )
+        self.log_in_manager()
+        self.delete(
+            f"data/tasks/{self.task.id}/comments/{self.comment['id']}", 403
+        )
+
+
+class CommentUpdateRoleTestCase(ApiDBTestCase):
+    """
+    Coverage audit fix: crud/comments.py
+    CommentResource.check_update_permissions resolves the project role via
+    check_belong_to_project before the has_manager check, so a demoted
+    manager loses comment-edit powers.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.generate_base_context()
+        self.generate_fixture_asset()
+        self.generate_fixture_task()
+        self.generate_fixture_comment()
+        self.generate_fixture_user_manager()
+
+    def test_demoted_manager_cannot_edit_others_comment(self):
+        manager_id = str(self.user_manager["id"])
+        projects_service.add_team_member(
+            str(self.project.id), manager_id, role="user"
+        )
+        self.log_in_manager()
+        self.put(
+            f"data/comments/{self.comment['id']}",
+            {"text": "Edited"},
+            403,
+        )
+
+
+class CommentReplyRoleTestCase(ApiDBTestCase):
+    """
+    Coverage audit fix: comments/resources.py reply() runs
+    check_task_action_access (which resolves the project role) before the
+    client-isolation branch, so a demoted client cannot reply across
+    studios.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.generate_base_context()
+        self.generate_fixture_asset()
+        self.generate_fixture_task()
+        self.generate_fixture_user_manager()
+        self.generate_fixture_user_client()
+
+    def test_demoted_client_blocked_from_replying_across_studios(self):
+        studio_a = Studio.create(name="Studio A", color="#FF0000")
+        studio_b = Studio.create(name="Studio B", color="#00FF00")
+
+        author_id = str(self.user_client["id"])
+        author = Person.get(author_id)
+        author.update({"studio_id": studio_a.id})
+        projects_service.add_team_member(
+            str(self.project.id), author_id, role="client"
+        )
+        comment = comments_service.create_comment(
+            person_id=author_id,
+            task_id=str(self.task.id),
+            task_status_id=str(self.task_status.id),
+            text="Client note",
+        )
+
+        manager_id = str(self.user_manager["id"])
+        manager = Person.get(manager_id)
+        manager.update({"studio_id": studio_b.id})
+        projects_service.add_team_member(
+            str(self.project.id), manager_id, role="client"
+        )
+
+        self.log_in_manager()
+        self.post(
+            f"data/tasks/{self.task.id}/comments/{comment['id']}/reply",
+            {"text": "reply"},
+            403,
+        )
+
+
+class PreviewThumbnailRoleTestCase(ApiDBTestCase):
+    """
+    Coverage audit fix: previews/resources.py
+    BasePreviewFileThumbnailResource.is_allowed resolves the project role
+    before checking has_vendor_permissions, so a demoted vendor does not
+    get the shared-preview shortcut.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.generate_base_context()
+        self.generate_fixture_asset()
+        self.generate_fixture_task()
+        self.generate_fixture_preview_file()
+        self.asset.update(
+            {
+                "preview_file_id": str(self.preview_file.id),
+                "is_shared": True,
+            }
+        )
+        self.generate_fixture_user_manager()
+
+    def test_demoted_vendor_must_be_assigned_for_shared_thumbnail(self):
+        manager_id = str(self.user_manager["id"])
+        projects_service.add_team_member(
+            str(self.project.id), manager_id, role="vendor"
+        )
+        self.log_in_manager()
+        self.get(
+            f"/pictures/thumbnails/preview-files/{self.preview_file.id}.png",
+            403,
+        )
+
+
+class PreviewFileReadRoleTestCase(ApiDBTestCase):
+    """
+    Coverage audit fix: crud/preview_file.py
+    PreviewFileResource.check_read_permissions resolves the project role
+    before checking has_vendor_permissions, so a demoted vendor must be
+    working on the task.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.generate_base_context()
+        self.generate_fixture_asset()
+        self.generate_fixture_task()
+        self.generate_fixture_preview_file()
+        self.generate_fixture_user_manager()
+
+    def test_demoted_vendor_not_working_on_task_cannot_read(self):
+        manager_id = str(self.user_manager["id"])
+        projects_service.add_team_member(
+            str(self.project.id), manager_id, role="vendor"
+        )
+        self.log_in_manager()
+        self.get(f"data/preview-files/{self.preview_file.id}", 403)
+
+
+class OutputFileUpdateRoleTestCase(ApiDBTestCase):
+    """
+    Coverage audit fix: crud/output_file.py
+    OutputFileResource.check_update_permissions checks
+    has_manager_project_access instead of the global
+    has_manager_permissions, so a demoted manager must be working on the
+    entity.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.generate_base_context()
+        self.generate_fixture_asset()
+        self.generate_fixture_output_type()
+        self.generate_fixture_output_file()
+        self.generate_fixture_user_manager()
+
+    def test_demoted_manager_must_be_working_on_entity(self):
+        manager_id = str(self.user_manager["id"])
+        projects_service.add_team_member(
+            str(self.project.id), manager_id, role="user"
+        )
+        self.log_in_manager()
+        self.put(
+            f"data/output-files/{self.output_file.id}",
+            {"comment": "Updated"},
+            403,
+        )
+
+
+class ProductionScheduleVersionRoleTestCase(ApiDBTestCase):
+    """
+    Coverage audit fix: crud/production_schedule_version.py
+    check_read_permissions methods run check_project_access before the
+    has_vendor/has_client deny, so a demoted client is caught by the deny
+    instead of slipping through on a stale global role.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.generate_base_context()
+        self.generate_fixture_user_manager()
+        self.version = self.post(
+            "data/production-schedule-versions",
+            {"name": "Version 1", "project_id": str(self.project.id)},
+        )
+
+    def test_demoted_client_cannot_read_production_schedule_version(self):
+        manager_id = str(self.user_manager["id"])
+        projects_service.add_team_member(
+            str(self.project.id), manager_id, role="client"
+        )
+        self.log_in_manager()
+        self.get(
+            f"data/production-schedule-versions/{self.version['id']}", 403
+        )
+
+
+class AllEditsRoleTestCase(ApiDBTestCase):
+    """
+    Coverage audit fix: edits/resources.py AllEditsResource.get moves
+    check_project_access above the vendor filter so a project-scoped
+    vendor demotion is honored.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.generate_base_context()
+        self.generate_fixture_edit()
+        self.generate_fixture_edit_task()
+        self.generate_fixture_user_manager()
+
+    def test_demoted_vendor_scoped_to_assigned_edits(self):
+        manager_id = str(self.user_manager["id"])
+        projects_service.add_team_member(
+            str(self.project.id), manager_id, role="vendor"
+        )
+        self.log_in_manager()
+        edits = self.get(f"data/edits?project_id={self.project.id}")
+        self.assertEqual(len(edits), 0)
+        tasks_service.assign_task(str(self.edit_task.id), manager_id)
+        edits = self.get(f"data/edits?project_id={self.project.id}")
+        self.assertEqual(len(edits), 1)
+
+
+class EntityMetadataRoleTestCase(ApiDBTestCase):
+    """
+    Coverage audit fix: user_service.check_metadata_department_access
+    resolves check_belong_to_project before has_manager/has_supervisor, so
+    a demoted manager loses entity metadata write access.
+
+    Exercised at the service level: crud/entity.py's EntityResource.put
+    wraps check_update_permissions in a bare `except Exception` that
+    downgrades PermissionDenied (403) to 400 before the response reaches
+    the client, a pre-existing bug unrelated to this fix. Calling the
+    service directly under a real, JWT-verified request context isolates
+    the ordering fix from that unrelated bug.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.generate_base_context()
+        self.generate_fixture_asset()
+        self.generate_fixture_user_manager()
+
+    def test_demoted_manager_cannot_update_entity_metadata(self):
+        manager_id = str(self.user_manager["id"])
+        projects_service.add_team_member(
+            str(self.project.id), manager_id, role="user"
+        )
+        self.log_in_manager()
+        entity = entities_service.get_entity(str(self.asset.id))
+        with app.test_request_context(headers=self.auth_headers):
+            verify_jwt_in_request()
+            self.assertRaises(
+                permissions.PermissionDenied,
+                user_service.check_metadata_department_access,
+                entity,
+                {"name": "Updated Tree"},
+            )
+
+
+class AllDepartmentsAccessRoleTestCase(ApiDBTestCase):
+    """
+    Coverage audit fix: user_service.check_all_departments_access resolves
+    check_belong_to_project before has_manager/has_supervisor, so a
+    demoted manager loses department-wide access.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.generate_base_context()
+        self.generate_fixture_user_manager()
+
+    def test_demoted_manager_cannot_create_metadata_descriptor(self):
+        manager_id = str(self.user_manager["id"])
+        projects_service.add_team_member(
+            str(self.project.id), manager_id, role="user"
+        )
+        self.log_in_manager()
+        data = {
+            "name": "Custom Field",
+            "data_type": "string",
+            "entity_type": "Asset",
+        }
+        self.post(
+            f"data/projects/{self.project.id}/metadata-descriptors",
+            data,
+            403,
+        )

--- a/tests/services/test_project_roles.py
+++ b/tests/services/test_project_roles.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 from flask import g
 from flask_jwt_extended import verify_jwt_in_request
 
@@ -83,6 +85,26 @@ class GetProjectRoleTestCase(ApiDBTestCase):
             ),
             self.person.role.code,
         )
+
+    def test_failed_membership_check_clears_the_role_slot(self):
+        project_a = self.project
+        self.add_to_team(self.person, role="supervisor")
+        project_b = self.generate_fixture_project("Other project")
+        current_user = self.person.serialize()
+        with app.test_request_context():
+            with mock.patch.object(
+                user_service.persons_service,
+                "get_current_user",
+                return_value=current_user,
+            ):
+                self.assertTrue(
+                    user_service.check_belong_to_project(str(project_a.id))
+                )
+                self.assertEqual(g.get("project_role"), "supervisor")
+                self.assertFalse(
+                    user_service.check_belong_to_project(str(project_b.id))
+                )
+                self.assertIsNone(g.get("project_role"))
 
 
 class PermissionOverrideTestCase(ApiDBTestCase):

--- a/tests/services/test_project_roles.py
+++ b/tests/services/test_project_roles.py
@@ -1,0 +1,27 @@
+from tests.base import ApiDBTestCase
+
+from zou.app import db
+from zou.app.models.project import ProjectPersonLink
+
+
+class ProjectPersonLinkRoleTestCase(ApiDBTestCase):
+    def setUp(self):
+        super().setUp()
+        self.generate_fixture_project_status()
+        self.generate_fixture_project()
+        self.generate_fixture_person()
+
+    def test_role_column_defaults_to_none(self):
+        self.project.team.append(self.person)
+        self.project.save()
+        link = ProjectPersonLink.query.filter_by(
+            project_id=self.project.id, person_id=self.person.id
+        ).first()
+        self.assertIsNotNone(link)
+        self.assertIsNone(link.role)
+        link.role = "supervisor"
+        db.session.commit()
+        link = ProjectPersonLink.query.filter_by(
+            project_id=self.project.id, person_id=self.person.id
+        ).first()
+        self.assertEqual(link.role.code, "supervisor")

--- a/tests/services/test_project_roles.py
+++ b/tests/services/test_project_roles.py
@@ -5,7 +5,12 @@ from tests.base import ApiDBTestCase
 from zou.app import app, db
 from zou.app.models.person import Person
 from zou.app.models.project import ProjectPersonLink
-from zou.app.services import projects_service, user_service
+from zou.app.services import (
+    comments_service,
+    projects_service,
+    tasks_service,
+    user_service,
+)
 from zou.app.services.exception import WrongParameterException
 from zou.app.utils import permissions
 
@@ -281,3 +286,28 @@ class TeamRoleApiTestCase(ApiDBTestCase):
             {"role": "manager"},
             400,
         )
+
+
+class DirectRoleReadTestCase(ApiDBTestCase):
+    def setUp(self):
+        super().setUp()
+        self.generate_base_context()
+        self.generate_fixture_asset()
+        self.generate_fixture_task()
+        self.generate_fixture_person()
+
+    def make_comment(self, author_id):
+        return comments_service.create_comment(
+            person_id=author_id,
+            task_id=str(self.task.id),
+            task_status_id=str(self.task_status.id),
+            text="hello",
+        )
+
+    def test_last_comment_map_uses_project_role(self):
+        projects_service.add_team_member(
+            str(self.project.id), str(self.person.id), role="client"
+        )
+        self.make_comment(str(self.person.id))
+        comment_map = tasks_service.get_last_comment_map([str(self.task.id)])
+        self.assertEqual(comment_map, {})

--- a/tests/services/test_project_roles.py
+++ b/tests/services/test_project_roles.py
@@ -1,7 +1,11 @@
+from flask import g
+
 from tests.base import ApiDBTestCase
 
-from zou.app import db
+from zou.app import app, db
 from zou.app.models.project import ProjectPersonLink
+from zou.app.services import user_service
+from zou.app.utils import permissions
 
 
 class ProjectPersonLinkRoleTestCase(ApiDBTestCase):
@@ -25,3 +29,67 @@ class ProjectPersonLinkRoleTestCase(ApiDBTestCase):
             project_id=self.project.id, person_id=self.person.id
         ).first()
         self.assertEqual(link.role.code, "supervisor")
+
+
+class GetProjectRoleTestCase(ApiDBTestCase):
+    def setUp(self):
+        super().setUp()
+        self.generate_fixture_project_status()
+        self.generate_fixture_project()
+        self.generate_fixture_person()
+
+    def add_to_team(self, person, role=None):
+        self.project.team.append(person)
+        self.project.save()
+        if role is not None:
+            link = ProjectPersonLink.query.filter_by(
+                project_id=self.project.id, person_id=person.id
+            ).first()
+            link.role = role
+            db.session.commit()
+
+    def test_explicit_link_role_wins(self):
+        self.add_to_team(self.person, role="supervisor")
+        self.assertEqual(
+            user_service.get_project_role(
+                str(self.person.id), str(self.project.id)
+            ),
+            "supervisor",
+        )
+
+    def test_null_link_role_inherits_global_role(self):
+        self.add_to_team(self.person)
+        self.assertEqual(
+            user_service.get_project_role(
+                str(self.person.id), str(self.project.id)
+            ),
+            self.person.role.code,
+        )
+
+    def test_no_link_falls_back_to_global_role(self):
+        self.assertEqual(
+            user_service.get_project_role(
+                str(self.person.id), str(self.project.id)
+            ),
+            self.person.role.code,
+        )
+
+
+class PermissionOverrideTestCase(ApiDBTestCase):
+    def test_project_role_overrides_global_checks(self):
+        with app.test_request_context():
+            g.project_role = "manager"
+            self.assertTrue(permissions.has_manager_permissions())
+            self.assertFalse(permissions.has_supervisor_permissions())
+            self.assertTrue(permissions.has_at_least_supervisor_permissions())
+            self.assertFalse(permissions.has_client_permissions())
+
+        with app.test_request_context():
+            g.project_role = "user"
+            self.assertFalse(permissions.has_manager_permissions())
+            self.assertTrue(permissions.has_artist_permissions())
+
+        with app.test_request_context():
+            g.project_role = "vendor"
+            self.assertTrue(permissions.has_vendor_permissions())
+            self.assertFalse(permissions.has_at_least_supervisor_permissions())

--- a/tests/services/test_project_roles.py
+++ b/tests/services/test_project_roles.py
@@ -590,6 +590,11 @@ class ProductionScheduleVersionRoleTestCase(ApiDBTestCase):
             f"data/production-schedule-versions/{self.version['id']}", 403
         )
 
+    def test_global_vendor_gets_403_not_500_with_no_query_args(self):
+        self.generate_fixture_user_vendor()
+        self.log_in_vendor()
+        self.get("data/production-schedule-versions", 403)
+
 
 class AllEditsRoleTestCase(ApiDBTestCase):
     """

--- a/tests/services/test_project_roles.py
+++ b/tests/services/test_project_roles.py
@@ -6,6 +6,7 @@ from zou.app import app, db
 from zou.app.models.person import Person
 from zou.app.models.project import ProjectPersonLink
 from zou.app.services import projects_service, user_service
+from zou.app.services.exception import WrongParameterException
 from zou.app.utils import permissions
 
 
@@ -182,3 +183,55 @@ class ProjectRoleSemanticsTestCase(ApiDBTestCase):
         self.add_member(self.project, artist_id, role="vendor")
         self.log_in_cg_artist()
         self.get(f"data/tasks/{self.task.id}", 403)
+
+
+class TeamRoleServiceTestCase(ApiDBTestCase):
+    def setUp(self):
+        super().setUp()
+        self.generate_fixture_project_status()
+        self.generate_fixture_project()
+        self.generate_fixture_person()
+
+    def test_add_team_member_with_role(self):
+        projects_service.add_team_member(
+            str(self.project.id), str(self.person.id), role="supervisor"
+        )
+        self.assertEqual(
+            projects_service.get_team_roles(str(self.project.id)),
+            {str(self.person.id): "supervisor"},
+        )
+
+    def test_add_team_member_without_role_inherits(self):
+        projects_service.add_team_member(
+            str(self.project.id), str(self.person.id)
+        )
+        self.assertEqual(
+            projects_service.get_team_roles(str(self.project.id)), {}
+        )
+
+    def test_update_team_member_role(self):
+        projects_service.add_team_member(
+            str(self.project.id), str(self.person.id)
+        )
+        projects_service.update_team_member_role(
+            str(self.project.id), str(self.person.id), "manager"
+        )
+        self.assertEqual(
+            projects_service.get_team_roles(str(self.project.id)),
+            {str(self.person.id): "manager"},
+        )
+        projects_service.update_team_member_role(
+            str(self.project.id), str(self.person.id), None
+        )
+        self.assertEqual(
+            projects_service.get_team_roles(str(self.project.id)), {}
+        )
+
+    def test_update_team_member_role_requires_membership(self):
+        self.assertRaises(
+            WrongParameterException,
+            projects_service.update_team_member_role,
+            str(self.project.id),
+            str(self.person.id),
+            "manager",
+        )

--- a/tests/services/test_project_roles.py
+++ b/tests/services/test_project_roles.py
@@ -3,8 +3,9 @@ from flask import g
 from tests.base import ApiDBTestCase
 
 from zou.app import app, db
+from zou.app.models.person import Person
 from zou.app.models.project import ProjectPersonLink
-from zou.app.services import user_service
+from zou.app.services import projects_service, user_service
 from zou.app.utils import permissions
 
 
@@ -93,3 +94,91 @@ class PermissionOverrideTestCase(ApiDBTestCase):
             g.project_role = "vendor"
             self.assertTrue(permissions.has_vendor_permissions())
             self.assertFalse(permissions.has_at_least_supervisor_permissions())
+
+
+class ProjectRoleRouteTestCase(ApiDBTestCase):
+    """
+    Promotion and demotion through a manager-gated route:
+    POST /data/projects/<id>/team goes through
+    check_manager_project_access.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.generate_fixture_project_status()
+        self.generate_fixture_project()
+        # generate_fixture_project reassigns self.project on every call, so
+        # the first project must be captured before creating the second one.
+        self.project_a = self.project
+        self.project_b = self.generate_fixture_project("Second project")
+        self.generate_fixture_person()
+        self.generate_fixture_user_cg_artist()
+        self.generate_fixture_user_manager()
+
+    def set_team_role(self, project, person_id, role):
+        link = ProjectPersonLink.query.filter_by(
+            project_id=project.id, person_id=person_id
+        ).first()
+        link.role = role
+        db.session.commit()
+
+    def add_member(self, project, person_id, role=None):
+        projects_service.add_team_member(str(project.id), person_id)
+        if role is not None:
+            self.set_team_role(project, person_id, role)
+
+    def test_project_manager_can_manage_team_on_their_project_only(self):
+        artist_id = str(self.user_cg_artist["id"])
+        person_id = str(self.person.id)
+        # Pre-add the target person so the POST under test only has to
+        # clear the permission gate, not also perform a fresh team insert.
+        projects_service.add_team_member(str(self.project_a.id), person_id)
+        self.add_member(self.project_a, artist_id, role="manager")
+        self.add_member(self.project_b, artist_id)
+        self.log_in_cg_artist()
+        data = {"person_id": person_id}
+        self.post(f"data/projects/{self.project_a.id}/team", data, 201)
+        self.post(f"data/projects/{self.project_b.id}/team", data, 403)
+
+    def test_demoted_manager_cannot_manage_team(self):
+        manager_id = str(self.user_manager["id"])
+        self.add_member(self.project_a, manager_id, role="user")
+        self.log_in_manager()
+        data = {"person_id": str(self.person.id)}
+        self.post(f"data/projects/{self.project_a.id}/team", data, 403)
+
+
+class ProjectRoleSemanticsTestCase(ApiDBTestCase):
+    def setUp(self):
+        super().setUp()
+        self.generate_base_context()
+        self.generate_fixture_asset()
+        self.generate_fixture_task()
+        self.generate_fixture_person()
+        self.generate_fixture_user_cg_artist()
+
+    def add_member(self, project, person_id, role=None):
+        project.team.append(Person.get(person_id))
+        project.save()
+        if role is not None:
+            link = ProjectPersonLink.query.filter_by(
+                project_id=project.id, person_id=person_id
+            ).first()
+            link.role = role
+            db.session.commit()
+
+    def test_admin_ignores_project_roles(self):
+        # ApiDBTestCase creates and logs in a global admin (self.user).
+        # A link role never demotes an admin.
+        admin_id = str(self.user["id"])
+        self.add_member(self.project, admin_id, role="user")
+        data = {"person_id": str(self.person.id)}
+        self.post(f"data/projects/{self.project.id}/team", data, 201)
+
+    def test_project_vendor_restricted_to_assigned_entities(self):
+        # Global artist set as vendor on the project: entity access
+        # restrictions apply, the unassigned task becomes forbidden.
+        artist_id = str(self.user_cg_artist["id"])
+        self.add_member(self.project, artist_id, role="vendor")
+        self.log_in_cg_artist()
+        self.get(f"data/tasks/{self.task.id}", 403)

--- a/tests/services/test_project_roles.py
+++ b/tests/services/test_project_roles.py
@@ -235,3 +235,49 @@ class TeamRoleServiceTestCase(ApiDBTestCase):
             str(self.person.id),
             "manager",
         )
+
+
+class TeamRoleApiTestCase(ApiDBTestCase):
+    def setUp(self):
+        super().setUp()
+        self.generate_fixture_project_status()
+        self.generate_fixture_project()
+        self.generate_fixture_person()
+
+    def test_add_team_member_with_role(self):
+        data = {"person_id": str(self.person.id), "role": "supervisor"}
+        self.post(f"data/projects/{self.project.id}/team", data, 201)
+        team = self.get(f"data/projects/{self.project.id}/team")
+        self.assertEqual(team[0]["project_role"], "supervisor")
+
+    def test_add_team_member_rejects_admin_role(self):
+        data = {"person_id": str(self.person.id), "role": "admin"}
+        self.post(f"data/projects/{self.project.id}/team", data, 400)
+
+    def test_put_team_member_role(self):
+        self.post(
+            f"data/projects/{self.project.id}/team",
+            {"person_id": str(self.person.id)},
+            201,
+        )
+        result = self.put(
+            f"data/projects/{self.project.id}/team/{self.person.id}",
+            {"role": "manager"},
+        )
+        self.assertEqual(result["role"], "manager")
+        result = self.put(
+            f"data/projects/{self.project.id}/team/{self.person.id}",
+            {"role": None},
+        )
+        self.assertIsNone(result["role"])
+        team = self.get(f"data/projects/{self.project.id}/team")
+        self.assertIsNone(team[0]["project_role"])
+
+    def test_put_team_member_role_requires_membership(self):
+        # update_team_member_role raises WrongParameterException for a
+        # non-member, which maps to 400, not 404.
+        self.put(
+            f"data/projects/{self.project.id}/team/{self.person.id}",
+            {"role": "manager"},
+            400,
+        )

--- a/tests/services/test_project_roles.py
+++ b/tests/services/test_project_roles.py
@@ -244,6 +244,18 @@ class TeamRoleServiceTestCase(ApiDBTestCase):
             "manager",
         )
 
+    def test_update_team_member_role_rejects_admin(self):
+        projects_service.add_team_member(
+            str(self.project.id), str(self.person.id)
+        )
+        self.assertRaises(
+            WrongParameterException,
+            projects_service.update_team_member_role,
+            str(self.project.id),
+            str(self.person.id),
+            "admin",
+        )
+
 
 class TeamRoleApiTestCase(ApiDBTestCase):
     def setUp(self):
@@ -287,6 +299,18 @@ class TeamRoleApiTestCase(ApiDBTestCase):
         self.put(
             f"data/projects/{self.project.id}/team/{self.person.id}",
             {"role": "manager"},
+            400,
+        )
+
+    def test_put_team_member_role_rejects_admin(self):
+        self.post(
+            f"data/projects/{self.project.id}/team",
+            {"person_id": str(self.person.id)},
+            201,
+        )
+        self.put(
+            f"data/projects/{self.project.id}/team/{self.person.id}",
+            {"role": "admin"},
             400,
         )
 

--- a/zou/app/blueprints/comments/resources.py
+++ b/zou/app/blueprints/comments/resources.py
@@ -673,6 +673,7 @@ class ReplyCommentResource(MethodView, ArgsMixin):
             raise permissions.PermissionDenied()
         current_user = persons_service.get_current_user()
         if comment["person_id"] != current_user["id"]:
+            user_service.check_task_action_access(task_id)
             if permissions.has_client_permissions():
                 author = persons_service.get_person(comment["person_id"])
                 task = tasks_service.get_task(task_id)
@@ -684,7 +685,6 @@ class ReplyCommentResource(MethodView, ArgsMixin):
                     == "client"
                 ):
                     raise permissions.PermissionDenied()
-            user_service.check_task_action_access(task_id)
 
         body = validation.validate_request_body(CommentReplySchema)
         files = request.files

--- a/zou/app/blueprints/comments/resources.py
+++ b/zou/app/blueprints/comments/resources.py
@@ -584,7 +584,10 @@ class CommentManyTasksResource(MethodView):
                     comment["object_id"], relations=True
                 )
                 if (
-                    person["role"] == "supervisor"
+                    user_service.get_project_role(
+                        person["id"], task["project_id"]
+                    )
+                    == "supervisor"
                     and (
                         len(person["departments"]) == 0
                         or tasks_service.get_task_type(task["task_type_id"])[
@@ -672,9 +675,13 @@ class ReplyCommentResource(MethodView, ArgsMixin):
         if comment["person_id"] != current_user["id"]:
             if permissions.has_client_permissions():
                 author = persons_service.get_person(comment["person_id"])
+                task = tasks_service.get_task(task_id)
                 if (
                     current_user["studio_id"] != author["studio_id"]
-                    and author["role"] == "client"
+                    and user_service.get_project_role(
+                        author["id"], task["project_id"]
+                    )
+                    == "client"
                 ):
                     raise permissions.PermissionDenied()
             user_service.check_task_action_access(task_id)

--- a/zou/app/blueprints/comments/resources.py
+++ b/zou/app/blueprints/comments/resources.py
@@ -578,16 +578,21 @@ class CommentManyTasksResource(MethodView):
 
     def get_allowed_comments_only(self, comments, person):
         allowed_comments = []
+        # The person is constant and the comments almost always share one
+        # project: memoize the role lookups instead of querying per comment.
+        role_cache = {}
         for comment in comments:
             try:
                 task = tasks_service.get_task(
                     comment["object_id"], relations=True
                 )
-                if (
-                    user_service.get_project_role(
-                        person["id"], task["project_id"]
+                project_id = task["project_id"]
+                if project_id not in role_cache:
+                    role_cache[project_id] = user_service.get_project_role(
+                        person["id"], project_id
                     )
-                    == "supervisor"
+                if (
+                    role_cache[project_id] == "supervisor"
                     and (
                         len(person["departments"]) == 0
                         or tasks_service.get_task_type(task["task_type_id"])[

--- a/zou/app/blueprints/crud/comments.py
+++ b/zou/app/blueprints/crud/comments.py
@@ -566,7 +566,7 @@ class CommentResource(BaseModelResource):
         """
         comment = tasks_service.get_comment(instance_id)
         task = tasks_service.get_task(comment["object_id"])
-        user_service.check_belong_to_project(task["project_id"])
+        user_service.resolve_project_role(task["project_id"])
         if permissions.has_manager_permissions():
             user_service.check_project_access(task["project_id"])
         else:

--- a/zou/app/blueprints/crud/comments.py
+++ b/zou/app/blueprints/crud/comments.py
@@ -11,7 +11,6 @@ from zou.app.services import (
     persons_service,
     tasks_service,
     user_service,
-    projects_service,
 )
 from zou.app.utils import events, permissions
 
@@ -432,11 +431,8 @@ class CommentResource(BaseModelResource):
                 instance["object_id"], relations=True
             )
             task_type = tasks_service.get_task_type(task["task_type_id"])
-            project = projects_service.get_project(
-                task["project_id"], relations=True
-            )
             current_user = persons_service.get_current_user(relations=True)
-            if current_user["id"] not in project["team"]:
+            if not user_service.check_belong_to_project(task["project_id"]):
                 raise permissions.PermissionDenied
 
             if permissions.has_manager_permissions():
@@ -570,6 +566,7 @@ class CommentResource(BaseModelResource):
         """
         comment = tasks_service.get_comment(instance_id)
         task = tasks_service.get_task(comment["object_id"])
+        user_service.check_belong_to_project(task["project_id"])
         if permissions.has_manager_permissions():
             user_service.check_project_access(task["project_id"])
         else:

--- a/zou/app/blueprints/crud/output_file.py
+++ b/zou/app/blueprints/crud/output_file.py
@@ -54,7 +54,8 @@ class OutputFileResource(BaseModelResource):
         return True
 
     def check_update_permissions(self, output_file, data):
-        if permissions.has_manager_permissions():
+        entity = entities_service.get_entity(output_file["entity_id"])
+        if user_service.has_manager_project_access(entity["project_id"]):
             return True
         else:
             return user_service.check_working_on_entity(

--- a/zou/app/blueprints/crud/preview_file.py
+++ b/zou/app/blueprints/crud/preview_file.py
@@ -189,10 +189,11 @@ class PreviewFileResource(BaseModelResource):
         If it's a vendor, check if the user is working on the task.
         If it's an artist, check if preview file belongs to user projects.
         """
+        task = tasks_service.get_task(preview_file["task_id"])
+        user_service.check_belong_to_project(task["project_id"])
         if permissions.has_vendor_permissions():
             user_service.check_working_on_task(preview_file["task_id"])
         else:
-            task = tasks_service.get_task(preview_file["task_id"])
             user_service.check_project_access(task["project_id"])
         return True
 

--- a/zou/app/blueprints/crud/preview_file.py
+++ b/zou/app/blueprints/crud/preview_file.py
@@ -190,7 +190,7 @@ class PreviewFileResource(BaseModelResource):
         If it's an artist, check if preview file belongs to user projects.
         """
         task = tasks_service.get_task(preview_file["task_id"])
-        user_service.check_belong_to_project(task["project_id"])
+        user_service.resolve_project_role(task["project_id"])
         if permissions.has_vendor_permissions():
             user_service.check_working_on_task(preview_file["task_id"])
         else:

--- a/zou/app/blueprints/crud/production_schedule_version.py
+++ b/zou/app/blueprints/crud/production_schedule_version.py
@@ -16,15 +16,15 @@ class ProductionScheduleVersionsResource(BaseModelsResource):
         BaseModelsResource.__init__(self, ProductionScheduleVersion)
 
     def check_read_permissions(self, options=None):
+        if "project_id" in options.keys():
+            user_service.check_project_access(options["project_id"])
+        else:
+            permissions.check_admin_permissions()
         if (
             permissions.has_vendor_permissions()
             or permissions.has_client_permissions()
         ):
             raise permissions.PermissionDenied
-        if "project_id" in options.keys():
-            return user_service.check_project_access(options["project_id"])
-        else:
-            return permissions.check_admin_permissions()
 
     @jwt_required()
     def get(self):
@@ -175,12 +175,12 @@ class ProductionScheduleVersionResource(BaseModelResource):
         BaseModelResource.__init__(self, ProductionScheduleVersion)
 
     def check_read_permissions(self, instance_dict):
+        user_service.check_project_access(instance_dict["project_id"])
         if (
             permissions.has_vendor_permissions()
             or permissions.has_client_permissions()
         ):
             raise permissions.PermissionDenied
-        return user_service.check_project_access(instance_dict["project_id"])
 
     @jwt_required()
     def get(self, instance_id):
@@ -339,15 +339,15 @@ class ProductionScheduleVersionTaskLinksResource(BaseModelsResource):
         return [ProductionScheduleVersionTaskLink.assignees]
 
     def check_read_permissions(self, options=None):
+        if "project_id" in options.keys():
+            user_service.check_project_access(options["project_id"])
+        else:
+            permissions.check_admin_permissions()
         if (
             permissions.has_vendor_permissions()
             or permissions.has_client_permissions()
         ):
             raise permissions.PermissionDenied
-        if "project_id" in options.keys():
-            return user_service.check_project_access(options["project_id"])
-        else:
-            return permissions.check_admin_permissions()
 
     @jwt_required()
     def get(self):
@@ -520,13 +520,13 @@ class ProductionScheduleVersionTaskLinkResource(BaseModelResource):
         ]
 
     def check_read_permissions(self, instance_dict):
+        task = tasks_service.get_task(instance_dict["task_id"])
+        user_service.check_project_access(task["project_id"])
         if (
             permissions.has_vendor_permissions()
             or permissions.has_client_permissions()
         ):
             raise permissions.PermissionDenied
-        task = tasks_service.get_task(instance_dict["task_id"])
-        return user_service.check_project_access(task["project_id"])
 
     @jwt_required()
     def get(self, instance_id):

--- a/zou/app/blueprints/crud/production_schedule_version.py
+++ b/zou/app/blueprints/crud/production_schedule_version.py
@@ -16,7 +16,7 @@ class ProductionScheduleVersionsResource(BaseModelsResource):
         BaseModelsResource.__init__(self, ProductionScheduleVersion)
 
     def check_read_permissions(self, options=None):
-        if "project_id" in options.keys():
+        if options and "project_id" in options:
             user_service.check_project_access(options["project_id"])
         else:
             permissions.check_admin_permissions()
@@ -339,7 +339,7 @@ class ProductionScheduleVersionTaskLinksResource(BaseModelsResource):
         return [ProductionScheduleVersionTaskLink.assignees]
 
     def check_read_permissions(self, options=None):
-        if "project_id" in options.keys():
+        if options and "project_id" in options:
             user_service.check_project_access(options["project_id"])
         else:
             permissions.check_admin_permissions()

--- a/zou/app/blueprints/edits/resources.py
+++ b/zou/app/blueprints/edits/resources.py
@@ -274,11 +274,11 @@ class AllEditsResource(MethodView):
                         example: "2023-01-01T12:30:00Z"
         """
         criterions = query.get_query_criterions_from_request(request)
+        user_service.check_project_access(criterions.get("project_id", None))
         if permissions.has_vendor_permissions():
             criterions["assigned_to"] = persons_service.get_current_user()[
                 "id"
             ]
-        user_service.check_project_access(criterions.get("project_id", None))
         return edits_service.get_edits(criterions)
 
 

--- a/zou/app/blueprints/persons/resources.py
+++ b/zou/app/blueprints/persons/resources.py
@@ -850,6 +850,7 @@ class PersonQuotaMixin(ArgsMixin):
         return (project_id, task_type_id, feedback, weighted)
 
     def check_permissions(self, person_id, project_id=None):
+        user_service.check_belong_to_project(project_id)
         if permissions.has_manager_permissions():
             user_service.check_manager_project_access(project_id)
         else:

--- a/zou/app/blueprints/persons/resources.py
+++ b/zou/app/blueprints/persons/resources.py
@@ -1,7 +1,7 @@
 import datetime
 import ipaddress
 
-from flask import abort, request, current_app
+from flask import request, current_app
 from flask.views import MethodView
 from flask_jwt_extended import jwt_required
 

--- a/zou/app/blueprints/persons/resources.py
+++ b/zou/app/blueprints/persons/resources.py
@@ -850,7 +850,7 @@ class PersonQuotaMixin(ArgsMixin):
         return (project_id, task_type_id, feedback, weighted)
 
     def check_permissions(self, person_id, project_id=None):
-        user_service.check_belong_to_project(project_id)
+        user_service.resolve_project_role(project_id)
         if permissions.has_manager_permissions():
             user_service.check_manager_project_access(project_id)
         else:

--- a/zou/app/blueprints/previews/resources.py
+++ b/zou/app/blueprints/previews/resources.py
@@ -1159,7 +1159,7 @@ class BasePreviewFileThumbnailResource(BasePreviewPictureResource):
         )
         task = tasks_service.get_task(self.preview_file["task_id"])
         entity = entities_service.get_entity(task["entity_id"])
-        user_service.check_belong_to_project(task["project_id"])
+        user_service.resolve_project_role(task["project_id"])
         if (
             entity["preview_file_id"] != preview_file_id
             or not entity["is_shared"]

--- a/zou/app/blueprints/previews/resources.py
+++ b/zou/app/blueprints/previews/resources.py
@@ -1159,6 +1159,7 @@ class BasePreviewFileThumbnailResource(BasePreviewPictureResource):
         )
         task = tasks_service.get_task(self.preview_file["task_id"])
         entity = entities_service.get_entity(task["entity_id"])
+        user_service.check_belong_to_project(task["project_id"])
         if (
             entity["preview_file_id"] != preview_file_id
             or not entity["is_shared"]

--- a/zou/app/blueprints/projects/__init__.py
+++ b/zou/app/blueprints/projects/__init__.py
@@ -5,7 +5,7 @@ from zou.app.blueprints.projects.resources import (
     AllProjectsResource,
     OpenProjectsResource,
     ProductionTeamResource,
-    ProductionTeamRemoveResource,
+    ProductionTeamMemberResource,
     ProductionAssetTypeResource,
     ProductionAssetTypeRemoveResource,
     ProductionPreviewBackgroundFileResource,
@@ -60,7 +60,7 @@ routes = [
     ("/data/projects/<project_id>/day-offs", ProductionDayOffsResource),
     (
         "/data/projects/<project_id>/team/<person_id>",
-        ProductionTeamRemoveResource,
+        ProductionTeamMemberResource,
     ),
     (
         "/data/projects/<project_id>/settings/asset-types",

--- a/zou/app/blueprints/projects/resources.py
+++ b/zou/app/blueprints/projects/resources.py
@@ -2798,14 +2798,14 @@ class ProductionScheduleVersionTaskLinksResource(MethodView, ArgsMixin):
                 production_schedule_version_id
             )
         )
+        user_service.check_project_access(
+            production_schedule_version["project_id"]
+        )
         if (
             permissions.has_vendor_permissions()
             or permissions.has_client_permissions()
         ):
             raise permissions.PermissionDenied
-        user_service.check_project_access(
-            production_schedule_version["project_id"]
-        )
 
         args = self.get_args(
             [

--- a/zou/app/blueprints/projects/resources.py
+++ b/zou/app/blueprints/projects/resources.py
@@ -1,4 +1,3 @@
-from flask import abort
 from flask.views import MethodView
 from flask_jwt_extended import jwt_required
 

--- a/zou/app/blueprints/projects/resources.py
+++ b/zou/app/blueprints/projects/resources.py
@@ -16,6 +16,7 @@ from zou.app.services import (
 from zou.app.utils import permissions, validation
 from zou.app.blueprints.projects.schemas import (
     ProjectTeamSchema,
+    ProjectTeamRoleSchema,
     ProjectAssetTypeSchema,
     ProjectTaskTypeSchema,
     ProjectTaskStatusSchema,
@@ -209,15 +210,24 @@ class ProductionTeamResource(MethodView, ArgsMixin):
                         type: string
                         description: Person email address
                         example: "john.doe@example.com"
+                      project_role:
+                        type: string
+                        nullable: true
+                        description: Person role on this project only. Null
+                          means the person's global role applies.
+                        example: "supervisor"
         """
         user_service.check_project_access(project_id)
         project = projects_service.get_project_raw(project_id)
+        role_map = projects_service.get_team_roles(project_id)
         persons = []
         for person in project.team:
             if permissions.has_manager_permissions():
-                persons.append(person.serialize_safe(relations=True))
+                data = person.serialize_safe(relations=True)
             else:
-                persons.append(person.present_minimal())
+                data = person.present_minimal()
+            data["project_role"] = role_map.get(str(person.id))
+            persons.append(data)
         return persons
 
     @jwt_required()
@@ -251,6 +261,12 @@ class ProductionTeamResource(MethodView, ArgsMixin):
                     format: uuid
                     description: Person unique identifier
                     example: b35b7fb5-df86-5776-b181-68564193d36
+                  role:
+                    type: string
+                    nullable: true
+                    description: Role of the person on this project only.
+                      Null means the person's global role applies.
+                    enum: [user, supervisor, manager, client, vendor, null]
         responses:
           201:
             description: Person added to the production team
@@ -275,12 +291,14 @@ class ProductionTeamResource(MethodView, ArgsMixin):
 
         user_service.check_manager_project_access(project_id)
         return (
-            projects_service.add_team_member(project_id, body.person_id),
+            projects_service.add_team_member(
+                project_id, body.person_id, role=body.role
+            ),
             201,
         )
 
 
-class ProductionTeamRemoveResource(MethodView):
+class ProductionTeamMemberResource(MethodView):
 
     @jwt_required()
     def delete(self, project_id, person_id):
@@ -314,6 +332,51 @@ class ProductionTeamRemoveResource(MethodView):
         user_service.check_manager_project_access(project_id)
         projects_service.remove_team_member(project_id, person_id)
         return "", 204
+
+    @jwt_required()
+    def put(self, project_id, person_id):
+        """
+        Set team member role
+        ---
+        description: Set the role of a person on this production only.
+                     A null role restores the person's global role.
+        tags:
+          - Projects
+        parameters:
+          - in: path
+            name: project_id
+            required: true
+            schema:
+              type: string
+              format: uuid
+          - in: path
+            name: person_id
+            required: true
+            schema:
+              type: string
+              format: uuid
+        requestBody:
+          required: true
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  role:
+                    type: string
+                    nullable: true
+                    enum: [user, supervisor, manager, client, vendor, null]
+        responses:
+          200:
+            description: Role updated
+          400:
+            description: Person is not a member of the project team
+        """
+        body = validation.validate_request_body(ProjectTeamRoleSchema)
+        user_service.check_manager_project_access(project_id)
+        return projects_service.update_team_member_role(
+            project_id, person_id, body.role
+        )
 
 
 class ProductionAssetTypeResource(MethodView, ArgsMixin):

--- a/zou/app/blueprints/projects/schemas.py
+++ b/zou/app/blueprints/projects/schemas.py
@@ -2,12 +2,15 @@
 Pydantic schemas for request body validation in the projects blueprint.
 """
 
-from typing import List, Optional
+from typing import List, Literal, Optional
 from uuid import UUID
 
 from pydantic import Field
 
 from zou.app.utils.validation import BaseSchema
+
+# Mirrors ROLE_TYPES minus admin: admin stays a global-only role.
+ProjectRole = Literal["user", "supervisor", "manager", "client", "vendor"]
 
 
 class ProjectTeamSchema(BaseSchema):
@@ -16,6 +19,16 @@ class ProjectTeamSchema(BaseSchema):
     """
 
     person_id: str = Field(..., min_length=1)
+    role: Optional[ProjectRole] = None
+
+
+class ProjectTeamRoleSchema(BaseSchema):
+    """
+    Body for setting the role of a team member on this project only. A null
+    role restores inheritance of the person's global role.
+    """
+
+    role: Optional[ProjectRole] = None
 
 
 class ProjectAssetTypeSchema(BaseSchema):

--- a/zou/app/blueprints/projects/schemas.py
+++ b/zou/app/blueprints/projects/schemas.py
@@ -3,7 +3,6 @@ Pydantic schemas for request body validation in the projects blueprint.
 """
 
 from typing import List, Literal, Optional
-from uuid import UUID
 
 from pydantic import Field
 

--- a/zou/app/blueprints/shots/resources.py
+++ b/zou/app/blueprints/shots/resources.py
@@ -405,11 +405,11 @@ class AllShotsResource(MethodView):
             criterions["project_id"] = sequence["project_id"]
             criterions["parent_id"] = sequence["id"]
             del criterions["sequence_id"]
+        user_service.check_project_access(criterions.get("project_id", None))
         if permissions.has_vendor_permissions():
             criterions["assigned_to"] = persons_service.get_current_user()[
                 "id"
             ]
-        user_service.check_project_access(criterions.get("project_id", None))
         return shots_service.get_shots(criterions)
 
 
@@ -2987,6 +2987,7 @@ class ProjectPersonQuotasResource(MethodView, ArgsMixin):
                 description: Invalid count_mode or parameter
         """
         projects_service.get_project(project_id)
+        user_service.check_belong_to_project(project_id)
         if (
             permissions.has_manager_permissions()
             or permissions.has_supervisor_permissions()

--- a/zou/app/blueprints/shots/resources.py
+++ b/zou/app/blueprints/shots/resources.py
@@ -2987,7 +2987,7 @@ class ProjectPersonQuotasResource(MethodView, ArgsMixin):
                 description: Invalid count_mode or parameter
         """
         projects_service.get_project(project_id)
-        user_service.check_belong_to_project(project_id)
+        user_service.resolve_project_role(project_id)
         if (
             permissions.has_manager_permissions()
             or permissions.has_supervisor_permissions()

--- a/zou/app/blueprints/tasks/resources.py
+++ b/zou/app/blueprints/tasks/resources.py
@@ -501,7 +501,7 @@ class TaskCommentResource(MethodView):
         """
         comment = tasks_service.get_comment(comment_id)
         task = tasks_service.get_task(comment["object_id"])
-        user_service.check_belong_to_project(task["project_id"])
+        user_service.resolve_project_role(task["project_id"])
         if permissions.has_manager_permissions():
             user_service.check_project_access(task["project_id"])
         else:

--- a/zou/app/blueprints/tasks/resources.py
+++ b/zou/app/blueprints/tasks/resources.py
@@ -501,6 +501,7 @@ class TaskCommentResource(MethodView):
         """
         comment = tasks_service.get_comment(comment_id)
         task = tasks_service.get_task(comment["object_id"])
+        user_service.check_belong_to_project(task["project_id"])
         if permissions.has_manager_permissions():
             user_service.check_project_access(task["project_id"])
         else:

--- a/zou/app/models/project.py
+++ b/zou/app/models/project.py
@@ -42,6 +42,8 @@ class ProjectPersonLink(db.Model):
         index=True,
     )
     shotgun_id = db.Column(db.Integer)
+    # NULL means the person inherits their global Person.role.
+    role = db.Column(ChoiceType(ROLE_TYPES), nullable=True)
 
 
 class ProjectTaskTypeLink(db.Model, BaseMixin, SerializerMixin):

--- a/zou/app/services/notifications_service.py
+++ b/zou/app/services/notifications_service.py
@@ -1,4 +1,5 @@
 from sqlalchemy.exc import StatementError
+from sqlalchemy.sql import func
 
 from zou.app.models.project import Project, ProjectPersonLink
 from zou.app.models.entity import Entity
@@ -513,7 +514,7 @@ def notify_clients_playlist_ready(
     query = (
         Person.query.join(ProjectPersonLink)
         .filter(Person.is_bot == False)
-        .filter(Person.role == "client")
+        .filter(func.coalesce(ProjectPersonLink.role, Person.role) == "client")
         .filter(ProjectPersonLink.project_id == project_id)
     )
 

--- a/zou/app/services/projects_service.py
+++ b/zou/app/services/projects_service.py
@@ -34,6 +34,7 @@ from zou.app.services.exception import (
 )
 
 from zou.app.utils import fields, events, cache
+from zou.app import db
 
 from sqlalchemy.exc import StatementError
 from sqlalchemy.orm import joinedload
@@ -419,11 +420,16 @@ def update_project(project_id, data):
     return project.serialize()
 
 
-def add_team_member(project_id, person_id):
+def add_team_member(project_id, person_id, role=None):
     """
-    Add a person listed in database to the the project team.
+    Add a person listed in database to the project team, with an optional
+    project-specific role.
     """
-    return _add_to_list_attr(project_id, Person, person_id, "team")
+    project = _add_to_list_attr(project_id, Person, person_id, "team")
+    if role is not None:
+        update_team_member_role(project_id, person_id, role)
+        project = get_project_raw(project_id).serialize()
+    return project
 
 
 def remove_team_member(project_id, person_id):
@@ -431,6 +437,45 @@ def remove_team_member(project_id, person_id):
     Remove a person listed in database from the the project team.
     """
     return _remove_from_list_attr(project_id, Person, person_id, "team")
+
+
+def update_team_member_role(project_id, person_id, role):
+    """
+    Set the role of given person on given project. A None role restores
+    inheritance of the person's global role.
+    """
+    link = ProjectPersonLink.query.filter_by(
+        project_id=project_id, person_id=person_id
+    ).first()
+    if link is None:
+        raise WrongParameterException(
+            "Person is not a member of the project team"
+        )
+    link.role = role
+    db.session.commit()
+    clear_project_cache(str(project_id))
+    events.emit("project:update", {}, project_id=str(project_id))
+    return {
+        "project_id": str(link.project_id),
+        "person_id": str(link.person_id),
+        "role": (
+            getattr(link.role, "code", link.role)
+            if link.role is not None
+            else None
+        ),
+    }
+
+
+def get_team_roles(project_id):
+    """
+    Return a dict mapping person ids to their explicit role on given
+    project. Persons inheriting their global role are absent from the dict.
+    """
+    return {
+        str(link.person_id): getattr(link.role, "code", link.role)
+        for link in ProjectPersonLink.query.filter_by(project_id=project_id)
+        if link.role is not None
+    }
 
 
 def add_asset_type_setting(project_id, asset_type_id):

--- a/zou/app/services/projects_service.py
+++ b/zou/app/services/projects_service.py
@@ -482,8 +482,9 @@ def get_team_roles(project_id):
     """
     return {
         str(link.person_id): getattr(link.role, "code", link.role)
-        for link in ProjectPersonLink.query.filter_by(project_id=project_id)
-        if link.role is not None
+        for link in ProjectPersonLink.query.filter_by(
+            project_id=project_id
+        ).filter(ProjectPersonLink.role.isnot(None))
     }
 
 

--- a/zou/app/services/projects_service.py
+++ b/zou/app/services/projects_service.py
@@ -423,8 +423,13 @@ def update_project(project_id, data):
 def add_team_member(project_id, person_id, role=None):
     """
     Add a person listed in database to the project team, with an optional
-    project-specific role.
+    project-specific role. The role is validated before the membership is
+    created so an invalid role leaves no partial state behind.
     """
+    if role == "admin":
+        raise WrongParameterException(
+            "admin is a global role and cannot be set per project"
+        )
     project = _add_to_list_attr(project_id, Person, person_id, "team")
     if role is not None:
         update_team_member_role(project_id, person_id, role)

--- a/zou/app/services/projects_service.py
+++ b/zou/app/services/projects_service.py
@@ -444,6 +444,10 @@ def update_team_member_role(project_id, person_id, role):
     Set the role of given person on given project. A None role restores
     inheritance of the person's global role.
     """
+    if role == "admin":
+        raise WrongParameterException(
+            "admin is a global role and cannot be set per project"
+        )
     link = ProjectPersonLink.query.filter_by(
         project_id=project_id, person_id=person_id
     ).first()

--- a/zou/app/services/tasks_service.py
+++ b/zou/app/services/tasks_service.py
@@ -18,7 +18,7 @@ from sqlalchemy import and_
 from sqlalchemy.exc import StatementError, IntegrityError, DataError
 from sqlalchemy.sql import func
 from sqlalchemy.sql.expression import case
-from sqlalchemy.orm import aliased, load_only, selectinload
+from sqlalchemy.orm import aliased, selectinload
 from sqlalchemy.orm.exc import StaleDataError
 
 from zou.app import config, db

--- a/zou/app/services/tasks_service.py
+++ b/zou/app/services/tasks_service.py
@@ -14,6 +14,7 @@ Two conventions matter when editing this module:
 import collections
 import uuid
 
+from sqlalchemy import and_
 from sqlalchemy.exc import StatementError, IntegrityError, DataError
 from sqlalchemy.sql import func
 from sqlalchemy.sql.expression import case
@@ -37,7 +38,11 @@ from zou.app.models.entity_type import EntityType, TaskTypeAssetTypeLink
 from zou.app.models.news import News
 from zou.app.models.person import Person
 from zou.app.models.preview_file import PreviewFile
-from zou.app.models.project import Project, ProjectTaskTypeLink
+from zou.app.models.project import (
+    Project,
+    ProjectPersonLink,
+    ProjectTaskTypeLink,
+)
 from zou.app.models.project_status import ProjectStatus
 from zou.app.models.task import Task, TaskPersonLink
 from zou.app.models.task_type import TaskType
@@ -761,7 +766,16 @@ def _prepare_query(task_id, is_client, is_manager):
         )
     )
     if not is_manager and not is_client:
-        query = query.filter(Person.role != "client")
+        task = get_task(task_id)
+        query = query.outerjoin(
+            ProjectPersonLink,
+            and_(
+                ProjectPersonLink.person_id == Person.id,
+                ProjectPersonLink.project_id == task["project_id"],
+            ),
+        ).filter(
+            func.coalesce(ProjectPersonLink.role, Person.role) != "client"
+        )
     return query
 
 
@@ -1230,7 +1244,15 @@ def get_last_comment_map(task_ids):
     comments = (
         Comment.query.filter(Comment.object_id.in_(task_ids))
         .join(Person, Comment.person_id == Person.id)
-        .filter(Person.role != "client")
+        .join(Task, Comment.object_id == Task.id)
+        .outerjoin(
+            ProjectPersonLink,
+            and_(
+                ProjectPersonLink.person_id == Person.id,
+                ProjectPersonLink.project_id == Task.project_id,
+            ),
+        )
+        .filter(func.coalesce(ProjectPersonLink.role, Person.role) != "client")
         .order_by(Comment.object_id, Comment.created_at)
         .all()
     )

--- a/zou/app/services/user_service.py
+++ b/zou/app/services/user_service.py
@@ -467,6 +467,17 @@ def check_belong_to_project(project_id):
     return True
 
 
+def resolve_project_role(project_id):
+    """
+    Resolve the current user's effective role for given project into
+    flask.g so that subsequent role checks apply the project role. Side
+    effect variant of check_belong_to_project for call sites where access
+    is enforced later: it never raises and its return value carries no
+    access guarantee.
+    """
+    return check_belong_to_project(project_id)
+
+
 def has_project_access(project_id):
     """
     Return true if current user is an admin or has a task assigned for this

--- a/zou/app/services/user_service.py
+++ b/zou/app/services/user_service.py
@@ -577,12 +577,13 @@ def check_supervisor_project_task_type_access(project_id, task_type_id):
     """
     is_allowed = False
     if permissions.has_admin_permissions() or (
-        permissions.has_manager_permissions()
-        and check_belong_to_project(project_id)
+        check_belong_to_project(project_id)
+        and permissions.has_manager_permissions()
     ):
         is_allowed = True
-    elif permissions.has_supervisor_permissions() and check_belong_to_project(
-        project_id
+    elif (
+        check_belong_to_project(project_id)
+        and permissions.has_supervisor_permissions()
     ):
         user = persons_service.get_current_user(relations=True)
         is_allowed = (
@@ -644,8 +645,8 @@ def has_manager_project_access(project_id):
     project.
     """
     return permissions.has_admin_permissions() or (
-        permissions.has_manager_permissions()
-        and check_belong_to_project(project_id)
+        check_belong_to_project(project_id)
+        and permissions.has_manager_permissions()
     )
 
 
@@ -670,8 +671,8 @@ def check_time_spent_access(task_id, person_id):
         persons_service.get_current_user()["id"] == person_id
         or permissions.has_admin_permissions()
         or (
-            permissions.has_manager_permissions()
-            and check_belong_to_project(task["project_id"])
+            check_belong_to_project(task["project_id"])
+            and permissions.has_manager_permissions()
         )
     )
 
@@ -686,11 +687,11 @@ def check_supervisor_project_access(project_id):
     assigned for this project.
     """
     is_allowed = permissions.has_admin_permissions() or (
-        (
+        check_belong_to_project(project_id)
+        and (
             permissions.has_manager_permissions()
             or permissions.has_supervisor_permissions()
         )
-        and check_belong_to_project(project_id)
     )
     if not is_allowed:
         raise permissions.PermissionDenied
@@ -707,12 +708,13 @@ def check_supervisor_task_access(task, new_data=None):
         new_data = {}
     is_allowed = False
     if permissions.has_admin_permissions() or (
-        permissions.has_manager_permissions()
-        and check_belong_to_project(task["project_id"])
+        check_belong_to_project(task["project_id"])
+        and permissions.has_manager_permissions()
     ):
         is_allowed = True
-    elif permissions.has_supervisor_permissions() and check_belong_to_project(
-        task["project_id"]
+    elif (
+        check_belong_to_project(task["project_id"])
+        and permissions.has_supervisor_permissions()
     ):
         # checks that the supervisor only modifies columns
         # for which he is authorized

--- a/zou/app/services/user_service.py
+++ b/zou/app/services/user_service.py
@@ -445,14 +445,18 @@ def check_belong_to_project(project_id):
     Return true if current user is assigned to a task of the given project or
     if current_user is part of the project team. As a side effect, resolve
     the member's effective role for this project into flask.g so that
-    subsequent role checks apply the project role.
+    subsequent role checks apply the project role. A failed check clears the
+    slot so a role resolved for another project earlier in the request never
+    leaks into this one.
     """
     if project_id is None:
+        g.project_role = None
         return False
 
     project = projects_service.get_project(str(project_id), relations=True)
     current_user = persons_service.get_current_user()
     if current_user["id"] not in project["team"]:
+        g.project_role = None
         return False
 
     if current_user["role"] != "admin":

--- a/zou/app/services/user_service.py
+++ b/zou/app/services/user_service.py
@@ -627,13 +627,13 @@ def check_comment_access(comment_id):
                     "id"
                 ] and not comment.get("for_client", False):
                     raise permissions.PermissionDenied
-            if persons_service.get_person(person_id)[
-                "role"
-            ] == "client" or comment.get("for_client", False):
+            if get_project_role(
+                person_id, task["project_id"]
+            ) == "client" or comment.get("for_client", False):
                 return True
             else:
                 raise permissions.PermissionDenied
-        elif persons_service.get_person(person_id)["role"] == "client":
+        elif get_project_role(person_id, task["project_id"]) == "client":
             raise permissions.PermissionDenied
 
         return True

--- a/zou/app/services/user_service.py
+++ b/zou/app/services/user_service.py
@@ -753,17 +753,16 @@ def check_metadata_department_access(entity, new_data=None):
     if new_data is None:
         new_data = {}
     is_allowed = False
+    belongs = check_belong_to_project(entity["project_id"])
     if permissions.has_admin_permissions() or (
-        (
+        belongs
+        and (
             permissions.has_manager_permissions()
             or entity["created_by"] == persons_service.get_current_user()["id"]
         )
-        and check_belong_to_project(entity["project_id"])
     ):
         is_allowed = True
-    elif permissions.has_supervisor_permissions() and check_belong_to_project(
-        entity["project_id"]
-    ):
+    elif belongs and permissions.has_supervisor_permissions():
         # checks that the supervisor only modifies columns
         # for which he is authorized
         allowed_columns = {"data"}
@@ -915,14 +914,12 @@ def check_all_departments_access(project_id, departments=None):
     if not isinstance(departments, list):
         departments = [departments]
     is_allowed = False
+    belongs = check_belong_to_project(project_id)
     if permissions.has_admin_permissions() or (
-        permissions.has_manager_permissions()
-        and check_belong_to_project(project_id)
+        belongs and permissions.has_manager_permissions()
     ):
         is_allowed = True
-    elif permissions.has_supervisor_permissions() and check_belong_to_project(
-        project_id
-    ):
+    elif belongs and permissions.has_supervisor_permissions():
         user_departments = persons_service.get_current_user(relations=True)[
             "departments"
         ]

--- a/zou/app/services/user_service.py
+++ b/zou/app/services/user_service.py
@@ -1,3 +1,4 @@
+from flask import g
 from sqlalchemy.orm import aliased
 from sqlalchemy import func, or_, and_
 
@@ -425,17 +426,41 @@ def check_person_access(person_id):
         raise permissions.PermissionDenied
 
 
+def get_project_role(person_id, project_id):
+    """
+    Return the effective role of given person on given project: the
+    project-specific role when one is set on the team link, the person's
+    global role otherwise.
+    """
+    link = ProjectPersonLink.query.filter_by(
+        project_id=str(project_id), person_id=str(person_id)
+    ).first()
+    if link is not None and link.role is not None:
+        return getattr(link.role, "code", link.role)
+    return persons_service.get_person(person_id)["role"]
+
+
 def check_belong_to_project(project_id):
     """
     Return true if current user is assigned to a task of the given project or
-    if current_user is part of the project team.
+    if current_user is part of the project team. As a side effect, resolve
+    the member's effective role for this project into flask.g so that
+    subsequent role checks apply the project role.
     """
     if project_id is None:
         return False
 
     project = projects_service.get_project(str(project_id), relations=True)
     current_user = persons_service.get_current_user()
-    return current_user["id"] in project["team"]
+    if current_user["id"] not in project["team"]:
+        return False
+
+    if current_user["role"] != "admin":
+        # Single slot: a request touching two projects keeps the role of the
+        # last access check performed, which always precedes the role checks
+        # it guards.
+        g.project_role = get_project_role(current_user["id"], project_id)
+    return True
 
 
 def has_project_access(project_id):

--- a/zou/app/utils/permissions.py
+++ b/zou/app/utils/permissions.py
@@ -1,4 +1,5 @@
 from functools import wraps
+from flask import g
 from flask_principal import RoleNeed, Permission
 from werkzeug.exceptions import Forbidden
 
@@ -18,17 +19,36 @@ class PermissionDenied(Forbidden):
     pass
 
 
+def _project_role():
+    """
+    Return the effective role resolved by the current request's project
+    access check, or None when no project context has been resolved.
+    """
+    try:
+        return g.get("project_role")
+    except RuntimeError:
+        return None
+
+
 def has_manager_permissions():
     """
-    Return True if user is an admin or a manager.
+    Return True if user is an admin or a manager, using the project role
+    when a project context is resolved.
     """
+    role = _project_role()
+    if role is not None:
+        return role == "manager"
     return admin_permission.can() or manager_permission.can()
 
 
 def has_artist_permissions():
     """
-    Return True if user is an artist.
+    Return True if user is an artist, using the project role when a project
+    context is resolved.
     """
+    role = _project_role()
+    if role is not None:
+        return role == "user"
     return artist_permission.can()
 
 
@@ -41,22 +61,34 @@ def has_admin_permissions():
 
 def has_client_permissions():
     """
-    Return True if user is a client.
+    Return True if user is a client, using the project role when a project
+    context is resolved.
     """
+    role = _project_role()
+    if role is not None:
+        return role == "client"
     return client_permission.can()
 
 
 def has_vendor_permissions():
     """
-    Return True if user is a vendor.
+    Return True if user is a vendor, using the project role when a project
+    context is resolved.
     """
+    role = _project_role()
+    if role is not None:
+        return role == "vendor"
     return vendor_permission.can()
 
 
 def has_supervisor_permissions():
     """
-    Return True if user is a supervisor.
+    Return True if user is a supervisor, using the project role when a
+    project context is resolved.
     """
+    role = _project_role()
+    if role is not None:
+        return role == "supervisor"
     return supervisor_permission.can()
 
 
@@ -69,8 +101,12 @@ def has_person_permissions():
 
 def has_at_least_supervisor_permissions():
     """
-    Return True if user is a supervisor, a manager or an admin.
+    Return True if user is a supervisor, a manager or an admin, using the
+    project role when a project context is resolved.
     """
+    role = _project_role()
+    if role is not None:
+        return role in ("supervisor", "manager")
     return (
         supervisor_permission.can()
         or admin_permission.can()

--- a/zou/migrations/versions/4159fed814b5_add_role_to_project_person_link.py
+++ b/zou/migrations/versions/4159fed814b5_add_role_to_project_person_link.py
@@ -1,0 +1,35 @@
+"""Add role to project person link
+
+Revision ID: 4159fed814b5
+Revises: f3a7c1e9b5d2
+Create Date: 2026-07-22
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+import sqlalchemy_utils
+
+from zou.app.models.person import ROLE_TYPES
+
+# revision identifiers, used by Alembic.
+revision = "4159fed814b5"
+down_revision = "f3a7c1e9b5d2"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("project_person_link", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "role",
+                sqlalchemy_utils.types.choice.ChoiceType(ROLE_TYPES),
+                nullable=True,
+            )
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("project_person_link", schema=None) as batch_op:
+        batch_op.drop_column("role")


### PR DESCRIPTION
**Problem**
- A person has one global role applied to every production: no way to be artist on one project and supervisor or manager on another (request: change role by project)
- Several project-scoped routes check the role before confirming membership, and some code reads `Person.role` directly, so a per-project role could not be enforced there

**Solution**
- Add nullable `role` to `ProjectPersonLink`: NULL inherits the global role continuously, no backfill, behavior unchanged after migration
- Resolve the member's effective role during project access checks; `permissions.has_*_permissions()` use it before falling back to the global role; admin stays global-only (schema and service both reject `admin` per project)
- Reorder 27 call sites so access checks run before role checks; switch direct role reads and client filters to effective-role lookups or SQL coalesce
- Team API: optional `role` on POST, `PUT /data/projects/<project_id>/team/<person_id>` to set or clear it, `project_role` in the team GET
- Note: output file update now requires project membership for managers (was global-manager only)
- 33 tests in `tests/services/test_project_roles.py`