### PR TITLE
[api] Scope every listing and the search to what a vendor may read

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -249,15 +249,6 @@ class ApiTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, code)
         return json.loads(response.data.decode("utf-8"))
 
-    def post_404(self, path, data):
-        """
-        Make sure that given path returns a 404 error for POST requests.
-        """
-        response = self.app.post(
-            path, data=json.dumps(data), headers=self.post_headers
-        )
-        self.assertEqual(response.status_code, 404)
-
     def put(self, path, data, code=200):
         """
         Run a put request at given path while making sure it sends data at JSON
@@ -424,6 +415,8 @@ class ApiDBTestCase(ApiTestCase):
         mixer.init_app(self.flask_app)
         return mixer.cycle(number).blend(cls, id=fields.gen_uuid, **kwargs)
 
+    # Productions
+
     def generate_fixture_project_status(self):
         if hasattr(self, "open_status"):
             return
@@ -473,240 +466,18 @@ class ApiDBTestCase(ApiTestCase):
         )
         return self.project_standard
 
-    def generate_fixture_asset(
-        self,
-        name="Tree",
-        description="Description Tree",
-        asset_type_id=None,
-        project_id=None,
-    ):
-        if (
-            name == "Tree"
-            and description == "Description Tree"
-            and asset_type_id is None
-            and project_id is None
-            and hasattr(self, "asset")
-        ):
-            return self.asset
-        self.generate_fixture_asset_type()
-        if not hasattr(self, "project"):
-            self.generate_fixture_project()
-        if asset_type_id is None:
-            asset_type_id = self.asset_type.id
-
-        if project_id is None:
-            project_id = self.project_id
-
-        self.asset = Entity.create(
-            name=name,
-            description=description,
-            project_id=project_id,
-            entity_type_id=asset_type_id,
-        )
-        return self.asset
-
-    def generate_fixture_asset_character(
-        self, name="Rabbit", description="Main char"
-    ):
-        if (
-            name == "Rabbit"
-            and description == "Main char"
-            and hasattr(self, "asset_character")
-        ):
-            return self.asset_character
-        self.generate_fixture_asset_types()
-        self.generate_fixture_project()
-        self.asset_character = Entity.create(
-            name=name,
-            description=description,
+    def generate_fixture_metadata_descriptor(self, entity_type="Asset"):
+        self.meta_descriptor = MetadataDescriptor.create(
             project_id=self.project.id,
-            entity_type_id=self.asset_type_character.id,
+            name="Contractor",
+            data_type="list",
+            field_name="contractor",
+            choices=["value 1", "value 2"],
+            entity_type=entity_type,
         )
-        return self.asset_character
+        return self.meta_descriptor
 
-    def generate_fixture_asset_camera(self):
-        if hasattr(self, "asset_camera"):
-            return
-        self.generate_fixture_asset_types()
-        self.generate_fixture_project()
-        self.asset_camera = Entity.create(
-            name="Main camera",
-            description="Description Camera",
-            project_id=self.project.id,
-            entity_type_id=self.asset_type_camera.id,
-        )
-
-    def generate_fixture_asset_standard(self):
-        if hasattr(self, "asset_standard"):
-            return
-        self.generate_fixture_asset_type()
-        self.generate_fixture_project_standard()
-        self.asset_standard = Entity.create(
-            name="Car",
-            project_id=self.project_standard.id,
-            entity_type_id=self.asset_type.id,
-        )
-
-    def generate_fixture_sequence(
-        self, name="S01", episode_id=None, project_id=None
-    ):
-        if (
-            name == "S01"
-            and episode_id is None
-            and project_id is None
-            and hasattr(self, "sequence")
-        ):
-            return self.sequence
-        self.generate_fixture_asset_type()
-        self.generate_fixture_project()
-        if episode_id is None and hasattr(self, "episode"):
-            episode_id = self.episode.id
-
-        if project_id is None:
-            project_id = self.project.id
-
-        self.sequence = Entity.create(
-            name=name,
-            project_id=project_id,
-            entity_type_id=self.sequence_type.id,
-            parent_id=episode_id,
-        )
-        return self.sequence
-
-    def generate_fixture_sequence_standard(self):
-        if hasattr(self, "sequence_standard"):
-            return self.sequence_standard
-        self.generate_fixture_asset_type()
-        self.generate_fixture_project_standard()
-        self.sequence_standard = Entity.create(
-            name="S01",
-            project_id=self.project_standard.id,
-            entity_type_id=self.sequence_type.id,
-        )
-        return self.sequence_standard
-
-    def generate_fixture_episode(self, name="E01", project_id=None):
-        self.generate_fixture_asset_type()
-        self.generate_fixture_project()
-        if project_id is None:
-            project_id = self.project.id
-        self.episode = Entity.create(
-            name=name,
-            project_id=project_id,
-            entity_type_id=self.episode_type.id,
-        )
-        return self.episode
-
-    def generate_fixture_shot(self, name="P01", nb_frames=0, sequence_id=None):
-        if (
-            name == "P01"
-            and nb_frames == 0
-            and sequence_id is None
-            and hasattr(self, "shot")
-            and self.shot.parent_id == self.sequence.id
-        ):
-            return self.shot
-        self.generate_fixture_asset_type()
-        self.generate_fixture_project()
-        self.generate_fixture_sequence()
-        if sequence_id is None:
-            sequence_id = self.sequence.id
-        self.shot = Entity.create(
-            name=name,
-            description="Description Shot 01",
-            data={"fps": 25, "frame_in": 0, "frame_out": 100},
-            project_id=self.project.id,
-            entity_type_id=self.shot_type.id,
-            parent_id=sequence_id,
-            nb_frames=nb_frames,
-        )
-        return self.shot
-
-    def generate_fixture_scene(
-        self, name="SC01", project_id=None, sequence_id=None
-    ):
-        if (
-            name == "SC01"
-            and project_id is None
-            and sequence_id is None
-            and hasattr(self, "scene")
-        ):
-            return self.scene
-        self.generate_fixture_asset_type()
-        self.generate_fixture_project()
-        self.generate_fixture_sequence()
-        if project_id is None:
-            project_id = self.project.id
-
-        if sequence_id is None:
-            sequence_id = self.sequence.id
-
-        self.scene = Entity.create(
-            name=name,
-            description="Description Scene 01",
-            data={},
-            project_id=project_id,
-            entity_type_id=self.scene_type.id,
-            parent_id=self.sequence.id,
-        )
-        return self.scene
-
-    def generate_fixture_shot_standard(self, name="SH01"):
-        if name == "SH01" and hasattr(self, "shot_standard"):
-            return self.shot_standard
-        self.generate_fixture_asset_type()
-        self.generate_fixture_project_standard()
-        self.generate_fixture_sequence_standard()
-        self.shot_standard = Entity.create(
-            name=name,
-            description="Description Shot 01",
-            data={"fps": 25, "frame_in": 0, "frame_out": 100},
-            project_id=self.project_standard.id,
-            entity_type_id=self.shot_type.id,
-            parent_id=self.sequence_standard.id,
-        )
-        return self.shot_standard
-
-    def generate_fixture_shot_asset_instance(
-        self, shot, asset_instance, number=1
-    ):
-        self.shot.instance_casting.append(asset_instance)
-        self.shot.save()
-        return self.shot
-
-    def generate_fixture_scene_asset_instance(
-        self, asset=None, scene=None, number=1
-    ):
-        if asset is None:
-            asset = self.asset
-        if scene is None:
-            scene = self.scene
-        self.asset_instance = AssetInstance.create(
-            asset_id=asset.id,
-            scene_id=scene.id,
-            number=number,
-            name=breakdown_service.build_asset_instance_name(
-                self.asset.id, number
-            ),
-            description="Asset instance description",
-        )
-        return self.asset_instance
-
-    def generate_fixture_asset_asset_instance(
-        self, asset=None, target_asset=None, number=1
-    ):
-        if asset is None:
-            asset = self.asset_character
-        if target_asset is None:
-            target_asset = self.asset
-        self.asset_instance = AssetInstance.create(
-            asset_id=asset.id,
-            target_asset_id=target_asset.id,
-            number=number,
-            name=breakdown_service.build_asset_instance_name(asset.id, number),
-            description="Asset instance description",
-        )
-        return self.asset_instance
+    # People, departments and roles
 
     def generate_fixture_user(self):
         self.user = Person.create(
@@ -810,6 +581,23 @@ class ApiDBTestCase(ApiTestCase):
             )
         return self.person
 
+    def generate_fixture_assigner(self):
+        if hasattr(self, "assigner"):
+            return self.assigner
+        self.assigner = Person.create(first_name="Ema", last_name="Peel")
+        return self.assigner
+
+    def generate_fixture_department(self):
+        if hasattr(self, "department"):
+            return self.department
+        self.department = Department.create(name="Modeling", color="#FFFFFF")
+        self.department_animation = Department.create(
+            name="Animation", color="#FFFFFF"
+        )
+        return self.department
+
+    # Entity types
+
     def generate_fixture_asset_type(self):
         if hasattr(self, "asset_type"):
             return
@@ -828,14 +616,258 @@ class ApiDBTestCase(ApiTestCase):
         self.asset_type_environment = EntityType.create(name="Environment")
         self.asset_type_camera = EntityType.create(name="Camera")
 
-    def generate_fixture_department(self):
-        if hasattr(self, "department"):
-            return self.department
-        self.department = Department.create(name="Modeling", color="#FFFFFF")
-        self.department_animation = Department.create(
-            name="Animation", color="#FFFFFF"
+    # Entities
+
+    def generate_fixture_asset(
+        self,
+        name="Tree",
+        description="Description Tree",
+        asset_type_id=None,
+        project_id=None,
+    ):
+        if (
+            name == "Tree"
+            and description == "Description Tree"
+            and asset_type_id is None
+            and project_id is None
+            and hasattr(self, "asset")
+        ):
+            return self.asset
+        self.generate_fixture_asset_type()
+        if not hasattr(self, "project"):
+            self.generate_fixture_project()
+        if asset_type_id is None:
+            asset_type_id = self.asset_type.id
+
+        if project_id is None:
+            project_id = self.project_id
+
+        self.asset = Entity.create(
+            name=name,
+            description=description,
+            project_id=project_id,
+            entity_type_id=asset_type_id,
         )
-        return self.department
+        return self.asset
+
+    def generate_fixture_asset_character(
+        self, name="Rabbit", description="Main char"
+    ):
+        if (
+            name == "Rabbit"
+            and description == "Main char"
+            and hasattr(self, "asset_character")
+        ):
+            return self.asset_character
+        self.generate_fixture_asset_types()
+        self.generate_fixture_project()
+        self.asset_character = Entity.create(
+            name=name,
+            description=description,
+            project_id=self.project.id,
+            entity_type_id=self.asset_type_character.id,
+        )
+        return self.asset_character
+
+    def generate_fixture_asset_camera(self):
+        if hasattr(self, "asset_camera"):
+            return
+        self.generate_fixture_asset_types()
+        self.generate_fixture_project()
+        self.asset_camera = Entity.create(
+            name="Main camera",
+            description="Description Camera",
+            project_id=self.project.id,
+            entity_type_id=self.asset_type_camera.id,
+        )
+
+    def generate_fixture_asset_standard(self):
+        if hasattr(self, "asset_standard"):
+            return
+        self.generate_fixture_asset_type()
+        self.generate_fixture_project_standard()
+        self.asset_standard = Entity.create(
+            name="Car",
+            project_id=self.project_standard.id,
+            entity_type_id=self.asset_type.id,
+        )
+
+    def generate_fixture_episode(self, name="E01", project_id=None):
+        self.generate_fixture_asset_type()
+        self.generate_fixture_project()
+        if project_id is None:
+            project_id = self.project.id
+        self.episode = Entity.create(
+            name=name,
+            project_id=project_id,
+            entity_type_id=self.episode_type.id,
+        )
+        return self.episode
+
+    def generate_fixture_sequence(
+        self, name="S01", episode_id=None, project_id=None
+    ):
+        if (
+            name == "S01"
+            and episode_id is None
+            and project_id is None
+            and hasattr(self, "sequence")
+        ):
+            return self.sequence
+        self.generate_fixture_asset_type()
+        self.generate_fixture_project()
+        if episode_id is None and hasattr(self, "episode"):
+            episode_id = self.episode.id
+
+        if project_id is None:
+            project_id = self.project.id
+
+        self.sequence = Entity.create(
+            name=name,
+            project_id=project_id,
+            entity_type_id=self.sequence_type.id,
+            parent_id=episode_id,
+        )
+        return self.sequence
+
+    def generate_fixture_sequence_standard(self):
+        if hasattr(self, "sequence_standard"):
+            return self.sequence_standard
+        self.generate_fixture_asset_type()
+        self.generate_fixture_project_standard()
+        self.sequence_standard = Entity.create(
+            name="S01",
+            project_id=self.project_standard.id,
+            entity_type_id=self.sequence_type.id,
+        )
+        return self.sequence_standard
+
+    def generate_fixture_shot(self, name="P01", nb_frames=0, sequence_id=None):
+        if (
+            name == "P01"
+            and nb_frames == 0
+            and sequence_id is None
+            and hasattr(self, "shot")
+            and self.shot.parent_id == self.sequence.id
+        ):
+            return self.shot
+        self.generate_fixture_asset_type()
+        self.generate_fixture_project()
+        self.generate_fixture_sequence()
+        if sequence_id is None:
+            sequence_id = self.sequence.id
+        self.shot = Entity.create(
+            name=name,
+            description="Description Shot 01",
+            data={"fps": 25, "frame_in": 0, "frame_out": 100},
+            project_id=self.project.id,
+            entity_type_id=self.shot_type.id,
+            parent_id=sequence_id,
+            nb_frames=nb_frames,
+        )
+        return self.shot
+
+    def generate_fixture_shot_standard(self, name="SH01"):
+        if name == "SH01" and hasattr(self, "shot_standard"):
+            return self.shot_standard
+        self.generate_fixture_asset_type()
+        self.generate_fixture_project_standard()
+        self.generate_fixture_sequence_standard()
+        self.shot_standard = Entity.create(
+            name=name,
+            description="Description Shot 01",
+            data={"fps": 25, "frame_in": 0, "frame_out": 100},
+            project_id=self.project_standard.id,
+            entity_type_id=self.shot_type.id,
+            parent_id=self.sequence_standard.id,
+        )
+        return self.shot_standard
+
+    def generate_fixture_scene(
+        self, name="SC01", project_id=None, sequence_id=None
+    ):
+        if (
+            name == "SC01"
+            and project_id is None
+            and sequence_id is None
+            and hasattr(self, "scene")
+        ):
+            return self.scene
+        self.generate_fixture_asset_type()
+        self.generate_fixture_project()
+        self.generate_fixture_sequence()
+        if project_id is None:
+            project_id = self.project.id
+
+        if sequence_id is None:
+            sequence_id = self.sequence.id
+
+        self.scene = Entity.create(
+            name=name,
+            description="Description Scene 01",
+            data={},
+            project_id=project_id,
+            entity_type_id=self.scene_type.id,
+            parent_id=self.sequence.id,
+        )
+        return self.scene
+
+    def generate_fixture_edit(self, name="Edit", parent_id=None):
+        self.generate_fixture_asset_type()
+        self.generate_fixture_project()
+        self.edit = Entity.create(
+            name=name,
+            description="Description of the Edit",
+            project_id=self.project.id,
+            entity_type_id=self.edit_type.id,
+            parent_id=parent_id,
+        )
+        return self.edit
+
+    # Asset instances
+
+    def generate_fixture_shot_asset_instance(
+        self, shot, asset_instance, number=1
+    ):
+        self.shot.instance_casting.append(asset_instance)
+        self.shot.save()
+        return self.shot
+
+    def generate_fixture_scene_asset_instance(
+        self, asset=None, scene=None, number=1
+    ):
+        if asset is None:
+            asset = self.asset
+        if scene is None:
+            scene = self.scene
+        self.asset_instance = AssetInstance.create(
+            asset_id=asset.id,
+            scene_id=scene.id,
+            number=number,
+            name=breakdown_service.build_asset_instance_name(
+                self.asset.id, number
+            ),
+            description="Asset instance description",
+        )
+        return self.asset_instance
+
+    def generate_fixture_asset_asset_instance(
+        self, asset=None, target_asset=None, number=1
+    ):
+        if asset is None:
+            asset = self.asset_character
+        if target_asset is None:
+            target_asset = self.asset
+        self.asset_instance = AssetInstance.create(
+            asset_id=asset.id,
+            target_asset_id=target_asset.id,
+            number=number,
+            name=breakdown_service.build_asset_instance_name(asset.id, number),
+            description="Asset instance description",
+        )
+        return self.asset_instance
+
+    # Task types, statuses and automations
 
     def generate_fixture_task_type(self):
         if hasattr(self, "task_type"):
@@ -979,11 +1011,7 @@ class ApiDBTestCase(ApiTestCase):
         )
         return self.status_automation_to_ready_for
 
-    def generate_fixture_assigner(self):
-        if hasattr(self, "assigner"):
-            return self.assigner
-        self.assigner = Person.create(first_name="Ema", last_name="Peel")
-        return self.assigner
+    # Tasks
 
     def generate_fixture_task(
         self, name="Master", entity_id=None, task_type_id=None, project_id=None
@@ -1101,6 +1129,27 @@ class ApiDBTestCase(ApiTestCase):
         self.project.save()
         return self.shot_task
 
+    def generate_fixture_shot_task_standard(self):
+        if hasattr(self, "shot_task_standard"):
+            return self.shot_task_standard
+        self.generate_fixture_shot_standard()
+        self.generate_fixture_task_type()
+        self.generate_fixture_task_status()
+        self.generate_fixture_person()
+        self.generate_fixture_assigner()
+        self.shot_task_standard = Task.create(
+            name="Super animation",
+            project_id=self.project_standard.id,
+            task_type_id=self.task_type_animation.id,
+            task_status_id=self.task_status.id,
+            entity_id=self.shot_standard.id,
+            assignees=[self.person],
+            assigner_id=self.assigner.id,
+        )
+        self.project.team.append(self.person)
+        self.project.save()
+        return self.shot_task_standard
+
     def generate_fixture_edit_task(self, name="Edit", task_type_id=None):
         if (
             name == "Edit"
@@ -1194,26 +1243,7 @@ class ApiDBTestCase(ApiTestCase):
         self.project.save()
         return self.sequence_task
 
-    def generate_fixture_shot_task_standard(self):
-        if hasattr(self, "shot_task_standard"):
-            return self.shot_task_standard
-        self.generate_fixture_shot_standard()
-        self.generate_fixture_task_type()
-        self.generate_fixture_task_status()
-        self.generate_fixture_person()
-        self.generate_fixture_assigner()
-        self.shot_task_standard = Task.create(
-            name="Super animation",
-            project_id=self.project_standard.id,
-            task_type_id=self.task_type_animation.id,
-            task_status_id=self.task_status.id,
-            entity_id=self.shot_standard.id,
-            assignees=[self.person],
-            assigner_id=self.assigner.id,
-        )
-        self.project.team.append(self.person)
-        self.project.save()
-        return self.shot_task_standard
+    # Comments
 
     def generate_fixture_comment(
         self, person=None, task_id=None, task_status_id=None
@@ -1253,6 +1283,8 @@ class ApiDBTestCase(ApiTestCase):
             self.task.id, self.task_status.id, self.user["id"], "first comment"
         )
         return self.comment
+
+    # Files and previews
 
     def generate_fixture_file_status(self):
         if hasattr(self, "file_status"):
@@ -1384,23 +1416,7 @@ class ApiDBTestCase(ApiTestCase):
         )
         return self.preview_background_file
 
-    def get_fixture_file_path(self, relative_path):
-        current_path = os.getcwd()
-        file_path_fixture = os.path.join(
-            current_path, "tests", "fixtures", relative_path
-        )
-        return file_path_fixture
-
-    def generate_fixture_metadata_descriptor(self, entity_type="Asset"):
-        self.meta_descriptor = MetadataDescriptor.create(
-            project_id=self.project.id,
-            name="Contractor",
-            data_type="list",
-            field_name="contractor",
-            choices=["value 1", "value 2"],
-            entity_type=entity_type,
-        )
-        return self.meta_descriptor
+    # Playlists, schedule and notifications
 
     def generate_fixture_playlist(
         self,
@@ -1488,17 +1504,7 @@ class ApiDBTestCase(ApiTestCase):
         )
         return self.day_off.serialize()
 
-    def generate_fixture_edit(self, name="Edit", parent_id=None):
-        self.generate_fixture_asset_type()
-        self.generate_fixture_project()
-        self.edit = Entity.create(
-            name=name,
-            description="Description of the Edit",
-            project_id=self.project.id,
-            entity_type_id=self.edit_type.id,
-            parent_id=parent_id,
-        )
-        return self.edit
+    # Whole contexts, for the tests that need a production standing up
 
     def generate_base_context(self):
         self.generate_fixture_project_status()
@@ -1590,6 +1596,8 @@ class ApiDBTestCase(ApiTestCase):
             preview_e201,
         )
 
+    # Helpers
+
     def assign_task(self, task_id, user_id):
         return tasks_service.assign_task(task_id, user_id)
 
@@ -1606,6 +1614,13 @@ class ApiDBTestCase(ApiTestCase):
             os.path.join("csv", f"{name}.csv")
         )
         self.upload_file(path, file_path_fixture)
+
+    def get_fixture_file_path(self, relative_path):
+        current_path = os.getcwd()
+        file_path_fixture = os.path.join(
+            current_path, "tests", "fixtures", relative_path
+        )
+        return file_path_fixture
 
     def get_file_path(self, filename):
         current_path = os.path.dirname(__file__)

--- a/tests/blueprints/assets/test_asset_tasks.py
+++ b/tests/blueprints/assets/test_asset_tasks.py
@@ -193,6 +193,13 @@ class AssetTasksTestCase(ApiDBTestCase):
         assets = self.get(f"data/assets/with-tasks?project_id={project_id}")
         self.assertNotIn("contractor", assets[0]["data"])
 
+        # The listings without the tasks answer the same production, so they
+        # hide the same descriptor.
+        for path in ["data/assets", "data/assets/all"]:
+            with self.subTest(path=path):
+                assets = self.get(f"{path}?project_id={project_id}")
+                self.assertNotIn("contractor", assets[0]["data"])
+
     def test_get_task_types_for_asset(self):
         task_types = self.get(f"data/assets/{self.asset_id}/task-types")
         self.assertEqual(len(task_types), 1)

--- a/tests/blueprints/edits/test_edit_routes.py
+++ b/tests/blueprints/edits/test_edit_routes.py
@@ -42,6 +42,27 @@ class EditRoutesTestCase(BaseEditTestCase):
         )
         self.assertEqual(task["data"], {"render_layer": "bg"})
 
+    def test_get_edits_for_episode(self):
+        edits = self.get(f"/data/episodes/{self.episode_id}/edits")
+
+        self.assertEqual([edit["id"] for edit in edits], [str(self.edit_id)])
+
+    def test_get_edit_tasks_for_episode(self):
+        """
+        The tasks of the edits an episode holds. A shot of that episode hangs
+        one level deeper, under a sequence, and none of its tasks belong here.
+        """
+        self.generate_fixture_sequence()
+        self.generate_fixture_shot()
+        self.generate_fixture_shot_task()
+
+        tasks = self.get(f"/data/episodes/{self.episode_id}/edit-tasks")
+
+        self.assertEqual(
+            sorted(task["entity_id"] for task in tasks),
+            sorted([str(self.edit_id)] * 2),
+        )
+
     def test_get_edits_with_tasks_wrong_id_format(self):
         self.get("/data/edits/with-tasks?project_id=not-a-uuid", 400)
         self.get("/data/edits/with-tasks?episode_id=not-a-uuid", 400)

--- a/tests/blueprints/edits/test_edit_tasks.py
+++ b/tests/blueprints/edits/test_edit_tasks.py
@@ -59,6 +59,13 @@ class EditTasksTestCase(BaseEditTestCase):
         edits = self.get(f"data/edits/with-tasks?project_id={project_id}")
         self.assertNotIn("contractor", edits[0]["data"])
 
+        # The listings without the tasks answer the same production, so they
+        # hide the same descriptor.
+        for path in ["data/edits", "data/edits/all"]:
+            with self.subTest(path=path):
+                edits = self.get(f"{path}?project_id={project_id}")
+                self.assertNotIn("contractor", edits[0]["data"])
+
     def test_get_task_types_for_edit(self):
         task_types = self.get(f"data/edits/{self.edit_id}/task-types")
         self.assertEqual(len(task_types), 1)

--- a/tests/blueprints/search/test_search.py
+++ b/tests/blueprints/search/test_search.py
@@ -2,7 +2,7 @@ import pytest
 
 from tests.base import ApiDBTestCase, indexer_is_up
 
-from zou.app.services import index_service
+from zou.app.services import index_service, projects_service, tasks_service
 
 pytestmark = [
     pytest.mark.integration,
@@ -196,3 +196,65 @@ class AssetSearchTestCase(ApiDBTestCase):
             200,
         )["assets"]
         self.assertEqual(len(assets), 2)
+
+
+class VendorSearchTestCase(ApiDBTestCase):
+    """
+    A vendor reads through the index what they read through the listings:
+    only the entities they hold a task on, without the metadata reserved to
+    departments they are not part of.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.generate_fixture_project_status()
+        self.generate_fixture_project()
+        self.generate_fixture_asset_type()
+        self.generate_fixture_asset(name="Girafe")
+        self.generate_fixture_asset_character("Chameau")
+        self.generate_fixture_person()
+        self.generate_fixture_assigner()
+        self.generate_fixture_department()
+        self.generate_fixture_task_status()
+        self.generate_fixture_task_type()
+        self.generate_fixture_task()
+
+        project_id = str(self.project.id)
+        self.generate_fixture_user_vendor()
+        person_id = self.user_vendor["id"]
+        projects_service.add_team_member(project_id, person_id)
+        projects_service.clear_project_cache(project_id)
+        # The vendor works on Girafe. Chameau is another asset of the same
+        # production, and none of their business.
+        tasks_service.assign_task(str(self.task.id), person_id)
+        projects_service.add_metadata_descriptor(
+            project_id,
+            "Asset",
+            "Contractor",
+            "list",
+            ["value 1"],
+            False,
+            [str(self.department.id)],
+        )
+        for asset in [self.asset, self.asset_character]:
+            asset.update({"data": {"contractor": "secret"}})
+        index_service.reset_index()
+        self.log_in_vendor()
+
+    def search_assets(self, query):
+        return self.post(
+            "data/search", {"query": query, "index_names": ["assets"]}, 200
+        )["assets"]
+
+    def test_an_asset_they_work_on_comes_back(self):
+        self.assertEqual(
+            [asset["name"] for asset in self.search_assets("Gira")], ["Girafe"]
+        )
+
+    def test_an_asset_they_do_not_work_on_does_not(self):
+        self.assertEqual(self.search_assets("Cham"), [])
+
+    def test_a_descriptor_of_another_department_is_left_out(self):
+        asset = self.search_assets("Gira")[0]
+
+        self.assertNotIn("contractor", asset["data"])

