### PR TITLE
[comments] Apply is_artist_allowed on every path that sets a status

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/psf/black
-    rev: 26.1.0
+    rev: 26.5.1
     hooks:
       - id: black
   - repo: https://github.com/PyCQA/autoflake

--- a/tests/blueprints/comments/test_comments.py
+++ b/tests/blueprints/comments/test_comments.py
@@ -7,7 +7,7 @@ from zou.app.models.comment import Comment
 from zou.app.models.notification import Notification
 from zou.app.models.person import Person
 from zou.app.models.task import Task
-from zou.app.services import comments_service, tasks_service
+from zou.app.services import comments_service, projects_service, tasks_service
 
 
 class CommentTestCase(ApiDBTestCase):
@@ -131,6 +131,62 @@ class CommentRoutesTestCase(CommentTestCase):
         ]
         self.assertIn("asset note", asset_texts)
         self.assertIn("shot note", shot_texts)
+
+    def an_artist_of_the_team(self):
+        artist = self.generate_fixture_user_cg_artist()
+        projects_service.add_team_member(self.project.id, artist["id"])
+        tasks_service.assign_task(str(self.task.id), artist["id"])
+        self.log_in_cg_artist()
+        return artist
+
+    def a_status_closed_to_artists(self):
+        status = self.generate_fixture_task_status_wip()
+        status.update({"is_artist_allowed": False})
+        tasks_service.clear_task_status_cache(str(status.id))
+        return str(status.id)
+
+    def test_batch_comment_tasks_refuses_a_status_closed_to_artists(self):
+        """
+        is_artist_allowed is read off the role the caller holds on the
+        production, which only the access check resolves. On this route the
+        status check used to run before that check, so the first comment of
+        the batch was measured against the global role and went through.
+        """
+        closed = self.a_status_closed_to_artists()
+        self.an_artist_of_the_team()
+
+        self.post(
+            "/actions/tasks/batch-comment",
+            {
+                "comments": [
+                    {
+                        "task_id": str(self.task.id),
+                        "task_status_id": closed,
+                        "text": "refused",
+                    }
+                ]
+            },
+            403,
+        )
+        texts = [c["text"] for c in tasks_service.get_comments(self.task.id)]
+        self.assertNotIn("refused", texts)
+
+    def test_batch_comment_task_refuses_a_status_closed_to_artists(self):
+        """
+        The single task route resolves the production before the loop, so
+        it always applied the restriction. Kept next to its twin: the two
+        serve the same data and must keep the same policy.
+        """
+        closed = self.a_status_closed_to_artists()
+        self.an_artist_of_the_team()
+
+        self.post(
+            f"/actions/tasks/{self.task.id}/batch-comment",
+            {"comments": [{"task_status_id": closed, "text": "refused"}]},
+            403,
+        )
+        texts = [c["text"] for c in tasks_service.get_comments(self.task.id)]
+        self.assertNotIn("refused", texts)
 
     def test_comment_many_tasks(self):
         result = self.post(

--- a/zou/app/blueprints/comments/resources.py
+++ b/zou/app/blueprints/comments/resources.py
@@ -282,6 +282,9 @@ class CommentTaskResource(MethodView):
                 != str(task["task_status_id"]).lower()
             ):
                 raise
+        permissions_service.resolve_project_role(
+            tasks_service.get_task(task_id)["project_id"]
+        )
         permissions_service.check_task_status_access(task_status_id)
         files = request.files
 
@@ -588,6 +591,9 @@ class CommentManyTasksResource(MethodView):
                 or "comment" not in comment
             ):
                 continue
+            permissions_service.resolve_project_role(
+                tasks_service.get_task(comment["object_id"])["project_id"]
+            )
             permissions_service.check_task_status_access(
                 comment["task_status_id"]
             )

--- a/zou/app/blueprints/crud/comments.py
+++ b/zou/app/blueprints/crud/comments.py
@@ -524,6 +524,9 @@ class CommentResource(BaseModelResource):
                     permissions_service.check_task_action_access(
                         instance["object_id"]
                     )
+                permissions_service.resolve_project_role(
+                    tasks_service.get_task(instance["object_id"])["project_id"]
+                )
                 permissions_service.check_task_status_access(
                     data["task_status_id"]
                 )

--- a/zou/app/blueprints/crud/comments.py
+++ b/zou/app/blueprints/crud/comments.py
@@ -514,9 +514,10 @@ class CommentResource(BaseModelResource):
                 raise permissions.PermissionDenied
 
             if "task_status_id" in data.keys():
-                if str(data["task_status_id"]).lower() != str(
-                    instance["task_status_id"]
-                ).lower():
+                if (
+                    str(data["task_status_id"]).lower()
+                    != str(instance["task_status_id"]).lower()
+                ):
                     # Writing in a task and steering it are different
                     # rights: a mentioned person may author a comment, but
                     # moving the status through an update of it requires

--- a/zou/app/blueprints/previews/resources.py
+++ b/zou/app/blueprints/previews/resources.py
@@ -584,14 +584,19 @@ class BaseBatchComment(BaseNewPreviewFilePicture, ArgsMixin):
 
         new_comments = []
         for i, comment in enumerate(args["comments"]):
-            permissions_service.check_task_status_access(
-                comment["task_status_id"]
-            )
-
             if task_id is None:
                 permissions_service.check_task_action_access(
                     comment["task_id"]
                 )
+
+            permissions_service.resolve_project_role(
+                tasks_service.get_task(task_id or comment["task_id"])[
+                    "project_id"
+                ]
+            )
+            permissions_service.check_task_status_access(
+                comment["task_status_id"]
+            )
 
             if not permissions.has_manager_permissions():
                 comment["person_id"] = None

--- a/zou/app/services/permissions_service.py
+++ b/zou/app/services/permissions_service.py
@@ -182,6 +182,11 @@ def check_entity_access(entity_id):
 def check_task_status_access(task_status_id):
     """
     Return true if current user can use this task status.
+
+    is_artist_allowed and is_client_allowed are read off the role the caller
+    holds on the production, so the caller resolves it first. Without a
+    resolved role the restriction does not apply at all: it lets everything
+    through rather than raise.
     """
     is_artist = permissions.has_artist_permissions()
     is_client = permissions.has_client_permissions()


### PR DESCRIPTION
**Problem**

- `is_artist_allowed` / `is_client_allowed` are read off the role the caller
  holds on the production, and `has_artist_permissions` has no global fallback:
  with no role resolved, `check_task_status_access` lets every status through
  instead of refusing.
- `POST /actions/tasks/batch-comment` resolved nothing, so an artist bypassed
  the restriction on the first comment of a batch and was measured against the
  previous comment's production on the following ones. The three other call
  sites relied on an access check happening to resolve first, which the CRUD one
  skips when the status does not change.
- `black` was pinned three releases behind, leaving one file unformatted.

**Solution**

- Resolve the production at each call site of `check_task_status_access` rather
  than inside it, and cover the restriction on both batch comment routes.
- Pin `black` to 26.5.1 and reformat the one file it touches.

Fix #1177
