### PR TITLE
[auth] Remove Flask-Principal

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,6 @@ install_requires =
     flask_caching==2.4.0
     flask-cors==6.0.2
     flask_mail==0.10.0
-    flask_principal==0.4.0
     flask_sqlalchemy==3.1.1
     flask-fs2[swift, s3]==0.8.2
     flask-jwt-extended==4.7.3

--- a/tests/auth/test_permission.py
+++ b/tests/auth/test_permission.py
@@ -1,6 +1,13 @@
+from types import SimpleNamespace
+from unittest import TestCase, mock
+
+from flask import g
+
 from tests.base import ApiDBTestCase
 
+from zou.app import app
 from zou.app.services import projects_service
+from zou.app.utils import permissions
 
 
 class PermissionTestCase(ApiDBTestCase):
@@ -138,23 +145,19 @@ class PermissionTestCase(ApiDBTestCase):
         self.get(f"data/assets/{asset_id}", 200)
 
 
-class GlobalRoleFallbackTestCase(ApiDBTestCase):
+class GlobalRoleFallbackTestCase(TestCase):
     """
     Unit coverage of the permission helpers' global fallback, which reads
-    the JWT identity directly since the Flask-Principal removal.
+    the JWT identity directly since the Flask-Principal removal. Everything
+    is mocked: no database fixture is needed, hence the plain TestCase.
     """
 
     def helpers_for(self, role):
-        from unittest import mock
-
-        from zou.app import app
-        from zou.app.utils import permissions
-
-        fake_user = mock.Mock()
-        fake_user.role = role
         with app.test_request_context():
             with mock.patch.object(
-                permissions, "get_current_user", return_value=fake_user
+                permissions,
+                "get_current_user",
+                return_value=SimpleNamespace(role=role),
             ):
                 return {
                     "admin": permissions.has_admin_permissions(),
@@ -193,12 +196,37 @@ class GlobalRoleFallbackTestCase(ApiDBTestCase):
         self.assertFalse(helpers["artist"])
         self.assertFalse(helpers["at_least_supervisor"])
 
+    def test_choice_role_objects_are_unwrapped(self):
+        # In production Person.role is a sqlalchemy_utils Choice object,
+        # not a plain string: the .code unwrapping branch must be covered.
+        with app.test_request_context():
+            with mock.patch.object(
+                permissions,
+                "get_current_user",
+                return_value=SimpleNamespace(
+                    role=SimpleNamespace(code="admin")
+                ),
+            ):
+                self.assertTrue(permissions.has_admin_permissions())
+                self.assertTrue(permissions.has_manager_permissions())
+
+    def test_admin_in_project_slot_falls_back_to_global_role(self):
+        # Admin is global-only: an "admin" value in the project role slot
+        # is invalid data and must not grant admin-tier rights.
+        with app.test_request_context():
+            g.project_role = "admin"
+            with mock.patch.object(
+                permissions,
+                "get_current_user",
+                return_value=SimpleNamespace(role="user"),
+            ):
+                self.assertFalse(permissions.has_admin_permissions())
+                self.assertFalse(permissions.has_manager_permissions())
+                self.assertFalse(
+                    permissions.has_at_least_supervisor_permissions()
+                )
+
     def test_person_permissions_follow_identity_type(self):
-        from unittest import mock
-
-        from zou.app import app
-        from zou.app.utils import permissions
-
         for identity_type, expected in [
             ("person", True),
             ("person_api", True),
@@ -214,9 +242,9 @@ class GlobalRoleFallbackTestCase(ApiDBTestCase):
                         permissions.has_person_permissions(), expected
                     )
 
-    def test_all_false_outside_request_context(self):
-        from zou.app.utils import permissions
-
+    def test_all_false_outside_app_context(self):
+        # Plain TestCase: unlike ApiDBTestCase, no app context is pushed,
+        # so this exercises the RuntimeError guards for real.
         self.assertFalse(permissions.has_admin_permissions())
         self.assertFalse(permissions.has_manager_permissions())
         self.assertFalse(permissions.has_person_permissions())

--- a/tests/auth/test_permission.py
+++ b/tests/auth/test_permission.py
@@ -136,3 +136,87 @@ class PermissionTestCase(ApiDBTestCase):
             self.project_id, self.user_cg_artist["id"]
         )
         self.get(f"data/assets/{asset_id}", 200)