--- a/tests/blueprints/shots/test_shot_tasks.py
+++ b/tests/blueprints/shots/test_shot_tasks.py
@@ -114,6 +114,13 @@ class ShotTasksTestCase(ApiDBTestCase):
         shots = self.get(f"data/shots/with-tasks?project_id={project_id}")
         self.assertNotIn("contractor", shots[0]["data"])
 
+        # The listings without the tasks answer the same production, so they
+        # hide the same descriptor.
+        for path in ["data/shots", "data/shots/all"]:
+            with self.subTest(path=path):
+                shots = self.get(f"{path}?project_id={project_id}")
+                self.assertNotIn("contractor", shots[0]["data"])
+
     def test_get_task_types_for_shot(self):
         task_types = self.get(f"/data/shots/{self.shot_id}/task-types")
         self.assertEqual(len(task_types), 1)

--- a/tests/misc/test_route_service_calls.py
+++ b/tests/misc/test_route_service_calls.py
@@ -15,8 +15,6 @@ KNOWN_BROKEN = {
         "departments_service",
         "get_softwares_for_department",
     ),
-    ("edits/resources.py", "edits_service", "get_episode"),
-    ("edits/resources.py", "tasks_service", "get_edit_tasks_for_episode"),
     ("projects/resources.py", "user_service", "get_project_by_name"),
     ("tasks/resources.py", "persons_service", "get"),
 }

