### PR TITLE
Clean up auth responses, CRUD filters and asset CSV task creation

### DIFF
--- a/tests/auth/test_auth_route.py
+++ b/tests/auth/test_auth_route.py
@@ -1224,6 +1224,33 @@ class ChangePasswordErrorsTestCase(ApiDBTestCase):
         )
         self.assertEqual(response.status_code, 400)
 
+    def test_change_password_while_locked_out(self):
+        """
+        check_auth applies the login lockout here too, and the handler
+        used to let TooMuchLoginFailedAttemps out as a 500.
+        """
+        _, headers = self.login()
+        Person.get(self.person_dict["id"]).update(
+            {
+                "login_failed_attemps": 5,
+                "last_login_failed": date_helpers.get_utc_now_datetime(),
+            }
+        )
+        response = self.app.post(
+            "auth/change-password",
+            data=json.dumps(
+                {
+                    "old_password": "secretpassword",
+                    "password": "newpassword1",
+                    "password_2": "newpassword1",
+                }
+            ),
+            headers=headers,
+        )
+        self.assertEqual(response.status_code, 400)
+        data = json.loads(response.data.decode("utf-8"))
+        self.assertTrue(data["too_many_failed_login_attemps"])
+
     def test_change_password_mismatch(self):
         """
         Change password with mismatched passwords returns 400.

--- a/tests/auth/test_auth_route.py
+++ b/tests/auth/test_auth_route.py
@@ -92,8 +92,31 @@ class AuthTestCase(ApiDBTestCase):
         self.person.update({"active": False})
         self.person.save()
         tokens = self.post("auth/login", self.credentials, 401)
+        # Flagged rather than spelled out only in the message, so a client
+        # does not have to parse English to tell this case apart.
+        self.assertTrue(tokens["unactive"])
         self.assertIsNotAuthenticated(tokens, 422)
         self.logout(tokens)
+
+    def test_unactive_login_is_hidden_from_a_wrong_password(self):
+        # Reading the account state before the password answered "user is
+        # unactive" to anybody holding an address and no credential at all,
+        # which tells a registered address from an unknown one.
+        self.person.update({"active": False})
+        persons_service.clear_person_cache()
+
+        credentials = {
+            "email": self.person_dict["email"],
+            "password": "wrongpassword",
+        }
+        result = self.post("auth/login", credentials, 400)
+        unknown = self.post(
+            "auth/login",
+            {"email": "nobody@example.com", "password": "wrongpassword"},
+            400,
+        )
+        self.assertFalse(result["login"])
+        self.assertEqual(result, unknown)
 
     def test_login_with_desktop_login(self):
         self.credentials = {

--- a/tests/auth/test_auth_route.py
+++ b/tests/auth/test_auth_route.py
@@ -837,19 +837,45 @@ class EmailOTPTestCase(ApiDBTestCase):
 
     def test_send_email_otp_not_enabled(self):
         """
-        GET /auth/email-otp returns 400 if email OTP not enabled.
+        GET /auth/email-otp answers like a sent OTP when the account has
+        none enabled, and sends nothing.
         """
-        response = self.app.get(
-            f"auth/email-otp?email={self.credentials['email']}"
-        )
-        self.assertEqual(response.status_code, 400)
+        email = self.credentials["email"]
+        response = self.app.get(f"auth/email-otp?email={email}")
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNone(auth_tokens_store.get(f"email-otp-count-{email}"))
 
     def test_send_email_otp_unknown_user(self):
         """
-        GET /auth/email-otp returns 404 for unknown email.
+        GET /auth/email-otp answers an unknown address exactly like a known
+        one. Answering 404 "User not found." told the two apart in a single
+        unauthenticated request.
         """
-        response = self.app.get("auth/email-otp?email=unknown@test.com")
-        self.assertEqual(response.status_code, 404)
+        known = self.app.get(
+            f"auth/email-otp?email={self.credentials['email']}"
+        )
+        unknown = self.app.get("auth/email-otp?email=unknown@test.com")
+        self.assertEqual(unknown.status_code, 200)
+        self.assertEqual(unknown.data, known.data)
+
+    def test_send_email_otp_unactive_user(self):
+        """
+        A deactivated account gets no OTP email, and is not told apart
+        from any other address.
+        """
+        email = self.credentials["email"]
+        self.person.update(
+            {
+                "active": False,
+                "email_otp_enabled": True,
+                "email_otp_secret": pyotp.random_base32(),
+            }
+        )
+        persons_service.clear_person_cache()
+
+        response = self.app.get(f"auth/email-otp?email={email}")
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNone(auth_tokens_store.get(f"email-otp-count-{email}"))
 
 
 class TOTPTestCase(ApiDBTestCase):

--- a/tests/auth/test_auth_route.py
+++ b/tests/auth/test_auth_route.py
@@ -858,6 +858,25 @@ class EmailOTPTestCase(ApiDBTestCase):
         self.assertEqual(unknown.status_code, 200)
         self.assertEqual(unknown.data, known.data)
 
+    def test_send_email_otp_empty_email(self):
+        """
+        An empty ?email= used to fall through to the desktop login lookup
+        and match the first account created without one.
+        """
+        email = self.credentials["email"]
+        self.person.update(
+            {
+                "desktop_login": "",
+                "email_otp_enabled": True,
+                "email_otp_secret": pyotp.random_base32(),
+            }
+        )
+        persons_service.clear_person_cache()
+
+        response = self.app.get("auth/email-otp?email=")
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNone(auth_tokens_store.get(f"email-otp-count-{email}"))
+
     def test_send_email_otp_unactive_user(self):
         """
         A deactivated account gets no OTP email, and is not told apart

--- a/tests/auth/test_auth_route.py
+++ b/tests/auth/test_auth_route.py
@@ -8,7 +8,7 @@ from tests.base import ApiDBTestCase
 from zou.app.utils import auth, date_helpers, fields
 from zou.app.models.person import Person
 from zou.app.stores import auth_tokens_store
-from zou.app.services import persons_service
+from zou.app.services import auth_service, persons_service
 
 
 class AuthTestCase(ApiDBTestCase):
@@ -207,6 +207,48 @@ class AuthTestCase(ApiDBTestCase):
             auth.check_password = original
 
         self.assertEqual(len(calls), 1)
+
+    def test_password_less_account_costs_a_password_check(self):
+        # A person imported from a CSV has no password at all, and the
+        # LDAP sync stores the literal b"default", which is not a hash.
+        # Both were refused without hashing, in a millisecond, where an
+        # unknown address pays a full bcrypt — one request told them
+        # apart. Counted rather than timed, as above.
+        for stored_password in [None, b"default"]:
+            self.person.update({"password": stored_password})
+            persons_service.clear_person_cache()
+
+            calls = []
+            original = auth.check_password
+
+            def counting_check_password(password_hash, password):
+                calls.append(password_hash)
+                return original(password_hash, password)
+
+            auth.check_password = counting_check_password
+            try:
+                self.post("auth/login", self.credentials, 400)
+            finally:
+                auth.check_password = original
+
+            # The dummy hash is the one comparison that really runs the
+            # KDF: b"default" fails on the salt before doing any work.
+            self.assertIn(auth_service._dummy_password_hash, calls)
+
+    def test_wrong_password_does_not_flush_the_person_cache(self):
+        # clear_person_cache drops every memoized person lookup for the
+        # whole instance, and the JWT loader reads that cache on every
+        # authenticated request. Calling it from the failure path let an
+        # anonymous caller keep it cold for a few requests a minute.
+        calls = []
+        original = persons_service.clear_person_cache
+        persons_service.clear_person_cache = lambda: calls.append(1)
+        try:
+            self._fail_login(1)
+        finally:
+            persons_service.clear_person_cache = original
+
+        self.assertEqual(calls, [])
 
     def test_logout(self):
         tokens = self.post("auth/login", self.credentials, 200)

