### PR TITLE
[qa] Share the streamed listing code between assets, shots and edits

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -84,6 +84,23 @@ config_store.config_store = fakeredis.FakeStrictRedis(decode_responses=True)
 _CACHED_PASSWORD_HASH = auth.encrypt_password("mypassword")
 
 
+def rebuild_from_compact(entity_fields, task_fields, rows):
+    """
+    Reverse the compact encoding of a listing by mapping positional values
+    back to the field names its header carries, as a client is expected to
+    do. Reading the names from the header rather than hardcoding positions
+    is the whole contract of the compact form.
+    """
+    entities = []
+    for row in rows:
+        entity = dict(zip(entity_fields, row))
+        entity["tasks"] = [
+            dict(zip(task_fields, task_row)) for task_row in entity["tasks"]
+        ]
+        entities.append(entity)
+    return entities
+
+
 class ApiTestCase(unittest.TestCase):
     """
     Set of helpers to make test development easier.

--- a/tests/blueprints/assets/test_asset_tasks.py
+++ b/tests/blueprints/assets/test_asset_tasks.py
@@ -1,4 +1,4 @@
-from tests.base import ApiDBTestCase
+from tests.base import ApiDBTestCase, rebuild_from_compact
 
 from zou.app.models.entity import EntityLink
 from zou.app.models.person import Person
@@ -8,21 +8,6 @@ from zou.app.services import (
     assets_service,
     persons_service,
 )
-
-
-def rebuild_from_compact(asset_fields, task_fields, rows):
-    """
-    Reverse the compact encoding by mapping positional values back to
-    field names, as a client is expected to do.
-    """
-    assets = []
-    for row in rows:
-        asset = dict(zip(asset_fields, row))
-        asset["tasks"] = [
-            dict(zip(task_fields, task_row)) for task_row in asset["tasks"]
-        ]
-        assets.append(asset)
-    return assets
 
 
 class AssetTasksTestCase(ApiDBTestCase):

--- a/tests/blueprints/shots/test_shot_tasks.py
+++ b/tests/blueprints/shots/test_shot_tasks.py
@@ -1,4 +1,4 @@
-from tests.base import ApiDBTestCase
+from tests.base import ApiDBTestCase, rebuild_from_compact
 
 from zou.app.services import (
     persons_service,
@@ -6,21 +6,6 @@ from zou.app.services import (
     tasks_service,
     shots_service,
 )
-
-
-def rebuild_from_compact(shot_fields, task_fields, rows):
-    """
-    Reverse the compact encoding by mapping positional values back to
-    field names, as a client is expected to do.
-    """
-    shots = []
-    for row in rows:
-        shot = dict(zip(shot_fields, row))
-        shot["tasks"] = [
-            dict(zip(task_fields, task_row)) for task_row in shot["tasks"]
-        ]
-        shots.append(shot)
-    return shots
 
 
 class ShotTasksTestCase(ApiDBTestCase):

--- a/zou/app/blueprints/assets/resources.py
+++ b/zou/app/blueprints/assets/resources.py
@@ -1,10 +1,8 @@
-import orjson
-
-from flask import request, Response
+from flask import request
 from flask.views import MethodView
 from flask_jwt_extended import jwt_required
 
-from zou.app.utils import permissions, query, validation
+from zou.app.utils import flask_utils, permissions, query, validation
 from zou.app.mixin import ArgsMixin
 from zou.app.services import (
     assets_service,
@@ -13,7 +11,6 @@ from zou.app.services import (
     shots_service,
     tasks_service,
     permissions_service,
-    user_service,
 )
 from zou.app.blueprints.assets.schemas import (
     NewAssetSchema,
@@ -328,14 +325,7 @@ class AssetsAndTasksResource(MethodView, ArgsMixin):
         compact = criterions.pop("compact", "false") == "true"
         query.check_criterion_id_format(criterions)
         check_criterion_access(criterions)
-        if permissions.has_vendor_permissions():
-            criterions["assigned_to"] = persons_service.get_current_user()[
-                "id"
-            ]
-            criterions["vendor_departments"] = [
-                str(department.id)
-                for department in persons_service.get_current_user_raw().departments
-            ]
+        permissions_service.scope_criterions_to_vendor(criterions)
         only_user_projects = not permissions.has_admin_permissions()
         if not stream and not compact:
             return assets_service.get_assets_and_tasks(
@@ -353,17 +343,7 @@ class AssetsAndTasksResource(MethodView, ArgsMixin):
                 assets_service.ASSETS_AND_TASKS_ASSET_FIELDS
             )
             header["task_fields"] = assets_service.ASSETS_AND_TASKS_TASK_FIELDS
-
-        if not stream:
-            header["rows"] = list(rows)
-            return header
-
-        def generate():
-            yield orjson.dumps(header) + b"\n"
-            for item in rows:
-                yield orjson.dumps(item) + b"\n"
-
-        return Response(generate(), mimetype="application/x-ndjson")
+        return flask_utils.rows_response(header, rows, stream)
 
 
 class AssetTypeResource(MethodView):

--- a/zou/app/blueprints/edits/resources.py
+++ b/zou/app/blueprints/edits/resources.py
@@ -9,7 +9,6 @@ from zou.app.services import (
     edits_service,
     tasks_service,
     permissions_service,
-    user_service,
 )
 
 from zou.app.mixin import ArgsMixin
@@ -751,14 +750,7 @@ class EditsAndTasksResource(MethodView):
         permissions_service.check_project_access(
             criterions.get("project_id", None)
         )
-        if permissions.has_vendor_permissions():
-            criterions["assigned_to"] = persons_service.get_current_user()[
-                "id"
-            ]
-            criterions["vendor_departments"] = [
-                str(department.id)
-                for department in persons_service.get_current_user_raw().departments
-            ]
+        permissions_service.scope_criterions_to_vendor(criterions)
         return edits_service.get_edits_and_tasks(criterions)
 
 

--- a/zou/app/blueprints/shots/resources.py
+++ b/zou/app/blueprints/shots/resources.py
@@ -1,6 +1,4 @@
-import orjson
-
-from flask import request, Response
+from flask import request
 from flask.views import MethodView
 from flask_jwt_extended import jwt_required
 
@@ -20,7 +18,13 @@ from zou.app.services import (
 )
 
 from zou.app.mixin import ArgsMixin
-from zou.app.utils import fields, query, permissions, validation
+from zou.app.utils import (
+    fields,
+    flask_utils,
+    permissions,
+    query,
+    validation,
+)
 from zou.app.blueprints.shots.schemas import (
     NewShotSchema,
     NewSequenceSchema,
@@ -1080,14 +1084,7 @@ class ShotsAndTasksResource(MethodView):
         permissions_service.check_project_access(
             criterions.get("project_id", None)
         )
-        if permissions.has_vendor_permissions():
-            criterions["assigned_to"] = persons_service.get_current_user()[
-                "id"
-            ]
-            criterions["vendor_departments"] = [
-                str(department.id)
-                for department in persons_service.get_current_user_raw().departments
-            ]
+        permissions_service.scope_criterions_to_vendor(criterions)
         if not stream and not compact:
             return shots_service.get_shots_and_tasks(criterions)
 
@@ -1098,17 +1095,7 @@ class ShotsAndTasksResource(MethodView):
         if compact:
             header["shot_fields"] = shots_service.SHOTS_AND_TASKS_SHOT_FIELDS
             header["task_fields"] = shots_service.SHOTS_AND_TASKS_TASK_FIELDS
-
-        if not stream:
-            header["rows"] = list(rows)
-            return header
-
-        def generate():
-            yield orjson.dumps(header) + b"\n"
-            for item in rows:
-                yield orjson.dumps(item) + b"\n"
-
-        return Response(generate(), mimetype="application/x-ndjson")
+        return flask_utils.rows_response(header, rows, stream)
 
 
 class SceneAndTasksResource(MethodView):

--- a/zou/app/services/permissions_service.py
+++ b/zou/app/services/permissions_service.py
@@ -161,6 +161,24 @@ def block_access_to_vendor():
     return True
 
 
+def scope_criterions_to_vendor(criterions):
+    """
+    Narrow a listing to what a vendor is allowed to see, in place. Anyone
+    else is left untouched.
+
+    A vendor only ever lists what they are assigned to, and the departments
+    travel with the assignee so that the query can keep the tasks of their
+    own departments on the entities they reach.
+    """
+    if permissions.has_vendor_permissions():
+        criterions["assigned_to"] = persons_service.get_current_user()["id"]
+        criterions["vendor_departments"] = [
+            str(department.id)
+            for department in persons_service.get_current_user_raw().departments
+        ]
+    return criterions
+
+
 def check_entity_access(entity_id):
     """
     Return true if current user is not a vendor or has a task assigned for this