--- a/tests/misc/test_vendor_metadata_masking.py
+++ b/tests/misc/test_vendor_metadata_masking.py
@@ -102,6 +102,7 @@ class VendorMetadataMaskingTestCase(ApiDBTestCase):
             "data/edits/all",
             "data/edits/with-tasks",
             f"data/projects/{project_id}/edits",
+            f"data/episodes/{episode_id}/edits",
             "data/episodes",
             "data/episodes/with-tasks",
             f"data/projects/{project_id}/episodes",

--- a/tests/misc/test_vendor_metadata_masking.py
+++ b/tests/misc/test_vendor_metadata_masking.py
@@ -1,0 +1,148 @@
+import json
+
+from tests.base import ApiDBTestCase
+
+from zou.app.services import (
+    persons_service,
+    projects_service,
+    tasks_service,
+)
+
+
+class VendorMetadataMaskingTestCase(ApiDBTestCase):
+    """
+    A metadata descriptor restricted to a department must not reach a vendor
+    who does not belong to it, whichever listing they read the entity from.
+
+    The listings carrying the tasks mask while they build their rows, the
+    others hand back whole serialized entities: two ways of answering the
+    same production, so they are checked together rather than one by one.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.generate_fixture_project_status()
+        self.generate_fixture_project()
+        self.generate_fixture_asset_type()
+        self.generate_fixture_asset()
+        self.generate_fixture_episode()
+        self.generate_fixture_sequence()
+        self.generate_fixture_shot()
+        self.generate_fixture_scene()
+        self.generate_fixture_edit()
+        self.generate_fixture_person()
+        self.generate_fixture_assigner()
+        self.generate_fixture_department()
+        self.generate_fixture_task_status()
+        self.generate_fixture_task_type()
+        self.generate_fixture_task()
+        self.generate_fixture_shot_task()
+        self.generate_fixture_episode_task()
+        self.generate_fixture_sequence_task()
+        self.generate_fixture_scene_task()
+        self.generate_fixture_edit_task()
+
+    def restrict_a_descriptor_the_vendor_cannot_read(self):
+        """
+        Give every entity a "contractor" field reserved to a department the
+        vendor is not part of, and put the vendor on a task of each of them
+        so that they reach the entities at all.
+        """
+        project_id = str(self.project.id)
+        self.generate_fixture_user_vendor()
+        person_id = self.user_vendor["id"]
+        projects_service.add_team_member(project_id, person_id)
+        for task in [
+            self.task,
+            self.shot_task,
+            self.episode_task,
+            self.sequence_task,
+            self.scene_task,
+            self.edit_task,
+        ]:
+            tasks_service.assign_task(str(task.id), person_id)
+
+        entities = {
+            "Asset": self.asset,
+            "Shot": self.shot,
+            "Episode": self.episode,
+            "Sequence": self.sequence,
+            "Scene": self.scene,
+            "Edit": self.edit,
+        }
+        for entity_type, entity in entities.items():
+            projects_service.add_metadata_descriptor(
+                project_id,
+                entity_type,
+                "Contractor",
+                "list",
+                ["value 1"],
+                False,
+                [str(self.department.id)],
+            )
+            entity.update({"data": {"contractor": "secret"}})
+        projects_service.clear_project_cache(project_id)
+        return project_id
+
+    def listing_paths(self, project_id):
+        episode_id = str(self.episode.id)
+        sequence_id = str(self.sequence.id)
+        return [
+            "data/assets",
+            "data/assets/all",
+            "data/assets/with-tasks",
+            f"data/projects/{project_id}/assets",
+            "data/shots",
+            "data/shots/all",
+            "data/shots/with-tasks",
+            f"data/projects/{project_id}/shots",
+            f"data/episodes/{episode_id}/shots",
+            f"data/sequences/{sequence_id}/shots",
+            "data/edits",
+            "data/edits/all",
+            "data/edits/with-tasks",
+            f"data/projects/{project_id}/edits",
+            "data/episodes",
+            "data/episodes/with-tasks",
+            f"data/projects/{project_id}/episodes",
+            "data/sequences",
+            "data/sequences/with-tasks",
+            f"data/projects/{project_id}/sequences",
+            f"data/episodes/{episode_id}/sequences",
+            "data/scenes/all",
+            "data/scenes/with-tasks",
+            f"data/projects/{project_id}/scenes",
+            f"data/sequences/{sequence_id}/scenes",
+        ]
+
+    def test_no_listing_hands_a_restricted_descriptor_to_a_vendor(self):
+        project_id = self.restrict_a_descriptor_the_vendor_cannot_read()
+        self.log_in_vendor()
+
+        reached = 0
+        for path in self.listing_paths(project_id):
+            with self.subTest(path=path):
+                response = self.app.get(
+                    f"/{path}?project_id={project_id}",
+                    headers=self.base_headers,
+                )
+                # A listing a vendor cannot reach at all leaks nothing; only
+                # the ones that answer have something to hide.
+                if response.status_code != 200:
+                    continue
+                reached += 1
+                for row in json.loads(response.data):
+                    self.assertNotIn("contractor", row.get("data") or {})
+        self.assertGreater(reached, 0)
+
+    def test_a_descriptor_of_their_own_department_still_reaches_them(self):
+        # The masking narrows, it does not blank the metadata out.
+        project_id = self.restrict_a_descriptor_the_vendor_cannot_read()
+        persons_service.add_to_department(
+            str(self.department.id), self.user_vendor["id"]
+        )
+        self.log_in_vendor()
+
+        shots = self.get(f"data/shots?project_id={project_id}")
+
+        self.assertEqual(shots[0]["data"]["contractor"], "secret")

--- a/tests/services/test_edits_service.py
+++ b/tests/services/test_edits_service.py
@@ -5,7 +5,11 @@ from tests.base import ApiDBTestCase
 from zou.app.models.entity import EntityVersion
 from zou.app.models.schedule_item import ScheduleItem
 from zou.app.services import edits_service
-from zou.app.services.exception import EditNotFoundException
+from zou.app.services.exception import (
+    EditNotFoundException,
+    WrongIdFormatException,
+    WrongParameterException,
+)
 
 
 class EditUtilsTestCase(ApiDBTestCase):
@@ -29,10 +33,22 @@ class EditUtilsTestCase(ApiDBTestCase):
         self.assertEqual(edit_type["name"], "Edit")
 
     def test_get_edits(self):
-        edits = edits_service.get_edits()
-        self.edit_dict = self.edit.serialize(obj_type="Edit")
-        self.edit_dict["project_name"] = self.project.name
-        self.assertDictEqual(edits[0], self.edit_dict)
+        edit_dict = self.edit.serialize(obj_type="Edit")
+        edit_dict["project_name"] = self.project.name
+
+        self.assertDictEqual(edits_service.get_edits()[0], edit_dict)
+
+    def test_get_edits_refuses_a_malformed_id(self):
+        # The uuid guard sits in query.cast_value, before the statement is
+        # even built.
+        with pytest.raises(WrongParameterException):
+            edits_service.get_edits({"id": "not-an-id"})
+
+    def test_get_edits_refuses_a_value_the_driver_turns_down(self):
+        # Any other column reaches the database as a cast, so the refusal
+        # only comes once the query runs.
+        with pytest.raises(WrongIdFormatException):
+            edits_service.get_edits({"nb_entities_out": "abc"})
 
     def test_get_edits_and_tasks(self):
         self.the_chain_a_task_needs()
@@ -57,6 +73,17 @@ class EditUtilsTestCase(ApiDBTestCase):
             edits[0]["tasks"][0]["task_type_id"],
             str(self.edit_task.task_type_id),
         )
+
+    def test_get_edits_and_tasks_for_one_episode(self):
+        first_episode = self.episode
+        elsewhere = self.generate_fixture_episode("E02")
+        self.generate_fixture_edit("Next", parent_id=elsewhere.id)
+
+        edits = edits_service.get_edits_and_tasks(
+            {"episode_id": str(first_episode.id)}
+        )
+
+        self.assertEqual([edit["name"] for edit in edits], ["Edit"])
 
     def test_get_edit(self):
         self.assertEqual(
@@ -85,6 +112,21 @@ class EditUtilsTestCase(ApiDBTestCase):
         )
         self.assertEqual(edit["name"], edit_name)
         self.assertEqual(edit["parent_id"], parent_id)
+
+    def test_create_edit_without_episode(self):
+        # The client sends an empty value rather than no value at all when
+        # the edit belongs to no episode.
+        edit = edits_service.create_edit(
+            self.project.id, "Standalone", parent_id=""
+        )
+
+        self.assertIsNone(edit["parent_id"])
+
+    def test_create_edit_twice_returns_the_first_one(self):
+        first = edits_service.create_edit(self.project.id, "Editor's Cut")
+        again = edits_service.create_edit(self.project.id, "Editor's Cut")
+
+        self.assertEqual(first["id"], again["id"])
 
     def test_get_edits_for_episode(self):
         """

