### PR TITLE
[crud] Log delete conflicts as warnings, not errors

### DIFF
--- a/zou/app/blueprints/crud/base.py
+++ b/zou/app/blueprints/crud/base.py
@@ -690,7 +690,7 @@ class BaseModelResource(MethodView, ArgsMixin):
             self.post_delete(instance_dict)
 
         except (IntegrityError, StatementError) as exception:
-            current_app.logger.error(str(exception), exc_info=1)
+            current_app.logger.warning(str(exception), exc_info=1)
             return {"message": build_db_error_message(exception)}, 400
 
         return "", 204


### PR DESCRIPTION
**Problem**

- Generic delete() already returns a client-safe 400 on a foreign-key
  conflict, but logged the caught IntegrityError/StatementError at
  ERROR level with a full traceback
- Sentry's default logging integration turns every ERROR-level log
  into an Issue regardless of the ignore_errors list (which only
  filters unhandled exceptions), so routine "still in use" conflicts
  flooded Sentry for over a year (KITSU-API-3VV, 2300+ events)

**Solution**

- Downgrade the log call to warning, matching the level already used
  for other expected client-facing failures (auth/resources.py)

Fixes KITSU-API-3VV