### PR TITLE
[events] Filter the log routes server side and align who can read them

### DIFF
--- a/tests/events/test_event_routes.py
+++ b/tests/events/test_event_routes.py
@@ -3,10 +3,12 @@ from datetime import datetime, timedelta
 from freezegun import freeze_time
 
 from tests.base import ApiDBTestCase
+from zou.app import db
 from zou.app.models.event import ApiEvent
 from zou.app.models.login_log import LoginLog
 from zou.app.models.person import Person
-from zou.app.models.project import Project
+from zou.app.models.project import Project, ProjectPersonLink
+from zou.app.utils import fields
 
 from zou.app.services import assets_service
 
@@ -148,6 +150,44 @@ class EventsRoutesTestCase(ApiDBTestCase):
         self.log_in_manager()
         self.get(f"/data/events/last?project_id={other_project.id}", 403)
         self.get(f"/data/events/last?project_id={self.project.id}", 200)
+
+    def test_get_last_events_project_manager_reads_his_project(self):
+        # Global role "user", manager on this production only: the project
+        # role must be resolved before the manager check reads it.
+        other_project = Project.create(
+            name="Other project", project_status_id=self.open_status.id
+        )
+        self.generate_fixture_user_cg_artist()
+        artist = Person.get(self.user_cg_artist["id"])
+        self.project.team.append(artist)
+        self.project.save()
+        link = ProjectPersonLink.query.filter_by(
+            project_id=self.project.id, person_id=artist.id
+        ).first()
+        link.role = "manager"
+        db.session.commit()
+
+        ApiEvent.create(name="task:update", project_id=self.project.id)
+        ApiEvent.create(name="task:update", project_id=other_project.id)
+
+        self.log_in_cg_artist()
+
+        # The denials come first on purpose: tests share a single application
+        # context, so a project role resolved by an earlier call would still
+        # sit in flask.g for the next one. In production g is per request.
+        # The per-project role opens neither the cross-production log nor a
+        # production he is not a member of.
+        self.get("/data/events/last", 403)
+        self.get(f"/data/events/last?project_id={other_project.id}", 403)
+
+        events = self.get(f"/data/events/last?project_id={self.project.id}")
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0]["project_id"], str(self.project.id))
+
+    def test_get_last_events_unknown_project_is_denied_not_disclosed(self):
+        self.generate_fixture_user_cg_artist()
+        self.log_in_cg_artist()
+        self.get(f"/data/events/last?project_id={fields.gen_uuid()}", 403)
 
     def test_get_event_names(self):
         ApiEvent.create(name="task:update")

--- a/tests/events/test_event_routes.py
+++ b/tests/events/test_event_routes.py
@@ -5,6 +5,8 @@ from freezegun import freeze_time
 from tests.base import ApiDBTestCase
 from zou.app.models.event import ApiEvent
 from zou.app.models.login_log import LoginLog
+from zou.app.models.person import Person
+from zou.app.models.project import Project
 
 from zou.app.services import assets_service
 
@@ -49,6 +51,116 @@ class EventsRoutesTestCase(ApiDBTestCase):
         self.assertEqual(len(events), 6)
         events = self.get("/data/events/last?only_files=true")
         self.assertEqual(len(events), 2)