--- a/tests/auth/test_fido.py
+++ b/tests/auth/test_fido.py
@@ -11,6 +11,7 @@ from unittest import mock
 from tests.base import ApiDBTestCase
 
 from zou.app.models.person import Person
+from zou.app.services import persons_service
 
 
 class FidoRoutesTestCase(ApiDBTestCase):
@@ -45,9 +46,21 @@ class FidoRoutesTestCase(ApiDBTestCase):
             )
 
     def test_get_challenge_unknown_user(self):
-        self.get("auth/fido?email=ghost@nowhere.com", 404)
+        # Answering 404 here and 400 below told a registered address from
+        # an unknown one, unauthenticated, in a single request.
+        unknown = self.get("auth/fido?email=ghost@nowhere.com", 400)
+        known = self.get(f"auth/fido?email={self.user['email']}", 400)
+        self.assertEqual(unknown, known)
 
     def test_get_challenge_fido_not_enabled(self):
+        self.get(f"auth/fido?email={self.user['email']}", 400)
+
+    def test_get_challenge_unactive_user(self):
+        self._register_device()
+        person = Person.get(self.user["id"])
+        person.update({"active": False})
+        persons_service.clear_person_cache()
+
         self.get(f"auth/fido?email={self.user['email']}", 400)
 
     def test_pre_register_returns_webauthn_options(self):

--- a/tests/fixtures/csv/assets_broken_task_status.csv
+++ b/tests/fixtures/csv/assets_broken_task_status.csv
@@ -1,0 +1,4 @@
+Type,Name,Description,Shaders
+Prop,Cassette Player,Description 01,
+Prop,Wood Stick,Description 02,
+Character,Victor,Description 03,NotAStatus

--- a/tests/fixtures/csv/assets_empty_type.csv
+++ b/tests/fixtures/csv/assets_empty_type.csv
@@ -1,0 +1,3 @@
+Type,Name,Description
+Prop,Cassette Player,Description 01
+,Wood Stick,Description 02

--- a/tests/fixtures/csv/assets_task_statuses.csv
+++ b/tests/fixtures/csv/assets_task_statuses.csv
@@ -1,0 +1,3 @@
+Type,Name,Description,Shaders,Concept,Modeling
+Prop,Cassette Player,Description 01,,,
+Prop,Wood Stick,Description 02,wip,,

--- a/tests/models/test_entity_type.py
+++ b/tests/models/test_entity_type.py
@@ -3,6 +3,8 @@ from tests.base import ApiDBTestCase
 from zou.app.models.entity_type import EntityType
 from zou.app.models.task_type import TaskType
 
+from zou.app.services import assets_service
+
 from zou.app.utils import fields
 
 
@@ -85,6 +87,27 @@ class EntityTypeTestCase(ApiDBTestCase):
         self.assertEqual(
             set(task_type for task_type in asset_type_again["task_types"]),
             set(task_types),
+        )
+
+    def test_update_asset_type_task_types_clears_cache(self):
+        self.generate_fixture_department()
+        self.generate_fixture_task_type()
+
+        asset_type = self.get_first("data/entity-types")
+        # Warm the memoized serialization: it carries the workflow, so it
+        # has to be dropped when the workflow changes.
+        self.assertEqual(
+            assets_service.get_asset_type(asset_type["id"])["task_types"], []
+        )
+
+        task_types = [str(self.task_type_modeling.id)]
+        self.put(
+            f"data/entity-types/{asset_type['id']}",
+            {"name": asset_type["name"], "task_types": task_types},
+        )
+        self.assertEqual(
+            assets_service.get_asset_type(asset_type["id"])["task_types"],
+            task_types,
         )
 
     def test_delete_entity_types(self):

--- a/tests/models/test_organisation.py
+++ b/tests/models/test_organisation.py
@@ -59,16 +59,16 @@ class OrganisationTestCase(ApiDBTestCase):
 
     def test_chat_tokens_are_not_filterable(self):
         # Hiding the tokens from the payload is not enough: filters run
-        # before serialization, so they stay answerable by equality.
+        # before serialization, so they stay answerable by equality. The
+        # filter is refused, not dropped, so the answer is never a wider
+        # result set the caller could read as a match.
         organisation = Organisation.query.first()
         organisation.update({field: "a-secret" for field in SENSITIVE_FIELDS})
-        total = len(self.get("data/organisations"))
 
         self.generate_fixture_user_cg_artist()
         self.log_in_cg_artist()
         for field in SENSITIVE_FIELDS:
