### PR TITLE
Speed up schedule version copy on large productions

### DIFF
--- a/tests/services/test_schedule_service.py
+++ b/tests/services/test_schedule_service.py
@@ -1,13 +1,20 @@
+from datetime import datetime
+
 from tests.base import ApiDBTestCase
 
+from zou.app import db
 from zou.app.models.entity import Entity
 from zou.app.models.milestone import Milestone
 from zou.app.models.production_schedule_version import (
     ProductionScheduleVersion,
+    ProductionScheduleVersionTaskLink,
+    ProductionScheduleVersionTaskLinkPersonLink,
 )
+from zou.app.models.task import Task
 from zou.app.services import schedule_service
 from zou.app.services.exception import (
     ProductionScheduleVersionNotFoundException,
+    WrongParameterException,
 )
 
 
@@ -273,13 +280,326 @@ class ScheduleServiceTestCase(ApiDBTestCase):
         )
         self.assertEqual(len(links), 0)
 
-    def test_set_production_schedule_version_task_links_from_production(
-        self,
-    ):
+    def _make_person(self, first_name, last_name):
+        # generate_fixture_person reassigns self.person; restore it afterwards.
+        original = self.person
+        person = self.generate_fixture_person(
+            first_name=first_name,
+            last_name=last_name,
+            desktop_login=f"{first_name}.{last_name}".lower(),
+            email=f"{first_name}.{last_name}@example.com".lower(),
+        )
+        self.person = original
+        return person
+
+    def _make_task(self, name, entity_id, assignees):
+        return Task.create(
+            name=name,
+            project_id=self.project.id,
+            task_type_id=self.task_type.id,
+            task_status_id=self.task_status.id,
+            entity_id=entity_id,
+            assignees=assignees,
+            assigner_id=self.assigner.id,
+            estimation=40,
+        )
+
+    def _assignees_by_task(self, psv_id):
+        tl = ProductionScheduleVersionTaskLink
+        pl = ProductionScheduleVersionTaskLinkPersonLink
+        rows = (
+            db.session.query(tl.task_id, pl.person_id)
+            .join(pl, pl.production_schedule_version_task_link_id == tl.id)
+            .filter(tl.production_schedule_version_id == psv_id)
+            .all()
+        )
+        result = {}
+        for task_id, person_id in rows:
+            result.setdefault(str(task_id), set()).add(str(person_id))
+        return result
+
+    def test_set_production_schedule_version_task_links_from_production(self):
+        # Two tasks assigned to DISTINCT people so a partial or cross-wired
+        # assignee copy is detectable.
+        jane = self._make_person("Jane", "Roe")
+        asset2 = self.generate_fixture_asset(name="Asset2")
+        task_john = self.task
+        task_jane = self._make_task("Master", asset2.id, [jane])
+
         psv = ProductionScheduleVersion.create(
             name="v1", project_id=self.project.id
         )
