### PR TITLE
Fix shot listing 500s, playlist concat drift and preview update 403

### DIFF
--- a/tests/blueprints/crud/test_preview_file.py
+++ b/tests/blueprints/crud/test_preview_file.py
@@ -41,7 +41,9 @@ class PreviewFileTestCase(ApiDBTestCase):
             name="PROJ1_TASK1_PF1"
         )
         self.task1_2 = self.generate_fixture_task(name="PROJ1_TASK2")
-        self.generate_fixture_preview_file(name="PROJ1_TASK2_PF1")
+        self.preview_file1_2 = self.generate_fixture_preview_file(
+            name="PROJ1_TASK2_PF1"
+        )
 
         self.project2 = self.generate_fixture_project("test")
         self.task2_1 = self.generate_fixture_task(name="PROJ2_TASK1")
@@ -179,6 +181,33 @@ class PreviewFileTestCase(ApiDBTestCase):
         )
         self.assertEqual(data["name"], preview_file_again["name"])
         self.put_404(f"data/preview-files/{fields.gen_uuid()}", data)
+
+    def test_update_preview_file_for_artist(self):
+        """
+        Test route PUT data/preview-files/<preview_file_id> for artist.
+        The artist can update the previews of the tasks he is assigned
+        to, and nothing else.
+        """
+        route1_1 = f"data/preview-files/{self.preview_file1_1.id!s}"
+        route1_2 = f"data/preview-files/{self.preview_file1_2.id!s}"
+
+        self.log_in_cg_artist()
+        self.put(route1_1, {"name": "PROJ1_TASK1_PF1_EDIT"})
+        preview_file = self.get(route1_1)
+        self.assertEqual(preview_file["name"], "PROJ1_TASK1_PF1_EDIT")
+        self.put(route1_2, {"name": "PROJ1_TASK2_PF1_EDIT"}, code=403)
+
+    def test_update_preview_file_for_vendor(self):
+        """
+        Test route PUT data/preview-files/<preview_file_id> for vendor.
+        Same rule as the artist: only the previews of assigned tasks.
+        """
+        route2_1 = f"data/preview-files/{self.preview_file2_1.id!s}"
+        route2_2 = f"data/preview-files/{self.preview_file2_2.id!s}"
+
+        self.log_in_vendor()
+        self.put(route2_2, {"name": "PROJ2_TASK2_PF1_EDIT"}, code=200)
+        self.put(route2_1, {"name": "PROJ2_TASK1_PF1_EDIT"}, code=403)
 
     def test_delete_preview_file(self):
         preview_files = self.get("data/preview-files")

--- a/tests/services/test_playlists_service.py
+++ b/tests/services/test_playlists_service.py
@@ -12,6 +12,8 @@ from zou.app.services import (
     projects_service,
 )
 from zou.app.services.exception import PlaylistLockTimeoutException
+from zou.utils import movie
+from zou.utils.movie import EncodingParameters
 
 
 class PlaylistsServiceTestCase(ApiDBTestCase):
@@ -360,6 +362,59 @@ class PlaylistsServiceTestCase(ApiDBTestCase):
         job = playlists_service.end_build_job(playlist, job, False)
         self.assertEqual(job["status"], "failed")
         self.assertIsNotNone(job["ended_at"])