+
+    def test_get_last_events_serializes_project_id(self):
+        ApiEvent.create(name="task:update", project_id=self.project.id)
+        events = self.get("/data/events/last")
+        self.assertEqual(events[0]["project_id"], str(self.project.id))
+
+    def test_get_last_events_person_ids(self):
+        self.generate_fixture_user_manager()
+        self.generate_fixture_user_cg_artist()
+        ApiEvent.create(name="task:update", user_id=self.user["id"])
+        ApiEvent.create(name="task:update", user_id=self.user_manager["id"])
+        ApiEvent.create(name="task:update", user_id=self.user_cg_artist["id"])
+
+        events = self.get(
+            f"/data/events/last?person_ids={self.user['id']}"
+            f"&person_ids={self.user_manager['id']}"
+        )
+        self.assertEqual(len(events), 2)
+        self.assertEqual(
+            {event["user_id"] for event in events},
+            {str(self.user["id"]), str(self.user_manager["id"])},
+        )
+
+    def test_get_last_events_invalid_person_ids(self):
+        self.get("/data/events/last?person_ids=invalid", 400)
+
+    def test_get_last_events_name_prefixes(self):
+        ApiEvent.create(name="task:update")
+        ApiEvent.create(name="comment:new")
+        ApiEvent.create(name="asset:delete")
+
+        events = self.get("/data/events/last?name_prefixes=task")
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0]["name"], "task:update")
+
+        events = self.get(
+            "/data/events/last?name_prefixes=task&name_prefixes=comment"
+        )
+        self.assertEqual(len(events), 2)
+
+    def test_get_last_events_name_suffixes(self):
+        ApiEvent.create(name="task:update")
+        ApiEvent.create(name="comment:new")
+        ApiEvent.create(name="asset:new")
+
+        events = self.get("/data/events/last?name_suffixes=new")
+        self.assertEqual(len(events), 2)
+
+    def test_get_last_events_name_prefixes_and_suffixes(self):
+        ApiEvent.create(name="task:update")
+        ApiEvent.create(name="task:new")
+        ApiEvent.create(name="comment:new")
+
+        events = self.get(
+            "/data/events/last?name_prefixes=task&name_suffixes=new"
+        )
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0]["name"], "task:new")
+
+    def test_get_last_events_name_parts_reject_like_wildcards(self):
+        ApiEvent.create(name="task:update")
+        # "%" and "_" must never reach the LIKE pattern as wildcards.
+        self.get("/data/events/last?name_prefixes=%25", 400)
+        self.get("/data/events/last?name_suffixes=_", 400)
+        self.get("/data/events/last?name_prefixes=Task", 400)
+
+    def test_get_last_events_manager_is_scoped_to_his_projects(self):
+        other_project = Project.create(
+            name="Other project", project_status_id=self.open_status.id
+        )
+        self.generate_fixture_user_manager()
+        self.project.team.append(Person.get(self.user_manager["id"]))
+        self.project.save()
+
+        ApiEvent.create(name="task:update", project_id=self.project.id)
+        ApiEvent.create(name="task:update", project_id=other_project.id)
+        ApiEvent.create(name="person:update")
+
+        events = self.get("/data/events/last")
+        self.assertEqual(len(events), 3)
+
+        self.log_in_manager()
+        events = self.get("/data/events/last")
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0]["project_id"], str(self.project.id))
+
+    def test_get_last_events_manager_cannot_target_other_project(self):
+        other_project = Project.create(
+            name="Other project", project_status_id=self.open_status.id
+        )
+        self.generate_fixture_user_manager()
+        self.project.team.append(Person.get(self.user_manager["id"]))
+        self.project.save()
+
+        self.log_in_manager()
+        self.get(f"/data/events/last?project_id={other_project.id}", 403)
+        self.get(f"/data/events/last?project_id={self.project.id}", 200)
+
+    def test_get_event_names(self):
+        ApiEvent.create(name="task:update")
+        ApiEvent.create(name="comment:new")
+        ApiEvent.create(name="task:update")
+
+        names = self.get("/data/events/names")
+        self.assertEqual(names, ["comment:new", "task:update"])
+
+    def test_get_event_names_permissions(self):
+        self.generate_fixture_user_cg_artist()
+        self.log_in_cg_artist()
+        self.get("/data/events/names", 403)
 
 
 class LoginLogsRoutesTestCase(ApiDBTestCase):
@@ -122,7 +234,33 @@ class LoginLogsRoutesTestCase(ApiDBTestCase):
             400,
         )
 
+    def test_get_last_login_logs_person_ids(self):
+        self.generate_fixture_user_manager()
+        LoginLog.create(
+            person_id=self.user["id"], ip_address="192.168.1.1", origin="web"
+        )
+        LoginLog.create(
+            person_id=self.user_manager["id"],
+            ip_address="192.168.1.2",
+            origin="web",
+        )
+
+        logs = self.get(
+            f"/data/events/login-logs/last?person_ids={self.user_manager['id']}"
+        )
+        self.assertEqual(len(logs), 1)
+        self.assertEqual(logs[0]["person_id"], str(self.user_manager["id"]))
+
+    def test_get_last_login_logs_invalid_person_ids(self):
+        self.get("/data/events/login-logs/last?person_ids=invalid", 400)
+
     def test_get_last_login_logs_permissions(self):
         self.generate_fixture_user_cg_artist()
         self.log_in_cg_artist()
