### PR TITLE
[fixes] Fix quota timezone day lists and CSV assignations import

### DIFF
--- a/tests/blueprints/source/csv/test_import_shots.py
+++ b/tests/blueprints/source/csv/test_import_shots.py
@@ -3,6 +3,7 @@ import os
 from tests.base import ApiDBTestCase
 from zou.app import db
 
+from zou.app.models.comment import Comment
 from zou.app.models.entity_type import EntityType
 from zou.app.models.metadata_descriptor import MetadataDescriptor
 from zou.app.models.project import ProjectTaskTypeLink
@@ -125,6 +126,54 @@ class ImportCsvShotsTestCase(ApiDBTestCase):
 
         shot = shots[0]
         self.assertEqual(shot["data"].get("contractor", None), "contractor 1")
+
+    def test_import_shots_assignations(self):
+        db.session.add(
+            ProjectTaskTypeLink(
+                project_id=self.project_id,
+                task_type_id=self.task_type_animation.id,
+            )
+        )
+        self.generate_fixture_person()
+        path = f"/import/csv/projects/{self.project.id}/shots"
+        self.project.update({"production_type": "tvshow"})
+
+        file_path_fixture = self.get_fixture_file_path(
+            os.path.join("csv", "shots_assignations.csv")
+        )
+        self.upload_file(path, file_path_fixture)
+
+        tasks = {
+            shots_service.get_shot(str(task.entity_id))["name"]: task
+            for task in Task.query.all()
+        }
+        self.assertEqual(
+            sorted(str(person.id) for person in tasks["S01"].assignees),
+            sorted([str(self.person.id), self.user["id"]]),
+        )
+        self.assertEqual(tasks["S02"].assignees, [])
+        # Assignations alone must not post a comment at the default status.
+        self.assertEqual(Comment.query.all(), [])
+
+        # Re-importing the same file must not duplicate the assignations.
+        self.upload_file(f"{path}?update=true", file_path_fixture)
+        task = Task.get(tasks["S01"].id)
+        self.assertEqual(len(task.assignees), 2)
+
+    def test_import_shots_unknown_assignation_fails(self):
+        db.session.add(
+            ProjectTaskTypeLink(
+                project_id=self.project_id,
+                task_type_id=self.task_type_animation.id,
+            )
+        )
+        path = f"/import/csv/projects/{self.project.id}/shots"
+        self.project.update({"production_type": "tvshow"})
+
+        file_path_fixture = self.get_fixture_file_path(
+            os.path.join("csv", "shots_assignations_unknown.csv")
+        )
+        self.upload_file(path, file_path_fixture, 400)
 
     def test_import_shots_empty_boolean_descriptor(self):
         MetadataDescriptor.create(

--- a/tests/fixtures/csv/shots_assignations.csv
+++ b/tests/fixtures/csv/shots_assignations.csv
@@ -1,0 +1,3 @@
+Episode,Sequence,Name,Animation,Animation assignations
+E01,SE01,S01,,"John Doe, John Did"
+E01,SE01,S02,,

--- a/tests/fixtures/csv/shots_assignations_unknown.csv
+++ b/tests/fixtures/csv/shots_assignations_unknown.csv
@@ -1,0 +1,2 @@
+Episode,Sequence,Name,Animation assignations
+E01,SE01,S01,Ghost Person

--- a/tests/services/test_shots_service.py
+++ b/tests/services/test_shots_service.py
@@ -792,6 +792,82 @@ class QuotaTestCase(ShotsTestCase):
             },
         )
 
