### PR TITLE
[schedule] Give supervisors task dates with anonymous busy periods

### DIFF
--- a/tests/blueprints/tasks/test_task_dates_and_previews.py
+++ b/tests/blueprints/tasks/test_task_dates_and_previews.py
@@ -77,12 +77,21 @@ class TaskDatesAndPreviewsTestCase(ApiDBTestCase):
         self.assertIn(str(self.person.id), person_ids)
 
     def test_get_persons_task_dates_manager_scoped_to_own_projects(self):
-        # A manager who belongs to no project sees no one (the default view is
-        # scoped to the caller's projects, not studio-wide).
+        # A manager who belongs to no project gets no task dates: other
+        # productions only show as anonymous busy periods, without any
+        # production or task detail (kitsu#1579).
         self.generate_fixture_user_manager()
         self.log_in_manager()
         result = self.get("/data/persons/task-dates")
-        self.assertEqual(result, [])
+        for entry in result:
+            self.assertIsNone(entry["min_date"])
+            self.assertIsNone(entry["max_date"])
+            self.assertEqual(
+                set(entry.keys()),
+                {"person_id", "min_date", "max_date", "busy_periods"},
+            )
+        person_ids = [entry["person_id"] for entry in result]
+        self.assertIn(str(self.person.id), person_ids)
 
     def test_get_persons_task_dates_manager_own_project_id(self):
         self.generate_fixture_user_manager()
@@ -109,6 +118,35 @@ class TaskDatesAndPreviewsTestCase(ApiDBTestCase):
             403,
         )
 