+        self.get("/data/events/login-logs/last", 403)
+
+    def test_get_last_login_logs_are_admin_only(self):
+        # Login logs expose everyone's IP address: managers are denied.
+        self.generate_fixture_user_manager()
+        self.log_in_manager()
         self.get("/data/events/login-logs/last", 403)

--- a/tests/services/test_events_service.py
+++ b/tests/services/test_events_service.py
@@ -6,6 +6,7 @@ from tests.base import ApiDBTestCase
 
 from zou.app.models.event import ApiEvent
 from zou.app.services import events_service, assets_service
+from zou.app.services.exception import WrongParameterException
 
 
 # Frozen mid-day time: these tests build date-boundary filters (before/
@@ -37,6 +38,45 @@ class EventsServiceTestCase(ApiDBTestCase):
         before = now - timedelta(seconds=1)
         events = events_service.get_last_events(before=before)
         self.assertEqual(len(events), 2)
+
+    def test_get_last_events_project_ids_hides_global_events(self):
+        ApiEvent.create(name="task:update", project_id=self.project.id)
+        ApiEvent.create(name="person:update")
+
+        events = events_service.get_last_events()
+        self.assertEqual(len(events), 2)
+
+        # An IN clause never matches NULL, so scoping on projects also hides
+        # the events carrying no project at all.
+        events = events_service.get_last_events(
+            project_ids=[str(self.project.id)]
+        )
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0]["name"], "task:update")
+
+        events = events_service.get_last_events(project_ids=[])
+        self.assertEqual(len(events), 0)
+
+    def test_get_last_events_rejects_like_wildcards(self):
+        for value in ["%", "_", "task:", "Task", ""]:
+            self.assertRaises(
+                WrongParameterException,
+                events_service.get_last_events,
+                name_prefixes=[value],
+            )
+            self.assertRaises(
+                WrongParameterException,
+                events_service.get_last_events,
+                name_suffixes=[value],
+            )
+
+    def test_get_event_names(self):
+        ApiEvent.create(name="task:update")
+        ApiEvent.create(name="task:update")
+        ApiEvent.create(name="comment:new")
+        self.assertEqual(
+            events_service.get_event_names(), ["comment:new", "task:update"]
+        )
 
     def test_get_last_login_logs(self):
         self.generate_fixture_person()

--- a/tests/services/test_events_service.py
+++ b/tests/services/test_events_service.py
@@ -7,6 +7,7 @@ from tests.base import ApiDBTestCase
 from zou.app.models.event import ApiEvent
 from zou.app.services import events_service, assets_service
 from zou.app.services.exception import WrongParameterException
+from zou.app.utils import events
 
 
 # Frozen mid-day time: these tests build date-boundary filters (before/
@@ -58,7 +59,8 @@ class EventsServiceTestCase(ApiDBTestCase):
         self.assertEqual(len(events), 0)
 
     def test_get_last_events_rejects_like_wildcards(self):