+
+    def test_end_build_job_message(self):
+        """
+        The optional message explains a degraded build to whoever looks
+        at the job afterwards.
+        """
+        playlist = self.generate_fixture_playlists()
+        job = playlists_service.start_build_job(playlist)
+        job = playlists_service.end_build_job(
+            playlist, job, True, message="built by the concat filter"
+        )
+        self.assertEqual(job["status"], "succeeded")
+        self.assertEqual(job["message"], "built by the concat filter")
+
+    def test_build_playlist_movie_file_reports_the_fallback(self):
+        """
+        When the concat demuxer rejects the previews and the re-encoding
+        concat filter builds the movie instead, the job says so rather
+        than reporting a plain success (cgwire/kitsu#2184).
+        """
+        playlist = self.generate_fixture_playlists()
+        job = playlists_service.start_build_job(playlist)
+        params = EncodingParameters(width=1920, height=1080, fps="25.00")
+
+        def fake_build(mode, tmp_file_paths, movie_file_path, **kwargs):
+            if mode is movie.concat_demuxer:
+                return {
+                    "success": False,
+                    "message": "a.mp4 has an unexpected video/audio "
+                    "stream number (3)",
+                }
+            open(movie_file_path, "w").close()
+            return {"success": True}
+
+        with (
+            patch.object(
+                playlists_service, "playlist_previews", return_value=[]
+            ),
+            patch.object(
+                playlists_service,
+                "retrieve_playlist_tmp_files",
+                return_value=[("/tmp/a.mp4", "a.mp4")],
+            ),
+            patch.object(movie, "build_playlist_movie", fake_build),
+            patch.object(playlists_service.file_store, "add_movie"),
+        ):
+            job = playlists_service.build_playlist_movie_file(
+                playlist, job, [], params, False, False
+            )
+
+        self.assertEqual(job["status"], "succeeded")
+        self.assertIn("concat filter", job["message"])
+        self.assertIn("stream number", job["message"])
 
     def test_an_entity_is_added_with_the_preview_it_names(self):
         self.generate_fixture_preview_files()

--- a/tests/utils/test_flask_utils.py
+++ b/tests/utils/test_flask_utils.py
@@ -1,6 +1,12 @@
+import json
 import unittest
 
-from zou.app.utils.flask_utils import ParsedUserAgent, is_from_browser
+from zou.app.utils.flask_utils import (
+    ParsedUserAgent,
+    dumps_bytes,
+    is_from_browser,
+    rows_response,
+)
 
 
 class FlaskUtilsTestCase(unittest.TestCase):
@@ -33,6 +39,17 @@ class FlaskUtilsTestCase(unittest.TestCase):
     def test_is_not_from_browser_curl(self):
         ua = ParsedUserAgent("curl/7.68.0")
         self.assertFalse(is_from_browser(ua))