+
+
+class GlobalRoleFallbackTestCase(ApiDBTestCase):
+    """
+    Unit coverage of the permission helpers' global fallback, which reads
+    the JWT identity directly since the Flask-Principal removal.
+    """
+
+    def helpers_for(self, role):
+        from unittest import mock
+
+        from zou.app import app
+        from zou.app.utils import permissions
+
+        fake_user = mock.Mock()
+        fake_user.role = role
+        with app.test_request_context():
+            with mock.patch.object(
+                permissions, "get_current_user", return_value=fake_user
+            ):
+                return {
+                    "admin": permissions.has_admin_permissions(),
+                    "manager": permissions.has_manager_permissions(),
+                    "supervisor": permissions.has_supervisor_permissions(),
+                    "at_least_supervisor": (
+                        permissions.has_at_least_supervisor_permissions()
+                    ),
+                    "client": permissions.has_client_permissions(),
+                    "vendor": permissions.has_vendor_permissions(),
+                    "artist": permissions.has_artist_permissions(),
+                }
+
+    def test_admin_implies_manager(self):
+        helpers = self.helpers_for("admin")
+        self.assertTrue(helpers["admin"])
+        self.assertTrue(helpers["manager"])
+        self.assertTrue(helpers["at_least_supervisor"])
+        self.assertFalse(helpers["supervisor"])
+
+    def test_manager_is_not_admin(self):
+        helpers = self.helpers_for("manager")
+        self.assertFalse(helpers["admin"])
+        self.assertTrue(helpers["manager"])
+        self.assertTrue(helpers["at_least_supervisor"])
+
+    def test_single_role_mappings(self):
+        self.assertTrue(self.helpers_for("supervisor")["supervisor"])
+        self.assertTrue(self.helpers_for("client")["client"])
+        self.assertTrue(self.helpers_for("vendor")["vendor"])
+
+    def test_artist_global_fallback_stays_false(self):
+        # Flask-Principal never granted a "user" need: the historical
+        # always-False global fallback is preserved on purpose.
+        helpers = self.helpers_for("user")
+        self.assertFalse(helpers["artist"])
+        self.assertFalse(helpers["at_least_supervisor"])
+
+    def test_person_permissions_follow_identity_type(self):
+        from unittest import mock
+
+        from zou.app import app
+        from zou.app.utils import permissions
+
+        for identity_type, expected in [
+            ("person", True),
+            ("person_api", True),
+            ("bot", False),
+        ]:
+            with app.test_request_context():
+                with mock.patch.object(
+                    permissions,
+                    "get_jwt",
+                    return_value={"identity_type": identity_type},
+                ):
+                    self.assertEqual(
+                        permissions.has_person_permissions(), expected
+                    )
+
+    def test_all_false_outside_request_context(self):
+        from zou.app.utils import permissions
+
+        self.assertFalse(permissions.has_admin_permissions())
+        self.assertFalse(permissions.has_manager_permissions())
+        self.assertFalse(permissions.has_person_permissions())

--- a/tests/services/test_user_service.py
+++ b/tests/services/test_user_service.py
@@ -1,6 +1,9 @@
 # -*- coding: UTF-8 -*-
+from flask_jwt_extended import verify_jwt_in_request
+
 from tests.base import ApiDBTestCase
 