-        for value in ["%", "_", "task:", "Task", ""]:
+        # "task\n" is the fullmatch case: "$" alone would accept it.
+        for value in ["%", "_", "task:", "Task", "", "task\n"]:
             self.assertRaises(
                 WrongParameterException,
                 events_service.get_last_events,
@@ -77,6 +79,29 @@ class EventsServiceTestCase(ApiDBTestCase):
         self.assertEqual(
             events_service.get_event_names(), ["comment:new", "task:update"]
         )
+
+    def test_invalidate_event_names_cache(self):
+        names = events_service.get_event_names()
+        self.assertNotIn("tests:brand-new", names)
+
+        ApiEvent.create(name="tests:brand-new")
+        # The memoized list still ignores the fresh name.
+        self.assertEqual(events_service.get_event_names(), names)
+
+        self.assertTrue(
+            events_service.invalidate_event_names_cache("tests:brand-new")
+        )
+        self.assertIn("tests:brand-new", events_service.get_event_names())
+
+        # A name already in the list costs a cache hit and nothing else.
+        self.assertFalse(
+            events_service.invalidate_event_names_cache("tests:brand-new")
+        )
+
+    def test_get_event_names_reflects_a_freshly_emitted_event(self):
+        self.assertNotIn("tests:brand-new", events_service.get_event_names())
+        events.emit("tests:brand-new", project_id=str(self.project.id))
+        self.assertIn("tests:brand-new", events_service.get_event_names())
 
     def test_get_last_login_logs(self):
         self.generate_fixture_person()

--- a/zou/app/blueprints/events/__init__.py
+++ b/zou/app/blueprints/events/__init__.py
@@ -2,12 +2,14 @@ from flask import Blueprint
 from zou.app.utils.api import configure_api_from_blueprint
 
 from zou.app.blueprints.events.resources import (
+    EventNamesResource,
     EventsResource,
     LoginLogsResource,
 )
 
 routes = [
     ("/data/events/last", EventsResource),
+    ("/data/events/names", EventNamesResource),
     ("/data/events/login-logs/last", LoginLogsResource),
 ]
 

--- a/zou/app/blueprints/events/resources.py
+++ b/zou/app/blueprints/events/resources.py
@@ -4,8 +4,20 @@ from flask_jwt_extended import jwt_required
 from zou.app.mixin import ArgsMixin
 from zou.app.utils import fields, permissions
 
-from zou.app.services import events_service
+from zou.app.services import events_service, user_service
 from zou.app.services.exception import WrongParameterException
+
+
+def check_person_ids(person_ids):
+    """
+    Make sure every entry of a person_ids filter is a valid id.
+    """
+    for person_id in person_ids or []:
+        if not fields.is_valid_id(person_id):
+            raise WrongParameterException(
+                "The person_ids parameter contains an invalid id"
+            )
+    return person_ids
 
 
 class EventsResource(MethodView, ArgsMixin):
@@ -62,6 +74,30 @@ class EventsResource(MethodView, ArgsMixin):
             type: string
             example: "user_login"
             description: Filter events by event name
+          - in: query
+            name: name_prefixes
+            type: array
+            items:
+              type: string
+            example: ["task", "comment"]
+            description: Filter events by object, the part of the event name
+              before the colon. Repeat the parameter for each value.
+          - in: query
+            name: name_suffixes
+            type: array
+            items:
+              type: string
+            example: ["update", "delete"]
+            description: Filter events by action, the part of the event name
+              after the colon. Repeat the parameter for each value.
+          - in: query
+            name: person_ids
+            type: array
+            items:
+              type: string
+              format: uuid
+            description: Filter events by author. Repeat the parameter for
+              each value.
         responses:
           200:
             description: List of events successfully retrieved
@@ -110,6 +146,9 @@ class EventsResource(MethodView, ArgsMixin):
                 ("limit", 100, False, int),
                 ("project_id", None, False),
                 ("name", None, False),
+                ("name_prefixes", [], False, str, "append"),
+                ("name_suffixes", [], False, str, "append"),
+                ("person_ids", [], False, str, "append"),
             ],
         )
 
@@ -121,6 +160,7 @@ class EventsResource(MethodView, ArgsMixin):
         only_files = args["only_files"] == "true"
         project_id = args.get("project_id", None)
         name = args["name"]
+        person_ids = check_person_ids(args["person_ids"])
         if project_id is not None and not fields.is_valid_id(project_id):
             raise WrongParameterException(
                 "The project_id parameter is not a valid id"
@@ -131,6 +171,18 @@ class EventsResource(MethodView, ArgsMixin):
             raise WrongParameterException(
                 "The cursor_event_id parameter is not a valid id"
             )
+
+        # Admins read the whole log. Managers are scoped to the productions
+        # they belong to, which also hides the events carrying no project at
+        # all (persons, organisation, settings).
+        project_ids = None
+        if not permissions.has_admin_permissions():
+            project_ids = [
+                project["id"] for project in user_service.get_projects()
+            ]
+            if project_id is not None and project_id not in project_ids:
+                raise permissions.PermissionDenied
+
         return events_service.get_last_events(
             after=after,
             before=before,
@@ -138,7 +190,11 @@ class EventsResource(MethodView, ArgsMixin):
             limit=limit,
             only_files=only_files,
             project_id=project_id,
+            project_ids=project_ids,
             name=name,
+            name_prefixes=args["name_prefixes"],
+            name_suffixes=args["name_suffixes"],
+            person_ids=person_ids,
         )
 
 
@@ -179,6 +235,14 @@ class LoginLogsResource(MethodView, ArgsMixin):
             default: 100
             example: 100
             description: Maximum number of login logs to return
+          - in: query
+            name: person_ids
+            type: array
+            items:
+              type: string
+              format: uuid
+            description: Filter login logs by person. Repeat the parameter for
+              each value.
         responses:
           200:
             description: List of login logs successfully retrieved
@@ -220,14 +284,18 @@ class LoginLogsResource(MethodView, ArgsMixin):
                 ("before", None, False),
                 ("cursor_login_log_id", None, False),
                 ("limit", 100, False, int),
+                ("person_ids", [], False, str, "append"),
             ],
         )
 