--- a/tests/services/test_emails_service.py
+++ b/tests/services/test_emails_service.py
@@ -184,3 +184,70 @@ class EmailsServiceTestCase(ApiDBTestCase):
                 "discord_message": "discord",
             },
         )
+
+
+class PlaylistMailTestCase(EmailsServiceTestCase):
+    """
+    The playlist mail is written in two passes: a fragment naming the
+    episode, then the body it sits in. Both used to escape it.
+    """
+
+    def a_playlist(self, name="Sunday & Monday"):
+        return {
+            "id": "00000000-0000-0000-0000-000000000001",
+            "project_id": str(self.project.id),
+            "episode_id": str(self.episode.id),
+            "name": name,
+            "for_entity": "shot",
+            "is_for_all": False,
+            "shots": [],
+        }
+
+    def playlist_mail(self, playlist):
+        with patch(
+            "zou.app.services.emails_service.emails.send_email"
+        ) as mock_send:
+            emails_service.send_playlist_ready_notification(
+                str(self.a_person("Jean", "en_US").id),
+                str(self.user["id"]),
+                playlist,
+            )
+            return mock_send.call_args[0][1]
+
+    def test_an_ampersand_is_escaped_once_wherever_it_sits(self):
+        """
+        The episode name went through two translations and came out
+        &amp;amp;, which the recipient reads as "Tom &amp; Jerry". The
+        playlist name, interpolated once, was already right: the two are
+        one sentence of one mail and have to agree.
+        """
+        self.episode.update({"name": "Tom & Jerry"})
+
+        html = self.playlist_mail(self.a_playlist())
+
+        self.assertIn("Tom &amp; Jerry", html)
+        self.assertIn("Sunday &amp; Monday", html)
+        self.assertNotIn("&amp;amp;", html)
+
+    def test_the_invitation_message_is_still_escaped(self):
+        """
+        Its segment is concatenated straight into the body rather than
+        handed to another template, so it is the one place a fragment must
+        keep being escaped where it is built.
+        """
+        with patch(
+            "zou.app.services.emails_service.emails.send_email"
+        ) as mock_send:
+            emails_service.send_share_invitation(
+                "guest@example.com",
+                {"full_name": "John Did"},
+                {"name": "Playlist"},
+                self.project.serialize(),
+                "https://localhost:8080/share/token",
+                message="<script>alert(1)</script>",
+                locale="en_US",
+            )
+            html = mock_send.call_args[0][1]
+
+        self.assertNotIn("<script>", html)
+        self.assertIn("&lt;script&gt;", html)

--- a/tests/services/test_emails_service.py
+++ b/tests/services/test_emails_service.py
@@ -251,3 +251,96 @@ class PlaylistMailTestCase(EmailsServiceTestCase):
 
         self.assertNotIn("<script>", html)
         self.assertIn("&lt;script&gt;", html)