+from zou.app import app
 from zou.app.models.person import Person
 from zou.app.services import (
     comments_service,
@@ -95,10 +98,16 @@ class UserServiceTestCase(ApiDBTestCase):
         self.log_in_vendor()
         person_id = str(self.get_current_user_raw().id)
         projects_service.add_team_member(self.project_id, person_id)
-        with self.assertRaises(permissions.PermissionDenied):
-            user_service.check_entity_access(str(self.asset_id))
-        tasks_service.assign_task(self.task_id, person_id)
-        self.assertTrue(user_service.check_entity_access(str(self.asset_id)))
+        # The permission helpers read the JWT identity: run the checks in a
+        # verified request context, as production does.
+        with app.test_request_context(headers=self.auth_headers):
+            verify_jwt_in_request()
+            with self.assertRaises(permissions.PermissionDenied):
+                user_service.check_entity_access(str(self.asset_id))
+            tasks_service.assign_task(self.task_id, person_id)
+            self.assertTrue(
+                user_service.check_entity_access(str(self.asset_id))
+            )
 
     def _log_in_cg_artist_as_current_user(self, team_member=True):
         """

--- a/zou/app/__init__.py
+++ b/zou/app/__init__.py
@@ -1,18 +1,9 @@
 import traceback
-import uuid
 
 from flask import Flask, jsonify, current_app, request
 from flasgger import Swagger
 from flask_cors import CORS
 from flask_jwt_extended import JWTManager
-from flask_principal import (
-    Principal,
-    Identity,
-    identity_changed,
-    RoleNeed,
-    UserNeed,
-    identity_loaded,
-)
 from flask_sqlalchemy import SQLAlchemy
 from flask_migrate import Migrate
 from flask_mail import Mail
@@ -285,51 +276,7 @@ def configure_auth(app):
             if request.path not in allowed_paths:
                 raise TwoFactorAuthenticationRequiredException()
 
-        identity_changed.send(
-            current_app._get_current_object(),
-            identity=Identity(identity.id, identity_type),
-        )
         return identity
-
-    @identity_loaded.connect_via(app)
-    def on_identity_loaded(_, identity):
-        try:
-            if isinstance(identity.id, (str, uuid.UUID)):
-                identity.user = persons_service.get_person_raw_cached(
-                    identity.id
-                )
-
-                if hasattr(identity.user, "id"):
-                    identity.provides.add(UserNeed(identity.user.id))
-
-                if identity.user.role == "admin":
-                    identity.provides.add(RoleNeed("admin"))
-                    identity.provides.add(RoleNeed("manager"))
-
-                elif identity.user.role == "manager":
-                    identity.provides.add(RoleNeed("manager"))
-
-                elif identity.user.role == "supervisor":
-                    identity.provides.add(RoleNeed("supervisor"))
-
-                elif identity.user.role == "client":
-                    identity.provides.add(RoleNeed("client"))
-
-                elif identity.user.role == "vendor":
-                    identity.provides.add(RoleNeed("vendor"))
-
-                identity.provides.add(RoleNeed(identity.auth_type))
-
-            return identity
-
-        except (PersonNotFoundException, UnactiveUserException):
-            return wrong_auth_handler()
-        except TimeoutError:
-            current_app.logger.error("Identity loading timed out")
-            return wrong_auth_handler()
-        except Exception as e:
-            current_app.logger.error(e, exc_info=1)
-            return wrong_auth_handler()
 
 
 def load_api(app):
@@ -369,7 +316,6 @@ def create_app(config_object=config):
 
     app.secret_key = app.config["SECRET_KEY"]
     jwt.init_app(app)
-    Principal(app)
     cache.cache.init_app(app)
     mail.init_app(app)
     swagger = Swagger(

--- a/zou/app/blueprints/auth/resources.py
+++ b/zou/app/blueprints/auth/resources.py
@@ -3,11 +3,6 @@ import secrets
 
 from flask import request, jsonify, current_app, redirect, make_response
 from flask.views import MethodView
-from flask_principal import (
-    Identity,
-    AnonymousIdentity,
-    identity_changed,
-)
 from flask_jwt_extended import (
     jwt_required,
     create_access_token,
@@ -143,9 +138,6 @@ class LogoutResource(MethodView):
         try:
             payload = get_jwt()
             auth_service.logout(payload["jti"], payload.get("refresh_jti"))
-            identity_changed.send(
-                current_app._get_current_object(), identity=AnonymousIdentity()
-            )
         except KeyError:
             return {"Access token not found."}, 500
 
@@ -262,10 +254,6 @@ class LoginResource(MethodView, ArgsMixin):
 
             access_token, refresh_token = auth_service.create_auth_tokens(
                 user["id"], additional_claims
-            )
-            identity_changed.send(
-                current_app._get_current_object(),
-                identity=Identity(user["id"], "person"),
             )
 
             ip_address = request.environ.get(
@@ -1436,10 +1424,6 @@ class SAMLSSOResource(MethodView, ArgsMixin):
             access_token, refresh_token = auth_service.create_auth_tokens(
                 user["id"], additional_claims
             )
-            identity_changed.send(
-                current_app._get_current_object(),
-                identity=Identity(user["id"], "person"),
-            )
 
             ip_address = request.environ.get(
                 "HTTP_X_REAL_IP", request.remote_addr
@@ -1604,10 +1588,6 @@ class OIDCCallbackResource(MethodView, ArgsMixin):
 
             access_token, refresh_token = auth_service.create_auth_tokens(
                 user["id"], additional_claims
-            )
-            identity_changed.send(
-                current_app._get_current_object(),
-                identity=Identity(user["id"], "person"),
             )
 
             ip_address = request.environ.get(

--- a/zou/app/blueprints/auth/resources.py
+++ b/zou/app/blueprints/auth/resources.py
@@ -1154,8 +1154,8 @@ class FIDOResource(MethodView, ArgsMixin):
             persons_service.get_current_user()["id"]
         )
 
-    @permissions.require_person
     @jwt_required()
+    @permissions.require_person
     def post(self):
         """
         Register FIDO device

--- a/zou/app/utils/permissions.py
+++ b/zou/app/utils/permissions.py
@@ -1,18 +1,8 @@
 from functools import wraps
+
 from flask import g
-from flask_principal import RoleNeed, Permission
+from flask_jwt_extended import get_current_user, get_jwt
 from werkzeug.exceptions import Forbidden
-
-admin_permission = Permission(RoleNeed("admin"))
-manager_permission = Permission(RoleNeed("manager"))
-supervisor_permission = Permission(RoleNeed("supervisor"))
-client_permission = Permission(RoleNeed("client"))
-vendor_permission = Permission(RoleNeed("vendor"))
-artist_permission = Permission(RoleNeed("user"))
-
-bot_permission = Permission(RoleNeed("bot"))
-person_permission = Permission(RoleNeed("person"), RoleNeed("person_api"))
-person_api_permission = Permission(RoleNeed("person_api"))
 
 
 class PermissionDenied(Forbidden):
@@ -30,6 +20,31 @@ def _project_role():
         return None
 
 
+def _global_role():
+    """
+    Return the authenticated identity's global role, or None outside an
+    authenticated request context.
+    """
+    try:
+        user = get_current_user()
+    except RuntimeError:
+        return None
+    if user is None:
+        return None
+    return getattr(user.role, "code", user.role)
+
+
+def _auth_type():
+    """
+    Return the JWT identity type (person, bot or person_api), or None
+    outside an authenticated request context.
+    """
+    try:
+        return get_jwt().get("identity_type")
+    except RuntimeError:
+        return None
+
+
 def has_manager_permissions():
     """
     Return True if user is an admin or a manager, using the project role
@@ -38,25 +53,26 @@ def has_manager_permissions():
     role = _project_role()
     if role is not None:
         return role == "manager"
-    return admin_permission.can() or manager_permission.can()
+    return _global_role() in ("admin", "manager")
 
 
 def has_artist_permissions():
     """
-    Return True if user is an artist, using the project role when a project
-    context is resolved.
+    Return True if user is an artist on the resolved project. Without a
+    project context this is always False: Flask-Principal never granted a
+    "user" need, so the historical global fallback is preserved as-is.
     """
     role = _project_role()
     if role is not None:
         return role == "user"
-    return artist_permission.can()
+    return False
 
 
 def has_admin_permissions():
     """
     Return True if user is an admin.
     """
-    return admin_permission.can()
+    return _global_role() == "admin"
 
 
 def has_client_permissions():
@@ -67,7 +83,7 @@ def has_client_permissions():
     role = _project_role()
     if role is not None:
         return role == "client"
-    return client_permission.can()
+    return _global_role() == "client"
 
 
 def has_vendor_permissions():
@@ -78,7 +94,7 @@ def has_vendor_permissions():
     role = _project_role()
     if role is not None:
         return role == "vendor"
-    return vendor_permission.can()
+    return _global_role() == "vendor"
 
 
 def has_supervisor_permissions():
@@ -89,14 +105,14 @@ def has_supervisor_permissions():
     role = _project_role()
     if role is not None:
         return role == "supervisor"
-    return supervisor_permission.can()
+    return _global_role() == "supervisor"
 
 
 def has_person_permissions():
     """
     Return True if user is a person.
     """
-    return person_permission.can()
+    return _auth_type() in ("person", "person_api")
 
 
 def has_at_least_supervisor_permissions():
@@ -107,11 +123,7 @@ def has_at_least_supervisor_permissions():
     role = _project_role()
     if role is not None:
         return role in ("supervisor", "manager")
-    return (
-        supervisor_permission.can()
-        or admin_permission.can()
-        or manager_permission.can()
-    )
+    return _global_role() in ("admin", "manager", "supervisor")
 
 
 def check_at_least_supervisor_permissions():
@@ -141,7 +153,7 @@ def check_admin_permissions():
     Return True if user is admin. It raises a PermissionDenied exception in case
     of failure.
     """
-    if admin_permission.can():
+    if has_admin_permissions():
         return True
     else:
         raise PermissionDenied
@@ -152,7 +164,7 @@ def check_person_permissions():
     Return True if user is a person. It raises a PermissionDenied exception in
     case of failure.
     """
-    if person_permission.can():
+    if has_person_permissions():
         return True
     else:
         raise PermissionDenied

--- a/zou/app/utils/permissions.py
+++ b/zou/app/utils/permissions.py
@@ -48,11 +48,12 @@ def _auth_type():
 def _effective_role():
     """
     Return the current identity's effective role: the project role when a
-    project context is resolved, the global role otherwise. The project
-    slot never holds "admin", so comparing the effective role against role
-    sets that include "admin" stays correct in both contexts.
+    project context is resolved, the global role otherwise. Admin is a
+    global-only role: a project slot holding "admin" is invalid data and
+    falls back to the global role instead of granting admin-tier rights.
     """
-    return _project_role() or _global_role()
+    role = _project_role()
+    return role if role not in (None, "admin") else _global_role()
 
 
 def has_manager_permissions():

--- a/zou/app/utils/permissions.py
+++ b/zou/app/utils/permissions.py
@@ -45,15 +45,22 @@ def _auth_type():
         return None
 
 
+def _effective_role():
+    """
+    Return the current identity's effective role: the project role when a
+    project context is resolved, the global role otherwise. The project
+    slot never holds "admin", so comparing the effective role against role
+    sets that include "admin" stays correct in both contexts.
+    """
+    return _project_role() or _global_role()
+
+
 def has_manager_permissions():
     """
     Return True if user is an admin or a manager, using the project role
     when a project context is resolved.
     """
-    role = _project_role()
-    if role is not None:
-        return role == "manager"
-    return _global_role() in ("admin", "manager")
+    return _effective_role() in ("admin", "manager")
 
 
 def has_artist_permissions():
@@ -62,15 +69,13 @@ def has_artist_permissions():
     project context this is always False: Flask-Principal never granted a
     "user" need, so the historical global fallback is preserved as-is.
     """
-    role = _project_role()
-    if role is not None:
-        return role == "user"
-    return False
+    return _project_role() == "user"
 
 
 def has_admin_permissions():
     """
-    Return True if user is an admin.
+    Return True if user is an admin. Admin is a global-only role, so this
+    check ignores any resolved project role.
     """
     return _global_role() == "admin"
 
@@ -80,10 +85,7 @@ def has_client_permissions():
     Return True if user is a client, using the project role when a project
     context is resolved.
     """
-    role = _project_role()
-    if role is not None:
-        return role == "client"
-    return _global_role() == "client"
+    return _effective_role() == "client"
 
 
 def has_vendor_permissions():
@@ -91,10 +93,7 @@ def has_vendor_permissions():
     Return True if user is a vendor, using the project role when a project
     context is resolved.
     """
-    role = _project_role()
-    if role is not None:
-        return role == "vendor"
-    return _global_role() == "vendor"
+    return _effective_role() == "vendor"
 
 
 def has_supervisor_permissions():
@@ -102,10 +101,7 @@ def has_supervisor_permissions():
     Return True if user is a supervisor, using the project role when a
     project context is resolved.
     """
-    role = _project_role()
-    if role is not None:
-        return role == "supervisor"
-    return _global_role() == "supervisor"
+    return _effective_role() == "supervisor"
 
 
 def has_person_permissions():
@@ -120,10 +116,7 @@ def has_at_least_supervisor_permissions():
     Return True if user is a supervisor, a manager or an admin, using the
     project role when a project context is resolved.
     """
-    role = _project_role()
-    if role is not None:
-        return role in ("supervisor", "manager")
-    return _global_role() in ("admin", "manager", "supervisor")
+    return _effective_role() in ("admin", "manager", "supervisor")
 
 
 def check_at_least_supervisor_permissions():


### PR DESCRIPTION
**Problem**
- Flask-Principal (unmaintained since 2013, pinned 0.4.0) only re-derived per request what the JWT identity already provides, through an `identity_changed`/`identity_loaded` round trip plus a session side channel
- The session side channel masked a decorator ordering bug: FIDO device registration ran its person check before JWT verification
- `has_artist_permissions()` never matched globally: the identity loader granted no `user` need

**Solution**
- Permission helpers read the JWT identity directly: global role from `current_user`, auth type from the `identity_type` claim; the per-project role override is unchanged
- Drop `Principal(app)`, the `identity_loaded` handler, the four `identity_changed` sends and the dependency pin
- Verify the JWT before the person check on FIDO registration
- Keep the always-False artist global fallback as is, now explicit in code and covered by unit tests on the fallback mapping