### PR TITLE
[import] Handle person and task metadata in CSV imports

### DIFF
--- a/tests/fixtures/csv/assets_person_metadata.csv
+++ b/tests/fixtures/csv/assets_person_metadata.csv
@@ -1,0 +1,3 @@
+Type,Name,Reviewer
+Prop,Cassette Player,John Doe
+Prop,Wood Stick,john.doe@gmail.com

--- a/tests/fixtures/csv/assets_person_metadata_unknown.csv
+++ b/tests/fixtures/csv/assets_person_metadata_unknown.csv
@@ -1,0 +1,2 @@
+Type,Name,Reviewer
+Prop,Cassette Player,Jane Unknown

--- a/tests/fixtures/csv/shots_boolean_metadata.csv
+++ b/tests/fixtures/csv/shots_boolean_metadata.csv
@@ -1,0 +1,3 @@
+Episode,Sequence,Name,Description,Delivery
+BE01,BSE01,BS01,Delivered,true
+BE01,BSE01,BS02,Not filled,

--- a/tests/source/csv/test_import_assets.py
+++ b/tests/source/csv/test_import_assets.py
@@ -4,6 +4,7 @@ from tests.base import ApiDBTestCase
 from zou.app import db
 
 from zou.app.models.entity import Entity
+from zou.app.models.metadata_descriptor import MetadataDescriptor
 from zou.app.models.project import ProjectTaskTypeLink
 from zou.app.models.task import Task
 from zou.app.models.task_type import TaskType
@@ -104,6 +105,41 @@ class ImportCsvAssetsTestCase(ApiDBTestCase):
 
         entities = Entity.query.all()
         self.assertEqual(len(entities), 3)
+
+    def generate_person_descriptor(self):
+        self.generate_fixture_person()
+        MetadataDescriptor.create(
+            project_id=self.project.id,
+            name="Reviewer",
+            data_type="person",
+            field_name="reviewer",
+            entity_type="Asset",
+        )
+
+    def test_import_assets_person_metadata(self):
+        self.generate_person_descriptor()
+        path = f"/import/csv/projects/{self.project.id}/assets"
+        file_path_fixture = self.get_fixture_file_path(
+            os.path.join("csv", "assets_person_metadata.csv")
+        )
+        self.upload_file(path, file_path_fixture)
+
+        # One row matches by full name, the other by email: both must
+        # resolve to the person id, not store the raw cell.
+        entities = Entity.query.all()
+        self.assertEqual(len(entities), 2)
+        for asset in entities:
+            self.assertEqual(asset.data.get("reviewer"), str(self.person.id))
+
+    def test_import_assets_person_metadata_unknown(self):
+        self.generate_person_descriptor()
+        path = f"/import/csv/projects/{self.project.id}/assets"
+        file_path_fixture = self.get_fixture_file_path(
+            os.path.join("csv", "assets_person_metadata_unknown.csv")
+        )
+        error = self.upload_file(path, file_path_fixture, 400)
+        self.assertIn("Person not found", error["message"])
+        self.assertEqual(len(Entity.query.all()), 0)
 
     def test_import_assets_with_non_comma_delimiter(self):
         path = f"/import/csv/projects/{self.project.id}/assets"

--- a/tests/source/csv/test_import_shots.py
+++ b/tests/source/csv/test_import_shots.py
@@ -4,6 +4,7 @@ from tests.base import ApiDBTestCase
 from zou.app import db
 
 from zou.app.models.entity_type import EntityType
+from zou.app.models.metadata_descriptor import MetadataDescriptor
 from zou.app.models.project import ProjectTaskTypeLink
 from zou.app.models.task import Task
 from zou.app.services import shots_service
@@ -80,6 +81,28 @@ class ImportCsvShotsTestCase(ApiDBTestCase):
 
         shot = shots[0]
         self.assertEqual(shot["data"].get("contractor", None), "contractor 1")