+
+
+class TaskUrlTestCase(EmailsServiceTestCase):
+    """
+    The link every notification mail carries. A tv show scopes it to an
+    episode, and an asset of one has none of its own.
+    """
+
+    def url_of(self, task):
+        return emails_service.get_task_descriptors(
+            self.person.id, task.serialize()
+        )[2]
+
+    def test_a_standard_production_names_no_episode(self):
+        self.assertIn("/assets/tasks/", self.url_of(self.task))
+        self.assertNotIn("/episodes/", self.url_of(self.task))
+
+    def test_a_tv_show_scopes_a_shot_task_to_its_episode(self):
+        self.project.update({"production_type": "tvshow"})
+        self.generate_fixture_shot_task()
+
+        self.assertIn(
+            f"/episodes/{self.episode.id}/shots/tasks/",
+            self.url_of(self.shot_task),
+        )
+
+    def test_a_tv_show_sends_an_asset_task_to_the_main_episode(self):
+        """
+        Assets of a tv show hang off no episode, so the link used to name
+        one called None and led nowhere. Kitsu reads main as the pseudo
+        episode holding them.
+        """
+        self.project.update({"production_type": "tvshow"})
+
+        url = self.url_of(self.task)
+
+        self.assertIn("/episodes/main/assets/tasks/", url)
+        self.assertNotIn("None", url)
+
+
+class SenderTestCase(EmailsServiceTestCase):
+    """
+    The four senders nothing held. Each writes to whoever it is given, and
+    stays quiet on a person who turned notifications off.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.comment = {"text": "Wrong picture"}
+        self.reply = {"text": "Fixed"}
+        self.task_dict = self.task.serialize()
+
+    def senders(self, person_id):
+        author_id = str(self.person.id)
+        return {
+            "mention": lambda: emails_service.send_mention_notification(
+                person_id, author_id, self.comment, self.task_dict
+            ),
+            "assignation": lambda: (
+                emails_service.send_assignation_notification(
+                    person_id, author_id, self.task_dict
+                )
+            ),
+            "reply": lambda: emails_service.send_reply_notification(
+                person_id, author_id, self.comment, self.task_dict, self.reply
+            ),
+            "comment": lambda: emails_service.send_comment_notification(
+                person_id, author_id, self.comment, self.task_dict
+            ),
+        }
+
+    def mail_of(self, send):
+        with patch(
+            "zou.app.services.emails_service.emails.send_email"
+        ) as mock_send:
+            send()
+            return mock_send.call_args[0][1] if mock_send.called else None
+
+    def test_each_sender_writes_the_task_it_is_given(self):
+        recipient = self.a_person("Jean", "en_US")
+
+        for name, send in self.senders(str(recipient.id)).items():
+            with self.subTest(sender=name):
+                html = self.mail_of(send)
+                self.assertIn("Shaders", html)
+                self.assertIn(str(self.task.id), html)
+
+    def test_no_sender_writes_to_someone_who_turned_them_off(self):
+        quiet = self.a_person("Muet", "en_US", notifications_enabled=False)
+
+        for name, send in self.senders(str(quiet.id)).items():
+            with self.subTest(sender=name):
+                self.assertIsNone(self.mail_of(send))

--- a/tests/services/test_index_service.py
+++ b/tests/services/test_index_service.py
@@ -6,7 +6,11 @@ from tests.base import ApiDBTestCase, indexer_is_up
 
 from zou.app.models.entity import Entity
 
-from zou.app.services import assets_service, index_service
+from zou.app.services import (
+    assets_service,
+    index_service,
+    projects_service,
+)
 from zou.app.services.exception import (
     EpisodeNotFoundException,
     SequenceNotFoundException,
@@ -32,6 +36,7 @@ class SearchTestCase(ApiDBTestCase):
         self.generate_fixture_project()
         self.generate_fixture_asset_type()
         self.generate_fixture_asset()
+        self.generate_fixture_episode()
         self.generate_fixture_sequence()
         self.generate_fixture_shot()
         self.generate_fixture_asset_character()
@@ -90,6 +95,33 @@ class SearchTestCase(ApiDBTestCase):
         assets_service.remove_asset(asset["id"])
 
         self.assertEqual(index_service.search_assets("girafe"), [])
+
+    def test_search_drops_a_hit_whose_row_is_gone(self):
+        """
+        The index and the database drift apart the moment a row leaves
+        without a reindex. The stale hit is dropped rather than answered as
+        a half built asset.
+        """
+        asset = assets_service.create_asset(
+            self.project_id, self.asset_type_id, "Girafe", "", {}
+        )
+        Entity.get(asset["id"]).delete()
+
+        self.assertEqual(index_service.search_assets("girafe"), [])
+
+    def test_search_shots_of_a_tv_show_carry_their_episode(self):
+        self.project.update({"production_type": "tvshow"})
+        projects_service.clear_project_cache(str(self.project.id))
+
+        shot = index_service.search_shots("P01", self.project_ids)[0]
+
+        self.assertEqual(shot["episode"], self.episode.name)
+        self.assertEqual(shot["episode_id"], str(self.episode.id))
+
+    def test_search_shots_of_a_film_carry_no_episode(self):
+        shot = index_service.search_shots("P01", self.project_ids)[0]
+
+        self.assertNotIn("episode", shot)
 
 
 class PrepareDocumentTestCase(ApiDBTestCase):
@@ -225,3 +257,30 @@ class WithoutIndexerTestCase(ApiDBTestCase):
         self.assertEqual(
             index_service.remove_person_index(str(self.person.id)), {}
         )
+
+    def test_an_indexer_that_stops_answering_is_swallowed_too(self):
+        """
+        A configured Meilisearch that goes down mid-run is the other half of
+        the same promise: an unreachable one is logged, never raised, so the
+        write that triggered the indexation still goes through.
+
+        The index handle is faked so that this holds whether or not the
+        machine running the tests has an indexer.
+        """
+        with patch.object(
+            index_service.indexing, "get_index", return_value=object()
+        ):
+            with patch.object(
+                index_service.indexing,
+                "index_document",
+                side_effect=ConnectionError("indexer is down"),
+            ):
+                self.assertEqual(index_service.index_asset(self.asset), {})
+            with patch.object(
+                index_service.indexing,
+                "remove_document",
+                side_effect=ConnectionError("indexer is down"),
+            ):
+                self.assertEqual(
+                    index_service.remove_asset_index(str(self.asset.id)), {}
+                )

--- a/tests/services/test_user_service.py
+++ b/tests/services/test_user_service.py
@@ -19,6 +19,7 @@ from zou.app.services import (
 )
 from zou.app.services.exception import (
     DepartmentNotFoundException,
+    NotificationNotFoundException,
     SearchFilterNotFoundException,
     SearchFilterGroupNotFoundException,
     WrongParameterException,
@@ -84,45 +85,211 @@ class RelatedProjectsTestCase(UserContextTestCase):
         with self.as_user():
             self.assertEqual(user_service.related_projects(), [])
 
-    def test_get_last_notifications(self):
-        """
-        What the artist sees in their bell: a comment on a task they hold.
-        A comment written by a client comes back with its text blanked,
-        since the artist may not read it.
-        """
+
+class NotificationTestCase(UserContextTestCase):
+    """
+    The bell of one artist: what lands in it, what it can be narrowed on,
+    and what a filter the driver cannot read answers.
+    """
+
+    def setUp(self):
+        super().setUp()
+
+        self.generate_fixture_project()
+        self.generate_fixture_asset()
+        self.generate_fixture_task_status_to_review()
+        self.generate_fixture_task()
         self.generate_fixture_user_cg_artist()
-        artist = self.user_cg_artist
-        projects_service.add_team_member(self.project_id, artist["id"])
-        tasks_service.assign_task(self.task_id, artist["id"])
+        self.generate_fixture_user_client()
+        self.artist = self.user_cg_artist
+        self.task_id = str(self.task.id)
+        self.project_id = str(self.project.id)
+        projects_service.add_team_member(self.project_id, self.artist["id"])
+        tasks_service.assign_task(self.task_id, self.artist["id"])
 
-        with self.as_user(artist):
-            self.assertEqual(user_service.get_last_notifications(), [])
-
-        comments_service.create_comment(
-            self.user["id"],
+    def a_comment(self, author=None, text="A note"):
+        """
+        A comment on the task the artist holds, which rings their bell.
+        """
+        return comments_service.create_comment(
+            (author or self.user)["id"],
             self.task_id,
             str(self.task_status_to_review.id),
-            "Lets go",
-            [],
-            {},
-            None,
-        )
-        comments_service.create_comment(
-            self.user_client["id"],
-            self.task_id,
-            str(self.task_status_to_review.id),
-            "Wrong picture",
+            text,
             [],
             {},
             None,
         )
 
-        with self.as_user(artist):
-            notifications = user_service.get_last_notifications()
+    def bell(self, **kwargs):
+        with self.as_user(self.artist):
+            return user_service.get_last_notifications(**kwargs)
 
-        self.assertEqual(len(notifications), 2)
-        self.assertEqual(notifications[0]["comment_text"], "")
-        self.assertEqual(notifications[1]["comment_text"], "Lets go")
+    def texts(self, **kwargs):
+        return [
+            notification["comment_text"]
+            for notification in self.bell(**kwargs)
+        ]
+
+    def test_the_bell_is_empty_until_someone_writes(self):
+        self.assertEqual(self.bell(), [])
+
+    def test_a_comment_on_a_held_task_rings_newest_first(self):
+        self.a_comment(text="Lets go")
+        self.a_comment(text="And again")
+
+        self.assertEqual(self.texts(), ["And again", "Lets go"])
+
+    def test_a_client_comment_comes_back_without_its_text(self):
+        """
+        An artist may not read what a client wrote, so the text is blanked
+        rather than the notification hidden: the bell still rings.
+        """
+        self.a_comment(text="Lets go")
+        self.a_comment(self.user_client, text="Wrong picture")
+
+        self.assertEqual(self.texts(), ["", "Lets go"])
+
+    def test_the_bell_holds_one_notification(self):
+        self.a_comment(text="Lets go")
+        self.a_comment(text="And again")
+        first = self.bell()[1]
+
+        self.assertEqual(self.texts(notification_id=first["id"]), ["Lets go"])
+
+    def test_the_bell_is_bounded_by_dates(self):
+        self.a_comment(text="Lets go")
+
+        self.assertEqual(self.texts(after="2020-01-01"), ["Lets go"])
+        self.assertEqual(self.texts(before="2020-01-01"), [])
+        self.assertEqual(self.texts(after="2100-01-01"), [])
+        self.assertEqual(self.texts(before="2100-01-01"), ["Lets go"])
+
+    def test_the_bell_holds_one_task_type(self):
+        self.a_comment(text="Lets go")
+        task_type_id = str(self.task.task_type_id)
+
+        self.assertEqual(self.texts(task_type_id=task_type_id), ["Lets go"])
+        self.assertEqual(self.texts(task_type_id=UNKNOWN), [])
+
+    def test_the_bell_holds_one_task_status(self):
+        self.a_comment(text="Lets go")
+        status_id = str(self.task_status_to_review.id)
+
+        self.assertEqual(self.texts(task_status_id=status_id), ["Lets go"])
+        self.assertEqual(self.texts(task_status_id=UNKNOWN), [])
+
+    def test_the_bell_holds_one_kind(self):
+        self.a_comment(text="Lets go")
+
+        self.assertEqual(self.texts(notification_type="comment"), ["Lets go"])
+        self.assertEqual(self.texts(notification_type="mention"), [])
+
+    def test_the_bell_holds_what_has_been_read(self):
+        self.a_comment(text="Lets go")
+        notification = self.bell()[0]
+
+        self.assertEqual(self.texts(read=False), ["Lets go"])
+        self.assertEqual(self.texts(read=True), [])
+
+        with self.as_user(self.artist):
+            user_service.update_notification(notification["id"], True)
+
+        self.assertEqual(self.texts(read=False), [])
+        self.assertEqual(self.texts(read=True), ["Lets go"])
+
+    def test_the_bell_holds_what_is_being_watched(self):
+        self.a_comment(text="Lets go")
+
+        self.assertEqual(self.texts(watching=True), [])
+        self.assertEqual(self.texts(watching=False), ["Lets go"])
+
+        with self.as_user(self.artist):
+            user_service.subscribe_to_task(self.task_id)
+
+        self.assertEqual(self.texts(watching=True), ["Lets go"])
+        self.assertEqual(self.texts(watching=False), [])
+
+    def test_a_malformed_id_is_answered_as_a_wrong_parameter(self):
+        """
+        These reach the query as raw values, so the driver used to reject
+        them and the route answered 500 where the caller made the mistake.
+        """
+        for field in ["notification_id", "task_type_id", "task_status_id"]:
+            with self.subTest(field=field):
+                with self.assertRaises(WrongParameterException):
+                    self.bell(**{field: "notanid"})
+
+    def test_a_date_the_driver_refuses_is_a_wrong_parameter(self):
+        """
+        The bounds are cast in SQL, so the driver is what refuses them and
+        it only speaks when the query runs. One value per case: the failed
+        statement leaves a transaction to roll back, and the rollback takes
+        the fixtures this class logs in with.
+        """
+        with self.assertRaises(WrongParameterException):
+            self.bell(after="notadate")
+
+    def test_an_empty_date_bound_is_a_wrong_parameter(self):
+        # A screen that drops its filter tends to send it empty rather
+        # than leave it out, and empty is not a date either.
+        with self.assertRaises(WrongParameterException):
+            self.bell(before="")
+
+    def test_get_notification(self):
+        self.a_comment(text="Lets go")
+        notification = self.bell()[0]
+
+        with self.as_user(self.artist):
+            again = user_service.get_notification(notification["id"])
+        self.assertEqual(again, notification)
+
+    def test_get_notification_of_someone_else(self):
+        """
+        The listing it runs is already scoped to the caller, so a
+        notification of another person reads as missing rather than leaking.
+        """
+        self.a_comment(text="Lets go")
+        notification = self.bell()[0]
+
+        with self.as_user():
+            with self.assertRaises(NotificationNotFoundException):
+                user_service.get_notification(notification["id"])
+
+    def test_update_notification_announces_both_ways(self):
+        self.a_comment(text="Lets go")
+        notification = self.bell()[0]
+
+        events = self.capture_events("notification:read")
+        with self.as_user(self.artist):
+            read = user_service.update_notification(notification["id"], True)
+        self.assertTrue(read["read"])
+        self.assertEqual(len(events), 1)
+
+        events = self.capture_events("notification:unread")
+        with self.as_user(self.artist):
+            unread = user_service.update_notification(
+                notification["id"], False
+            )
+        self.assertFalse(unread["read"])
+        self.assertEqual(len(events), 1)
+
+    def test_update_notification_of_someone_else(self):
+        self.a_comment(text="Lets go")
+        notification = self.bell()[0]
+
+        with self.as_user():
+            with self.assertRaises(NotificationNotFoundException):
+                user_service.update_notification(notification["id"], True)
+
+    def test_the_unread_count_and_marking_them_all(self):
+        self.a_comment(text="Lets go")
+        self.a_comment(text="And again")
+
+        with self.as_user(self.artist):
+            self.assertEqual(user_service.get_unread_notifications_count(), 2)
+            user_service.mark_notifications_as_read()
+            self.assertEqual(user_service.get_unread_notifications_count(), 0)
 
 
 class SearchFilterTestCase(UserContextTestCase):

--- a/tests/services/test_user_service.py
+++ b/tests/services/test_user_service.py
@@ -10,6 +10,8 @@ from zou.app import app
 from zou.app.models.entity import Entity
 from zou.app.models.person import Person
 from zou.app.models.project import Project
+from zou.app.models.search_filter import SearchFilter
+from zou.app.models.search_filter_group import SearchFilterGroup
 from zou.app.models.task import Task
 from zou.app.services import (
     comments_service,
@@ -292,12 +294,10 @@ class NotificationTestCase(UserContextTestCase):
             self.assertEqual(user_service.get_unread_notifications_count(), 0)
 
 
-class SearchFilterTestCase(UserContextTestCase):
+class SavedSearchTestCase(UserContextTestCase):
     """