-        links = schedule_service.set_production_schedule_version_task_links_from_production(
+        result = schedule_service.set_production_schedule_version_task_links_from_production(
             str(psv.id)
         )
-        self.assertGreater(len(links), 0)
+        self.assertEqual(result, {"success": True, "task_link_count": 2})
+
+        links = schedule_service.get_production_schedule_version_task_links(
+            str(psv.id), relations=True
+        )
+        self.assertEqual(len(links), 2)
+        got = {link["task_id"]: set(link["assignees"]) for link in links}
+        self.assertEqual(
+            got,
+            {
+                str(task_john.id): {str(self.person.id)},
+                str(task_jane.id): {str(jane.id)},
+            },
+        )
+
+    def test_set_production_schedule_version_task_links_is_idempotent(self):
+        # A second copy must not duplicate links nor change their assignees.
+        psv = ProductionScheduleVersion.create(
+            name="v1", project_id=self.project.id
+        )
+        schedule_service.set_production_schedule_version_task_links_from_production(
+            str(psv.id)
+        )
+        expected = self._assignees_by_task(str(psv.id))
+
+        result = schedule_service.set_production_schedule_version_task_links_from_production(
+            str(psv.id)
+        )
+        self.assertEqual(result["task_link_count"], 1)
+        self.assertEqual(self._assignees_by_task(str(psv.id)), expected)
+
+        # The DELETE-then-reinsert leaves exactly one person link.
+        tl = ProductionScheduleVersionTaskLink
+        pl = ProductionScheduleVersionTaskLinkPersonLink
+        person_link_count = (
+            db.session.query(pl)
+            .join(tl, tl.id == pl.production_schedule_version_task_link_id)
+            .filter(tl.production_schedule_version_id == str(psv.id))
+            .count()
+        )
+        self.assertEqual(person_link_count, 1)
+
+    def test_set_production_schedule_version_task_links_updates_existing(self):
+        # The ON CONFLICT DO UPDATE branch must refresh every copied value:
+        # estimation AND the start/due dates.
+        psv = ProductionScheduleVersion.create(
+            name="v1", project_id=self.project.id
+        )
+        schedule_service.set_production_schedule_version_task_links_from_production(
+            str(psv.id)
+        )
+        self.task.update(
+            {
+                "estimation": 123,
+                "start_date": datetime(2021, 3, 1),
+                "due_date": datetime(2021, 3, 15),
+            }
+        )
+        schedule_service.set_production_schedule_version_task_links_from_production(
+            str(psv.id)
+        )
+        links = schedule_service.get_production_schedule_version_task_links(
+            str(psv.id)
+        )
+        self.assertEqual(len(links), 1)
+        task = self.task.serialize()
+        self.assertEqual(links[0]["estimation"], 123)
+        self.assertEqual(links[0]["start_date"], task["start_date"])
+        self.assertEqual(links[0]["due_date"], task["due_date"])
+
+    def test_set_production_schedule_version_task_links_refreshes_assignees(
+        self,
+    ):
+        # The scoped DELETE + INSERT must REFRESH assignees to their new set on
+        # a re-copy: a removed assignee disappears and an added one appears.
+        jane = self._make_person("Jane", "Roe")
+        psv = ProductionScheduleVersion.create(
+            name="v1", project_id=self.project.id
+        )
+        schedule_service.set_production_schedule_version_task_links_from_production(
+            str(psv.id)
+        )
+        self.assertEqual(
+            self._assignees_by_task(str(psv.id)),
+            {str(self.task.id): {str(self.person.id)}},
+        )
+
+        # self.person is dropped and jane is added.
+        self.task.assignees = [jane]
+        db.session.commit()
+        schedule_service.set_production_schedule_version_task_links_from_production(
+            str(psv.id)
+        )
+        self.assertEqual(
+            self._assignees_by_task(str(psv.id)),
+            {str(self.task.id): {str(jane.id)}},
+        )
+
+    def test_set_production_schedule_version_task_links_unassigned_task(self):
+        # A task with no assignee yields a link with no person link.
+        asset2 = self.generate_fixture_asset(name="Asset2")
+        self._make_task("Master", asset2.id, [])
+
+        psv = ProductionScheduleVersion.create(
+            name="v1", project_id=self.project.id
+        )
+        result = schedule_service.set_production_schedule_version_task_links_from_production(
+            str(psv.id)
+        )
+        self.assertEqual(result["task_link_count"], 2)
+        self.assertEqual(
+            self._assignees_by_task(str(psv.id)),
+            {str(self.task.id): {str(self.person.id)}},
+        )
+
+    def test_set_production_schedule_version_task_links_no_task(self):
+        # A production with no task must not crash and report an empty copy.
+        empty_project = self.generate_fixture_project(name="Empty Project")
+        psv = ProductionScheduleVersion.create(
+            name="v1", project_id=empty_project.id
+        )
+        result = schedule_service.set_production_schedule_version_task_links_from_production(
+            str(psv.id)
+        )
+        self.assertEqual(result, {"success": True, "task_link_count": 0})
+
+    def test_set_production_schedule_version_task_links_from_version(self):
+        # Copy version A -> B; two tasks assigned to distinct people.
+        jane = self._make_person("Jane", "Roe")
+        asset2 = self.generate_fixture_asset(name="Asset2")
+        task_john = self.task
+        task_jane = self._make_task("Master", asset2.id, [jane])
+
+        source = ProductionScheduleVersion.create(
+            name="A", project_id=self.project.id
+        )
+        schedule_service.set_production_schedule_version_task_links_from_production(
+            str(source.id)
+        )
+        target = ProductionScheduleVersion.create(
+            name="B", project_id=self.project.id
+        )
+        result = schedule_service.set_production_schedule_version_task_links_from_production_schedule_version(
+            str(target.id), str(source.id)
+        )
+        self.assertEqual(result, {"success": True, "task_link_count": 2})
+        self.assertEqual(
+            self._assignees_by_task(str(target.id)),
+            {
+                str(task_john.id): {str(self.person.id)},
+                str(task_jane.id): {str(jane.id)},
+            },
+        )
+        # The copy records its origin version.
+        copied = ProductionScheduleVersion.get(target.id)
+        self.assertEqual(
+            str(copied.production_schedule_from), str(source.id)
+        )
+
+    def test_set_production_schedule_version_task_links_from_version_preserves_unrelated(
+        self,
+    ):
+        # A target link whose task is not in the source keeps its assignees.
+        jane = self._make_person("Jane", "Roe")
+        asset2 = self.generate_fixture_asset(name="Asset2")
+        task_john = self.task
+        task_jane = self._make_task("Master", asset2.id, [jane])
+
+        source = ProductionScheduleVersion.create(
+            name="A", project_id=self.project.id
+        )
+        source_link = ProductionScheduleVersionTaskLink.create(
+            production_schedule_version_id=source.id, task_id=task_john.id
+        )
+        source_link.assignees = [self.person]
+
+        target = ProductionScheduleVersion.create(
+            name="B", project_id=self.project.id
+        )
+        unrelated_link = ProductionScheduleVersionTaskLink.create(
+            production_schedule_version_id=target.id, task_id=task_jane.id
+        )
+        unrelated_link.assignees = [jane]
+        db.session.commit()
+
+        result = schedule_service.set_production_schedule_version_task_links_from_production_schedule_version(
+            str(target.id), str(source.id)
+        )
+        # Only task_john is copied from the source; the count reflects the
+        # copied links, not the 2 links now on the target.
+        self.assertEqual(result, {"success": True, "task_link_count": 1})
+        self.assertEqual(
+            self._assignees_by_task(str(target.id)),
+            {
+                str(task_john.id): {str(self.person.id)},
+                str(task_jane.id): {str(jane.id)},
+            },
+        )
+
+    def test_set_production_schedule_version_task_links_from_version_rejects_self_copy(
+        self,
+    ):
+        # Copying a version onto itself is rejected, not an assignee wipe.
+        psv = ProductionScheduleVersion.create(
+            name="v1", project_id=self.project.id
+        )
+        schedule_service.set_production_schedule_version_task_links_from_production(
+            str(psv.id)
+        )
+        with self.assertRaises(WrongParameterException):
+            schedule_service.set_production_schedule_version_task_links_from_production_schedule_version(
+                str(psv.id), str(psv.id)
+            )
+        self.assertEqual(
+            self._assignees_by_task(str(psv.id)),
+            {str(self.task.id): {str(self.person.id)}},
+        )
+
+    def test_set_task_links_from_version_rejects_cross_project(self):
+        # The route rejects copying between two different projects with a 400.
+        target = ProductionScheduleVersion.create(
+            name="target", project_id=self.project.id
+        )
+        other_project = self.generate_fixture_project(name="Other Project")
+        source = ProductionScheduleVersion.create(
+            name="source", project_id=other_project.id
+        )
+        self.post(
+            f"/actions/production-schedule-versions/{target.id}"
+            "/set-task-links-from-production-schedule-version",
+            {"production_schedule_version_id": str(source.id)},
+            400,
+        )
+
+    def test_apply_production_schedule_version_to_production(self):
+        # apply copies the version's task-link values back onto the tasks,
+        # locks the version and records it as the project's source version.
+        psv = ProductionScheduleVersion.create(
+            name="v1", project_id=self.project.id
+        )
+        schedule_service.set_production_schedule_version_task_links_from_production(
+            str(psv.id)
+        )
+        link = ProductionScheduleVersionTaskLink.get_by(
+            production_schedule_version_id=psv.id, task_id=self.task.id
+        )
+        link.update(
+            {
+                "estimation": 321,
+                "start_date": datetime(2022, 5, 2),
+                "due_date": datetime(2022, 5, 20),
+            }
+        )
+
+        result = schedule_service.apply_production_schedule_version_to_production(
+            str(psv.id)
+        )
+        self.assertEqual(result, {"success": True, "task_count": 1})
+
+        task = Task.get(self.task.id)
+        self.assertEqual(task.estimation, 321)
+        self.assertEqual(task.start_date, datetime(2022, 5, 2))
+        self.assertEqual(task.due_date, datetime(2022, 5, 20))
+
+        version = ProductionScheduleVersion.get(psv.id)
+        self.assertTrue(version.locked)
+
+        db.session.refresh(self.project)
+        self.assertEqual(
+            str(self.project.from_schedule_version_id), str(psv.id)
+        )

--- a/tests/services/test_schedule_service.py
+++ b/tests/services/test_schedule_service.py
@@ -566,6 +566,29 @@ class ScheduleServiceTestCase(ApiDBTestCase):
             400,
         )
 