+    def test_a_time_spent_day_is_not_shifted_by_the_timezone(self):
+        """
+        A time spent is logged against a calendar day, not an instant:
+        west of UTC it must stay on the day the artist picked instead of
+        sliding to the previous one.
+        """
+        quotas = {}
+        shots_service._add_quota_entry(
+            quotas,
+            "person",
+            datetime.date(2024, 1, 8),
+            "America/New_York",
+            100,
+            2,
+            25,
+        )
+        self.assertEqual(
+            quotas["person"]["day"]["frames"], {"2024-01-08": 100}
+        )
+
+    def test_an_end_date_lands_on_the_local_day_and_week(self):
+        """
+        End dates are UTC instants: a feedback given Sunday evening UTC is
+        Monday in Kuala Lumpur, and the week bucket must follow that local
+        day or the day and week totals disagree.
+        """
+        quotas = {}
+        shots_service._add_quota_entry(
+            quotas,
+            "person",
+            datetime.datetime(2024, 12, 15, 18, 0),
+            "Asia/Kuala_Lumpur",
+            100,
+            2,
+            25,
+        )
+        entry = quotas["person"]
+        self.assertEqual(entry["day"]["frames"], {"2024-12-16": 100})
+        self.assertEqual(entry["week"]["frames"], {"2024-51": 100})
+
+    def test_the_day_list_agrees_with_the_day_the_shot_is_counted_on(self):
+        """
+        The issue 1612 symptom: the aggregate counted a shot on the right
+        local day but the day detail list queried the raw UTC day, so the
+        shot was missing from the list. A feedback at 18:00 UTC is the
+        17th in Kuala Lumpur: the 17th's list must hold it, the 16th's
+        must not.
+        """
+        self.generate_shot_task()
+        task = self.generate_fixture_shot_task(
+            name="quota", shot_id=self.shot.id
+        )
+        task.update(
+            {
+                "end_date": fields.get_date_object(
+                    "2024-12-16T18:00:00", "%Y-%m-%dT%H:%M:%S"
+                )
+            }
+        )
+        args = dict(
+            project_id=str(self.project.id),
+            task_type_id=str(self.task_type_animation.id),
+            weighted=False,
+            timezone="Asia/Kuala_Lumpur",
+        )
+
+        counted_day = shots_service.get_day_quota_shots(
+            str(self.person.id), 2024, 12, 17, **args
+        )
+        wrong_day = shots_service.get_day_quota_shots(
+            str(self.person.id), 2024, 12, 16, **args
+        )
+
+        self.assertEqual([shot["name"] for shot in counted_day], ["P01"])
+        self.assertEqual(wrong_day, [])
+
     def test_a_shot_is_weighted_by_the_share_of_the_task_it_took(self):
         """
         The shots a person worked on in the window, weighted by the share of

--- a/tests/utils/test_date_helpers.py
+++ b/tests/utils/test_date_helpers.py
@@ -38,6 +38,30 @@ class DateHelpersTestCase(unittest.TestCase):
         self.assertEqual(start.strftime("%Y-%m-%d"), "2021-02-10")
         self.assertEqual(end.strftime("%Y-%m-%d"), "2021-02-11")
 
+    def test_timezoned_interval_converts_local_time_to_utc(self):
+        """
+        The interval bounds come in as local wall-clock time and must come
+        out as the UTC instants they name: a Kuala Lumpur day starts at
+        16:00 UTC the day before, not at 08:00 UTC the same day.
+        """
+        start, end = date_helpers.get_timezoned_interval(
+            datetime.datetime(2024, 12, 17),
+            datetime.datetime(2024, 12, 18),
+            "Asia/Kuala_Lumpur",
+        )
+        self.assertEqual(start, datetime.datetime(2024, 12, 16, 16, 0))
+        self.assertEqual(end, datetime.datetime(2024, 12, 17, 16, 0))
+
+        # Plain dates (the week interval helper returns them) are taken as
+        # local midnight.
+        start, end = date_helpers.get_timezoned_interval(
+            datetime.date(2024, 12, 17),
+            datetime.date(2024, 12, 18),
+            "America/New_York",
+        )
+        self.assertEqual(start, datetime.datetime(2024, 12, 17, 5, 0))
+        self.assertEqual(end, datetime.datetime(2024, 12, 18, 5, 0))
+
     def test_interval_allows_future_years(self):
         next_year = date_helpers.get_utc_now_datetime().year + 1
         start, _ = date_helpers.get_month_interval(next_year, 1)

--- a/zou/app/blueprints/source/csv/assets.py
+++ b/zou/app/blueprints/source/csv/assets.py
@@ -149,16 +149,19 @@ class AssetsCsvImportResource(BaseCsvProjectImportResource):
                     )
 
             task_comment_text = row.get(f"{task_type.name} comment", None)
+            task_assignees = self.get_assignation_ids(row, task_type.name)
 
-            if task_status_id is not None or task_comment_text not in [
-                None,
-                "",
-            ]:
+            if (
+                task_status_id is not None
+                or task_comment_text not in [None, ""]
+                or task_assignees
+            ):
                 tasks_update.append(
                     {
                         "task_type_id": str(task_type.id),
                         "task_status_id": task_status_id,
                         "comment": task_comment_text,
+                        "assignees": task_assignees,
                     }
                 )
 
@@ -212,9 +215,18 @@ class AssetsCsvImportResource(BaseCsvProjectImportResource):
                     continue
                 tasks_map[task_type_id] = task
             task = tasks_map[task_type_id]
-            if (
-                task_update["comment"] is not None
-                or task_update["task_status_id"] != task["task_status_id"]
+            already_assigned = set(task.get("assignees") or [])
+            for person_id in task_update["assignees"]:
+                if person_id not in already_assigned:
+                    tasks_service.assign_task(
+                        task["id"], person_id, self.current_user_id
+                    )
+            # The status guard needs the explicit None check: an entry
+            # created for its assignations alone must not post an empty
+            # comment at the default status.
+            if task_update["comment"] is not None or (
+                task_update["task_status_id"] is not None
+                and task_update["task_status_id"] != task["task_status_id"]
             ):
                 try:
                     comments_service.create_comment(

--- a/zou/app/blueprints/source/csv/base.py
+++ b/zou/app/blueprints/source/csv/base.py
@@ -210,3 +210,19 @@ class BaseCsvProjectImportResource(BaseCsvImportResource, ArgsMixin):
         if person_id is None:
             raise RowException(f"Person not found for {value}")
         return person_id
+
+    def get_assignation_ids(self, row, task_type_name):
+        """
+        Resolve the "<task type> assignations" cell into person ids. The
+        cell holds comma-separated full names, emails or ids (the export
+        writes full names); an empty or absent cell means no assignation
+        change.
+        """
+        value = row.get(f"{task_type_name} assignations", None)
+        if value in (None, ""):
+            return []
+        return [
+            self.get_person_id(name)
+            for name in value.split(",")
+            if name.strip() != ""
+        ]

--- a/zou/app/blueprints/source/csv/shots.py
+++ b/zou/app/blueprints/source/csv/shots.py
@@ -13,6 +13,7 @@ from zou.app.services import (
     persons_service,
 )
 from zou.app.services.tasks_service import (
+    assign_task,
     create_task,
     create_tasks,
     get_tasks_for_shot,
@@ -129,16 +130,19 @@ class ShotsCsvImportResource(BaseCsvProjectImportResource):
                     )
 
             task_comment_text = row.get(f"{task_type.name} comment", None)
+            task_assignees = self.get_assignation_ids(row, task_type.name)
 
-            if task_status_id is not None or task_comment_text not in [
-                None,
-                "",
-            ]:
+            if (
+                task_status_id is not None
+                or task_comment_text not in [None, ""]
+                or task_assignees
+            ):
                 tasks_update.append(
                     {
                         "task_type_id": str(task_type.id),
                         "task_status_id": task_status_id,
                         "comment": task_comment_text,
+                        "assignees": task_assignees,
                     }
                 )
 
@@ -168,9 +172,18 @@ class ShotsCsvImportResource(BaseCsvProjectImportResource):
                         entity.serialize(),
                     )
                 task = tasks_map[task_update["task_type_id"]]
-                if (
-                    task_update["comment"] is not None
-                    or task_update["task_status_id"] != task["task_status_id"]
+                already_assigned = set(task.get("assignees") or [])
+                for person_id in task_update["assignees"]:
+                    if person_id not in already_assigned:
+                        assign_task(
+                            task["id"], person_id, self.current_user_id
+                        )
+                # The status guard needs the explicit None check: an entry
+                # created for its assignations alone must not post an
+                # empty comment at the default status.
+                if task_update["comment"] is not None or (
+                    task_update["task_status_id"] is not None
+                    and task_update["task_status_id"] != task["task_status_id"]
                 ):
                     try:
                         create_comment(

--- a/zou/app/services/shots_service.py
+++ b/zou/app/services/shots_service.py
@@ -1,4 +1,4 @@
-from datetime import timedelta
+from datetime import datetime, timedelta
 from operator import itemgetter
 from sqlalchemy.orm import aliased
 from sqlalchemy.exc import IntegrityError, StatementError
@@ -1529,11 +1529,22 @@ def _add_quota_entry(
     the project fps.
     """
     nb_seconds = nb_frames / fps