-    The saved searches of the side panel. A filter belongs to one person
-    unless a manager of the production shares it with the team, and the
-    listing is memoized per person, so who may see what and when the cache
-    is dropped are the same question.
+    One production, one department and the people the saved searches are
+    read as. Holds no test of its own.
     """
 
     def setUp(self):
@@ -317,9 +317,24 @@ class SearchFilterTestCase(UserContextTestCase):
             "shot", name, '{"status": "wip"}', **kwargs
         )
 
+    def a_group(self, name="group", **kwargs):
+        kwargs.setdefault("project_id", self.project_id)
+        return user_service.create_filter_group(
+            "shot", name, "#000000", **kwargs
+        )
+
     def filters_of(self, user):
         with self.as_user(user):
             return user_service.get_filters()
+
+
+class SearchFilterTestCase(SavedSearchTestCase):
+    """
+    The saved searches of the side panel. A filter belongs to one person
+    unless a manager of the production shares it with the team, and the
+    listing is memoized per person, so who may see what and when the cache
+    is dropped are the same question.
+    """
 
     def test_get_filters_groups_by_list_type_and_production(self):
         with self.as_user():
@@ -520,6 +535,128 @@ class SearchFilterTestCase(UserContextTestCase):
             self.a_filter("shared", is_shared=True)
 
         self.assertIn("shot", self.filters_of(self.user_cg_artist))
+
+
+class SearchFilterGroupTestCase(SavedSearchTestCase):
+    """
+    A group of saved searches. update_filter refuses a filter whose
+    is_shared differs from its group's, so the two are one state: whatever
+    moves the group has to move the filters it holds, or they can never be
+    written to again.
+    """
+
+    def setUp(self):
+        super().setUp()
+        projects_service.add_team_member(
+            self.project_id, self.user_manager["id"]
+        )
+
+    def a_shared_group_holding_a_filter(self):
+        group = self.a_group(is_shared=True)
+        search_filter = self.a_filter(
+            is_shared=True, search_filter_group_id=group["id"]
+        )
+        return group, search_filter
+
+    def sharings(self, group, search_filter):
+        return (
+            SearchFilterGroup.get(group["id"]).is_shared,
+            SearchFilter.get(search_filter["id"]).is_shared,
+        )
+
+    def test_get_filter_group(self):
+        with self.as_user():
+            group = self.a_group()
+
+            self.assertEqual(user_service.get_filter_group(group["id"]), group)
+            with self.assertRaises(SearchFilterGroupNotFoundException):
+                user_service.get_filter_group(UNKNOWN)
+
+    def test_a_group_of_someone_else_is_out_of_reach(self):
+        with self.as_user():
+            group = self.a_group()
+
+        with self.as_user(self.user_cg_artist):
+            with self.assertRaises(SearchFilterGroupNotFoundException):
+                user_service.get_filter_group(group["id"])
+            with self.assertRaises(SearchFilterGroupNotFoundException):
+                user_service.update_filter_group(group["id"], {"name": "his"})
+            with self.assertRaises(SearchFilterGroupNotFoundException):
+                user_service.remove_filter_group(group["id"])
+
+    def test_an_admin_reaches_a_group_of_someone_else(self):
+        with self.as_user(self.user_cg_artist):
+            group = self.a_group()
+
+        with self.as_user():
+            self.assertEqual(
+                user_service.get_filter_group(group["id"])["id"], group["id"]
+            )
+
+    def test_update_filter_group(self):
+        with self.as_user():
+            group = self.a_group()
+
+            renamed = user_service.update_filter_group(
+                group["id"], {"name": "renamed", "color": "#FFFFFF"}
+            )
+        self.assertEqual(renamed["name"], "renamed")
+        self.assertEqual(renamed["color"], "#FFFFFF")
+
+    def test_update_filter_group_cannot_share_without_manager_access(self):
+        with self.as_user(self.user_cg_artist):
+            group = self.a_group()
+
+            shared = user_service.update_filter_group(
+                group["id"],
+                {"is_shared": True, "project_id": self.project_id},
+            )
+        self.assertFalse(shared["is_shared"])
+
+    def test_sharing_a_group_shares_the_filters_it_holds(self):
+        with self.as_user(self.user_manager):
+            group = self.a_group()
+            search_filter = self.a_filter(search_filter_group_id=group["id"])
+            self.assertEqual(
+                self.sharings(group, search_filter), (False, False)
+            )
+
+            user_service.update_filter_group(
+                group["id"],
+                {"is_shared": True, "project_id": self.project_id},
+            )
+        self.assertEqual(self.sharings(group, search_filter), (True, True))
+
+    def test_unsharing_a_group_unshares_them_too(self):
+        """
+        A client that only sends the field it changed leaves project_id out.
+        The cascade used to hang on it, so the group turned private while
+        its filters stayed shared: still visible to the whole team, and
+        refused by update_filter from then on, whatever the change.
+        """
+        with self.as_user(self.user_manager):
+            group, search_filter = self.a_shared_group_holding_a_filter()
+            self.assertEqual(self.sharings(group, search_filter), (True, True))
+
+            user_service.update_filter_group(group["id"], {"is_shared": False})
+
+            self.assertEqual(
+                self.sharings(group, search_filter), (False, False)
+            )
+            renamed = user_service.update_filter(
+                search_filter["id"], {"name": "renamed"}
+            )
+        self.assertEqual(renamed["name"], "renamed")
+
+    def test_remove_filter_group_takes_its_filters_with_it(self):
+        with self.as_user(self.user_manager):
+            group, search_filter = self.a_shared_group_holding_a_filter()
+
+            user_service.remove_filter_group(group["id"])
+
+            with self.assertRaises(SearchFilterGroupNotFoundException):
+                user_service.get_filter_group(group["id"])
+        self.assertIsNone(SearchFilter.get(search_filter["id"]))
 
 
 class UserVisibleEntitiesTestCase(UserContextTestCase):

--- a/zou/app/blueprints/assets/resources.py
+++ b/zou/app/blueprints/assets/resources.py
@@ -214,10 +214,7 @@ class AllAssetsResource(MethodView):
         """
         criterions = query.get_query_criterions_from_request(request)
         check_criterion_access(criterions)