+
+    def test_dumps_bytes_big_int(self):
+        payload = {"frame": 2**70}
+        self.assertEqual(json.loads(dumps_bytes(payload)), payload)
+
+    def test_rows_response_stream_big_int(self):
+        response = rows_response(
+            {"compact": False}, iter([{"frame": 2**70}]), stream=True
+        )
+        lines = list(response.response)
+        self.assertEqual(json.loads(lines[1]), {"frame": 2**70})
 
     def test_parsed_user_agent_properties(self):
         ua = ParsedUserAgent(

--- a/tests/utils/test_movie.py
+++ b/tests/utils/test_movie.py
@@ -213,6 +213,84 @@ class MovieTestCase(unittest.TestCase):
         self.assertFalse(result.get("message"))
         self.assertEqual(movie.get_movie_size(out), (320, 240))
 
+    def test_concat_demuxer_accepts_audio_first_files(self):
+        # Stream order inside a container is free: some muxers write the
+        # audio track first. The output maps streams by type and the
+        # layout check keeps the set homogeneous, so an audio-first set
+        # takes the exact demuxer path too.
+        videos = []
+        for i in range(0, 2):
+            video = str(Path(self.tmpdir) / f"{i}-audio-first.mp4")
+            video_in = ffmpeg.input(
+                "testsrc=size=320x240:rate=25:duration=1", f="lavfi"
+            )
+            audio_in = ffmpeg.input(
+                "anullsrc=r=48000:cl=stereo:d=1", f="lavfi"
+            )
+            ffmpeg.output(
+                audio_in,
+                video_in,
+                video,
+                vcodec="libx264",
+                pix_fmt="yuv420p",
+                acodec="aac",
+                shortest=None,
+            ).overwrite_output().run(quiet=True)
+            codec_types = [
+                stream["codec_type"]
+                for stream in ffmpeg.probe(video)["streams"]
+            ]
+            self.assertEqual(codec_types, ["audio", "video"])
+            videos.append((video, None))
+
+        out = str(Path(self.tmpdir) / "out-audio-first.mp4")
+        result = movie.build_playlist_movie(
+            movie.concat_demuxer, videos, out, 320, 240, fps=25
+        )
+        self.assertTrue(result.get("success"))
+        self.assertFalse(result.get("message"))
+        self.assertEqual(movie.get_movie_size(out), (320, 240))
+
+    def test_concat_demuxer_rejects_mixed_stream_layouts(self):
+        # The concat demuxer matches streams across files by index, so
+        # tolerating extra data streams is only safe when every file has
+        # the same layout. A mixed set must be rejected up front.
+        with_tmcd = str(Path(self.tmpdir) / "with-tmcd.mp4")
+        without_tmcd = str(Path(self.tmpdir) / "without-tmcd.mp4")
+        for video, timecode in (
+            (with_tmcd, "01:00:00:00"),
+            (without_tmcd, None),
+        ):
+            video_in = ffmpeg.input(
+                "testsrc=size=320x240:rate=25:duration=1", f="lavfi"
+            )
+            audio_in = ffmpeg.input(
+                "anullsrc=r=48000:cl=stereo:d=1", f="lavfi"
+            )
+            kwargs = {"timecode": timecode} if timecode else {}
+            ffmpeg.output(
+                video_in,
+                audio_in,
+                video,
+                vcodec="libx264",
+                pix_fmt="yuv420p",
+                acodec="aac",
+                shortest=None,
+                **kwargs,
+            ).overwrite_output().run(quiet=True)
+
+        out = str(Path(self.tmpdir) / "out-mixed.mp4")
+        result = movie.build_playlist_movie(
+            movie.concat_demuxer,
+            [(with_tmcd, None), (without_tmcd, None)],
+            out,
+            320,
+            240,
+            fps=25,
+        )
+        self.assertFalse(result.get("success"))
+        self.assertIn("layout", result.get("message"))
+
     def test_concat_filter_testing(self):
         test_name = "test_concate_filter"
         self.concat_testing(movie.concat_filter, test_name)

--- a/tests/utils/test_movie.py
+++ b/tests/utils/test_movie.py
@@ -174,6 +174,45 @@ class MovieTestCase(unittest.TestCase):
         test_name = "test_concate_demuxer"
         self.concat_testing(movie.concat_demuxer, test_name)
 
+    def test_concat_demuxer_ignores_timecode_stream(self):
+        # Previews exported from DaVinci Resolve carry a tmcd data stream
+        # next to video and audio. The demuxer path must ignore it instead
+        # of silently falling back to the re-encoding concat filter, which
+        # drifts (cgwire/kitsu#2184).
+        videos = []
+        for i in range(0, 2):
+            video = str(Path(self.tmpdir) / f"{i}-tmcd.mp4")
+            video_in = ffmpeg.input(
+                "testsrc=size=320x240:rate=25:duration=1", f="lavfi"
+            )
+            audio_in = ffmpeg.input(
+                "anullsrc=r=48000:cl=stereo:d=1", f="lavfi"
+            )
+            ffmpeg.output(
+                video_in,
+                audio_in,
+                video,
+                vcodec="libx264",
+                pix_fmt="yuv420p",
+                acodec="aac",
+                shortest=None,
+                timecode="01:00:00:00",
+            ).overwrite_output().run(quiet=True)
+            codec_types = [
+                stream["codec_type"]
+                for stream in ffmpeg.probe(video)["streams"]
+            ]
+            self.assertEqual(codec_types, ["video", "audio", "data"])
+            videos.append((video, None))
+
+        out = str(Path(self.tmpdir) / "out-tmcd.mp4")
+        result = movie.build_playlist_movie(
+            movie.concat_demuxer, videos, out, 320, 240, fps=25
+        )
+        self.assertTrue(result.get("success"))
+        self.assertFalse(result.get("message"))
+        self.assertEqual(movie.get_movie_size(out), (320, 240))
+
     def test_concat_filter_testing(self):
         test_name = "test_concate_filter"
         self.concat_testing(movie.concat_filter, test_name)

--- a/zou/app/blueprints/crud/preview_file.py
+++ b/zou/app/blueprints/crud/preview_file.py
@@ -329,7 +329,7 @@ class PreviewFileResource(BaseModelResource):
         task = tasks_service.get_task(preview_file["task_id"])
         permissions_service.check_project_access(task["project_id"])
         if not permissions.has_manager_permissions():
-            permissions_service.check_working_on_task(task["entity_id"])
+            permissions_service.check_working_on_task(preview_file["task_id"])
         return True
 
     def pre_update(self, instance_dict, data):

--- a/zou/app/models/build_job.py
+++ b/zou/app/models/build_job.py
@@ -23,6 +23,8 @@ class BuildJob(db.Model, BaseMixin, SerializerMixin):
     status = db.Column(ChoiceType(STATUSES), default="running", nullable=False)
     job_type = db.Column(ChoiceType(TYPES), default="movie", nullable=False)
     ended_at = db.Column(db.DateTime)
+    # Explains a degraded or failed build, e.g. a re-encoding fallback.
+    message = db.Column(db.Text())
 
     playlist_id = db.Column(
         UUIDType(binary=False),
@@ -31,11 +33,12 @@ class BuildJob(db.Model, BaseMixin, SerializerMixin):
         index=True,
     )
 
-    def end(self, status):
+    def end(self, status, message=None):
         self.update(
             {
                 "status": status,
                 "ended_at": date_helpers.get_utc_now_datetime(),
+                "message": message,
             }
         )
 
@@ -45,5 +48,6 @@ class BuildJob(db.Model, BaseMixin, SerializerMixin):
                 "id": self.id,
                 "status": self.status,
                 "created_at": self.created_at,
+                "message": self.message,
             }
         )