-    date_str = date_helpers.get_simple_string_with_timezone_from_date(
-        date, timezone
-    )
+    # TimeSpent dates are plain calendar days, already the user's working
+    # day: converting them would shift them for users west of UTC. Only
+    # real datetimes (end / done dates, stored in UTC) need the user
+    # timezone applied to find the local day they belong to. The week
+    # bucket follows the same local day, or day and week totals disagree
+    # around midnight UTC.
+    if isinstance(date, datetime):
+        date_str = date_helpers.get_simple_string_with_timezone_from_date(
+            date, timezone
+        )
+        local_date = date_helpers.get_date_from_string(date_str)
+    else:
+        local_date = date
+        date_str = date.strftime("%Y-%m-%d")
     year = date_str[:4]
-    week = year + "-" + str(date.isocalendar()[1])
+    week = f"{year}-{local_date.isocalendar()[1]}"
     month = date_str[:7]
     if entry_id not in quotas:
         _init_quota_entry(quotas, entry_id)
@@ -1632,13 +1643,13 @@ def get_month_quota_shots(
     task_type_id=None,
     weighted=True,
     feedback=True,
+    timezone=None,
 ):
     """
     Return shots that are included in quota computation for given
     person and month.
     """
     start, end = date_helpers.get_month_interval(year, month)