-        if permissions.has_vendor_permissions():
-            criterions["assigned_to"] = persons_service.get_current_user()[
-                "id"
-            ]
+        permissions_service.scope_criterions_to_vendor(criterions)
         return assets_service.get_assets(
             criterions,
             only_user_projects=not permissions.has_admin_permissions(),
@@ -616,10 +613,7 @@ class ProjectAssetsResource(MethodView):
         permissions_service.check_project_access(project_id)
         criterions = query.get_query_criterions_from_request(request)
         criterions["project_id"] = project_id
-        if permissions.has_vendor_permissions():
-            criterions["assigned_to"] = persons_service.get_current_user()[
-                "id"
-            ]
+        permissions_service.scope_criterions_to_vendor(criterions)
         return assets_service.get_assets(criterions)
 
 
@@ -700,10 +694,7 @@ class ProjectAssetTypeAssetsResource(MethodView):
         criterions = query.get_query_criterions_from_request(request)
         criterions["project_id"] = project_id
         criterions["entity_type_id"] = asset_type_id
-        if permissions.has_vendor_permissions():
-            criterions["assigned_to"] = persons_service.get_current_user()[
-                "id"
-            ]
+        permissions_service.scope_criterions_to_vendor(criterions)
         return assets_service.get_assets(criterions)
 
 

--- a/zou/app/blueprints/edits/resources.py
+++ b/zou/app/blueprints/edits/resources.py
@@ -196,10 +196,7 @@ class EditsResource(MethodView):
         permissions_service.check_project_access(
             criterions.get("project_id", None)
         )
-        if permissions.has_vendor_permissions():
-            criterions["assigned_to"] = persons_service.get_current_user()[
-                "id"
-            ]
+        permissions_service.scope_criterions_to_vendor(criterions)
         return edits_service.get_edits(criterions)
 
 
@@ -281,10 +278,7 @@ class AllEditsResource(MethodView):
         permissions_service.check_project_access(
             criterions.get("project_id", None)
         )
-        if permissions.has_vendor_permissions():
-            criterions["assigned_to"] = persons_service.get_current_user()[
-                "id"
-            ]
+        permissions_service.scope_criterions_to_vendor(criterions)
         return edits_service.get_edits(criterions)
 
 

--- a/zou/app/blueprints/edits/resources.py
+++ b/zou/app/blueprints/edits/resources.py
@@ -7,6 +7,7 @@ from zou.app.services import (
     projects_service,
     playlists_service,
     edits_service,
+    shots_service,
     tasks_service,
     permissions_service,
 )
@@ -490,7 +491,7 @@ class EpisodeEditTasksResource(MethodView, ArgsMixin):
                         description: Last update timestamp
                         example: "2023-01-01T12:30:00Z"
         """
-        episode = edits_service.get_episode(episode_id)
+        episode = shots_service.get_episode(episode_id)
         permissions_service.check_project_access(episode["project_id"])
         permissions_service.check_entity_access(episode["id"])
         if permissions.has_vendor_permissions():
@@ -568,12 +569,15 @@ class EpisodeEditsResource(MethodView, ArgsMixin):
                         description: Last update timestamp
                         example: "2023-01-01T12:30:00Z"
         """
-        episode = edits_service.get_episode(episode_id)
+        episode = shots_service.get_episode(episode_id)
         permissions_service.check_project_access(episode["project_id"])
         permissions_service.check_entity_access(episode["id"])
         relations = self.get_relations()
-        return edits_service.get_edits_for_episode(
-            episode_id, relations=relations
+        return permissions_service.mask_metadata_for_vendor(
+            "Edit",
+            edits_service.get_edits_for_episode(
+                episode_id, relations=relations
+            ),
         )
 
 

--- a/zou/app/blueprints/edits/resources.py
+++ b/zou/app/blueprints/edits/resources.py
@@ -811,8 +811,12 @@ class ProjectEditsResource(MethodView, ArgsMixin):
         """
         projects_service.get_project(project_id)
         permissions_service.check_project_access(project_id)
-        return edits_service.get_edits_for_project(
-            project_id, only_assigned=permissions.has_vendor_permissions()
+        return permissions_service.mask_metadata_for_vendor(
+            "Edit",
+            edits_service.get_edits_for_project(
+                project_id, only_assigned=permissions.has_vendor_permissions()
+            ),
+            project_id,
         )
 
     @jwt_required()

--- a/zou/app/blueprints/search/resources.py
+++ b/zou/app/blueprints/search/resources.py
@@ -4,11 +4,29 @@ from flask_jwt_extended import jwt_required
 
 from zou.app.mixin import ArgsMixin
 from zou.app.utils import permissions, validation
-from zou.app.services import index_service, projects_service, user_service
+from zou.app.services import (
+    index_service,
+    permissions_service,
+    projects_service,
+    user_service,
+)
 from zou.app.blueprints.search.schemas import SearchSchema
 
 
 class SearchResource(MethodView, ArgsMixin):
+    def scope_to_vendor(self, entity_type, entities):
+        """
+        Narrow a search answer to what a vendor may read: the entities they
+        hold a task on, without the metadata reserved to other departments.
+
+        The listings apply both rules already. The index knows neither, so
+        it answers the whole production to whoever can reach the project.
+        """
+        return permissions_service.mask_metadata_for_vendor(
+            entity_type,
+            permissions_service.keep_entities_a_vendor_reaches(entities),
+        )
+
     @jwt_required()
     def post(self):
         """
@@ -127,8 +145,11 @@ class SearchResource(MethodView, ArgsMixin):
             ):
                 results["assets"] = []
             else:
-                results["assets"] = index_service.search_assets(
-                    query, project_ids, limit=limit, offset=offset
+                results["assets"] = self.scope_to_vendor(
+                    "Asset",
+                    index_service.search_assets(
+                        query, project_ids, limit=limit, offset=offset
+                    ),
                 )
         if "shots" in index_names:
             if (
@@ -137,8 +158,11 @@ class SearchResource(MethodView, ArgsMixin):
             ):
                 results["shots"] = []
             else:
-                results["shots"] = index_service.search_shots(
-                    query, project_ids, limit=limit, offset=offset
+                results["shots"] = self.scope_to_vendor(
+                    "Shot",
+                    index_service.search_shots(
+                        query, project_ids, limit=limit, offset=offset
+                    ),
                 )
 
         return results

--- a/zou/app/blueprints/shots/resources.py
+++ b/zou/app/blueprints/shots/resources.py
@@ -838,8 +838,11 @@ class EpisodeShotsResource(MethodView, ArgsMixin):
         permissions_service.check_project_access(episode["project_id"])
         permissions_service.check_entity_access(episode["id"])
         relations = self.get_relations()
-        return shots_service.get_shots_for_episode(
-            episode_id, relations=relations
+        return permissions_service.mask_metadata_for_vendor(
+            "Shot",
+            shots_service.get_shots_for_episode(
+                episode_id, relations=relations
+            ),
         )
 
 
@@ -1231,7 +1234,11 @@ class SequenceAndTasksResource(MethodView):
             criterions["assigned_to"] = persons_service.get_current_user()[
                 "id"
             ]
-        return entities_service.get_entities_and_tasks(criterions)
+        return permissions_service.mask_metadata_for_vendor(
+            "Sequence",
+            entities_service.get_entities_and_tasks(criterions),
+            criterions.get("project_id"),
+        )
 
 
 class EpisodeAndTasksResource(MethodView):
@@ -1303,7 +1310,11 @@ class EpisodeAndTasksResource(MethodView):
             criterions["assigned_to"] = persons_service.get_current_user()[
                 "id"
             ]
-        return entities_service.get_entities_and_tasks(criterions)
+        return permissions_service.mask_metadata_for_vendor(
+            "Episode",
+            entities_service.get_entities_and_tasks(criterions),
+            criterions.get("project_id"),
+        )
 
 
 class ProjectShotsResource(MethodView, ArgsMixin):
@@ -1351,8 +1362,12 @@ class ProjectShotsResource(MethodView, ArgsMixin):
         """
         projects_service.get_project(project_id)
         permissions_service.check_project_access(project_id)
-        return shots_service.get_shots_for_project(
-            project_id, only_assigned=permissions.has_vendor_permissions()
+        return permissions_service.mask_metadata_for_vendor(
+            "Shot",
+            shots_service.get_shots_for_project(
+                project_id, only_assigned=permissions.has_vendor_permissions()
+            ),
+            project_id,
         )
 
     @jwt_required()
@@ -1488,8 +1503,12 @@ class ProjectSequencesResource(MethodView, ArgsMixin):
         """
         projects_service.get_project(project_id)
         permissions_service.check_project_access(project_id)
-        return shots_service.get_sequences_for_project(
-            project_id, only_assigned=permissions.has_vendor_permissions()
+        return permissions_service.mask_metadata_for_vendor(
+            "Sequence",
+            shots_service.get_sequences_for_project(
+                project_id, only_assigned=permissions.has_vendor_permissions()
+            ),
+            project_id,
         )
 
     @jwt_required()
@@ -1614,8 +1633,12 @@ class ProjectEpisodesResource(MethodView, ArgsMixin):
         """
         projects_service.get_project(project_id)
         permissions_service.check_project_access(project_id)
-        return shots_service.get_episodes_for_project(
-            project_id, only_assigned=permissions.has_vendor_permissions()
+        return permissions_service.mask_metadata_for_vendor(
+            "Episode",
+            shots_service.get_episodes_for_project(
+                project_id, only_assigned=permissions.has_vendor_permissions()
+            ),
+            project_id,
         )
 
     @jwt_required()
@@ -2038,9 +2061,12 @@ class EpisodesResource(MethodView):
         if permissions.has_vendor_permissions():
             project_id = criterions.get("project_id", None)
             if project_id is not None:
-                return shots_service.get_episodes_for_project(
+                return permissions_service.mask_metadata_for_vendor(
+                    "Episode",
+                    shots_service.get_episodes_for_project(
+                        project_id, only_assigned=True
+                    ),
                     project_id,
-                    only_assigned=True,
                 )
             return []
         return shots_service.get_episodes(criterions)
@@ -2102,8 +2128,11 @@ class EpisodeSequencesResource(MethodView):
         criterions = query.get_query_criterions_from_request(request)
         criterions["parent_id"] = episode_id
         if permissions.has_vendor_permissions():
-            return shots_service.get_sequences_for_episode(
-                episode_id, only_assigned=True
+            return permissions_service.mask_metadata_for_vendor(
+                "Sequence",
+                shots_service.get_sequences_for_episode(
+                    episode_id, only_assigned=True
+                ),
             )
         else:
             return shots_service.get_sequences(criterions)
@@ -2343,9 +2372,12 @@ class SequencesResource(MethodView):
         if permissions.has_vendor_permissions():
             project_id = criterions.get("project_id", None)
             if project_id is not None:
-                return shots_service.get_sequences_for_project(
+                return permissions_service.mask_metadata_for_vendor(
+                    "Sequence",
+                    shots_service.get_sequences_for_project(
+                        project_id, only_assigned=True
+                    ),
                     project_id,
-                    only_assigned=True,
                 )
             return []
         return shots_service.get_sequences(criterions)
@@ -2453,8 +2485,12 @@ class ProjectScenesResource(MethodView, ArgsMixin):
         projects_service.get_project(project_id)
         permissions_service.check_project_access(project_id)
         only_assigned = permissions.has_vendor_permissions()
-        return shots_service.get_scenes_for_project(
-            project_id, only_assigned=only_assigned
+        return permissions_service.mask_metadata_for_vendor(
+            "Scene",
+            shots_service.get_scenes_for_project(
+                project_id, only_assigned=only_assigned
+            ),
+            project_id,
         )
 
     @jwt_required()
@@ -2573,7 +2609,9 @@ class SequenceScenesResource(MethodView):
         sequence = shots_service.get_sequence(sequence_id)
         permissions_service.check_project_access(sequence["project_id"])
         permissions_service.check_entity_access(sequence_id)
-        return shots_service.get_scenes_for_sequence(sequence_id)
+        return permissions_service.mask_metadata_for_vendor(
+            "Scene", shots_service.get_scenes_for_sequence(sequence_id)
+        )
 
 
 class SceneTaskTypesResource(MethodView):

--- a/zou/app/blueprints/shots/resources.py
+++ b/zou/app/blueprints/shots/resources.py
@@ -348,10 +348,7 @@ class ShotsResource(MethodView):
         permissions_service.check_project_access(
             criterions.get("project_id", None)
         )
-        if permissions.has_vendor_permissions():
-            criterions["assigned_to"] = persons_service.get_current_user()[
-                "id"
-            ]
+        permissions_service.scope_criterions_to_vendor(criterions)
         return shots_service.get_shots(criterions)
 
 
@@ -419,10 +416,7 @@ class AllShotsResource(MethodView):
         permissions_service.check_project_access(
             criterions.get("project_id", None)
         )
-        if permissions.has_vendor_permissions():
-            criterions["assigned_to"] = persons_service.get_current_user()[
-                "id"
-            ]
+        permissions_service.scope_criterions_to_vendor(criterions)
         return shots_service.get_shots(criterions)
 
 
@@ -2410,10 +2404,7 @@ class SequenceShotsResource(MethodView):
         permissions_service.check_project_access(sequence["project_id"])
         criterions = query.get_query_criterions_from_request(request)
         criterions["parent_id"] = sequence_id
-        if permissions.has_vendor_permissions():
-            criterions["assigned_to"] = persons_service.get_current_user()[
-                "id"
-            ]
+        permissions_service.scope_criterions_to_vendor(criterions)
         return shots_service.get_shots(criterions)
 
 

--- a/zou/app/services/assets_service.py
+++ b/zou/app/services/assets_service.py
@@ -159,7 +159,9 @@ def get_assets(criterions=None, only_user_projects=False):
         ]
     else:
         result = query.all()
-    return Entity.serialize_list(result, obj_type="Asset")
+    return entities_service.remove_not_allowed_metadata_for_vendor(
+        "Asset", criterions, Entity.serialize_list(result, obj_type="Asset")
+    )
 
 
 def get_all_raw_assets():

--- a/zou/app/services/assets_service.py
+++ b/zou/app/services/assets_service.py
@@ -160,7 +160,9 @@ def get_assets(criterions=None, only_user_projects=False):
     else:
         result = query.all()
     return entities_service.remove_not_allowed_metadata_for_vendor(
-        "Asset", criterions, Entity.serialize_list(result, obj_type="Asset")
+        "Asset",
+        criterions.get("vendor_departments"),
+        Entity.serialize_list(result, obj_type="Asset"),
     )
 
 

--- a/zou/app/services/edits_service.py
+++ b/zou/app/services/edits_service.py
@@ -133,7 +133,7 @@ def get_edits(criterions=None):
         edits.append(edit)
 
     return entities_service.remove_not_allowed_metadata_for_vendor(
-        "Edit", criterions, edits
+        "Edit", criterions.get("vendor_departments"), edits
     )
 
 

--- a/zou/app/services/edits_service.py
+++ b/zou/app/services/edits_service.py
@@ -132,7 +132,9 @@ def get_edits(criterions=None):
         edit["project_name"] = project_name
         edits.append(edit)
 
-    return edits
+    return entities_service.remove_not_allowed_metadata_for_vendor(
+        "Edit", criterions, edits
+    )
 
 
 def get_edits_and_tasks(criterions=None):

--- a/zou/app/services/emails_service.py
+++ b/zou/app/services/emails_service.py
@@ -273,7 +273,11 @@ def get_task_descriptors(person_id, task):
     elif task_type["for_entity"] == "Edit":
         entity_type = "edits"
     if project["production_type"] == "tvshow":
-        episode_segment = f"/episodes/{episode_id}"
+        # An asset of a tv show hangs off no episode of its own. Kitsu reads
+        # "main" as the pseudo episode holding them, which the playlist url
+        # below already builds: without it every mail about such a task
+        # linked to /episodes/None/.
+        episode_segment = f"/episodes/{episode_id or 'main'}"
 
     task_name = f"{project['name']} / {entity_name} / {task_type['name']}"
     task_url = (

--- a/zou/app/services/entities_service.py
+++ b/zou/app/services/entities_service.py
@@ -588,26 +588,30 @@ def remove_not_allowed_fields_from_metadata(
     }
 
 
-def remove_not_allowed_metadata_for_vendor(entity_type, criterions, entities):
+def remove_not_allowed_metadata_for_vendor(
+    entity_type, departments, entities, project_id=None
+):
     """
-    Strip from a serialized listing the metadata a vendor must not see, in
-    place. Anyone else is left untouched.
+    Strip from a serialized listing the metadata a vendor of given departments
+    must not see, in place. No departments means nothing to narrow down.
 
-    The twin listing that carries the tasks picks its columns one by one and
-    masks them while it builds its rows. This one hands back whole serialized
+    The listings that carry the tasks pick their columns one by one and mask
+    them while they build their rows. These hand back whole serialized
     entities, so the restricted descriptors come along unless they are taken
-    out here.
+    out here. Some of those listings drop the project on the way, hence the
+    fallback the caller passes in.
     """
-    if "vendor_departments" not in criterions:
+    if departments is None:
         return entities
     not_allowed_map = get_not_allowed_descriptors_fields_for_vendor(
         entity_type,
-        criterions["vendor_departments"],
-        set(entity["project_id"] for entity in entities),
+        departments,
+        set(entity.get("project_id") or project_id for entity in entities),
     )
     for entity in entities:
         entity["data"] = remove_not_allowed_fields_from_metadata(
-            not_allowed_map[entity["project_id"]], entity["data"]
+            not_allowed_map[entity.get("project_id") or project_id],
+            entity["data"],
         )
     return entities
 

--- a/zou/app/services/entities_service.py
+++ b/zou/app/services/entities_service.py
@@ -588,6 +588,30 @@ def remove_not_allowed_fields_from_metadata(
     }
 
 
+def remove_not_allowed_metadata_for_vendor(entity_type, criterions, entities):
+    """
+    Strip from a serialized listing the metadata a vendor must not see, in
+    place. Anyone else is left untouched.
+
+    The twin listing that carries the tasks picks its columns one by one and
+    masks them while it builds its rows. This one hands back whole serialized
+    entities, so the restricted descriptors come along unless they are taken
+    out here.
+    """
+    if "vendor_departments" not in criterions:
+        return entities
+    not_allowed_map = get_not_allowed_descriptors_fields_for_vendor(
+        entity_type,
+        criterions["vendor_departments"],
+        set(entity["project_id"] for entity in entities),
+    )
+    for entity in entities:
+        entity["data"] = remove_not_allowed_fields_from_metadata(
+            not_allowed_map[entity["project_id"]], entity["data"]
+        )
+    return entities
+
+
 def get_linked_entities_with_tasks(entity_id):
     """
     Return all entities and their tasks linked to given entity.

--- a/zou/app/services/permissions_service.py
+++ b/zou/app/services/permissions_service.py
@@ -221,6 +221,28 @@ def check_entity_access(entity_id):
     return is_allowed
 
 
+def keep_entities_a_vendor_reaches(entities):
+    """
+    Drop from a listing the entities a vendor holds no task on. Anyone else
+    keeps all of them.
+
+    This is check_entity_access applied to a whole answer at once, for the
+    paths that do not walk their rows one by one. A page can come back
+    shorter than it was asked for, which beats handing over a production a
+    vendor was never meant to read.
+    """
+    if not entities or not permissions.has_vendor_permissions():
+        return entities
+    assigned = {
+        str(entity_id)
+        for (entity_id,) in Task.query.with_entities(Task.entity_id)
+        .filter(Task.entity_id.in_([entity["id"] for entity in entities]))
+        .filter(user_service.build_assignee_filter())
+        .all()
+    }
+    return [entity for entity in entities if entity["id"] in assigned]
+
+
 def check_task_status_access(task_status_id):
     """
     Return true if current user can use this task status.

--- a/zou/app/services/permissions_service.py
+++ b/zou/app/services/permissions_service.py
@@ -172,11 +172,35 @@ def scope_criterions_to_vendor(criterions):
     """
     if permissions.has_vendor_permissions():
         criterions["assigned_to"] = persons_service.get_current_user()["id"]
-        criterions["vendor_departments"] = [
-            str(department.id)
-            for department in persons_service.get_current_user_raw().departments
-        ]
+        criterions["vendor_departments"] = get_vendor_departments()
     return criterions
+
+
+def get_vendor_departments():
+    """
+    Return the departments the current user belongs to, or None when they are
+    not a vendor and nothing has to be narrowed down.
+    """
+    if not permissions.has_vendor_permissions():
+        return None
+    return [
+        str(department.id)
+        for department in persons_service.get_current_user_raw().departments
+    ]
+
+
+def mask_metadata_for_vendor(entity_type, entities, project_id=None):
+    """
+    Hide from a listing the metadata a vendor may not see, in place. Anyone
+    else is left untouched.
+
+    The listings built from criterions carry the departments along in them.
+    These take no criterions, so the scope is read here, in the layer that
+    still knows who is asking.
+    """
+    return entities_service.remove_not_allowed_metadata_for_vendor(
+        entity_type, get_vendor_departments(), entities, project_id
+    )
 
 
 def check_entity_access(entity_id):

--- a/zou/app/services/shots_service.py
+++ b/zou/app/services/shots_service.py
@@ -190,7 +190,9 @@ def get_shots(criterions=None):
         shot["sequence_name"] = sequence_name
         shots.append(shot)
 
-    return shots
+    return entities_service.remove_not_allowed_metadata_for_vendor(
+        "Shot", criterions, shots
+    )
 
 
 def get_scenes(criterions=None):

--- a/zou/app/services/shots_service.py
+++ b/zou/app/services/shots_service.py
@@ -191,7 +191,7 @@ def get_shots(criterions=None):
         shots.append(shot)
 
     return entities_service.remove_not_allowed_metadata_for_vendor(
-        "Shot", criterions, shots
+        "Shot", criterions.get("vendor_departments"), shots
     )
 
 

--- a/zou/app/services/tasks_service.py
+++ b/zou/app/services/tasks_service.py
@@ -368,6 +368,21 @@ def get_shot_tasks_for_episode(episode_id, relations=False):
     return _convert_rows_to_detailed_tasks(query.all(), relations)
 
 
+def get_edit_tasks_for_episode(episode_id, relations=False):
+    """
+    Get all edit tasks for given episode.
+    """
+    query = (
+        _get_entity_task_query(relations=relations)
+        # An edit hangs straight off its episode, where a shot goes through
+        # a sequence, so the entity type is what tells them apart here.
+        .filter(
+            Entity.entity_type_id == edits_service.get_edit_type()["id"]
+        ).filter(Entity.parent_id == episode_id)
+    )
+    return _convert_rows_to_detailed_tasks(query.all(), relations)
+
+
 def get_asset_tasks_for_episode(episode_id, relations=False):
     """
     Get all assets tasks for given episode.

--- a/zou/app/services/user_service.py
+++ b/zou/app/services/user_service.py
@@ -1,5 +1,6 @@
 from sqlalchemy.orm import aliased
 from sqlalchemy import func, or_, and_
+from sqlalchemy.exc import DataError
 
 from zou.app.models.comment import Comment
 from zou.app.models.entity import Entity
@@ -903,6 +904,19 @@ def get_last_notifications(
     """
     Return last 100 user notifications.
     """
+    # These reach the query as raw values, so the driver is the one that
+    # rejects them: a malformed id raises a StatementError while binding,
+    # a malformed date a DataError on execution. Both surfaced as a 500.
+    for id_field, value in (
+        ("notification_id", notification_id),
+        ("task_type_id", task_type_id),
+        ("task_status_id", task_status_id),
+    ):
+        if value is not None and not fields.is_valid_id(value):
+            raise WrongParameterException(
+                f"Invalid UUID format for {id_field}: {value}"
+            )
+
     current_user = persons_service.get_current_user()
     Author = aliased(Person, name="author")
     is_current_user_artist = current_user["role"] == "user"
@@ -968,7 +982,12 @@ def get_last_notifications(
         else:
             query = query.filter(Subscription.id == None)
 
-    notifications = query.limit(100).all()
+    try:
+        # The query is lazy: a date the driver refuses raises here, not
+        # while the filters are being stacked above.
+        notifications = query.limit(100).all()
+    except DataError:
+        raise WrongParameterException("Wrong date format for after or before.")
 
     for (
         notification,

--- a/zou/app/services/user_service.py
+++ b/zou/app/services/user_service.py
@@ -790,15 +790,17 @@ def update_filter_group(search_filter_group_id, data):
 
     search_filter_group.update(data)
 
-    if (
-        data.get("is_shared", None) is not None
-        and data.get("project_id", None) is not None
-        and permissions_service.has_manager_project_access(data["project_id"])
-    ):
+    if data.get("is_shared", None) is not None:
+        # The group carries the authorized value by now, since
+        # _deny_sharing_without_manager_access turned down what the caller
+        # could not ask for. The filters have to follow it rather than the
+        # body: update_filter refuses any change to a filter whose is_shared
+        # differs from its group, so a group left out of step with them
+        # makes them unmodifiable for good.
         if (
             SearchFilter.query.filter_by(
                 search_filter_group_id=search_filter_group_id
-            ).update({"is_shared": data["is_shared"]})
+            ).update({"is_shared": search_filter_group.is_shared})
             > 0
         ):
             SearchFilter.query.session.commit()

--- a/zou/app/utils/email_i18n.py
+++ b/zou/app/utils/email_i18n.py
@@ -844,6 +844,14 @@ def _normalize_locale(locale):
 #  in a subject line instead of letting markup into a body.
 PLAIN_TEXT_KEY_SUFFIXES = ("_subject", "_title")
 
+#  Keys whose result its caller hands to another template, or to a chat
+#  channel, rather than to a mail body. Escaping here would reach the
+#  recipient twice over, or push &amp; into Slack: whoever interpolates the
+#  fragment is the one that escapes it. Named one by one on purpose, since
+#  share_invitation_message_segment is concatenated straight into the html
+#  and has to keep being escaped right here.
+PRE_RENDERED_KEYS = ("playlist_episode_segment",)
+
 
 def _escape_params(key, params):
     """
@@ -853,7 +861,7 @@ def _escape_params(key, params):
     anything, so they used to reach the recipient as markup in a mail the
     studio genuinely sends, SPF and DKIM included.
     """
-    if key.endswith(PLAIN_TEXT_KEY_SUFFIXES):
+    if key.endswith(PLAIN_TEXT_KEY_SUFFIXES) or key in PRE_RENDERED_KEYS:
         return params
     return {
         name: html.escape(value) if isinstance(value, str) else value


### PR DESCRIPTION
**Problem**

- Fifteen listings handed a vendor the metadata descriptors restricted to departments they do not belong to, while their `/with-tasks` twin masked them. Episodes and sequences leaked on both paths at once.
- Searching an index returned every asset and shot of the productions a vendor belongs to, assigned to them or not, metadata included: the index knows neither of the two rules the listings apply.
- `/data/episodes/<id>/edits` and `/data/episodes/<id>/edit-tasks` raised an AttributeError on every call, reaching for a service function that was never written.
- Five notification filters answered 500 on an id or a date the driver refuses.
- Unsharing a filter group left its filters shared, which made them unmodifiable for good.
- The playlist mail escaped an episode name twice, and every mail about a tv show asset task linked to `/episodes/None/`.

**Solution**

- One masking helper for every listing, fed either by the criterions it already carries or by the vendor scope read in the resource. The eight routes that built that scope by hand go through `scope_criterions_to_vendor` now.
- Search results pass the vendor assignment filter and the same masking. A page can come back shorter than the limit asked for, since rows are dropped after the index answered.
- `get_episode` comes from `shots_service`; `get_edit_tasks_for_episode` exists and tells edit tasks from shot tasks by entity type. Both routes leave the known broken list.
- Malformed notification filters answer 400 naming the field, a group being unshared drags its filters along, the mail templates escape once, and a tv show asset task links to the main pseudo episode.
- `edits_service` reaches 100% coverage and `index_service` 85%; a contract test walks every listing at once rather than one route at a time. The 83 fixture generators of `tests/base.py` are grouped by theme, bodies untouched.