--- a/zou/app/openapi_schemas.py
+++ b/zou/app/openapi_schemas.py
@@ -118,6 +118,10 @@ BuildJobSchema = {
             "description": "Type of build job (archive, movie)",
         },
         "ended_at": {"type": "string", "format": "date-time"},
+        "message": {
+            "type": "string",
+            "description": "Explains a degraded or failed build",
+        },
         "playlist_id": {
             "type": "string",
             "format": "UUID",

--- a/zou/app/services/playlists_service.py
+++ b/zou/app/services/playlists_service.py
@@ -791,6 +791,7 @@ def build_playlist_movie_file(playlist, job, shots, params, full, remote):
     Build a movie for all files for a given playlist into the temporary folder.
     """
     success = False
+    message = None
     from zou.app import app
 
     with app.app_context():
@@ -802,8 +803,9 @@ def build_playlist_movie_file(playlist, job, shots, params, full, remote):
             if tmp_file_paths:
                 if not remote:
                     success = False
+                    demuxer_message = None
                     if not full:
-                        success = _run_concatenation(
+                        success, demuxer_message = _run_concatenation(
                             playlist,
                             job,
                             tmp_file_paths,
@@ -814,7 +816,7 @@ def build_playlist_movie_file(playlist, job, shots, params, full, remote):
 
                     # Try again using concat filter
                     if not success:
-                        success = _run_concatenation(
+                        success, _ = _run_concatenation(
                             playlist,
                             job,
                             tmp_file_paths,
@@ -822,6 +824,15 @@ def build_playlist_movie_file(playlist, job, shots, params, full, remote):
                             params,
                             movie.concat_filter,
                         )
+                        if success and demuxer_message is not None:
+                            message = (
+                                "The exact concat demuxer rejected the "
+                                f"previews ({demuxer_message}). The movie "
+                                "was built by the re-encoding concat "
+                                "filter instead, its timing can drift "
+                                "from the source previews."
+                            )
+                            app.logger.warning(message)
                 else:
                     try:
                         _run_remote_job_build_playlist(
@@ -838,7 +849,7 @@ def build_playlist_movie_file(playlist, job, shots, params, full, remote):
 
         # exception will be logged by rq
         finally:
-            job = end_build_job(playlist, job, success)
+            job = end_build_job(playlist, job, success, message)
 
     if not success:
         raise Exception(f"Failure while building playlist {playlist['id']!r}")
@@ -851,21 +862,24 @@ def _run_concatenation(
 ):
     """
     Concatenate the downloaded previews into the playlist movie, then
-    store it and clean the temporary files up.
+    store it and clean the temporary files up. Return whether it
+    succeeded, along with the concatenation message, if any.
     """
     success = False
+    message = None
     try:
         result = movie.build_playlist_movie(
             mode, tmp_file_paths, movie_file_path, **params._asdict()
         )
+        message = result.get("message")
         if result["success"] and os.path.exists(movie_file_path):
             file_store.add_movie("playlists", job["id"], movie_file_path)
             success = True
-        if result.get("message"):
+        if message:
             from zou.app import app
 
             with app.app_context():
-                app.logger.error(result["message"])
+                app.logger.error(message)
     except Exception:
         from zou.app import app
 
@@ -875,7 +889,7 @@ def _run_concatenation(
                 (playlist["id"], mode.__qualname__),
                 exc_info=1,
             )
-    return success
+    return success, message
 
 
 def _run_remote_job_build_playlist(
@@ -930,10 +944,11 @@ def start_build_job(playlist):
     return job.serialize()
 
 
-def end_build_job(playlist, job, success):
+def end_build_job(playlist, job, success, message=None):
     """
     Register in database that a build is finished. Emits an event to notify
-    clients that the build is done.
+    clients that the build is done. The optional message explains a
+    degraded or failed build.
     """
     if success:
         status = "succeeded"
@@ -942,13 +957,14 @@ def end_build_job(playlist, job, success):
 
     build_job = BuildJob.get(job["id"])
     if build_job is not None:
-        build_job.end(status=status)
+        build_job.end(status=status, message=message)
     events.emit(
         "build-job:update",
         {
             "build_job_id": job["id"],
             "playlist_id": playlist["id"],
             "status": status,
+            "message": message,
         },
         project_id=playlist["project_id"],
     )

--- a/zou/app/utils/flask_utils.py
+++ b/zou/app/utils/flask_utils.py
@@ -4,9 +4,25 @@ from werkzeug.utils import cached_property
 from flask.json.provider import JSONProvider
 from flask import Response, request, abort
 
+import json
 import orjson
 
 orjson_options = orjson.OPT_NON_STR_KEYS
+
+
+def dumps_bytes(obj):
+    """
+    Serialize a response payload to JSON bytes.
+
+    orjson refuses integers outside the 64-bit range, which JSONB columns
+    can legitimately hold (a metadata value written as a huge number reads
+    back from PostgreSQL as an arbitrary-precision int). Fall back to the
+    stdlib for those payloads instead of turning them into a 500.
+    """
+    try:
+        return orjson.dumps(obj, option=orjson_options)
+    except TypeError:
+        return json.dumps(obj, default=str).encode("utf-8")
 
 
 class ORJSONProvider(JSONProvider):
@@ -18,7 +34,7 @@ class ORJSONProvider(JSONProvider):
         return orjson.loads(s)
 
     def dumps(self, obj, **kwargs):
-        return orjson.dumps(obj, option=orjson_options).decode("utf-8")
+        return dumps_bytes(obj).decode("utf-8")
 
 
 class ParsedUserAgent(UserAgent):
@@ -72,9 +88,9 @@ def rows_response(header, rows, stream=False):
         return {**header, "rows": list(rows)}
 
     def generate():
-        yield orjson.dumps(header) + b"\n"
+        yield dumps_bytes(header) + b"\n"
         for row in rows:
-            yield orjson.dumps(row) + b"\n"
+            yield dumps_bytes(row) + b"\n"
 
     return Response(generate(), mimetype="application/x-ndjson")
 

--- a/zou/migrations/versions/a3f7c2d91b45_add_message_to_build_job.py
+++ b/zou/migrations/versions/a3f7c2d91b45_add_message_to_build_job.py
@@ -1,0 +1,29 @@
+"""add a message column to build job
+
+The playlist builder can fall back from the exact concat demuxer to the
+re-encoding concat filter, whose output timing can drift. The message
+column lets the build report such a degraded run instead of a plain
+success.
+
+Revision ID: a3f7c2d91b45
+Revises: b7d419c25e08
+Create Date: 2026-08-24 10:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "a3f7c2d91b45"
+down_revision = "b7d419c25e08"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("build_job", sa.Column("message", sa.Text(), nullable=True))
+
+
+def downgrade():
+    op.drop_column("build_job", "message")

--- a/zou/remote/playlist.py
+++ b/zou/remote/playlist.py
@@ -57,6 +57,12 @@ def _run_build_playlist(input_paths, output_movie_path, enc_params, full):
             )
             if result["success"] and os.path.exists(output_movie_path):
                 is_build_successful = True
