### PR TITLE
[user] Expose per project roles in the user context

### DIFF
--- a/tests/user/test_route_context.py
+++ b/tests/user/test_route_context.py
@@ -866,3 +866,26 @@ class UserContextRoutesTestCase(ApiDBTestCase):
 
     def create_test_folder(self):
         return super().create_test_folder()
+
+
+class UserContextProjectRolesTestCase(ApiDBTestCase):
+    def setUp(self):
+        super().setUp()
+        self.generate_fixture_project_status()
+        self.generate_fixture_project()
+        self.user_id = self.user["id"]
+        projects_service.add_team_member(str(self.project.id), self.user_id)
+
+    def test_context_exposes_explicit_project_roles(self):
+        projects_service.update_team_member_role(
+            str(self.project.id), self.user_id, "supervisor"
+        )
+        context = self.get("data/user/context")
+        self.assertEqual(
+            context["project_roles"],
+            {str(self.project.id): "supervisor"},
+        )
+
+    def test_context_project_roles_empty_when_inherited(self):
+        context = self.get("data/user/context")
+        self.assertEqual(context["project_roles"], {})

--- a/zou/app/services/user_service.py
+++ b/zou/app/services/user_service.py
@@ -1724,6 +1724,22 @@ def get_timezone():
     return timezone or persons_service.get_default_timezone()
 
 
+def get_project_roles():
+    """
+    Return a dict mapping project ids to the explicit role the current user
+    holds on them. Projects where the user inherits their global role are
+    absent from the dict.
+    """
+    current_user = persons_service.get_current_user()
+    return {
+        str(link.project_id): getattr(link.role, "code", link.role)
+        for link in ProjectPersonLink.query.filter(
+            ProjectPersonLink.person_id == current_user["id"],
+            ProjectPersonLink.role.isnot(None),
+        )
+    }
+
+
 def get_context():
     context = {
         "asset_types": assets_service.get_asset_types(),
@@ -1736,6 +1752,7 @@ def get_context():
             minimal=not permissions.has_manager_permissions()
         ),
         "project_status": projects_service.get_project_statuses(),
+        "project_roles": get_project_roles(),
         "projects": get_open_projects(),
         "task_types": tasks_service.get_task_types(),
         "task_status": tasks_service.get_task_statuses(),


### PR DESCRIPTION
**Problem**
- Clients have no cheap way to know the current user's effective role per production: kitsu gates its role-based UI on the global role, so per-project supervisors and managers cannot see controls the API grants them

**Solution**
- Add a `project_roles` key to `GET /data/user/context`: a dict mapping project ids to the current user's explicit role on them, absent entries meaning the global role applies