+    def test_get_persons_task_dates_as_supervisor(self):
+        # A supervisor reaches the team schedule too (kitsu#1579), scoped
+        # to their own projects like a manager.
+        self.generate_fixture_user_supervisor()
+        projects_service.add_team_member(
+            self.project_id, self.user_supervisor["id"]
+        )
+        self.log_in_supervisor()
+        result = self.get("/data/persons/task-dates")
+        person_ids = [entry["person_id"] for entry in result]
+        self.assertIn(str(self.person.id), person_ids)
+
+    def test_get_persons_task_dates_supervisor_foreign_project_id(self):
+        self.generate_fixture_user_supervisor()
+        projects_service.add_team_member(
+            self.project_id, self.user_supervisor["id"]
+        )
+        self.generate_fixture_project_standard()
+        self.log_in_supervisor()
+        self.get(
+            f"/data/persons/task-dates?project_id={self.project_standard.id}",
+            403,
+        )
+
+    def test_get_persons_task_dates_refused_to_artists(self):
+        self.generate_fixture_user_cg_artist()
+        self.log_in_cg_artist()
+        self.get("/data/persons/task-dates", 403)
+
     def test_get_persons_task_dates_admin_project_id(self):
         # Admin can scope the studio-wide view to a single project.
         result = self.get(
@@ -117,9 +155,10 @@ class TaskDatesAndPreviewsTestCase(ApiDBTestCase):
         person_ids = [entry["person_id"] for entry in result]
         self.assertIn(str(self.person.id), person_ids)
 
-    def test_get_persons_task_dates_manager_excludes_foreign_persons(self):
-        # A manager only sees persons from their own projects, never a person
-        # whose tasks live solely in a project they are not a member of.
+    def test_get_persons_task_dates_foreign_work_is_anonymous(self):
+        # A person whose tasks live solely in a project the manager is not a
+        # member of appears with anonymous busy periods only: merged date
+        # pairs, no task dates, no production or task detail (kitsu#1579).
         person_id = str(self.person.id)
         self.generate_fixture_user_manager()
         projects_service.add_team_member(
@@ -131,22 +170,49 @@ class TaskDatesAndPreviewsTestCase(ApiDBTestCase):
             last_name="Artist",
             email="foreign.artist@gmail.com",
         )
-        Task.create(
-            name="Foreign task",
-            project_id=self.project_standard.id,
-            task_type_id=self.task_type.id,
-            task_status_id=self.task_status.id,
-            entity_id=self.asset_standard.id,
-            assignees=[foreign_person],
-            assigner_id=self.assigner.id,
-            start_date=fields.get_date_object("2017-02-20"),
-            due_date=fields.get_date_object("2017-02-28"),
-        )
+        for name, start_date, due_date in [
+            ("Foreign task", "2017-02-20", "2017-02-28"),
+            # Overlaps the first task: both must merge into one period so
+            # the split of the hidden work is not revealed.
+            ("Foreign task 2", "2017-02-24", "2017-03-06"),
+        ]:
+            Task.create(
+                name=name,
+                project_id=self.project_standard.id,
+                task_type_id=self.task_type.id,
+                task_status_id=self.task_status.id,
+                entity_id=self.asset_standard.id,
+                assignees=[foreign_person],
+                assigner_id=self.assigner.id,
+                start_date=fields.get_date_object(start_date),
+                due_date=fields.get_date_object(due_date),
+            )
         self.log_in_manager()
         result = self.get("/data/persons/task-dates")
-        person_ids = [entry["person_id"] for entry in result]
-        self.assertIn(person_id, person_ids)
-        self.assertNotIn(str(foreign_person.id), person_ids)
+        entries = {entry["person_id"]: entry for entry in result}
+        self.assertIn(person_id, entries)
+        foreign_entry = entries[str(foreign_person.id)]
+        self.assertIsNone(foreign_entry["min_date"])
+        self.assertIsNone(foreign_entry["max_date"])
+        self.assertEqual(
+            foreign_entry["busy_periods"],
+            [
+                {
+                    "start_date": "2017-02-20 00:00:00",
+                    "end_date": "2017-03-06 00:00:00",
+                }
+            ],
+        )
+        self.assertEqual(
+            set(foreign_entry.keys()),
+            {"person_id", "min_date", "max_date", "busy_periods"},
+        )
+
+    def test_get_persons_task_dates_admin_has_no_busy_periods(self):
+        # Admin sees every project in detail, nothing is anonymised.
+        result = self.get("/data/persons/task-dates")
+        for entry in result:
+            self.assertEqual(entry["busy_periods"], [])
 
     def test_get_persons_task_dates_empty_project_id(self):
         # An empty `?project_id=` filter is treated as absent, not as an
@@ -207,11 +273,15 @@ class TaskDatesAndPreviewsTestCase(ApiDBTestCase):
         person_ids = [entry["person_id"] for entry in result]
         self.assertIn(str(closed_person.id), person_ids)
 
-    def test_get_persons_task_dates_supervisor_unauthorized(self):
-        # The gate is manager-or-above: a supervisor is rejected.
+    def test_get_persons_task_dates_supervisor_scoped_to_own_projects(self):
+        # The gate is supervisor-or-above (kitsu#1579): a supervisor who
+        # belongs to no project gets anonymous busy periods only, not a 403.
         self.generate_fixture_user_supervisor()
         self.log_in_supervisor()
-        self.get("/data/persons/task-dates", 403)
+        result = self.get("/data/persons/task-dates")
+        for entry in result:
+            self.assertIsNone(entry["min_date"])
+            self.assertIsNone(entry["max_date"])
 
     def test_get_persons_task_dates_unauthorized(self):
         self.generate_fixture_user_vendor()

--- a/zou/app/blueprints/tasks/resources.py
+++ b/zou/app/blueprints/tasks/resources.py
@@ -2823,8 +2823,8 @@ class PersonsTasksDatesResource(MethodView, ArgsMixin):
         - Tasks
         description: For each active person, return the first start date of all
           tasks assigned to them and the last end date. Useful for schedule
-          planning. Admins get the studio-wide view; managers are restricted to
-          the projects of their own teams.
+          planning. Admins get the studio-wide view; managers and supervisors
+          are restricted to the projects of their own teams.
         parameters:
           - in: query
             name: project_id
@@ -2859,6 +2859,21 @@ class PersonsTasksDatesResource(MethodView, ArgsMixin):
                           description: Last task due date for this person
                             within the requested scope
                           example: "2024-03-21 00:00:00"
+                        busy_periods:
+                          type: array
+                          description: Anonymous, merged date intervals
+                            covering the person's tasks in open productions
+                            outside the caller's scope. No production or
+                            task detail is exposed.
+                          items:
+                            type: object
+                            properties:
+                              start_date:
+                                type: string
+                                example: "2024-01-15 00:00:00"
+                              end_date:
+                                type: string
+                                example: "2024-03-21 00:00:00"
         """
         # Normalise the `project_id` filter once, before branching on the
         # caller's role. An empty or whitespace-only `?project_id=` is treated
@@ -2869,14 +2884,30 @@ class PersonsTasksDatesResource(MethodView, ArgsMixin):
         if project_id is not None and not fields.is_valid_id(project_id):
             raise WrongParameterException("Invalid project_id.")
         project_ids = None
+        busy_project_ids = None
         if not permissions.has_admin_permissions():
-            permissions.check_manager_permissions()
+            # Supervisors reach the team schedule page too (kitsu#1579):
+            # like managers, they only see the projects of their own teams.
+            permissions.check_at_least_supervisor_permissions()
             if project_id is not None:
-                permissions_service.check_manager_project_access(project_id)
+                if not permissions_service.check_belong_to_project(project_id):
+                    raise permissions.PermissionDenied
             else:
                 project_ids = user_service.get_open_project_ids()
+                # The other open productions come back as anonymous busy
+                # periods: date pairs only, so the schedule can show a
+                # person is taken without naming the production or the
+                # task.
+                own_project_ids = set(project_ids)
+                busy_project_ids = [
+                    open_project_id
+                    for open_project_id in projects_service.open_project_ids()
+                    if open_project_id not in own_project_ids
+                ]
         return tasks_service.get_persons_tasks_dates(
-            project_id=project_id, project_ids=project_ids
+            project_id=project_id,
+            project_ids=project_ids,
+            busy_project_ids=busy_project_ids,
         )
 
 

--- a/zou/app/services/tasks_service.py
+++ b/zou/app/services/tasks_service.py
@@ -2149,7 +2149,9 @@ def reset_task_data(task_id):
     return task.serialize(relations=True)
 
 
-def get_persons_tasks_dates(project_id=None, project_ids=None):
+def get_persons_tasks_dates(
+    project_id=None, project_ids=None, busy_project_ids=None
+):
     """
     For schedule usages, for each active person, it returns the first start
     date of all tasks of assigned to this person and the last end date.
@@ -2166,6 +2168,12 @@ def get_persons_tasks_dates(project_id=None, project_ids=None):
       project gets an empty result -- the guard must stay an `is None` identity
       test and never become `if not project_ids:`, otherwise such a manager
       would leak the studio-wide view.
+    - busy_project_ids lists the projects the caller must not see in detail:
+      tasks found there come back as anonymous busy_periods, merged date
+      pairs carrying no production or task information, so a schedule can
+      show that a person is taken without leaking what they work on
+      (kitsu#1579). A person with only such tasks is listed with null
+      min_date / max_date.
     """
     if project_id is not None:
         # An explicit, access-checked project scopes the lookup directly. This
@@ -2187,14 +2195,58 @@ def get_persons_tasks_dates(project_id=None, project_ids=None):
         .join(Task.assignees)
     )
 
-    return [
-        {
+    entries = {}
+    for person_id, min_date, max_date in query.all():
+        entries[str(person_id)] = {
             "person_id": str(person_id),
             "min_date": str(min_date),
             "max_date": str(max_date),
+            "busy_periods": [],
         }
-        for (person_id, min_date, max_date) in query.all()
-    ]
+
+    if busy_project_ids:
+        busy_query = (
+            Task.query.with_entities(Person.id, Task.start_date, Task.due_date)
+            .filter(Person.active)
+            .filter(Task.project_id.in_(busy_project_ids))
+            .filter(Task.start_date != None)
+            .filter(Task.due_date != None)
+            .join(Task.assignees)
+        )
+        intervals_by_person = {}
+        for person_id, start_date, due_date in busy_query.all():
+            intervals_by_person.setdefault(str(person_id), []).append(
+                (start_date, due_date)
+            )
+        for person_id, intervals in intervals_by_person.items():
+            if person_id not in entries:
+                entries[person_id] = {
+                    "person_id": person_id,
+                    "min_date": None,
+                    "max_date": None,
+                    "busy_periods": [],
+                }
+            entries[person_id]["busy_periods"] = [
+                {"start_date": str(start), "end_date": str(end)}
+                for start, end in _merge_date_intervals(intervals)
+            ]
+
+    return list(entries.values())
+
+
+def _merge_date_intervals(intervals):
+    """
+    Merge overlapping (start, end) pairs into the smallest set of disjoint
+    intervals, so anonymous busy periods reveal neither the task count nor
+    how the underlying work is split.
+    """
+    merged = []
+    for start, end in sorted(intervals):
+        if merged and start <= merged[-1][1]:
+            merged[-1][1] = max(merged[-1][1], end)
+        else:
+            merged.append([start, end])
+    return [(start, end) for start, end in merged]
 
 
 def get_open_tasks(


### PR DESCRIPTION
**Problem**

- /data/persons/task-dates required the manager role, so the team schedule page 403ed for supervisors although the kitsu route is open to them (part of cgwire/kitsu#1579).
- Tasks on productions outside the caller's teams were absent from the response, so booked artists looked free.

**Solution**

- Allow supervisor-or-above, scoped to the caller's own open projects; an explicit project_id still requires belonging to the project.
- Return the other open productions as anonymous busy_periods: merged date pairs with no production or task detail. Admins keep the full view.