+    def test_set_task_links_from_version_rejects_case_mismatched_self_copy(
+        self,
+    ):
+        # An uppercase UUID in the path resolves (in SQL) to the same version
+        # as the normalized source id, so the self-copy guard must still fire
+        # and the assignees must not be wiped.
+        psv = ProductionScheduleVersion.create(
+            name="v1", project_id=self.project.id
+        )
+        schedule_service.set_production_schedule_version_task_links_from_production(
+            str(psv.id)
+        )
+        self.post(
+            f"/actions/production-schedule-versions/{str(psv.id).upper()}"
+            "/set-task-links-from-production-schedule-version",
+            {"production_schedule_version_id": str(psv.id)},
+            400,
+        )
+        self.assertEqual(
+            self._assignees_by_task(str(psv.id)),
+            {str(self.task.id): {str(self.person.id)}},
+        )
+
     def test_apply_production_schedule_version_to_production(self):
         # apply copies the version's task-link values back onto the tasks,
         # locks the version and records it as the project's source version.

--- a/zou/app/blueprints/projects/resources.py
+++ b/zou/app/blueprints/projects/resources.py
@@ -2850,6 +2850,12 @@ class ProductionScheduleVersionSetTaskLinksFromTasksResource(
               application/json:
                 schema:
                   type: object
+                  properties:
+                    success:
+                      type: boolean
+                    task_link_count:
+                      type: integer
+                      description: Number of task links copied
           400:
             description: Wrong ID format
         """
@@ -2895,6 +2901,12 @@ class ProductionScheduleVersionApplyToProductionResource(
               application/json:
                 schema:
                   type: object
+                  properties:
+                    success:
+                      type: boolean
+                    task_count:
+                      type: integer
+                      description: Number of tasks updated
           400:
             description: Wrong ID format
         """
@@ -2958,6 +2970,12 @@ class ProductionScheduleVersionSetTaskLinksFromProductionScheduleVersionResource
               application/json:
                 schema:
                   type: object
+                  properties:
+                    success:
+                      type: boolean
+                    task_link_count:
+                      type: integer
+                      description: Number of task links copied
           400:
             description: Wrong ID format
         """

--- a/zou/app/blueprints/projects/resources.py
+++ b/zou/app/blueprints/projects/resources.py
@@ -3005,7 +3005,7 @@ class ProductionScheduleVersionSetTaskLinksFromProductionScheduleVersionResource
             )
 
         return schedule_service.set_production_schedule_version_task_links_from_production_schedule_version(
-            production_schedule_version_id,
+            production_schedule_version["id"],
             other_production_schedule_version_id=other_production_schedule_version[
                 "id"
             ],

--- a/zou/app/services/schedule_service.py
+++ b/zou/app/services/schedule_service.py
@@ -390,7 +390,9 @@ def _upsert_task_links_from_select(source_select):
     generated id, the target production schedule version id, the task id and
     the copied start_date, due_date and estimation. The whole copy runs in the
     database (INSERT ... SELECT), so it scales to productions with tens of
-    thousands of tasks without loading them into Python.
+    thousands of tasks without loading them into Python. Returns the number
+    of task links copied, taken from the statement RETURNING rows (rowcount
+    is unreliable for INSERT ... SELECT).
     """
     tl = ProductionScheduleVersionTaskLink
     insert_stmt = insert(tl).from_select(
@@ -411,8 +413,9 @@ def _upsert_task_links_from_select(source_select):
             "due_date": insert_stmt.excluded.due_date,
             "estimation": insert_stmt.excluded.estimation,
         },
-    )
-    db.session.execute(insert_stmt)
+    ).returning(tl.id)
+    result = db.session.execute(insert_stmt)
+    return len(result.all())
 
 
 def _replace_task_link_assignees(refreshed_link_ids, person_source):