+
+    def test_import_shots_empty_boolean_descriptor(self):
+        MetadataDescriptor.create(
+            project_id=self.project.id,
+            name="Delivery",
+            data_type="boolean",
+            field_name="delivery",
+            choices=[],
+            entity_type="Shot",
+        )
+        path = f"/import/csv/projects/{self.project.id}/shots"
+        self.project.update({"production_type": "tvshow"})
+
+        file_path_fixture = self.get_fixture_file_path(
+            os.path.join("csv", "shots_boolean_metadata.csv")
+        )
+        self.upload_file(path, file_path_fixture)
+
+        shots = {s["name"]: s for s in shots_service.get_shots()}
+        self.assertEqual(shots["BS01"]["data"]["delivery"], "true")
+        # An empty boolean cell must not fail the import.
+        self.assertEqual(shots["BS02"]["data"]["delivery"], "")
 
     def test_import_shots_frame_range_is_normalized(self):
         path = f"/import/csv/projects/{self.project.id}/shots"

--- a/tests/source/csv/test_import_task_type_estimations.py
+++ b/tests/source/csv/test_import_task_type_estimations.py
@@ -3,6 +3,7 @@ import tempfile
 
 from tests.base import ApiDBTestCase
 
+from zou.app.models.metadata_descriptor import MetadataDescriptor
 from zou.app.models.task import Task
 
 
@@ -39,3 +40,36 @@ class ImportCsvTaskTypeEstimationsTestCase(ApiDBTestCase):
 
         task = Task.get(self.task.id)
         self.assertEqual(task.start_date.strftime("%Y-%m-%d"), "2024-01-05")
+
+    def test_import_task_metadata(self):
+        self.generate_fixture_task()
+        MetadataDescriptor.create(
+            project_id=self.project.id,
+            name="Contractor",
+            data_type="string",
+            field_name="contractor",
+            entity_type="Task",
+            task_type_id=self.task_type.id,
+        )
+        MetadataDescriptor.create(
+            project_id=self.project.id,
+            name="Other",
+            data_type="string",
+            field_name="other",
+            entity_type="Task",
+            task_type_id=self.task_type_animation.id,
+        )
+        self.task.update({"data": {"note": "keep me"}})
+        path = (
+            f"/import/csv/projects/{self.project.id}"
+            f"/task-types/{self.task_type.id}/estimations"
+        )
+        content = "Parent,Entity,Contractor,Other\nProps,Tree,value 1,nope\n"
+        self.upload_file(path, self.write_csv(content))
+
+        task = Task.get(self.task.id)
+        self.assertEqual(task.data.get("contractor"), "value 1")
+        # A descriptor bound to another task type must be ignored.
+        self.assertIsNone(task.data.get("other"))
+        # Metadata absent from the CSV must survive the import.
+        self.assertEqual(task.data.get("note"), "keep me")

--- a/zou/app/blueprints/source/csv/assets.py
+++ b/zou/app/blueprints/source/csv/assets.py
@@ -16,7 +16,7 @@ from zou.app.services import (
 )
 from zou.app.models.entity import Entity
 from zou.app.services.exception import WrongParameterException
-from zou.app.utils import events, cache, string
+from zou.app.utils import events, cache
 
 
 class AssetsCsvImportResource(BaseCsvProjectImportResource):
@@ -242,25 +242,13 @@ class AssetsCsvImportResource(BaseCsvProjectImportResource):
         if description is not None:
             asset_new_values["description"] = description
 
-        if entity is None or not entity.data:
-            asset_new_values["data"] = {}
-        else:
-            asset_new_values["data"] = entity.data.copy()
+        data = {} if entity is None else entity.data
 
         resolution = row.get("Resolution", None)
         if resolution is not None:
-            asset_new_values["data"]["resolution"] = resolution
+            data = {**(data or {}), "resolution": resolution}
 