-            organisations = self.get(f"data/organisations?{field}=a-secret")
-            self.assertEqual(len(organisations), total)
+            self.get(f"data/organisations?{field}=a-secret", 400)
 
     def get_listed_organisation(self, organisation_id):
         return next(

--- a/tests/models/test_person.py
+++ b/tests/models/test_person.py
@@ -13,6 +13,7 @@ from zou.app.models.person import (
 from zou.app.utils import fields
 
 from operator import itemgetter
+from urllib.parse import quote
 
 
 class NormalizeCountryTestCase(unittest.TestCase):
@@ -434,6 +435,24 @@ class PersonTestCase(ApiDBTestCase):
         self.assertEqual(persons[0]["id"], str(person.id))
 
         self.assertEqual(self.get("data/persons?email=nobody@gmail.com"), [])
+
+    def test_full_name_is_filterable(self):
+        # full_name is a hybrid whose SQL expression is a concat_ws inside
+        # a trim, two functions SQLAlchemy types as NullType: casting the
+        # value to it raised a CompileError, and the route answered
+        # gazu.person.get_person_by_full_name() with a 500.
+        person = Person.get_by(email="ema.doe@gmail.com")
+        path = f"data/persons?full_name={quote('Ema Doe')}"
+
+        persons = self.get(path)
+        self.assertEqual(len(persons), 1)
+        self.assertEqual(persons[0]["id"], str(person.id))
+
+        self.generate_fixture_user_cg_artist()
+        self.log_in_cg_artist()
+        persons = self.get(path)
+        self.assertEqual(len(persons), 1)
+        self.assertEqual(persons[0]["id"], str(person.id))
 
     def test_visible_columns_stay_filterable(self):
         person = Person.get_by(email="ema.doe@gmail.com")

--- a/tests/models/test_person.py
+++ b/tests/models/test_person.py
@@ -412,22 +412,28 @@ class PersonTestCase(ApiDBTestCase):
         # Filters run before serialization, so a column absent from
         # present_minimal stays answerable by equality unless the filter
         # keys are narrowed too: ?daily_salary=320 would walk the payroll.
+        # A refused filter must be an error, never a wider result set.
         person = Person.get_by(email="ema.doe@gmail.com")
         person.update({"daily_salary": 320, "phone": "0600000000"})
         self.generate_fixture_user_cg_artist()
         self.log_in_cg_artist()
 
-        for query in [
-            "daily_salary=320",
-            "phone=0600000000",
-            "email=ema.doe@gmail.com",
-        ]:
-            persons = self.get(f"data/persons?{query}")
-            self.assertGreater(
-                len(persons),
-                1,
-                f"{query} was answered as a filter",
-            )
+        for query in ["daily_salary=320", "phone=0600000000"]:
+            self.get(f"data/persons?{query}", 400)
+
+    def test_email_stays_filterable_for_non_admins(self):
+        # gazu.person.get_person_by_email() reads the first row of this
+        # route, so dropping the filter handed out an arbitrary person
+        # instead of no match.
+        person = Person.get_by(email="ema.doe@gmail.com")
+        self.generate_fixture_user_cg_artist()
+        self.log_in_cg_artist()
+
+        persons = self.get("data/persons?email=ema.doe@gmail.com")
+        self.assertEqual(len(persons), 1)
+        self.assertEqual(persons[0]["id"], str(person.id))
+
+        self.assertEqual(self.get("data/persons?email=nobody@gmail.com"), [])
 
     def test_visible_columns_stay_filterable(self):
         person = Person.get_by(email="ema.doe@gmail.com")
@@ -447,8 +453,7 @@ class PersonTestCase(ApiDBTestCase):
     def test_secrets_are_never_filterable(self):
         person = Person.get_by(email="ema.doe@gmail.com")
         person.update({"totp_secret": "SECRETSEED"})
-        persons = self.get("data/persons?totp_secret=SECRETSEED")
-        self.assertGreater(len(persons), 1)
+        self.get("data/persons?totp_secret=SECRETSEED", 400)
 
     def test_country_not_exposed_in_present_minimal(self):
         # The minimal representation is served to non-managers (including

--- a/tests/services/test_auth_service.py
+++ b/tests/services/test_auth_service.py
@@ -12,6 +12,7 @@ from zou.app.stores import auth_tokens_store
 from zou.app.services import persons_service, auth_service
 from zou.app.services.exception import (
     PersonNotFoundException,
+    UnactiveUserException,
     WrongPasswordException,
     WrongUserException,
 )
@@ -112,6 +113,42 @@ class AuthTestCase(ApiDBTestCase):
             app, "john.doe@gmail.com", "mypassword"
         )
         self.assertEqual(person["first_name"], "John")
+
+    def test_unactive_user_is_disclosed_to_the_right_password_only(self):
+        app.config["AUTH_STRATEGY"] = "auth_local_classic"
+        self.person.update({"active": False})
+        persons_service.clear_person_cache()
+
+        self.assertRaises(
+            WrongPasswordException,
+            auth_service.check_auth,
+            app,
+            self.person_dict["email"],
+            "wrongpassword",
+        )
+        self.assertRaises(
+            UnactiveUserException,
+            auth_service.check_auth,
+            app,
+            self.person_dict["email"],
+            "secretpassword",
+        )
+
+    def test_unactive_user_is_checked_before_the_second_factor(self):
+        # Below the 2FA block, the check would let MissingOTPException go
+        # first and hand the enabled 2FA methods of a deactivated account
+        # to whoever holds its password.
+        app.config["AUTH_STRATEGY"] = "auth_local_classic"
+        self.person.update({"active": False, "totp_enabled": True})
+        persons_service.clear_person_cache()
+
+        self.assertRaises(
+            UnactiveUserException,
+            auth_service.check_auth,
+            app,
+            self.person_dict["email"],
+            "secretpassword",
+        )
 
     def test_check_auth_works_on_a_copy(self):
         app.config["AUTH_STRATEGY"] = "auth_local_classic"

--- a/tests/services/test_persons_service.py
+++ b/tests/services/test_persons_service.py
@@ -93,6 +93,17 @@ class PersonServiceTestCase(ApiDBTestCase):
                 empty,
             )
 
+    def test_lockout_state_is_not_published(self):
+        # serialize_safe published how far each account was into its login
+        # burst, and the field being filterable answered who is locked
+        # right now. The unsafe serialization still carries it.
+        person = persons_service.get_person(self.person_id)
+        self.assertNotIn("login_failed_attemps", person)
+        self.assertNotIn("last_login_failed", person)
+
+        person = persons_service.get_person(self.person_id, unsafe=True)
+        self.assertIn("login_failed_attemps", person)
+
     def test_create_person(self):
         person = persons_service.create_person(
             "john.doe2@gmail.com",

--- a/tests/services/test_persons_service.py
+++ b/tests/services/test_persons_service.py
@@ -71,6 +71,28 @@ class PersonServiceTestCase(ApiDBTestCase):
             self.person_desktop_login,
         )
 
