### PR TITLE
[schedule] Drop the issue references from the busy periods comments

### DIFF
--- a/tests/blueprints/tasks/test_task_dates_and_previews.py
+++ b/tests/blueprints/tasks/test_task_dates_and_previews.py
@@ -79,7 +79,7 @@ class TaskDatesAndPreviewsTestCase(ApiDBTestCase):
     def test_get_persons_task_dates_manager_scoped_to_own_projects(self):
         # A manager who belongs to no project gets no task dates: other
         # productions only show as anonymous busy periods, without any
-        # production or task detail (kitsu#1579).
+        # production or task detail.
         self.generate_fixture_user_manager()
         self.log_in_manager()
         result = self.get("/data/persons/task-dates")
@@ -119,7 +119,7 @@ class TaskDatesAndPreviewsTestCase(ApiDBTestCase):
         )
 
     def test_get_persons_task_dates_as_supervisor(self):
-        # A supervisor reaches the team schedule too (kitsu#1579), scoped
+        # A supervisor reaches the team schedule too, scoped
         # to their own projects like a manager.
         self.generate_fixture_user_supervisor()
         projects_service.add_team_member(
@@ -158,7 +158,7 @@ class TaskDatesAndPreviewsTestCase(ApiDBTestCase):
     def test_get_persons_task_dates_foreign_work_is_anonymous(self):
         # A person whose tasks live solely in a project the manager is not a
         # member of appears with anonymous busy periods only: merged date
-        # pairs, no task dates, no production or task detail (kitsu#1579).
+        # pairs, no task dates, no production or task detail.
         person_id = str(self.person.id)
         self.generate_fixture_user_manager()
         projects_service.add_team_member(
@@ -274,7 +274,7 @@ class TaskDatesAndPreviewsTestCase(ApiDBTestCase):
         self.assertIn(str(closed_person.id), person_ids)
 
     def test_get_persons_task_dates_supervisor_scoped_to_own_projects(self):
-        # The gate is supervisor-or-above (kitsu#1579): a supervisor who
+        # The gate is supervisor-or-above: a supervisor who
         # belongs to no project gets anonymous busy periods only, not a 403.
         self.generate_fixture_user_supervisor()
         self.log_in_supervisor()

--- a/zou/app/blueprints/tasks/resources.py
+++ b/zou/app/blueprints/tasks/resources.py
@@ -2886,8 +2886,8 @@ class PersonsTasksDatesResource(MethodView, ArgsMixin):
         project_ids = None
         busy_project_ids = None
         if not permissions.has_admin_permissions():
-            # Supervisors reach the team schedule page too (kitsu#1579):
-            # like managers, they only see the projects of their own teams.
+            # Supervisors reach the team schedule page too: like managers,
+            # they only see the projects of their own teams.
             permissions.check_at_least_supervisor_permissions()
             if project_id is not None:
                 if not permissions_service.check_belong_to_project(project_id):

--- a/zou/app/services/tasks_service.py
+++ b/zou/app/services/tasks_service.py
@@ -2186,8 +2186,8 @@ def get_persons_tasks_dates(
     - busy_project_ids lists the projects the caller must not see in detail:
       tasks found there come back as anonymous busy_periods, merged date
       pairs carrying no production or task information, so a schedule can
-      show that a person is taken without leaking what they work on
-      (kitsu#1579). A person with only such tasks is listed with null
+      show that a person is taken without leaking what they work on. A
+      person with only such tasks is listed with null
       min_date / max_date.
     """
     if project_id is not None:


### PR DESCRIPTION
**Problem**

- The rebase over the merged busy periods PR resurrected comments naming kitsu#1579; comments carry the why, not tracker links.

**Solution**

- Drop the issue references from the busy periods comments in the resource, service, and tests.