-        permissions.check_manager_permissions()
+        # Login logs carry the IP address of every person and cover the whole
+        # studio, with no production to scope them on: admins only.
+        permissions.check_admin_permissions()
         before = self.parse_date_parameter(args["before"])
         after = self.parse_date_parameter(args["after"])
         cursor_login_log_id = args["cursor_login_log_id"]
         limit = min(args["limit"], 1000)
+        person_ids = check_person_ids(args["person_ids"])
         if cursor_login_log_id is not None and not fields.is_valid_id(
             cursor_login_log_id
         ):
@@ -239,4 +307,32 @@ class LoginLogsResource(MethodView, ArgsMixin):
             before=before,
             cursor_login_log_id=cursor_login_log_id,
             limit=limit,
+            person_ids=person_ids,
         )
+
+
+class EventNamesResource(MethodView):
+    @jwt_required()
+    def get(self):
+        """
+        Get event names
+        ---
+        description: Retrieve the distinct event names present in the log. It
+          is meant to build the object and action filters of the log screen.
+          The list is not scoped to the caller's productions: it exposes the
+          event vocabulary, not any production data.
+        tags:
+          - Events
+        responses:
+          200:
+            description: Sorted list of the event names in use
+            content:
+              application/json:
+                schema:
+                  type: array
+                  items:
+                    type: string
+                    example: "task:update"
+        """
+        permissions.check_manager_permissions()
+        return events_service.get_event_names()

--- a/zou/app/blueprints/events/resources.py
+++ b/zou/app/blueprints/events/resources.py
@@ -5,19 +5,10 @@ from zou.app.mixin import ArgsMixin
 from zou.app.utils import fields, permissions
 
 from zou.app.services import events_service, user_service
-from zou.app.services.exception import WrongParameterException
-
-
-def check_person_ids(person_ids):
-    """
-    Make sure every entry of a person_ids filter is a valid id.
-    """
-    for person_id in person_ids or []:
-        if not fields.is_valid_id(person_id):
-            raise WrongParameterException(
-                "The person_ids parameter contains an invalid id"
-            )
-    return person_ids
+from zou.app.services.exception import (
+    ProjectNotFoundException,
+    WrongParameterException,
+)
 
 
 class EventsResource(MethodView, ArgsMixin):
@@ -152,19 +143,34 @@ class EventsResource(MethodView, ArgsMixin):
             ],
         )
 
+        project_id = args.get("project_id", None)
+        if project_id is not None and not fields.is_valid_id(project_id):
+            raise WrongParameterException(
+                "The project_id parameter is not a valid id"
+            )
+
+        # A manager role can be held per production, so resolve it before the
+        # role check reads it, otherwise the global role silently wins. An
+        # unknown project is reported as a denial rather than a 404: the
+        # caller has no right to learn whether it exists. The check stays
+        # ahead of every other parameter so an unauthorized caller never
+        # gets a validation error instead of a denial.
+        if (
+            project_id is not None
+            and not permissions.has_manager_permissions()
+        ):
+            try:
+                user_service.resolve_project_role(project_id)
+            except ProjectNotFoundException:
+                raise permissions.PermissionDenied
         permissions.check_manager_permissions()
+
         before = self.parse_date_parameter(args["before"])
         after = self.parse_date_parameter(args["after"])
         cursor_event_id = args["cursor_event_id"]
         limit = min(args["limit"], 1000)
         only_files = args["only_files"] == "true"
-        project_id = args.get("project_id", None)
         name = args["name"]
