### PR TITLE
[emails] Match email locales with a script subtag like zh_Hans_CN

### DIFF
--- a/tests/utils/test_email_i18n.py
+++ b/tests/utils/test_email_i18n.py
@@ -83,6 +83,35 @@ class EmailI18nTestCase(unittest.TestCase):
         result_pt = get_email_translation("pt", "comment_title")
         self.assertEqual(result_pt, "Novo comentário")
 
+    def test_get_email_translation_with_script_subtag(self):
+        # Babel's canonical form of zh_CN, also used as DEFAULT_LOCALE value
+        result = get_email_translation("zh_Hans_CN", "comment_title")
+        self.assertEqual(result, "新评论")
+
+        result_dashed = get_email_translation("zh-Hans-CN", "comment_title")
+        self.assertEqual(result_dashed, "新评论")
+
+        result_script_only = get_email_translation("zh_Hans", "comment_title")
+        self.assertEqual(result_script_only, "新评论")
+
+        # No Traditional Chinese strings: fall back on the zh_CN ones
+        result_hant = get_email_translation("zh_Hant_TW", "comment_title")
+        self.assertEqual(result_hant, "新评论")
+
+    def test_get_email_translation_separator_and_case(self):
+        result_dashed = get_email_translation("fr-FR", "comment_title")
+        self.assertEqual(result_dashed, "Nouveau commentaire")
+
+        result_lower = get_email_translation("fr_fr", "comment_title")
+        self.assertEqual(result_lower, "Nouveau commentaire")
+
+    def test_get_email_translation_unsupported_region(self):
+        result_fr_ca = get_email_translation("fr_CA", "comment_title")
+        self.assertEqual(result_fr_ca, "Nouveau commentaire")
+
+        result_en_gb = get_email_translation("en_GB", "comment_title")
+        self.assertEqual(result_en_gb, "New Comment")
+
     def test_all_locales_have_all_keys(self):
         en_keys = set(EMAIL_TRANSLATIONS["en_US"].keys())
 

--- a/zou/app/utils/email_i18n.py
+++ b/zou/app/utils/email_i18n.py
@@ -4,13 +4,26 @@ Emails are sent in the recipient's preferred locale when available.
 
 Supported locales: en_US, fr_FR, es_ES, ja_JP, de_DE, nl_NL, zh_CN, pt_BR.
 To add a language: copy the en_US block, change the key (e.g. de_DE) and translate
-all values. Then add the 2-letter code to _normalize_locale's lang_map if desired.
+all values. Then add the language code to LANGUAGE_LOCALES if desired.
 """
 
 from zou.app import config
 
 # Default locale used when user locale is missing or unsupported
 DEFAULT_EMAIL_LOCALE = "en_US"
+
+# Locale used for a given language when the region is missing or unsupported:
+# "zh", "zh_Hant_TW" and "zh_SG" all end up on the zh_CN strings.
+LANGUAGE_LOCALES = {
+    "en": "en_US",
+    "fr": "fr_FR",
+    "es": "es_ES",
+    "ja": "ja_JP",
+    "de": "de_DE",
+    "nl": "nl_NL",
+    "zh": "zh_CN",
+    "pt": "pt_BR",
+}
 
 # Email translation strings per locale.
 # Use {name} placeholders for interpolation.
@@ -797,24 +810,31 @@ O IP de quem solicitou é: {person_IP}.</p>
 def _normalize_locale(locale):
     """
     Return a locale string suitable for lookup (e.g. en_US, fr_FR).
+
+    Accepts the forms Babel, browsers and SSO providers emit: dash
+    separators (fr-FR), any casing (fr_fr), bare language codes (fr) and
+    script subtags (zh_Hans_CN, which is Babel's canonical form of zh_CN).
+    An unsupported region falls back to the language default (fr_CA gives
+    fr_FR); an unsupported language is returned as-is so that
+    get_email_translation falls back to en_US.
     """
     if not locale or not isinstance(locale, str):
-        locale = "en_US"
+        return DEFAULT_EMAIL_LOCALE
 
     locale = locale.strip()
-    if len(locale) == 2:
-        lang_map = {
-            "en": "en_US",
-            "fr": "fr_FR",
-            "es": "es_ES",
-            "ja": "ja_JP",
-            "de": "de_DE",
-            "nl": "nl_NL",
-            "zh": "zh_CN",
-            "pt": "pt_BR",
-        }
-        return lang_map.get(locale.lower(), locale)
-    return locale
+    parts = [part for part in locale.replace("-", "_").split("_") if part]
+    if not parts:
+        return DEFAULT_EMAIL_LOCALE
+
+    language = parts[0].lower()
+    # A 4-letter subtag is a script (Hans in zh_Hans_CN); translation keys
+    # are language_REGION only, so scripts are dropped.
+    regions = [part for part in parts[1:] if len(part) != 4]
+    if regions:
+        candidate = f"{language}_{regions[-1].upper()}"
+        if candidate in EMAIL_TRANSLATIONS:
+            return candidate
+    return LANGUAGE_LOCALES.get(language, locale)
 
 
 def get_email_translation(locale, key, **params):


### PR DESCRIPTION
**Problem**
  - With DEFAULT_LOCALE=zh_Hans_CN (Babel's canonical form of zh_CN, and what Locale.parse returns for it), notification and invitation emails are sent in English
  - _normalize_locale only expanded bare 2-letter language codes, so any locale carrying a script subtag matched no EMAIL_TRANSLATIONS key and fell through to the en_US fallback
  - Same silent English fallback for dash-separated (fr-FR), lowercase (fr_fr) and unsupported-region (fr_CA, en_GB) values, all of which reach the mailer from person locales
  and SSO payloads

**Solution**
  - Parse the locale into language / script / region instead of switching on its length: drop the 4-letter script subtag, accept - as separator and normalise casing
  - Extract the language table to a module-level LANGUAGE_LOCALES and use it when the region is missing or unsupported, so fr_CA gets the fr_FR strings and zh_Hant_TW the zh_CN
  ones instead of English
  - Keep returning an unsupported language as-is so get_email_translation still falls back to en_US (it_IT unchanged)
  - Cover the new forms in tests/utils/test_email_i18n.py (script subtag, separator, casing, unsupported region)