+    def test_get_person_by_empty_desktop_login(self):
+        # create_person defaults desktop_login to "" and the column is not
+        # unique, so an empty lookup used to return the first account
+        # without a desktop login.
+        persons_service.create_person(
+            "no.login@gmail.com",
+            auth.encrypt_password("passwordhash"),
+            "No",
+            "Login",
+        )
+        for empty in ["", None]:
+            self.assertRaises(
+                PersonNotFoundException,
+                persons_service.get_person_by_desktop_login,
+                empty,
+            )
+            self.assertRaises(
+                PersonNotFoundException,
+                persons_service.get_person_by_email_desktop_login,
+                empty,
+            )
+
     def test_create_person(self):
         person = persons_service.create_person(
             "john.doe2@gmail.com",

--- a/tests/source/csv/test_import_assets.py
+++ b/tests/source/csv/test_import_assets.py
@@ -9,7 +9,7 @@ from zou.app.models.project import ProjectTaskTypeLink
 from zou.app.models.task import Task
 from zou.app.models.task_type import TaskType
 
-from zou.app.services import assets_service
+from zou.app.services import assets_service, tasks_service
 
 
 class ImportCsvAssetsTestCase(ApiDBTestCase):
@@ -93,6 +93,115 @@ class ImportCsvAssetsTestCase(ApiDBTestCase):
 
         asset = entities[0]
         self.assertEqual(asset.data.get("contractor", None), "contractor 1")
+
+    def link_asset_task_types_to_project(self):
+        """
+        Enable the three Asset task types of the fixtures on the project and
+        return them, so that a CSV column can be named after each of them.
+        """
+        task_types = [
+            self.task_type,
+            self.task_type_concept,
+            self.task_type_modeling,
+        ]
+        for task_type in task_types:
+            db.session.add(
+                ProjectTaskTypeLink(
+                    project_id=self.project_id, task_type_id=task_type.id
+                )
+            )
+        db.session.commit()
+        return task_types
+
+    def test_import_assets_initializes_empty_task_columns_to_default(self):
+        task_types = self.link_asset_task_types_to_project()
+        self.generate_fixture_task_status_wip()
+        # The status list the importer matches columns against is memoized.
+        tasks_service.clear_task_status_cache(str(self.task_status_wip.id))
+        default_status_id = tasks_service.get_default_status()["id"]
+
+        path = f"/import/csv/projects/{self.project.id}/assets"
+        file_path_fixture = self.get_fixture_file_path(
+            os.path.join("csv", "assets_task_statuses.csv")
+        )
+        self.upload_file(path, file_path_fixture)
+
+        # Every asset gets one task per task type of the project, whether
+        # its column was filled or left empty.
+        for asset_name in ("Cassette Player", "Wood Stick"):
+            asset = Entity.get_by(name=asset_name, project_id=self.project_id)
+            tasks = {
+                str(task.task_type_id): task
+                for task in Task.query.filter_by(entity_id=asset.id).all()
+            }
+            self.assertEqual(len(tasks), len(task_types))
+            for task_type in task_types:
+                self.assertIn(str(task_type.id), tasks)
+
+        # An empty column means "not started": the task must exist and hold
+        # the default status, not be skipped.
+        cassette = Entity.get_by(
+            name="Cassette Player", project_id=self.project_id
+        )
+        for task in Task.query.filter_by(entity_id=cassette.id).all():
+            self.assertEqual(str(task.task_status_id), default_status_id)
+
+        # A filled column only overrides the status of its own task.
+        stick = Entity.get_by(name="Wood Stick", project_id=self.project_id)
+        statuses = {
+            str(task.task_type_id): str(task.task_status_id)
+            for task in Task.query.filter_by(entity_id=stick.id).all()
+        }
+        self.assertEqual(
+            statuses[str(self.task_type.id)], str(self.task_status_wip.id)
+        )
+        self.assertEqual(
+            statuses[str(self.task_type_concept.id)], default_status_id
+        )
+        self.assertEqual(
+            statuses[str(self.task_type_modeling.id)], default_status_id
+        )
+
+    def test_import_assets_creates_tasks_of_rows_before_a_failing_one(self):
+        task_types = self.link_asset_task_types_to_project()
+        default_status_id = tasks_service.get_default_status()["id"]
+
+        path = f"/import/csv/projects/{self.project.id}/assets"
+        file_path_fixture = self.get_fixture_file_path(
+            os.path.join("csv", "assets_broken_task_status.csv")
+        )
+        error = self.upload_file(path, file_path_fixture, 400)
+        self.assertEqual(error["imported_rows"], 2)
+
+        # Rows are committed one by one, so the two valid assets remain.
+        # Their tasks must remain too: they used to be created only after
+        # the whole file had been read, and were lost with the failing row.
+        entities = Entity.query.all()
+        self.assertEqual(len(entities), 2)
+        for asset in entities:
+            tasks = Task.query.filter_by(entity_id=asset.id).all()
+            self.assertEqual(len(tasks), len(task_types))
+            for task in tasks:
+                self.assertEqual(str(task.task_status_id), default_status_id)
+
+    def test_import_assets_repairs_missing_tasks_without_update(self):
+        path = f"/import/csv/projects/{self.project.id}/assets"
+        file_path_fixture = self.get_fixture_file_path(
+            os.path.join("csv", "assets_no_metadata.csv")
+        )
+        self.upload_file(path, file_path_fixture)
+        self.assertEqual(len(Task.query.all()), 0)
+
+        # Task types enabled after a first import: re-importing the same
+        # file backfills the missing tasks, even without update=true.
+        task_types = self.link_asset_task_types_to_project()
+        self.upload_file(path, file_path_fixture)
+
+        entities = Entity.query.all()
+        self.assertEqual(len(entities), 3)
+        self.assertEqual(
+            len(Task.query.all()), len(task_types) * len(entities)
+        )
 
     def test_import_assets_duplicates(self):
         path = f"/import/csv/projects/{self.project.id}/assets"

--- a/tests/source/csv/test_import_assets.py
+++ b/tests/source/csv/test_import_assets.py
@@ -204,6 +204,35 @@ class ImportCsvAssetsTestCase(ApiDBTestCase):
             len(Task.query.all()), len(task_types) * len(entities)
         )
 
+    def test_import_assets_task_type_without_for_entity(self):
+        # for_entity was added nullable in 2018 and only ever backfilled for
+        # shots, so long lived databases still hold asset task types reading
+        # NULL. They must not be dropped from the import.
+        legacy_task_type = TaskType.create(
+            name="Legacy",
+            short_name="lgc",
+            department_id=self.department.id,
+        )
+        # The column default only applies on insert, so this really stores
+        # NULL, as a database migrated from before 2018 would hold.
+        legacy_task_type.for_entity = None
+        db.session.add(
+            ProjectTaskTypeLink(
+                project_id=self.project_id, task_type_id=legacy_task_type.id
+            )
+        )
+        db.session.commit()
+
+        path = f"/import/csv/projects/{self.project.id}/assets"
+        file_path_fixture = self.get_fixture_file_path(
+            os.path.join("csv", "assets_no_metadata.csv")
+        )
+        self.upload_file(path, file_path_fixture)
+
+        self.assertEqual(len(Entity.query.all()), 3)
+        tasks = Task.query.filter_by(task_type_id=legacy_task_type.id).all()
+        self.assertEqual(len(tasks), 3)
+
     def test_import_assets_duplicates(self):
         path = f"/import/csv/projects/{self.project.id}/assets"
 

--- a/tests/source/csv/test_import_assets.py
+++ b/tests/source/csv/test_import_assets.py
@@ -4,6 +4,7 @@ from tests.base import ApiDBTestCase
 from zou.app import db
 
 from zou.app.models.entity import Entity
+from zou.app.models.entity_type import EntityType
 from zou.app.models.metadata_descriptor import MetadataDescriptor
 from zou.app.models.project import ProjectTaskTypeLink
 from zou.app.models.task import Task
@@ -291,3 +292,16 @@ class ImportCsvAssetsTestCase(ApiDBTestCase):
         self.assertEqual(error["line_number"], 2)
         entities = Entity.query.all()
         self.assertEqual(len(entities), 0)
+
+    def test_import_assets_empty_type(self):
+        # An empty Type cell used to create an asset type named "", which
+        # every later row with an empty cell then reused.
+        path = f"/import/csv/projects/{self.project.id}/assets"
+        file_path_fixture = self.get_fixture_file_path(
+            os.path.join("csv", "assets_empty_type.csv")
+        )
+        error = self.upload_file(path, file_path_fixture, 400)
+        self.assertIn("asset type is required", error["message"])
+        self.assertEqual(error["line_number"], 3)
+        self.assertEqual(error["imported_rows"], 1)
+        self.assertIsNone(EntityType.get_by(name=""))

--- a/tests/tasks/test_route_tasks.py
+++ b/tests/tasks/test_route_tasks.py
@@ -123,17 +123,38 @@ class TaskRoutesTestCase(ApiDBTestCase):
     def test_create_entity_tasks_rejects_task_type_not_in_asset_workflow(
         self,
     ):
-        # task_type is in project, but asset_type workflow is empty
+        # task_type is in project, but the asset_type workflow is set to
+        # another task type
         ProjectTaskTypeLink.create(
             project_id=self.project.id,
             task_type_id=self.task_type.id,
         )
+        self.asset_type.task_types = [self.task_type_modeling]
+        self.asset_type.save()
+
         path = f"/data/entities/{self.asset_id}/tasks"
         self.post(
             path,
             {"task_type_ids": [self.task_type_id]},
             code=400,
         )
