### PR TITLE
[video] Fix preview tiles not synced up with video

### DIFF
--- a/zou/utils/movie.py
+++ b/zou/utils/movie.py
@@ -180,7 +180,10 @@ def get_movie_fps(movie_path=None, video_track=None):
         video_track = get_video_track(movie_path, "get_movie_fps")
     fps = 25
     if video_track is not None:
-        fps = float(video_track["r_frame_rate"].split("/")[0])
+        numerator, denominator = [
+            float(number) for number in video_track["r_frame_rate"].split("/")
+        ]
+        fps = numerator / denominator
     return fps
 
 


### PR DESCRIPTION
**Problem**

- When uploading a video with a decimal framerate, the preview tiles aren't synced correctly to the video.
- FFprobe always returns the framerate as a fraction, but the [`get_movie_fps`](https://github.com/cgwire/zou/blob/4ee5dbcf34d077d37f2b329d764a4a5f1d90c3a2/zou/utils/movie.py#L183) used to generate preview tiles only returns the numerator, so a 12.5 fps video will be reported as `25/2` in FFprobe and cut to `25` in Zou.

**Solution**

- Compute the framerate based on the fraction given by FFprobe