-        for name, descriptor in self.descriptor_fields.items():
-            if name in row:
-                if descriptor["data_type"] == "boolean":
-                    asset_new_values["data"][descriptor["field_name"]] = (
-                        "true" if string.strtobool(row[name]) else "false"
-                    )
-                else:
-                    asset_new_values["data"][descriptor["field_name"]] = row[
-                        name
-                    ]
+        asset_new_values["data"] = self.get_descriptor_values(row, data)
 
         ready_for = row.get("Ready for", None)
         if ready_for is not None:

--- a/zou/app/blueprints/source/csv/base.py
+++ b/zou/app/blueprints/source/csv/base.py
@@ -10,7 +10,8 @@ from flask_jwt_extended import jwt_required
 
 from zou.app.mixin import ArgsMixin
 from zou.app import app
-from zou.app.utils import permissions
+from zou.app.models.person import Person
+from zou.app.utils import permissions, string
 from zou.app.services import user_service, projects_service
 
 
@@ -146,8 +147,49 @@ class BaseCsvProjectImportResource(BaseCsvImportResource, ArgsMixin):
 
     def get_descriptor_field_map(self, project_id, entity_type):
         descriptor_map = {}
+        self.person_lookup = None
         descriptors = projects_service.get_metadata_descriptors(project_id)
         for descriptor in descriptors:
             if descriptor["entity_type"] == entity_type:
                 descriptor_map[descriptor["name"]] = descriptor
         return descriptor_map
+
+    def get_descriptor_values(self, row, data=None):
+        """
+        Return a new data dict merging the row's metadata descriptor cells
+        into the given base data, storing typed values in their canonical
+        form: booleans as true/false strings, persons as their id.
+        """
+        new_data = dict(data or {})
+        for name, descriptor in self.descriptor_fields.items():
+            if name in row:
+                value = row[name]
+                # An empty cell means "not set": store it as is instead of
+                # feeding it to the typed conversions (strtobool raises on "").
+                if value not in (None, ""):
+                    if descriptor["data_type"] == "boolean":
+                        value = "true" if string.strtobool(value) else "false"
+                    elif descriptor["data_type"] == "person":
+                        value = self.get_person_id(value)
+                new_data[descriptor["field_name"]] = value
+        return new_data
+
+    def get_person_id(self, value):
+        """
+        Resolve a person cell to a person id. Accepts the person full name,
+        email or id, so that CSV files exported by Kitsu (full names) and
+        older files built from raw ids both import correctly.
+        """
+        if value in (None, ""):
+            return value
+        if self.person_lookup is None:
+            self.person_lookup = {}
+            for person in Person.query.all():
+                self.person_lookup[str(person.id)] = str(person.id)
+                self.person_lookup[person.full_name.lower()] = str(person.id)
+                if person.email:
+                    self.person_lookup[person.email.lower()] = str(person.id)
+        person_id = self.person_lookup.get(value.strip().lower())
+        if person_id is None:
+            raise RowException(f"Person not found for {value}")
+        return person_id

--- a/zou/app/blueprints/source/csv/edits.py
+++ b/zou/app/blueprints/source/csv/edits.py
@@ -21,7 +21,7 @@ from zou.app.services.tasks_service import (
 )
 from zou.app.services.comments_service import create_comment
 from zou.app.services.exception import WrongParameterException
-from zou.app.utils import events, string
+from zou.app.utils import events
 
 
 class EditsCsvImportResource(BaseCsvProjectImportResource):
@@ -225,21 +225,9 @@ class EditsCsvImportResource(BaseCsvProjectImportResource):
         if description is not None:
             edit_new_values["description"] = description
 
-        if entity is None or not entity.data:
-            edit_new_values["data"] = {}
-        else:
-            edit_new_values["data"] = entity.data.copy()
-
-        for name, descriptor in self.descriptor_fields.items():
-            if name in row:
-                if descriptor["data_type"] == "boolean":
-                    edit_new_values["data"][descriptor["field_name"]] = (
-                        "true" if string.strtobool(row[name]) else "false"
-                    )
-                else:
-                    edit_new_values["data"][descriptor["field_name"]] = row[
-                        name
-                    ]
+        edit_new_values["data"] = self.get_descriptor_values(
+            row, {} if entity is None else entity.data
+        )
 
         tasks_update = self.get_tasks_update(row)
 

