### PR TITLE
Align the batch entity deletion with the single routes on force

### DIFF
--- a/tests/entities/test_route_entities.py
+++ b/tests/entities/test_route_entities.py
@@ -105,6 +105,27 @@ class EntityRoutesTestCase(ApiDBTestCase):
         self.post(path, [asset_id], 200)
         self.get(f"/data/assets/{asset_id}", 404)
 
+    def test_delete_entities_with_force(self):
+        # Force removes the entities and their tasks for real, even though
+        # they have tasks and were never canceled before.
+        self.generate_fixture_sequence()
+        self.generate_fixture_shot()
+        self.generate_fixture_shot_task()
+        asset_id = str(self.asset.id)
+        shot_id = str(self.shot.id)
+        asset_task_id = str(self.task.id)
+        shot_task_id = str(self.shot_task.id)
+        path = (
+            f"/actions/projects/{self.project.id}"
+            "/delete-entities?force=true"
+        )
+        result = self.post(path, [asset_id, shot_id], 200)
+        self.assertEqual(result, [asset_id, shot_id])
+        self.get(f"/data/assets/{asset_id}", 404)
+        self.get(f"/data/shots/{shot_id}", 404)
+        self.get(f"/data/tasks/{asset_task_id}", 404)
+        self.get(f"/data/tasks/{shot_task_id}", 404)
+
     def test_delete_entities_ignores_absent_entities(self):
         # An id that no longer exists (e.g. deleted by someone else) must not
         # fail the whole batch: it is skipped and the others are processed.

--- a/zou/app/blueprints/entities/resources.py
+++ b/zou/app/blueprints/entities/resources.py
@@ -3,6 +3,7 @@ from flask.views import MethodView
 from flask_jwt_extended import jwt_required
 
 from zou.app.blueprints.entities.schemas import CreateEntityTasksSchema
+from zou.app.mixin import ArgsMixin
 from zou.app.services.exception import EntityNotFoundException
 from zou.app.services import (
     deletion_service,
@@ -371,7 +372,7 @@ class EntityTaskCreationResource(MethodView):
         return tasks, 201
 
 
-class ProjectDeleteEntitiesResource(MethodView):
+class ProjectDeleteEntitiesResource(MethodView, ArgsMixin):
     @jwt_required()
     def post(self, project_id):
         """
@@ -379,10 +380,10 @@ class ProjectDeleteEntitiesResource(MethodView):
         ---
         description: Delete assets, shots, edits and concepts given by id
           list in a single request. Each entity follows the same rules as
-          its single deletion route. Entities with tasks are marked as
-          canceled on first deletion, then removed for real when already
-          canceled; concepts are always removed. Only entity creators or
-          project managers can delete entities.
+          its single deletion route. Without force, entities with tasks are
+          marked as canceled on first deletion, then removed for real when
+          already canceled; concepts are always removed. Only entity
+          creators or project managers can delete entities.
         tags:
           - Entities
         parameters:
@@ -394,6 +395,14 @@ class ProjectDeleteEntitiesResource(MethodView):
               format: uuid
             description: Unique identifier of the project
             example: a24a6ea4-ce75-4665-a070-57453082c25
+          - in: query
+            name: force
+            required: false
+            schema:
+              type: boolean
+            description: Remove the entities and their tasks for real,
+              instead of only canceling the ones that have tasks
+            example: false
         requestBody:
           required: true
           content:
@@ -417,6 +426,7 @@ class ProjectDeleteEntitiesResource(MethodView):
                     type: string
                     format: uuid
         """
+        force = self.get_force()
         projects_service.get_project(project_id)
         entity_ids = validation.validate_id_list()
         current_user_id = persons_service.get_current_user()["id"]
@@ -434,4 +444,9 @@ class ProjectDeleteEntitiesResource(MethodView):
             else:
                 user_service.check_manager_project_access(project_id)
 
-        return deletion_service.remove_entities(project_id, entity_ids), 200
+        return (
+            deletion_service.remove_entities(
+                project_id, entity_ids, force=force
+            ),
+            200,
+        )

--- a/zou/app/services/deletion_service.py
+++ b/zou/app/services/deletion_service.py
@@ -384,13 +384,14 @@ def remove_tasks(project_id, task_ids):
     return task_ids
 
 
-def remove_entities(project_id, entity_ids):
+def remove_entities(project_id, entity_ids, force=False):
     """
     Delete a list of a project's entities, dispatching each to the right
-    removal by its type (asset, shot, edit, concept). Entities with tasks are
-    canceled on first deletion, then removed for real when already canceled;
-    concepts are always removed. Absent entities and entities that do not
-    belong to the project or are not one of those types are skipped.
+    removal by its type (asset, shot, edit, concept). Without force, entities
+    with tasks are canceled on first deletion, then removed for real when
+    already canceled; concepts are always removed. With force, every entity is
+    removed for real along with its tasks. Absent entities and entities that
+    do not belong to the project or are not one of those types are skipped.
     Returns the ids of the entities that were removed.
     """
     from zou.app.services import (
@@ -416,24 +417,22 @@ def remove_entities(project_id, entity_ids):
         if entity["project_id"] != project_id:
             continue
         entity_type_id = entity["entity_type_id"]
+        entity_force = force or entity["canceled"]
         if entity_type_id == shot_type_id:
             remove = shots_service.remove_shot
-            force = entity["canceled"]
         elif entity_type_id == edit_type_id:
             remove = edits_service.remove_edit
-            force = entity["canceled"]
         elif entity_type_id == concept_type_id:
             remove = concepts_service.remove_concept
-            force = True
+            entity_force = True
         elif assets_service.is_asset_dict(entity):
             remove = assets_service.remove_asset
-            force = entity["canceled"]
         else:
             continue
-        to_remove.append((entity_id, remove, force))
+        to_remove.append((entity_id, remove, entity_force))
 
-    for entity_id, remove, force in to_remove:
-        remove(entity_id, force=force)
+    for entity_id, remove, entity_force in to_remove:
+        remove(entity_id, force=entity_force)
     return [entity_id for entity_id, _, _ in to_remove]
 
 


### PR DESCRIPTION
**Problem**
- The delete-entities action ignored the `force` flag and decided it on its own from each entity's canceled state: an asset with tasks was only marked as canceled, whatever the client asked, while the single deletion routes let the caller pass `force=true` and remove the entity for real. Kitsu got a 200 with the entity ids, dropped them from its list, and saw them come back canceled on the next load.

**Solution**
- Read the `force` query parameter like the single-entity routes and pass it down to `remove_entities`, which keeps the previous behavior when force is absent: entities with tasks are canceled first, and concepts are always removed for real.