-    start, end = _get_timezoned_interval(start, end)
     if weighted:
         return get_weighted_quota_shots_between(
             person_id,
@@ -1647,6 +1658,7 @@ def get_month_quota_shots(
             project_id=project_id,
             task_type_id=task_type_id,
             feedback=feedback,
+            timezone=timezone,
         )
     else:
         return get_raw_quota_shots_between(
@@ -1656,6 +1668,7 @@ def get_month_quota_shots(
             project_id=project_id,
             task_type_id=task_type_id,
             feedback=feedback,
+            timezone=timezone,
         )
 
 
@@ -1667,13 +1680,13 @@ def get_week_quota_shots(
     task_type_id=None,
     weighted=True,
     feedback=True,
+    timezone=None,
 ):
     """
     Return shots that are included in quota comptutation for given
     person and week.
     """
     start, end = date_helpers.get_week_interval(year, week)
-    start, end = _get_timezoned_interval(start, end)
     if weighted:
         return get_weighted_quota_shots_between(
             person_id,
@@ -1682,6 +1695,7 @@ def get_week_quota_shots(
             project_id=project_id,
             task_type_id=task_type_id,
             feedback=feedback,
+            timezone=timezone,
         )
     else:
         return get_raw_quota_shots_between(
@@ -1691,6 +1705,7 @@ def get_week_quota_shots(
             project_id=project_id,
             task_type_id=task_type_id,
             feedback=feedback,
+            timezone=timezone,
         )
 
 
@@ -1703,6 +1718,7 @@ def get_day_quota_shots(
     task_type_id=None,
     weighted=True,
     feedback=True,
+    timezone=None,
 ):
     """
     Return shots that are included in quota comptutation for given
@@ -1717,6 +1733,7 @@ def get_day_quota_shots(
             project_id=project_id,
             task_type_id=task_type_id,
             feedback=feedback,
+            timezone=timezone,
         )
     else:
         return get_raw_quota_shots_between(
@@ -1726,11 +1743,18 @@ def get_day_quota_shots(
             project_id=project_id,
             task_type_id=task_type_id,
             feedback=feedback,
+            timezone=timezone,
         )
 
 
 def get_weighted_quota_shots_between(
-    person_id, start, end, project_id=None, task_type_id=None, feedback=True
+    person_id,
+    start,
+    end,
+    project_id=None,
+    task_type_id=None,
+    feedback=True,
+    timezone=None,
 ):
     """
     Get all shots leading to a quota computation during the given period.
@@ -1740,11 +1764,22 @@ def get_weighted_quota_shots_between(
         * If there is no time spent, weight it by the number of business days
           in the time interval spent between WIP date (start) and
           feedback date (end).
+
+    The period bounds are expressed in the user's local time. TimeSpent
+    dates are plain calendar days, so the bounds apply to them as-is; task
+    end / done dates are UTC instants, so the bounds are converted to UTC
+    before comparing (a feedback given in the local evening east of UTC
+    belongs to the next local day).
     """
     shot_type = get_shot_type()
     person = persons_service.get_person_raw(person_id)
     shots = []
     already_listed = {}
+    if type(start) is str:
+        start = date_helpers.get_datetime_from_string(start)
+    if type(end) is str:
+        end = date_helpers.get_datetime_from_string(end)
+    utc_start, utc_end = _get_timezoned_interval(start, end, timezone)
 
     query = (
         Entity.query.filter(Entity.entity_type_id == shot_type["id"])
@@ -1780,10 +1815,6 @@ def get_weighted_quota_shots_between(
             shot = already_listed[shot["id"]]
             shot["weight"] += round(duration / task_duration, 2)
 
-    if type(start) is str:
-        start = date_helpers.get_datetime_from_string(start)
-    if type(end) is str:
-        end = date_helpers.get_datetime_from_string(end)
     query = (
         Entity.query.filter(Entity.entity_type_id == shot_type["id"])
         .filter(Task.project_id == project_id)
@@ -1799,13 +1830,19 @@ def get_weighted_quota_shots_between(
     if feedback:
         query = (
             query.filter(Task.end_date != None)
-            .filter((Task.real_start_date <= end) & (Task.end_date >= start))
+            .filter(
+                (Task.real_start_date <= utc_end)
+                & (Task.end_date >= utc_start)
+            )
             .add_columns(Task.real_start_date, Task.end_date)
         )
     else:
         query = (
             query.filter(Task.done_date != None)
-            .filter((Task.real_start_date <= end) & (Task.done_date >= start))
+            .filter(
+                (Task.real_start_date <= utc_end)
+                & (Task.done_date >= utc_start)
+            )
             .add_columns(Task.real_start_date, Task.done_date)
         )
 
@@ -1838,14 +1875,28 @@ def get_weighted_quota_shots_between(
 
 
 def get_raw_quota_shots_between(
-    person_id, start, end, project_id=None, task_type_id=None, feedback=True
+    person_id,
+    start,
+    end,
+    project_id=None,
+    task_type_id=None,
+    feedback=True,
+    timezone=None,
 ):
     """
     Get all shots leading to a quota computation during the given period.
+    The period bounds are expressed in the user's local time; end / done
+    dates are UTC instants, so the bounds are converted to UTC before
+    comparing.
     """
     shot_type = get_shot_type()
     person = persons_service.get_person_raw(person_id)
     shots = []
+    if type(start) is str:
+        start = date_helpers.get_datetime_from_string(start)
+    if type(end) is str:
+        end = date_helpers.get_datetime_from_string(end)
+    start, end = _get_timezoned_interval(start, end, timezone)
 
     query = (
         Entity.query.filter(Entity.entity_type_id == shot_type["id"])
@@ -1883,11 +1934,12 @@ def get_raw_quota_shots_between(
     return sorted(shots, key=itemgetter("full_name"))
 
 
-def _get_timezoned_interval(start, end):
+def _get_timezoned_interval(start, end, timezone=None):
     """
-    Get time intervals adapted to the user timezone.
+    Convert an interval expressed in the user's local time to naive UTC.
     """
-    timezone = user_service.get_timezone()
+    if timezone is None:
+        timezone = user_service.get_timezone()
     return date_helpers.get_timezoned_interval(start, end, timezone)
 
 

--- a/zou/app/utils/date_helpers.py
+++ b/zou/app/utils/date_helpers.py
@@ -1,5 +1,6 @@
 import datetime
 
+import pytz
 from babel.dates import format_datetime
 from dateutil import relativedelta
 from zou.app.services.exception import WrongDateFormatException
@@ -126,12 +127,25 @@ def get_day_interval(year, month, day):
 
 def get_timezoned_interval(start, end, timezone):
     """
-    Get interval between two dates based on timezones.
+    Convert an interval expressed in the given timezone's local time into
+    its naive UTC equivalent, to compare against UTC-stored datetime
+    columns.
     """
     return (
-        get_string_with_timezone_from_date(start, timezone),
-        get_string_with_timezone_from_date(end, timezone),
+        get_utc_from_local_datetime(start, timezone),
+        get_utc_from_local_datetime(end, timezone),
     )
+
+
+def get_utc_from_local_datetime(date_obj, timezone):
+    """
+    Interpret a naive date or datetime as local time in the given timezone
+    and return the matching naive UTC datetime.
+    """
+    if not isinstance(date_obj, datetime.datetime):
+        date_obj = datetime.datetime.combine(date_obj, datetime.time.min)
+    localized = pytz.timezone(timezone).localize(date_obj)
+    return localized.astimezone(pytz.utc).replace(tzinfo=None)
 
 
 def get_business_days(start, end):


### PR DESCRIPTION
**Problem**

- Quota buckets counted a shot on the user's local day but the day detail list queried the raw UTC day, so the shot was missing from the list; week and month bounds were converted in the wrong direction, and week totals could disagree with day totals around midnight UTC (fixes cgwire/kitsu#1612).
- The CSV import ignored the assignations column the export writes, so assignees never round-tripped (part of cgwire/kitsu#1272).

**Solution**

- Convert local period bounds to UTC where end and done dates are compared, keep time spents on their plain calendar day, and derive the week bucket from the local day, with regression tests pinning a UTC+8 user.
- Resolve "<task type> assignations" cells (full names, emails or ids) through the shared person lookup and assign the listed people idempotently in the shot and asset importers, without posting an empty comment.