--- a/zou/app/blueprints/source/csv/shots.py
+++ b/zou/app/blueprints/source/csv/shots.py
@@ -21,7 +21,7 @@ from zou.app.services.tasks_service import (
 )
 from zou.app.services.comments_service import create_comment
 from zou.app.services.exception import WrongParameterException
-from zou.app.utils import events, string
+from zou.app.utils import events
 
 
 class ShotsCsvImportResource(BaseCsvProjectImportResource):
@@ -296,16 +296,9 @@ class ShotsCsvImportResource(BaseCsvProjectImportResource):
         if resolution is not None:
             shot_new_values["data"]["resolution"] = resolution
 
-        for name, descriptor in self.descriptor_fields.items():
-            if name in row:
-                if descriptor["data_type"] == "boolean":
-                    shot_new_values["data"][descriptor["field_name"]] = (
-                        "true" if string.strtobool(row[name]) else "false"
-                    )
-                else:
-                    shot_new_values["data"][descriptor["field_name"]] = row[
-                        name
-                    ]
+        shot_new_values["data"] = self.get_descriptor_values(
+            row, shot_new_values["data"]
+        )
 
         tasks_update = self.get_tasks_update(row)
 

--- a/zou/app/blueprints/source/csv/task_type_estimations.py
+++ b/zou/app/blueprints/source/csv/task_type_estimations.py
@@ -92,6 +92,13 @@ class TaskTypeEstimationsCsvImportResource(BaseCsvProjectImportResource):
         self.assets_map = {}
         self.shots_map = {}
         self.tasks_map = {}
+        self.descriptor_fields = {
+            name: descriptor
+            for name, descriptor in self.get_descriptor_field_map(
+                project_id, "Task"
+            ).items()
+            if descriptor["task_type_id"] == task_type["id"]
+        }
 
         if task_type["for_entity"] == "Asset":
             asset_types_map = {}
@@ -130,7 +137,7 @@ class TaskTypeEstimationsCsvImportResource(BaseCsvProjectImportResource):
         for task in tasks_service.get_tasks_for_project_and_task_type(
             project_id, task_type["id"]
         ):
-            self.tasks_map[task["entity_id"]] = task["id"]
+            self.tasks_map[task["entity_id"]] = task
 
     def import_row(self, row, project_id, task_type, episode_id=None):
         key = slugify(f"{row['Parent']}{row['Entity']}")
@@ -173,7 +180,14 @@ class TaskTypeEstimationsCsvImportResource(BaseCsvProjectImportResource):
         if row.get("Difficulty") not in [None, ""]:
             new_data["difficulty"] = int(row["Difficulty"])
 
-        tasks_service.update_task(self.tasks_map[entity_id], new_data)
+        task = self.tasks_map[entity_id]
+
+        # Merge descriptor cells into the task's own metadata instead of
+        # replacing it, so columns absent from the CSV are preserved.
+        if any(name in row for name in self.descriptor_fields):
+            new_data["data"] = self.get_descriptor_values(row, task["data"])
+
+        tasks_service.update_task(task["id"], new_data)
 
 
 class TaskTypeEstimationsEpisodeCsvImportResource(


### PR DESCRIPTION
**Problem**

- Person descriptor columns were stored as raw cells, so CSV files exported by Kitsu (full names) broke the export/import round trip
- The task type estimations import ignored metadata descriptors entirely
- An empty boolean metadata cell failed the whole import
- The descriptor conversion loop was duplicated in the assets, shots and edits imports

**Solution**

- Shared helpers resolve person cells from full name, email or id, with a clear row error when no person matches
- The estimations import writes descriptor columns of the target task type into task data, merged with existing values
- Empty metadata cells are stored as is instead of being fed to typed conversions
- New tests cover person resolution, unknown persons, task type scoping and empty booleans