+
+    def test_create_entity_tasks_accepts_asset_type_without_workflow(self):
+        # an asset type with no configured workflow accepts every task
+        # type enabled in the project
+        ProjectTaskTypeLink.create(
+            project_id=self.project.id,
+            task_type_id=self.task_type.id,
+        )
+        path = f"/data/entities/{self.asset_id}/tasks"
+        tasks = self.post(
+            path,
+            {"task_type_ids": [self.task_type_id]},
+            code=201,
+        )
+        self.assertEqual(len(tasks), 1)
+        self.assertEqual(tasks[0]["task_type_id"], self.task_type_id)
+        self.assertEqual(tasks[0]["entity_id"], self.asset_id)
 
     def test_create_entity_tasks_for_asset(self):
         ProjectTaskTypeLink.create(
@@ -199,6 +220,27 @@ class TaskRoutesTestCase(ApiDBTestCase):
 
         self.assertEqual(len(tasks), 1)
         self.assertEqual(tasks[0]["task_type_id"], self.task_type_id)
+
+    def test_create_entity_tasks_defaults_without_workflow_on_asset(self):
+        # No workflow on the asset type: an empty body should create one
+        # task per asset task type enabled in the project.
+        for task_type_id in (
+            self.task_type.id,
+            self.task_type_modeling.id,
+            self.task_type_animation.id,
+        ):
+            ProjectTaskTypeLink.create(
+                project_id=self.project.id, task_type_id=task_type_id
+            )
+
+        path = f"/data/entities/{self.asset_id}/tasks"
+        tasks = self.post(path, {}, code=201)
+
+        created_type_ids = {task["task_type_id"] for task in tasks}
+        self.assertEqual(
+            created_type_ids,
+            {self.task_type_id, str(self.task_type_modeling.id)},
+        )
 
     def test_task_assign(self):
         self.generate_fixture_task()

--- a/zou/app/blueprints/auth/resources.py
+++ b/zou/app/blueprints/auth/resources.py
@@ -886,9 +886,8 @@ class EmailOTPResource(MethodView, ArgsMixin):
             description: User email address
         responses:
           200:
-            description: OTP by email sent
-          400:
-            description: OTP by email not enabled
+            description: Answered the same way whether or not the address
+              belongs to an account able to receive an OTP
         """
         args = self.get_args(
             [
@@ -897,27 +896,24 @@ class EmailOTPResource(MethodView, ArgsMixin):
             location="values",
         )
 
+        # Answer with the same status and the same body whether or not the
+        # account exists, is active and has OTP by email enabled. This used
+        # to answer 404 "User not found.", 400 "OTP by email not enabled."
+        # and 200, which told the three apart in a single unauthenticated
+        # request. Response time still tracks the one branch that mails the
+        # OTP, emails.send_email talking SMTP synchronously.
+        generic_response = {"success": True}
         try:
-            try:
-                person = persons_service.get_person_by_email_desktop_login(
-                    args["email"]
-                )
-            except PersonNotFoundException:
-                raise WrongUserException()
-            if not person["email_otp_enabled"]:
-                raise EmailOTPNotEnabledException
-            auth_service.send_email_otp(person)
-            return {"success": True}
-        except EmailOTPNotEnabledException:
-            return (
-                {"error": True, "message": "OTP by email not enabled."},
-                400,
+            person = persons_service.get_person_by_email_desktop_login(
+                args["email"]
             )
-        except WrongUserException:
-            return (
-                {"error": True, "message": "User not found."},
-                404,
-            )
+        except PersonNotFoundException:
+            return generic_response
+        if not person["active"] or not person["email_otp_enabled"]:
+            return generic_response
+
+        auth_service.send_email_otp(person)
+        return generic_response
 
     @jwt_required()
     @permissions.require_person
@@ -1095,7 +1091,7 @@ class FIDOResource(MethodView, ArgsMixin):
           200:
             description: FIDO challenge generated
           400:
-            description: FIDO not enabled
+            description: No FIDO challenge available for this address
         """
         args = self.get_args(
             [
@@ -1104,26 +1100,28 @@ class FIDOResource(MethodView, ArgsMixin):
             location="values",
         )
 
+        # An unknown address, a deactivated account and an account without
+        # FIDO all get the same answer, so this public endpoint does not
+        # tell a registered address from an unknown one. It used to answer
+        # 404 "User not found." to the first and 400 to the second. What a
+        # challenge still discloses is that the account has FIDO enabled;
+        # hiding that too would mean handing out a decoy challenge no
+        # authenticator could ever honour.
         try:
-            try:
-                person = persons_service.get_person_by_email_desktop_login(
-                    args["email"]
-                )
-            except PersonNotFoundException:
-                raise WrongUserException()
-            if not person["fido_enabled"]:
-                raise FIDONotEnabledException
-            return auth_service.get_challenge_fido(person["id"])
-        except FIDONotEnabledException:
-            return (
-                {"error": True, "message": "FIDO not enabled."},
-                400,
+            person = persons_service.get_person_by_email_desktop_login(
+                args["email"]
             )
-        except WrongUserException:
-            return (
-                {"error": True, "message": "User not found."},
-                404,
-            )
+        except PersonNotFoundException:
+            person = None
+
+        if (
+            person is None
+            or not person["active"]
+            or not person["fido_enabled"]
+        ):
+            return {"error": True, "message": "FIDO not enabled."}, 400
+
+        return auth_service.get_challenge_fido(person["id"])
 
     @jwt_required()
     @permissions.require_person

--- a/zou/app/blueprints/auth/resources.py
+++ b/zou/app/blueprints/auth/resources.py
@@ -207,6 +207,8 @@ class LoginResource(MethodView, ArgsMixin):
             description: Login successful
           400:
             description: Login failed
+          401:
+            description: User is unactive, flagged by "unactive" in the body
         """
         body = validation.validate_request_body(LoginSchema)
         email = body.email
@@ -323,6 +325,7 @@ class LoginResource(MethodView, ArgsMixin):
                 {
                     "error": True,
                     "login": False,
+                    "unactive": True,
                     "message": "User is unactive, he cannot log in.",
                 },
                 401,

--- a/zou/app/blueprints/auth/resources.py
+++ b/zou/app/blueprints/auth/resources.py
@@ -545,6 +545,19 @@ class ChangePasswordResource(MethodView, ArgsMixin):
             return {"error": True, "message": "User is unactive."}, 400
         except WrongPasswordException:
             return {"error": True, "message": "Old password is wrong."}, 400
+        except TooMuchLoginFailedAttemps:
+            # check_auth applies the login lockout here too, so a user who
+            # just failed five logins and then changes his password used to
+            # get a 500. The caller holds a token for the account, telling
+            # him the truth discloses nothing.
+            return (
+                {
+                    "error": True,
+                    "message": "Too many failed login attempts.",
+                    "too_many_failed_login_attemps": True,
+                },
+                400,
+            )
 
     def get_arguments(self):
         body = validation.validate_request_body(ChangePasswordSchema)

--- a/zou/app/blueprints/crud/base.py
+++ b/zou/app/blueprints/crud/base.py
@@ -141,11 +141,23 @@ class BaseModelsResource(MethodView, ArgsMixin):
         filters = {}
 
         column_names = self.get_filterable_column_names()
+        model_column_names = inspect(self.model).all_orm_descriptors.keys()
         for key, value in options.items():
-            if (
-                key not in ["page", "relations", "fields"]
-                and key in column_names
-            ):
+            if key in ["page", "relations", "fields"]:
+                continue
+
+            if key not in column_names:
+                # A column kept out of the filter set must be refused, not
+                # dropped: dropping it answers a broader question than the
+                # one asked, and a client reading the first row as the
+                # match (gazu's fetch_first) then gets an arbitrary record
+                # instead of an error. Names that are not columns at all
+                # stay ignored, resources take their own parameters.
+                if key in model_column_names:
+                    raise WrongParameterException(
+                        f"Filtering on {key} is not allowed."
+                    )
+            else:
                 field_key = getattr(self.model, key)
 
                 is_many_to_many_field = hasattr(

--- a/zou/app/blueprints/crud/person.py
+++ b/zou/app/blueprints/crud/person.py
@@ -16,7 +16,11 @@ from zou.app.models.person import (
 )
 
 # Columns behind Person.present_minimal, the payload every non admin gets
-# from the list route.
+# from the list route, plus email. Email is not in that payload but the
+# lookup is part of the API every studio pipeline builds on
+# (gazu.person.get_person_by_email); matching an address the caller already
+# holds is not the sweep the other hidden columns allow, since equality
+# answers nothing about a value that has not been guessed first.
 MINIMAL_PERSON_FILTER_FIELDS = [
     "id",
     "first_name",
@@ -28,6 +32,7 @@ MINIMAL_PERSON_FILTER_FIELDS = [
     "studio_id",
     "role",
     "desktop_login",
+    "email",
     "is_bot",
 ]
 from zou.app.services import (
@@ -324,10 +329,10 @@ class PersonsResource(BaseModelsResource):
 
     def get_filterable_column_names(self):
         """
-        Mirror what all_entries actually returns. Without this, filtering
-        answers questions the response refuses to: ?daily_salary=320 walks
-        the payroll one value at a time, and email, phone, contract_type or
-        seniority go the same way.
+        Mirror what all_entries actually returns, plus the email lookup.
+        Without this, filtering answers questions the response refuses to:
+        ?daily_salary=320 walks the payroll one value at a time, and phone,
+        contract_type or seniority go the same way.
         """
         if permissions.has_admin_permissions():
             return [

--- a/zou/app/blueprints/source/csv/assets.py
+++ b/zou/app/blueprints/source/csv/assets.py
@@ -1,3 +1,5 @@
+from sqlalchemy import or_
+
 from zou.app.blueprints.source.csv.base import (
     BaseCsvProjectImportResource,
     RowException,
@@ -101,7 +103,16 @@ class AssetsCsvImportResource(BaseCsvProjectImportResource):
         self.task_types_in_project_for_assets = (
             TaskType.query.join(ProjectTaskTypeLink)
             .filter(ProjectTaskTypeLink.project_id == project_id)
-            .filter(TaskType.for_entity == "Asset")
+            # for_entity was added nullable in 2018 and only ever backfilled
+            # for shots, so a task type predating it reads NULL and means
+            # "Asset", the model default. Databases we cannot inspect still
+            # carry those rows.
+            .filter(
+                or_(
+                    TaskType.for_entity == "Asset",
+                    TaskType.for_entity.is_(None),
+                )
+            )
             .all()
         )
         self.task_type_ids_in_project_for_assets = [

--- a/zou/app/blueprints/source/csv/assets.py
+++ b/zou/app/blueprints/source/csv/assets.py
@@ -222,6 +222,11 @@ class AssetsCsvImportResource(BaseCsvProjectImportResource):
     def import_row(self, row, project_id):
         asset_name = row["Name"]
         entity_type_name = row["Type"]
+        if entity_type_name is None or not entity_type_name.strip():
+            # get_or_create_asset_type matches names exactly, so an empty
+            # cell used to create an asset type named "" that every later
+            # empty row then reused.
+            raise RowException("An asset type is required in the Type column")
         episode_name = row.get("Episode", None)
         episode_id = None
 

--- a/zou/app/blueprints/source/csv/assets.py
+++ b/zou/app/blueprints/source/csv/assets.py
@@ -16,7 +16,7 @@ from zou.app.services import (
 )
 from zou.app.models.entity import Entity
 from zou.app.services.exception import WrongParameterException
-from zou.app.utils import events, cache
+from zou.app.utils import events
 
 
 class AssetsCsvImportResource(BaseCsvProjectImportResource):
@@ -98,12 +98,17 @@ class AssetsCsvImportResource(BaseCsvProjectImportResource):
             self.episodes = {
                 episode["name"]: episode["id"] for episode in episodes
             }
-        self.created_assets = []
         self.task_types_in_project_for_assets = (
             TaskType.query.join(ProjectTaskTypeLink)
             .filter(ProjectTaskTypeLink.project_id == project_id)
             .filter(TaskType.for_entity == "Asset")
+            .all()
         )
+        self.task_type_ids_in_project_for_assets = [
+            str(task_type.id)
+            for task_type in self.task_types_in_project_for_assets
+        ]
+        self.task_types_for_asset_type = {}
         self.task_statuses = {
             status["id"]: [status[n].lower() for n in ("name", "short_name")]
             for status in tasks_service.get_task_statuses()
@@ -148,53 +153,71 @@ class AssetsCsvImportResource(BaseCsvProjectImportResource):
 
         return tasks_update
 
+    def create_missing_tasks(self, entity, tasks_map=None):
+        """
+        Create the workflow tasks the entity does not have yet, each at the
+        default status, and return the map of task type id to task. This
+        runs for every row, including the ones whose task columns are all
+        empty: those are exactly the tasks the import must initialize.
+        """
+        if tasks_map is None:
+            tasks_map = {
+                task["task_type_id"]: task
+                for task in tasks_service.get_tasks_for_asset(str(entity.id))
+            }
+        entity_dict = entity.serialize()
+        for task_type_id in self.get_task_types_for_asset_type(
+            entity.entity_type_id
+        ):
+            if task_type_id not in tasks_map:
+                task = tasks_service.create_task(
+                    {"id": task_type_id}, entity_dict
+                )
+                if task is not None:
+                    tasks_map[task_type_id] = task
+        return tasks_map
+
     def create_and_update_tasks(
         self, tasks_update, entity, asset_creation=False
     ):
-        if tasks_update:
-            tasks_map = {}
-            if asset_creation:
-                task_type_ids = self.get_task_types_for_asset_type(
-                    entity.entity_type_id
-                )
-                for task_type_id in task_type_ids:
-                    task = tasks_service.create_task(
-                        {"id": task_type_id}, entity.serialize()
-                    )
-                    tasks_map[task_type_id] = task
-            else:
-                for task in tasks_service.get_tasks_for_asset(str(entity.id)):
-                    tasks_map[task["task_type_id"]] = task
+        """
+        Create the workflow tasks of the entity, then apply the statuses and
+        comments read from the row.
+        """
+        tasks_map = self.create_missing_tasks(
+            entity, {} if asset_creation else None
+        )
 
-            for task_update in tasks_update:
-                if task_update["task_type_id"] not in tasks_map:
-                    task = tasks_service.create_task(
-                        tasks_service.get_task_type(
-                            task_update["task_type_id"]
-                        ),
-                        entity.serialize(),
+        for task_update in tasks_update:
+            task_type_id = task_update["task_type_id"]
+            if task_type_id not in tasks_map:
+                # The column names a task type outside the asset type
+                # workflow: the explicit status still creates its task.
+                task = tasks_service.create_task(
+                    tasks_service.get_task_type(task_type_id),
+                    entity.serialize(),
+                )
+                if task is None:
+                    continue
+                tasks_map[task_type_id] = task
+            task = tasks_map[task_type_id]
+            if (
+                task_update["comment"] is not None
+                or task_update["task_status_id"] != task["task_status_id"]
+            ):
+                try:
+                    comments_service.create_comment(
+                        self.current_user_id,
+                        task["id"],
+                        task_update["task_status_id"]
+                        or task["task_status_id"],
+                        task_update["comment"] or "",
+                        [],
+                        {},
+                        "",
                     )
-                    tasks_map[task_update["task_type_id"]] = task
-                task = tasks_map[task_update["task_type_id"]]
-                if (
-                    task_update["comment"] is not None
-                    or task_update["task_status_id"] != task["task_status_id"]
-                ):
-                    try:
-                        comments_service.create_comment(
-                            self.current_user_id,
-                            task["id"],
-                            task_update["task_status_id"]
-                            or task["task_status_id"],
-                            task_update["comment"] or "",
-                            [],
-                            {},
-                            "",
-                        )
-                    except WrongParameterException:
-                        pass
-        elif asset_creation:
-            self.created_assets.append(entity.serialize())
+                except WrongParameterException:
+                    pass
 
     def import_row(self, row, project_id):
         asset_name = row["Name"]
@@ -295,36 +318,35 @@ class AssetsCsvImportResource(BaseCsvProjectImportResource):
             self.create_and_update_tasks(
                 tasks_update, entity, asset_creation=False
             )
+
+        else:
+            # The asset is left untouched, but a re-import is the documented
+            # way to repair a production whose assets miss their tasks.
+            self.create_missing_tasks(entity)
+
         return entity.serialize()
 
-    @cache.memoize_function(10)
     def get_task_types_for_asset_type(self, asset_type_id):
-        task_type_ids = [
-            str(task_type.id)
-            for task_type in self.task_types_in_project_for_assets
-        ]
-        asset_type = assets_service.get_asset_type(asset_type_id)
-        type_task_type_ids = asset_type["task_types"]
-        type_task_types_map = {
-            task_type_id: True for task_type_id in type_task_type_ids
-        }
-        if len(type_task_type_ids) > 0:
-            task_type_ids = [
-                task_type_id
-                for task_type_id in task_type_ids
-                if task_type_id in type_task_types_map
-            ]
-        return task_type_ids
-
-    def run_import(self, file_path, project_id):
-        entities = super().run_import(
-            file_path,
-            project_id,
-        )
-        for asset in entities:
-            task_type_ids = self.get_task_types_for_asset_type(
-                asset["entity_type_id"]
-            )
-            for task_type_id in task_type_ids:
-                tasks_service.create_tasks({"id": task_type_id}, [asset])
-        return entities
+        """
+        Return the ids of the task types to create for a given asset type:
+        the ones enabled on the project, narrowed by the asset type workflow
+        when it defines one. Memoized on the resource instance only: the
+        result depends on the project being imported, which a cache key
+        built from the arguments alone cannot express.
+        """
+        asset_type_id = str(asset_type_id)
+        if asset_type_id not in self.task_types_for_asset_type:
+            task_type_ids = self.task_type_ids_in_project_for_assets
+            asset_type = assets_service.get_asset_type(asset_type_id)
+            type_task_type_ids = asset_type["task_types"]
+            if len(type_task_type_ids) > 0:
+                type_task_types_map = {
+                    task_type_id: True for task_type_id in type_task_type_ids
+                }
+                task_type_ids = [
+                    task_type_id
+                    for task_type_id in task_type_ids
+                    if task_type_id in type_task_types_map
+                ]
+            self.task_types_for_asset_type[asset_type_id] = task_type_ids
+        return self.task_types_for_asset_type[asset_type_id]

--- a/zou/app/models/person.py
+++ b/zou/app/models/person.py
@@ -75,6 +75,11 @@ SENSITIVE_FIELDS = [
     "fido_credentials",
     "fido_devices",
     "jti",
+    # Lockout state: serialize_safe published how far each account was
+    # into its login burst, and, being filterable, answered who is locked
+    # right now. An admin can still clear it, writes are unaffected.
+    "login_failed_attemps",
+    "last_login_failed",
 ]
 
 

--- a/zou/app/services/assets_service.py
+++ b/zou/app/services/assets_service.py
@@ -47,6 +47,9 @@ def clear_asset_cache(asset_id):
 
 def clear_asset_type_cache():
     cache.cache.delete_memoized(get_all_asset_types)
+    # get_asset_type carries the task types of the workflow, so editing it
+    # must not keep serving the previous one for the whole TTL.
+    cache.cache.delete_memoized(get_asset_type)
 
 
 def get_temporal_type_ids():

--- a/zou/app/services/auth_service.py
+++ b/zou/app/services/auth_service.py
@@ -186,14 +186,27 @@ def local_auth_strategy(person, password, app=None):
     to given password).
     Password hash comparison is based on BCrypt.
     """
-    try:
-        password_hash = person["password"] or ""
-        if password_hash and auth.check_password(password_hash, password):
-            return person
-        else:
-            raise WrongPasswordException()
-    except ValueError:
+    # Refusing an account whose stored value cannot be compared answered
+    # in a millisecond, where an unknown address pays the bcrypt
+    # _spend_password_check_time deliberately costs. That identified a
+    # registered address in a single request, by response time alone, and
+    # both cases are ordinary: a person imported from a CSV has no
+    # password at all, and the LDAP sync stores the literal b"default",
+    # which is not a hash.
+    password_hash = person["password"] or ""
+    if not password_hash:
+        _spend_password_check_time(password)
         raise WrongPasswordException()
+
+    try:
+        password_matches = auth.check_password(password_hash, password)
+    except ValueError:
+        _spend_password_check_time(password)
+        raise WrongPasswordException()
+
+    if not password_matches:
+        raise WrongPasswordException()
+    return person
 
 
 def ldap_auth_strategy(person, password, app):
@@ -262,13 +275,19 @@ def update_login_failed_attemps(
 ):
     """
     Update login failed attemps for a person_id.
+
+    The person cache is deliberately left alone: check_login_failed_attemps
+    reads the counter from the row, so nothing needs the cached copy to be
+    in step, and clear_person_cache drops every memoized person lookup for
+    the whole instance. Calling it here let an anonymous caller keep that
+    cache cold with a handful of wrong passwords a minute, while the JWT
+    loader reads it on every authenticated request.
     """
     person = Person.get(person_id)
     person.login_failed_attemps = login_failed_attemps
     if last_login_failed is not None:
         person.last_login_failed = last_login_failed
     person.commit()
-    persons_service.clear_person_cache()
     return person.serialize()
 
 
@@ -810,17 +829,20 @@ def check_login_failed_attemps(person):
     another minute, so anyone knowing an address could hold it shut
     indefinitely at one request a minute — the owner included, correct
     password and all. Rearming now costs a fresh burst.
+
+    The counter is read from the row, not from the person dict: that dict
+    comes from a lookup memoized for two minutes, and keeping it in step
+    meant dropping the whole instance person cache on every wrong
+    password. See update_login_failed_attemps.
     """
-    login_failed_attemps = person["login_failed_attemps"] or 0
+    row = Person.get(person["id"])
+    login_failed_attemps = row.login_failed_attemps or 0
     if login_failed_attemps < MAX_LOGIN_FAILED_ATTEMPS:
         return login_failed_attemps
 
-    last_login_failed = person["last_login_failed"]
+    last_login_failed = row.last_login_failed
     if last_login_failed is not None:
-        locked_until = (
-            date_helpers.get_datetime_from_string(last_login_failed)
-            + LOGIN_LOCKOUT_DELAY
-        )
+        locked_until = last_login_failed + LOGIN_LOCKOUT_DELAY
         if locked_until > date_helpers.get_utc_now_datetime():
             raise TooMuchLoginFailedAttemps()
 

--- a/zou/app/services/auth_service.py
+++ b/zou/app/services/auth_service.py
@@ -85,10 +85,17 @@ def check_auth(
     no_otp=False,
 ):
     """
-    Depending on configured strategy, it checks if given email and password
-    mach an active user in the database. It raises exceptions adapted to
-    encountered error (no auth strategy configured, wrong email, wrong passwor
-    or unactive user).
+    Depending on the configured strategy, check that the given email and
+    password match an active user in the database. Raise the exception
+    fitting the error met (no auth strategy configured, wrong email, wrong
+    password, unactive user).
+
+    The account state is read only once the password has been proven.
+    Reading it earlier answered "this account exists and is deactivated" to
+    anybody holding an address and no credential at all, which enumerates
+    registered addresses the same way the timing gap closed by
+    _spend_password_check_time did.
+
     App is needed as parameter to give access to configuration while avoiding
     cyclic imports.
     """
@@ -99,9 +106,6 @@ def check_auth(
     except PersonNotFoundException:
         _spend_password_check_time(password)
         raise WrongUserException()
-
-    if not person.get("active", False):
-        raise UnactiveUserException()
 
     login_failed_attemps = check_login_failed_attemps(person)
 
@@ -122,6 +126,11 @@ def check_auth(
             date_helpers.get_utc_now_datetime(),
         )
         raise WrongPasswordException()
+
+    # Past the password, and before the second factor: a deactivated
+    # account does not hand out the list of its enabled 2FA methods.
+    if not person.get("active", False):
+        raise UnactiveUserException()
 
     if not no_otp and person_two_factor_authentication_enabled(person):
         if not check_two_factor_authentication(

--- a/zou/app/services/persons_service.py
+++ b/zou/app/services/persons_service.py
@@ -241,6 +241,11 @@ def get_person_by_desktop_login(desktop_login):
     Return person that matches given desktop login as a dictionary. It is useful
     to authenticate user from their desktop session login.
     """
+    # An empty desktop login is what create_person gives anybody who has
+    # none, and the column is not unique, so matching on it handed out the
+    # first such account, usually the admin created at install time.
+    if not desktop_login:
+        raise PersonNotFoundException()
     try:
         person = Person.get_by(desktop_login=desktop_login, is_bot=False)
     except StatementError:
@@ -312,6 +317,11 @@ def get_person_by_email_desktop_login(email_or_desktop_login):
     """
     Return person that matches given email or desktop login as a dictionary.
     """
+    # Neither column is unique nor NOT NULL, so a falsy identifier must
+    # never reach a query: it would resolve to whichever account happens to
+    # have a blank one. Public routes pass a raw query parameter here.
+    if not email_or_desktop_login:
+        raise PersonNotFoundException()
     try:
         return get_person_by_email(email_or_desktop_login, unsafe=True)
     except PersonNotFoundException:

--- a/zou/app/services/tasks_service.py
+++ b/zou/app/services/tasks_service.py
@@ -1335,7 +1335,8 @@ def create_tasks_for_entity(entity, task_types=None):
     for the entity: enabled in the project, in the asset-type workflow
     (for assets), and whose for_entity matches the entity kind. When a
     list is provided, each task type is validated against those same
-    constraints. Existing tasks for the same (entity, task_type,
+    constraints. An asset type with no configured workflow accepts every
+    task type. Existing tasks for the same (entity, task_type,
     name="main") are skipped.
     """
     project_id = entity["project_id"]
@@ -1354,6 +1355,8 @@ def create_tasks_for_entity(entity, task_types=None):
             ProjectTaskTypeLink.project_id == project_id
         ).all()
     }
+    # None means unrestricted: not an asset, or no workflow configured
+    # on the asset type ("Includes all asset task types" in Kitsu).
     enabled_in_workflow = None
     if is_asset:
         enabled_in_workflow = {
@@ -1361,11 +1364,11 @@ def create_tasks_for_entity(entity, task_types=None):
             for link in TaskTypeAssetTypeLink.query.filter(
                 TaskTypeAssetTypeLink.asset_type_id == entity["entity_type_id"]
             ).all()
-        }
+        } or None
 
     if not task_types:
         candidate_ids = enabled_in_project
-        if is_asset:
+        if enabled_in_workflow is not None:
             candidate_ids = candidate_ids & enabled_in_workflow
         if not candidate_ids:
             return []
@@ -1392,7 +1395,10 @@ def create_tasks_for_entity(entity, task_types=None):
                     f"Task type {type_id} is not enabled in project "
                     f"{project_id}."
                 )
-            if is_asset and str(type_id) not in enabled_in_workflow:
+            if (
+                enabled_in_workflow is not None
+                and str(type_id) not in enabled_in_workflow
+            ):
                 raise WrongParameterException(
                     f"Task type {type_id} is not in the workflow of "
                     f"asset type {entity['entity_type_id']}."

--- a/zou/app/utils/query.py
+++ b/zou/app/utils/query.py
@@ -7,7 +7,7 @@ import sqlalchemy.orm as orm
 from zou.app import config
 from zou.app.utils import fields, string
 from zou.app.services.exception import WrongParameterException
-from sqlalchemy import func
+from sqlalchemy import func, types as sa_types
 from sqlalchemy.inspection import inspect
 
 
@@ -185,6 +185,14 @@ def apply_sort_by(model, query, sort_by):
 
 
 def cast_value(value, field_key):
+    # A hybrid expression built from functions SQLAlchemy does not know
+    # carries NullType: Person.full_name is a concat_ws inside a trim.
+    # CAST(... AS NULL) cannot even be compiled, and the CompileError is
+    # not a StatementError, so it escaped as a 500 instead of a filter.
+    # Comparing the bare value is what the cast stood in for anyway.
+    if isinstance(field_key.type, sa_types.NullType):
+        return value
+
     # Some column types (ChoiceType, LocaleType, TimezoneType, ...) do not
     # implement python_type and raise NotImplementedError; they just fall
     # through to the generic cast below instead of crashing the request.


### PR DESCRIPTION
**Problem**
- The public auth routes (login, email OTP, FIDO) handled their edge cases inconsistently, with uneven status codes, responses, and password-check paths
- A blank identifier in the person lookups could match an unintended account, and a failed login flushed the whole person cache
- A filter on a hidden column was dropped instead of refused, so a caller reading the first row got an arbitrary record as a match, and filtering on `full_name` raised a 500 (cast on an untyped SQL expression)
- The asset CSV import created tasks only after the whole file was read (lost with a failing row), left empty task columns without tasks, dropped task types whose `for_entity` is NULL, and accepted an empty Type cell (creating an asset type named "")
- An asset type with no configured workflow rejected every task type instead of accepting them all

**Solution**
- Normalize the responses and the password-check path of the public auth routes, and read the account state at a consistent point of the login flow
- Refuse blank identifiers in the person lookups, and keep the person cache out of the login failure path
- Refuse a filter on a hidden column with a 400 (email stays filterable for `gazu.person.get_person_by_email`), and skip the cast for NullType expressions
- Create the CSV asset tasks row by row, initialize empty task columns at the default status, include NULL `for_entity` task types, and refuse an empty Type column
- Treat an empty asset type workflow as unrestricted, matching the Kitsu setting
