### PR TITLE
[previews] Convert pictures to sRGB through their ICC profile

### DIFF
--- a/tests/utils/test_thumbnail.py
+++ b/tests/utils/test_thumbnail.py
@@ -1,7 +1,7 @@
 import unittest
 import os
 
-from PIL import Image
+from PIL import Image, ImageCms
 
 from werkzeug.datastructures import FileStorage
 
@@ -135,6 +135,34 @@ class ThumbnailTestCase(unittest.TestCase):
         )
         self.assertTrue(os.path.exists(file_path))
         self.assertTrue(Image.open(file_path).size, thumbnail.SQUARE_SIZE)
+
+    def test_to_srgb(self):
+        profile = ImageCms.ImageCmsProfile(
+            ImageCms.createProfile("sRGB")
+        ).tobytes()
+
+        im = Image.new("RGB", (4, 4), (200, 30, 30))
+        im.info["icc_profile"] = profile
+        self.assertEqual(thumbnail.to_srgb(im).tobytes(), im.tobytes())
+
+        im = Image.new("RGBA", (4, 4), (200, 30, 30, 128))
+        im.info["icc_profile"] = profile
+        converted = thumbnail.to_srgb(im)
+        self.assertEqual(converted.mode, "RGBA")
+        self.assertEqual(converted.getpixel((0, 0)), (200, 30, 30, 128))
+
+        im = Image.new("CMYK", (4, 4), (0, 255, 255, 0))
+        self.assertEqual(thumbnail.to_srgb(im).mode, "RGB")
+        self.assertEqual(thumbnail.to_srgb(im, "RGBA").mode, "RGBA")
+        self.assertEqual(
+            thumbnail.to_srgb(im, "RGBA").getpixel((0, 0))[3], 255
+        )
+
+        im.info["icc_profile"] = b"not a profile"
+        self.assertEqual(thumbnail.to_srgb(im).mode, "RGB")
+
+        im = Image.new("L", (4, 4))
+        self.assertEqual(thumbnail.to_srgb(im).mode, "L")
 
     def test_turn_hdr_into_thumbnail(self):
         file_path_fixture = self.get_fixture_file_path("thumbnails/sample.hdr")

--- a/zou/app/utils/thumbnail.py
+++ b/zou/app/utils/thumbnail.py
@@ -2,9 +2,10 @@ import os
 import shutil
 import math
 
+from io import BytesIO
 from pathlib import Path
 
-from PIL import Image, ImageFile
+from PIL import Image, ImageCms, ImageFile
 
 from zou.app import config
 from zou.app.utils import fs
@@ -17,6 +18,37 @@ SQUARE_SIZE = 100, 100
 PREVIEW_SIZE = 1200, 0
 BIG_SQUARE_SIZE = 400, 400
 BIG_RECTANGLE_SIZE = 300, 200
+SRGB_PROFILE = ImageCms.createProfile("sRGB")
+
+
+def to_srgb(im, mode="RGB"):
+    """
+    Convert given picture to sRGB, honouring its embedded ICC profile.
+
+    Image.convert() ignores that profile: it turns CMYK into RGB with a
+    plain arithmetic formula, which oversaturates pictures meant for print.
+    Wide gamut pictures (Adobe RGB, Display P3) suffer from the same problem
+    once a browser reads their pixels as sRGB.
+    """
+    if im.mode not in ("CMYK", "RGB", "RGBA"):
+        return im
+    if im.mode == "RGBA":
+        mode = "RGBA"
+    icc_profile = im.info.get("icc_profile")
+    if icc_profile:
+        try:
+            im = ImageCms.profileToProfile(
+                im,
+                ImageCms.ImageCmsProfile(BytesIO(icc_profile)),
+                SRGB_PROFILE,
+                # littleCMS fills the alpha channel with zeroes when the
+                # source has none, so never ask it for RGBA out of CMYK.
+                outputMode="RGBA" if im.mode == "RGBA" else "RGB",
+            )
+        except (ImageCms.PyCMSError, OSError):
+            # A broken or unreadable profile is not worth failing an upload.
+            pass
+    return im.convert(mode) if im.mode != mode else im
 
 
 def save_file(tmp_folder, instance_id, file_to_save):
@@ -28,9 +60,7 @@ def save_file(tmp_folder, instance_id, file_to_save):
     file_name = instance_id + extension.lower()
     file_path = os.path.join(tmp_folder, file_name)
     file_to_save.save(file_path)
-    im = Image.open(file_path)
-    if im.mode == "CMYK":
-        im = im.convert("RGB")
+    im = to_srgb(Image.open(file_path))
     im.save(file_path, "PNG")
     return file_path
 
@@ -41,9 +71,7 @@ def convert_jpg_to_png(file_source_path):
     """
     file_target_path = Path(file_source_path).with_suffix(".png")
 
-    im = Image.open(file_source_path)
-    if im.mode == "CMYK":
-        im = im.convert("RGB")
+    im = to_srgb(Image.open(file_source_path))
     im.save(file_target_path, "PNG")
     fs.rm_file(file_source_path)
     return file_target_path
@@ -106,7 +134,7 @@ def turn_into_thumbnail(file_path, size=None):
     """
     Turn given picture into a smaller version.
     """
-    im = Image.open(file_path)
+    im = to_srgb(Image.open(file_path), "RGBA")
 
     if size is not None:
         width, height = size
@@ -119,8 +147,6 @@ def turn_into_thumbnail(file_path, size=None):
     im = fit_to_target_size(im, size)
 
     im.thumbnail(size, Image.Resampling.LANCZOS)
-    if im.mode == "CMYK":
-        im = im.convert("RGBA")
     final = Image.new("RGBA", size, (0, 0, 0, 0))
     final.paste(
         im, (int((size[0] - im.size[0]) / 2), int((size[1] - im.size[1]) / 2))
@@ -133,12 +159,10 @@ def resize(file_path, size, crop=False):
     """
     Resize given picture
     """
-    im = Image.open(file_path)
+    im = to_srgb(Image.open(file_path))
     if crop:
         im = prepare_image_for_thumbnail(im, size)
     im = im.resize(size, Image.Resampling.LANCZOS)
-    if im.mode == "CMYK":
-        im = im.convert("RGB")
     im.save(file_path, "PNG")
     return file_path
 


### PR DESCRIPTION
**Problem**

- Uploading a CMYK picture gave a preview 64% more saturated than the original:
  `Image.convert()` ignores the embedded ICC profile.
- Pillow copied the CMYK profile onto the RGB output, tagging previews with a
  press profile their pixels no longer match.
- Wide gamut pictures (Adobe RGB, Display P3) were read as sRGB, with the same
  oversaturation.

**Solution**

- Add `to_srgb()`, running the conversion through littleCMS, and call it at the
  four sites that converted CMYK by hand.
- Convert CMYK to RGB before adding alpha: littleCMS zeroes the alpha channel
  when the source has none.
- Fall back to the plain conversion when the profile is unreadable instead of
  failing the upload.
- Cover the no-op, alpha, fallback and passthrough paths in `test_to_srgb`.