+            elif result.get("message"):
+                logger.warning(
+                    "concat_demuxer rejected the previews (%s), falling "
+                    "back to the re-encoding concat_filter",
+                    result["message"],
+                )
         except Exception:
             logger.warning(
                 "concat_demuxer failed, falling back to concat_filter",

--- a/zou/utils/movie.py
+++ b/zou/utils/movie.py
@@ -488,12 +488,26 @@ def concat_demuxer(in_files, output_path, *args):
     with any container formats.
     """
 
+    first_layout = None
     for input_path in in_files:
         try:
             info = ffmpeg.probe(input_path)
         except ffmpeg._run.Error as e:
             log_ffmpeg_error(e, "concat_demuxer")
             raise (e)
+        # The concat demuxer matches streams across files by index, so
+        # every file must share the stream layout of the first one.
+        codec_types = [stream["codec_type"] for stream in info["streams"]]
+        if first_layout is None:
+            first_layout = codec_types
+        elif codec_types != first_layout:
+            return {
+                "success": False,
+                "message": (
+                    f"{input_path} has a stream layout ({codec_types}) "
+                    f"different from the first file's ({first_layout})"
+                ),
+            }
         # NLE exports often carry a timecode (tmcd) or other data stream
         # next to video and audio. The output only maps video and audio,
         # so ignore anything else instead of rejecting the file.
@@ -518,12 +532,6 @@ def concat_demuxer(in_files, output_path, *args):
                 "message": (
                     f"{input_path} has unexpected stream type ({stream_infos})"
                 ),
-            }
-
-        if streams[0]["codec_type"] != "video":
-            return {
-                "success": False,
-                "message": f"{input_path} has an unexpected stream order",
             }
 
     with tempfile.NamedTemporaryFile(mode="w") as temp:

--- a/zou/utils/movie.py
+++ b/zou/utils/movie.py
@@ -494,13 +494,20 @@ def concat_demuxer(in_files, output_path, *args):
         except ffmpeg._run.Error as e:
             log_ffmpeg_error(e, "concat_demuxer")
             raise (e)
-        streams = info["streams"]
+        # NLE exports often carry a timecode (tmcd) or other data stream
+        # next to video and audio. The output only maps video and audio,
+        # so ignore anything else instead of rejecting the file.
+        streams = [
+            stream
+            for stream in info["streams"]
+            if stream["codec_type"] in ("video", "audio")
+        ]
         if len(streams) != 2:
             return {
                 "success": False,
                 "message": (
-                    f"{input_path} has an unexpected stream number "
-                    f"({len(streams)})"
+                    f"{input_path} has an unexpected video/audio stream "
+                    f"number ({len(streams)})"
                 ),
             }
 
@@ -513,10 +520,7 @@ def concat_demuxer(in_files, output_path, *args):
                 ),
             }
 
-        video_index = [
-            x["index"] for x in streams if x["codec_type"] == "video"
-        ][0]
-        if video_index != 0:
+        if streams[0]["codec_type"] != "video":
             return {
                 "success": False,
                 "message": f"{input_path} has an unexpected stream order",


### PR DESCRIPTION
**Problem**

- A huge integer stored in an entity's JSONB metadata makes orjson raise, turning every response holding the shot into a 500 (KITSU-API-4XG)
- Playlist builds with a tmcd track fell back to the re-encoding concat filter, drifting out of sync, while reporting plain success
- Every non-manager PUT on a preview file got a 403, even from the assigned artist

**Solution**

- Fall back to stdlib json when orjson refuses a payload, in the JSON provider and the streamed NDJSON rows
- Ignore non audio/video streams in the concat demuxer validation, and record any remaining fallback on the build job via a new message column
- Require the previews to share the first file's stream layout (the demuxer pairs streams by index) and drop the video-first requirement, so audio-first exports use the exact path too
- Pass the task id to check_working_on_task in the update guard, as the read guard already does

Fix cgwire/kitsu#2184
Fix #1197