-        person_ids = check_person_ids(args["person_ids"])
-        if project_id is not None and not fields.is_valid_id(project_id):
-            raise WrongParameterException(
-                "The project_id parameter is not a valid id"
-            )
         if cursor_event_id is not None and not fields.is_valid_id(
             cursor_event_id
         ):
@@ -194,7 +200,7 @@ class EventsResource(MethodView, ArgsMixin):
             name=name,
             name_prefixes=args["name_prefixes"],
             name_suffixes=args["name_suffixes"],
-            person_ids=person_ids,
+            person_ids=args["person_ids"],
         )
 
 
@@ -295,7 +301,6 @@ class LoginLogsResource(MethodView, ArgsMixin):
         after = self.parse_date_parameter(args["after"])
         cursor_login_log_id = args["cursor_login_log_id"]
         limit = min(args["limit"], 1000)
-        person_ids = check_person_ids(args["person_ids"])
         if cursor_login_log_id is not None and not fields.is_valid_id(
             cursor_login_log_id
         ):
@@ -307,7 +312,7 @@ class LoginLogsResource(MethodView, ArgsMixin):
             before=before,
             cursor_login_log_id=cursor_login_log_id,
             limit=limit,
-            person_ids=person_ids,
+            person_ids=args["person_ids"],
         )
 
 

--- a/zou/app/services/events_service.py
+++ b/zou/app/services/events_service.py
@@ -1,8 +1,28 @@
+import re
+
 from zou.app.models.event import ApiEvent
 from zou.app.models.login_log import LoginLog
-from zou.app.utils import fields
+from zou.app.utils import cache, fields
 from zou.app.services.exception import WrongParameterException
-from sqlalchemy import func
+from sqlalchemy import distinct, func, or_
+
+# Event names are made of lowercase words, digits and dashes on both sides of
+# the colon separator. Anything else is rejected before it can reach a LIKE
+# pattern: "%" and "_" would otherwise be interpreted as wildcards.
+ALLOWED_NAME_PART = re.compile(r"^[a-z0-9-]+$")
+
+
+def check_name_parts(values, parameter_name):
+    """
+    Raise a WrongParameterException if one of the given event name parts is
+    not a plain lowercase word usable in a LIKE pattern.
+    """
+    for value in values:
+        if not ALLOWED_NAME_PART.match(value or ""):
+            raise WrongParameterException(
+                f"The {parameter_name} parameter contains an invalid value"
+            )
+    return True
 
 
 def get_last_events(
@@ -12,11 +32,20 @@ def get_last_events(
     limit=100,
     only_files=False,
     project_id=None,
+    project_ids=None,
     name=None,
+    name_prefixes=None,
+    name_suffixes=None,
+    person_ids=None,
 ):
     """
     Return paginated events using cursor-based pagination.
     If cursor_event_id is set, it returns events older than this event.
+
+    project_ids is a scoping allowlist, distinct from the project_id the
+    caller asked for: it restricts the result to the projects the caller is
+    allowed to see. Events without a project are never returned when it is
+    set, since an IN clause does not match NULL.
     """
     query = ApiEvent.query.order_by(ApiEvent.created_at.desc())
 
@@ -45,8 +74,38 @@ def get_last_events(
     if project_id is not None:
         query = query.filter(ApiEvent.project_id == project_id)
 
+    if project_ids is not None:
+        query = query.filter(ApiEvent.project_id.in_(project_ids))
+
+    if person_ids:
+        query = query.filter(ApiEvent.user_id.in_(person_ids))
+
     if name is not None:
         query = query.filter(ApiEvent.name == name)
+
+    # Event names are "<object>:<action>", so an object filter is a prefix
+    # match and an action filter is a suffix match.
+    if name_prefixes:
+        check_name_parts(name_prefixes, "name_prefixes")
+        query = query.filter(
+            or_(
+                *[
+                    ApiEvent.name.like(f"{prefix}:%")
+                    for prefix in name_prefixes
+                ]
+            )
+        )
+
+    if name_suffixes:
+        check_name_parts(name_suffixes, "name_suffixes")
+        query = query.filter(
+            or_(
+                *[
+                    ApiEvent.name.like(f"%:{suffix}")
+                    for suffix in name_suffixes
+                ]
+            )
+        )
 
     if cursor_event_id is not None:
         cursor_event = ApiEvent.query.get(cursor_event_id)
@@ -64,11 +123,23 @@ def get_last_events(
                 "created_at": event.created_at,
                 "name": event.name,
                 "user_id": event.user_id,
+                "project_id": event.project_id,
                 "data": event.data,
             }
         )
         for event in events
     ]