--- a/zou/app/utils/flask_utils.py
+++ b/zou/app/utils/flask_utils.py
@@ -2,7 +2,7 @@ from ua_parser import user_agent_parser
 from werkzeug.user_agent import UserAgent
 from werkzeug.utils import cached_property
 from flask.json.provider import JSONProvider
-from flask import request, abort
+from flask import Response, request, abort
 
 import orjson
 
@@ -56,6 +56,27 @@ def is_from_browser(user_agent):
         "Safari",
         "Vivaldi",
     ]
+
+
+def rows_response(header, rows, stream=False):
+    """
+    Answer a listing described by a header, either as a single JSON object
+    carrying every row, or as NDJSON: the header on the first line, then one
+    row per line.
+
+    Streaming exists so that a full production never sits in memory at once,
+    so rows stays a generator until the last moment: the non streamed branch
+    is the only one that spends it.
+    """
+    if not stream:
+        return {**header, "rows": list(rows)}
+
+    def generate():
+        yield orjson.dumps(header) + b"\n"
+        for row in rows:
+            yield orjson.dumps(row) + b"\n"
+
+    return Response(generate(), mimetype="application/x-ndjson")
 
 
 def wrong_auth_handler(identity_user=None):


### PR DESCRIPTION
**Problem**

- The with-tasks routes of assets and shots carried the same twenty lines twice:
  the header, the `generate()` closure yielding NDJSON, and the comment above
  them. The vendor scoping was a third copy, in edits too.
- `rebuild_from_compact` was duplicated in the two test files.

**Solution**

- Answer through `flask_utils.rows_response`, scope through
  `permissions_service.scope_criterions_to_vendor`, and move the compact decoder
  to `tests/base`.
- `EditsResource.get` keeps its own partial copy: `get_edits` does not know
  `vendor_departments`, so the two edit listings still disagree on whether a
  vendor is held to their departments.