@@ -460,12 +463,7 @@ def set_production_schedule_version_task_links_from_production(
     )
 
     tl = ProductionScheduleVersionTaskLink
-    copied_count = (
-        db.session.query(func.count(Task.id))
-        .filter(Task.project_id == production_schedule_version["project_id"])
-        .scalar()
-    )
-    _upsert_task_links_from_select(
+    copied_count = _upsert_task_links_from_select(
         select(
             _generate_task_link_id(),
             literal(
@@ -512,15 +510,7 @@ def set_production_schedule_version_task_links_from_production_schedule_version(
     other_tl = aliased(ProductionScheduleVersionTaskLink)
     pl = ProductionScheduleVersionTaskLinkPersonLink
 
-    copied_count = (
-        db.session.query(func.count(tl.id))
-        .filter(
-            tl.production_schedule_version_id
-            == other_production_schedule_version_id
-        )
-        .scalar()
-    )
-    _upsert_task_links_from_select(
+    copied_count = _upsert_task_links_from_select(
         select(
             _generate_task_link_id(),
             literal(

--- a/zou/app/services/schedule_service.py
+++ b/zou/app/services/schedule_service.py
@@ -1,19 +1,20 @@
 from datetime import date, timedelta
 from sqlalchemy.exc import StatementError
 from sqlalchemy.dialects.postgresql import insert
-from sqlalchemy.orm import selectinload
-from sqlalchemy import update
+from sqlalchemy.orm import aliased
+from sqlalchemy import Text, and_, cast, delete, func, literal, select, update
 
 
 from zou.app.models.entity import Entity
 from zou.app.models.entity_type import EntityType
 from zou.app.models.milestone import Milestone
 from zou.app.models.schedule_item import ScheduleItem
-from zou.app.models.task import Task
+from zou.app.models.task import Task, TaskPersonLink
 from zou.app.models.task_type import TaskType
 from zou.app.models.production_schedule_version import (
     ProductionScheduleVersion,
     ProductionScheduleVersionTaskLink,
+    ProductionScheduleVersionTaskLinkPersonLink,
 )
 from zou.app.utils import events, fields, cache
 from zou.app.services import (
@@ -28,6 +29,7 @@ from zou.app import db
 
 from zou.app.services.exception import (
     ProductionScheduleVersionNotFoundException,
+    WrongParameterException,
 )
 
 
@@ -361,6 +363,91 @@ def update_production_schedule_version(production_schedule_version_id, data):
     return production_schedule_version.serialize()
 
 
+def _generate_task_link_id():
+    """
+    Per-row UUID expression for the INSERT ... SELECT copies. gen_random_uuid()
+    is a core built-in only from PostgreSQL 13 (the CI matrix still covers
+    PostgreSQL 12), and a Python-side default (fields.gen_uuid) is evaluated
+    once per from_select batch, so every row would share the same primary key.
+    md5(text) has been core since well before any PostgreSQL version we
+    support, and applied to random() || clock_timestamp() it yields a
+    distinct uuid per row.
+    """
+    return cast(
+        func.md5(
+            func.concat(
+                cast(func.random(), Text),
+                cast(func.clock_timestamp(), Text),
+            )
+        ),
+        ProductionScheduleVersionTaskLink.id.type,
+    )
+
+
+def _upsert_task_links_from_select(source_select):
+    """
+    Upsert the target version task links from a select yielding, in order, the
+    generated id, the target production schedule version id, the task id and
+    the copied start_date, due_date and estimation. The whole copy runs in the
+    database (INSERT ... SELECT), so it scales to productions with tens of
+    thousands of tasks without loading them into Python.
+    """
+    tl = ProductionScheduleVersionTaskLink
+    insert_stmt = insert(tl).from_select(
+        [
+            tl.id,
+            tl.production_schedule_version_id,
+            tl.task_id,
+            tl.start_date,
+            tl.due_date,
+            tl.estimation,
+        ],
+        source_select,
+    )
+    insert_stmt = insert_stmt.on_conflict_do_update(
+        index_elements=["production_schedule_version_id", "task_id"],
+        set_={
+            "start_date": insert_stmt.excluded.start_date,
+            "due_date": insert_stmt.excluded.due_date,
+            "estimation": insert_stmt.excluded.estimation,
+        },
+    )
+    db.session.execute(insert_stmt)
+
+
+def _replace_task_link_assignees(refreshed_link_ids, person_source):
+    """
+    Refresh the assignees of the task links selected by refreshed_link_ids
+    (a select of task link ids) with the rows from person_source, a select
+    yielding (task_link_id, person_id). The delete is scoped to the refreshed
+    links only, so task links left untouched by the copy keep their assignees.
+    Runs in the database so it stays cheap whatever the number of assignees.
+    """
+    pl = ProductionScheduleVersionTaskLinkPersonLink
+    db.session.execute(
+        delete(pl).where(
+            pl.production_schedule_version_task_link_id.in_(refreshed_link_ids)
+        )
+    )
+    db.session.execute(
+        insert(pl)
+        .from_select(
+            [pl.production_schedule_version_task_link_id, pl.person_id],
+            person_source,
+        )
+        .on_conflict_do_nothing()
+    )
+
+
+def _build_task_links_summary(task_link_count):
+    """
+    Lightweight response for the set-task-links actions: the clients discard
+    the payload, so avoid serializing the (possibly tens of thousands of) task
+    links and just report the number of copied links.
+    """
+    return {"success": True, "task_link_count": task_link_count}
+
+
 def set_production_schedule_version_task_links_from_production(
     production_schedule_version_id,
 ):
@@ -372,44 +459,42 @@ def set_production_schedule_version_task_links_from_production(
         production_schedule_version_id
     )
 
-    tasks = (
-        db.session.query(Task)
-        .options(selectinload(Task.assignees))
+    tl = ProductionScheduleVersionTaskLink
+    copied_count = (
+        db.session.query(func.count(Task.id))
         .filter(Task.project_id == production_schedule_version["project_id"])
-        .all()
+        .scalar()
+    )
+    _upsert_task_links_from_select(
+        select(
+            _generate_task_link_id(),
+            literal(
+                production_schedule_version_id,
+                tl.production_schedule_version_id.type,
+            ),
+            Task.id,
+            Task.start_date,
+            Task.due_date,
+            Task.estimation,
+        ).where(Task.project_id == production_schedule_version["project_id"])
     )
 
-    rows = [
-        {
-            "id": fields.gen_uuid(),
-            "production_schedule_version_id": production_schedule_version_id,
-            "task_id": task.id,
-            "start_date": task.start_date,
-            "due_date": task.due_date,
-            "estimation": task.estimation,
-        }
-        for task in tasks
-    ]
-    insert_stmt = insert(ProductionScheduleVersionTaskLink).values(rows)
-    insert_stmt = insert_stmt.on_conflict_do_update(
-        index_elements=["production_schedule_version_id", "task_id"],
-        set_={
-            "start_date": insert_stmt.excluded.start_date,
-            "due_date": insert_stmt.excluded.due_date,
-            "estimation": insert_stmt.excluded.estimation,
-        },
-    ).returning(ProductionScheduleVersionTaskLink)
-
-    results = db.session.execute(insert_stmt).scalars().all()
-
-    tasks_map = {task.id: task for task in tasks}
-
-    for task_link in results:
-        task_link.assignees = tasks_map[task_link.task_id].assignees
+    # Every project task is a copy source, so all target links are refreshed.
+    _replace_task_link_assignees(
+        select(tl.id).where(
+            tl.production_schedule_version_id == production_schedule_version_id
+        ),
+        select(tl.id, TaskPersonLink.person_id)
+        .join(TaskPersonLink, TaskPersonLink.task_id == tl.task_id)
+        .where(
+            tl.production_schedule_version_id
+            == production_schedule_version_id
+        ),
+    )
 
     db.session.commit()
 
-    return fields.serialize_models(results, relations=True)
+    return _build_task_links_summary(copied_count)
 
 
 def set_production_schedule_version_task_links_from_production_schedule_version(
@@ -418,44 +503,67 @@ def set_production_schedule_version_task_links_from_production_schedule_version(
     """
     Set task links for given production schedule version from another.
     """
+    if production_schedule_version_id == other_production_schedule_version_id:
+        raise WrongParameterException(
+            "A production schedule version cannot be copied onto itself."
+        )
 
-    other_links = (
-        db.session.query(ProductionScheduleVersionTaskLink)
+    tl = ProductionScheduleVersionTaskLink
+    other_tl = aliased(ProductionScheduleVersionTaskLink)
+    pl = ProductionScheduleVersionTaskLinkPersonLink
+
+    copied_count = (
+        db.session.query(func.count(tl.id))
         .filter(
-            ProductionScheduleVersionTaskLink.production_schedule_version_id
+            tl.production_schedule_version_id
             == other_production_schedule_version_id
         )
-        .all()
+        .scalar()
+    )
+    _upsert_task_links_from_select(
+        select(
+            _generate_task_link_id(),
+            literal(
+                production_schedule_version_id,
+                tl.production_schedule_version_id.type,
+            ),
+            other_tl.task_id,
+            other_tl.start_date,
+            other_tl.due_date,
+            other_tl.estimation,
+        ).where(
+            other_tl.production_schedule_version_id
+            == other_production_schedule_version_id
+        )
     )
 
-    rows = [
-        {
-            "id": fields.gen_uuid(),
-            "production_schedule_version_id": production_schedule_version_id,
-            "task_id": links.task_id,
-            "start_date": links.start_date,
-            "due_date": links.due_date,
-            "estimation": links.estimation,
-        }
-        for links in other_links
-    ]
-
-    insert_stmt = insert(ProductionScheduleVersionTaskLink).values(rows)
-    insert_stmt = insert_stmt.on_conflict_do_update(
-        index_elements=["production_schedule_version_id", "task_id"],
-        set_={
-            "start_date": insert_stmt.excluded.start_date,
-            "due_date": insert_stmt.excluded.due_date,
-            "estimation": insert_stmt.excluded.estimation,
-        },
-    ).returning(ProductionScheduleVersionTaskLink)
-
-    results = db.session.execute(insert_stmt).scalars().all()
-
-    tasks_map = {link.task_id: link for link in other_links}
-
-    for task_link in results:
-        task_link.assignees = tasks_map[task_link.task_id].assignees
+    # Only the links whose task exists in the source version are refreshed;
+    # target links absent from the source keep their assignees.
+    source_task_ids = select(other_tl.task_id).where(
+        other_tl.production_schedule_version_id
+        == other_production_schedule_version_id
+    )
+    _replace_task_link_assignees(
+        select(tl.id).where(
+            tl.production_schedule_version_id
+            == production_schedule_version_id,
+            tl.task_id.in_(source_task_ids),
+        ),
+        select(tl.id, pl.person_id)
+        .join(
+            other_tl,
+            and_(
+                other_tl.task_id == tl.task_id,
+                other_tl.production_schedule_version_id
+                == other_production_schedule_version_id,
+            ),
+        )
+        .join(pl, pl.production_schedule_version_task_link_id == other_tl.id)
+        .where(
+            tl.production_schedule_version_id
+            == production_schedule_version_id
+        ),
+    )
 
     db.session.commit()
 
@@ -464,7 +572,7 @@ def set_production_schedule_version_task_links_from_production_schedule_version(
         {"production_schedule_from": other_production_schedule_version_id},
     )
 
-    return fields.serialize_models(results, relations=True)
+    return _build_task_links_summary(copied_count)
 
 
 def apply_production_schedule_version_to_production(
@@ -486,18 +594,18 @@ def apply_production_schedule_version_to_production(
             ProductionScheduleVersionTaskLink.production_schedule_version_id
             == production_schedule_version_id
         )
-        .returning(Task)
+        .returning(Task.id, Task.project_id)
     )
 
-    results = db.session.execute(stmt).scalars().all()
+    updated_tasks = db.session.execute(stmt).all()
 
     db.session.commit()
 
-    for task in results:
+    for task_id, project_id in updated_tasks:
         events.emit(
             "task:update",
-            {"task_id": str(task.id)},
-            project_id=str(task.project_id),
+            {"task_id": str(task_id)},
+            project_id=str(project_id),
         )
 
     production_schedule_version = update_production_schedule_version(
@@ -509,4 +617,4 @@ def apply_production_schedule_version_to_production(
         {"from_schedule_version_id": production_schedule_version_id},
     )
 
-    return fields.serialize_models(results, relations=True)
+    return {"success": True, "task_count": len(updated_tasks)}


### PR DESCRIPTION
**Problem**
- Copying task links into a schedule version 500'd past ~10900 tasks (Postgres 65535 parameter limit) and timed out over 60s on large productions.

**Solution**
- Copy links and assignees in SQL (INSERT ... SELECT) and return a lightweight count instead of the discarded payload.
- Portable to PostgreSQL 12, self-copy rejected, apply-to-production lightened the same way.