+
+
+@cache.memoize_function(3600)
+def get_event_names():
+    """
+    Return the sorted list of the event names present in the log. It is used
+    to build the object and action filters, so it must stay caller
+    independent: no scoping is applied here.
+    """
+    names = ApiEvent.query.with_entities(distinct(ApiEvent.name)).all()
+    return sorted(name for (name,) in names)
 
 
 def create_login_log(person_id, ip_address, origin):
@@ -86,12 +157,16 @@ def get_last_login_logs(
     before=None,
     cursor_login_log_id=None,
     limit=100,
+    person_ids=None,
 ):
     """
     Return paginated login logs using cursor-based pagination.
     If cursor_login_log_id is set, it returns login logs older than this log.
     """
     query = LoginLog.query.order_by(LoginLog.created_at.desc())
+
+    if person_ids:
+        query = query.filter(LoginLog.person_id.in_(person_ids))
 
     if after is not None:
         query = query.filter(

--- a/zou/app/services/events_service.py
+++ b/zou/app/services/events_service.py
@@ -8,8 +8,9 @@ from sqlalchemy import distinct, func, or_
 
 # Event names are made of lowercase words, digits and dashes on both sides of
 # the colon separator. Anything else is rejected before it can reach a LIKE
-# pattern: "%" and "_" would otherwise be interpreted as wildcards.
-ALLOWED_NAME_PART = re.compile(r"^[a-z0-9-]+$")
+# pattern: "%" and "_" would otherwise be interpreted as wildcards. Matched
+# with fullmatch, so no anchor is needed and a trailing newline is rejected.
+ALLOWED_NAME_PART = re.compile(r"[a-z0-9-]+")
 
 
 def check_name_parts(values, parameter_name):
@@ -18,9 +19,22 @@ def check_name_parts(values, parameter_name):
     not a plain lowercase word usable in a LIKE pattern.
     """
     for value in values:
-        if not ALLOWED_NAME_PART.match(value or ""):
+        if not ALLOWED_NAME_PART.fullmatch(value or ""):
             raise WrongParameterException(
                 f"The {parameter_name} parameter contains an invalid value"
+            )
+    return True
+
+
+def check_person_ids(person_ids):
+    """
+    Raise a WrongParameterException if one entry of a person_ids filter is
+    not a valid id.
+    """
+    for person_id in person_ids or []:
+        if not fields.is_valid_id(person_id):
+            raise WrongParameterException(
+                "The person_ids parameter contains an invalid id"
             )
     return True
 
@@ -78,6 +92,7 @@ def get_last_events(
         query = query.filter(ApiEvent.project_id.in_(project_ids))
 
     if person_ids:
+        check_person_ids(person_ids)
         query = query.filter(ApiEvent.user_id.in_(person_ids))
 
     if name is not None:
@@ -137,9 +152,26 @@ def get_event_names():
     Return the sorted list of the event names present in the log. It is used
     to build the object and action filters, so it must stay caller
     independent: no scoping is applied here.
+
+    The DISTINCT is served by the index on api_event.name, but it still walks
+    the whole index: the result is memoized and only invalidated when an
+    unseen name is stored.
     """
     names = ApiEvent.query.with_entities(distinct(ApiEvent.name)).all()
     return sorted(name for (name,) in names)
+
+
+def invalidate_event_names_cache(name):
+    """
+    Drop the memoized name list when an unseen event name is stored. The list
+    feeds the log filters, so a brand new event type must show up without
+    waiting for the TTL. Reading the cached list first keeps the common case
+    to a single cache hit.
+    """
+    if name not in get_event_names():
+        cache.cache.delete_memoized(get_event_names)
+        return True
+    return False
 
 
 def create_login_log(person_id, ip_address, origin):
@@ -166,6 +198,7 @@ def get_last_login_logs(
     query = LoginLog.query.order_by(LoginLog.created_at.desc())
 
     if person_ids:
+        check_person_ids(person_ids)
         query = query.filter(LoginLog.person_id.in_(person_ids))
 
     if after is not None:

--- a/zou/app/services/sync_service.py
+++ b/zou/app/services/sync_service.py
@@ -231,6 +231,35 @@ special_events = [
 ]
 
 
+def check_sync_account():
+    """
+    Warn when the sync account is not an admin on the source instance. The log
+    routes are scoped to the caller's productions, so a non-admin account
+    never sees the events carrying no project at all, nor the productions it
+    is not a member of. Never raises: syncing a single production with a
+    manager account stays legitimate.
+    """
+    try:
+        user = gazu.client.get_current_user()
+    except Exception:
+        logger.warning(
+            "Could not read the role of the sync account on the source "
+            "instance."
+        )
+        return False
+
+    if user.get("role") != "admin":
+        logger.warning(
+            f"The sync account ({user.get('email')}) is not an admin on the "
+            "source instance: the event log is scoped to its productions. "
+            "Events carrying no project (organisation and person thumbnails, "
+            "settings) and events of productions it does not belong to will "
+            "be missing from the sync."
+        )
+        return False
+    return True
+
+
 def init(source, login, password, multithreaded=False, number_workers=30):
     """
     Set parameters for the client that will retrieve data from the source.
@@ -248,6 +277,7 @@ def init(source, login, password, multithreaded=False, number_workers=30):
 
     gazu.set_host(source)
     gazu.log_in(login, password)
+    check_sync_account()
 
 
 def init_events_listener(source, event_source, login, password, logs_dir=None):
@@ -259,6 +289,7 @@ def init_events_listener(source, event_source, login, password, logs_dir=None):
     gazu.log_in(login, password)
     if logs_dir is not None:
         set_logger(logs_dir)
+    check_sync_account()
 
     return gazu.events.init()
 

--- a/zou/app/utils/events.py
+++ b/zou/app/utils/events.py
@@ -111,6 +111,21 @@ def save_event(event, data, project_id=None):
     if project_id == "None":
         project_id = None
 
-    return ApiEvent.create(
+    api_event = ApiEvent.create(
         name=event, data=data, user_id=person_id, project_id=project_id
     )
+
+    try:
+        from zou.app.services.events_service import (
+            invalidate_event_names_cache,
+        )
+
+        invalidate_event_names_cache(event)
+    except Exception:
+        # Refreshing the name list must never break the write path: an
+        # unreachable cache only means the log filters stay stale until the
+        # entry expires.
+        current_app.logger.warning(
+            "Could not invalidate the event name list cache.", exc_info=1
+        )
+    return api_event


### PR DESCRIPTION
**Problem**
  - `/data/events/last` and `/data/events/login-logs/last` only filter by date, so the log screens have to filter by user in the browser over the page they already loaded — the
  filter is wrong as soon as there are more rows than one page
  - `ApiEvent.project_id` is described in the response schema but never serialized, so a client cannot show which production an event belongs to
  - There is no way to list the event names in use, so an object/action filter would need a hardcoded vocabulary that drifts and misses plugin events
  - Both routes call `check_manager_permissions()` while Kitsu gates `/logs` on admin: a production manager has no screen but can read the whole audit trail and everyone's login
  logs, IP addresses included, straight from the API
  - Activity logs are not scoped at all — a manager sees events of productions they are not a member of
**Solution**
  - `get_last_events()` accepts `person_ids`, `name_prefixes` and `name_suffixes`; event names are `<object>:<action>`, so an object filter is a prefix match and an action
  filter is a suffix match, which lets both combine without enumerating the vocabulary
  - Both name parts are validated against `^[a-z0-9-]+$` in the service rather than in the resource, so no caller can slip a `%` or a `_` into a LIKE pattern
  - `get_last_login_logs()` accepts `person_ids`
  - `project_id` is added to the serialized event
  - New `GET /data/events/names` returns the distinct event names, memoized for an hour and deliberately unscoped: it exposes the vocabulary, not production data
  - Login logs become admin only — an IP address is personal data and there is no production to scope such a log on
  - Activity logs stay open to managers but are scoped to the productions they belong to, and a `project_id` outside that set is refused; since an `IN` clause never matches
  `NULL`, that scoping also hides the studio-wide events

  Breaking change: a non-admin manager account calling `/data/events/login-logs/last` now gets a 403. No gazu helper targets that route.