### PR TITLE
[misc] Fix plugin listing JSON, comment read loads and fps parsing

### DIFF
--- a/tests/blueprints/comments/test_comments.py
+++ b/tests/blueprints/comments/test_comments.py
@@ -735,3 +735,22 @@ class CommentAttachmentTestCase(CommentTestCase):
             403,
         )
         self.assertIsNotNone(AttachmentFile.get(attachment.id))
+
+
+class TaskCommentRouteTestCase(CommentTestCase):
+    """
+    The task scoped comment read, exercised by a non admin who goes
+    through the full comment access check.
+    """
+
+    def test_get_task_comment_as_artist(self):
+        self.generate_fixture_user_cg_artist()
+        projects_service.add_team_member(
+            str(self.project.id), self.user_cg_artist["id"]
+        )
+        path = f"data/tasks/{self.task.id}/comments/{self.comment['id']}"
+
+        self.log_in_cg_artist()
+        comment = self.get(path)
+        self.assertEqual(comment["id"], self.comment["id"])
+        self.assertEqual(comment["text"], "first comment")

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -1,5 +1,6 @@
 import datetime
 import io
+import json as stdlib_json
 from contextlib import redirect_stdout
 from unittest.mock import patch
 
@@ -12,6 +13,7 @@ from zou.app.services import preview_files_service
 from zou.app.stores import auth_tokens_store, file_store
 from zou.app.utils import commands
 from zou.app.models.entity_type import EntityType
+from zou.app.models.plugin import Plugin
 from zou.app.models.task_type import TaskType
 from zou.cli import cli
 
@@ -401,3 +403,28 @@ class CreateBotCommandTestCase(ApiDBTestCase):
         # The token is the deliverable of the command, not a log line.
         token = result.output.strip().splitlines()[-1]
         self.assertGreater(len(token), 20)
+
+
+class ListPluginsCommandTestCase(ApiDBTestCase):
+    """
+    The JSON output is meant to be piped into another tool, so it has to
+    be parseable, not just printed.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.runner = CliRunner()
+
+    def test_json_output_is_valid_json(self):
+        Plugin.create(
+            plugin_id="studio-tools",
+            name="Studio Tools",
+            version="1.0.0",
+            maintainer_name="Ellen Ripley",
+            license="MIT",
+        )
+        result = self.runner.invoke(cli, ["list-plugins", "--format", "json"])
+        self.assertEqual(result.exit_code, 0, result.output)
+        plugins = stdlib_json.loads(result.output)
+        self.assertEqual(plugins[0]["Plugin ID"], "studio-tools")
+        self.assertEqual(plugins[0]["Name"], "Studio Tools")

--- a/tests/services/test_persons_service.py
+++ b/tests/services/test_persons_service.py
@@ -196,6 +196,20 @@ class PersonReadTestCase(PersonsTestCase):
             },
         )
 
+    def test_get_short_person_is_cached(self):
+        """
+        Comment feeds read the same authors over and over: the short dict
+        stays cached until the person caches are dropped.
+        """
+        short = persons_service.get_short_person(self.person_id)
+        person = Person.get(self.person_id)
+        person.update({"first_name": "Updated"})
+        cached = persons_service.get_short_person(self.person_id)
+        self.assertEqual(cached["first_name"], short["first_name"])
+        persons_service.clear_person_cache()
+        fresh = persons_service.get_short_person(self.person_id)
+        self.assertEqual(fresh["first_name"], "Updated")
+
     def test_get_short_persons_map(self):
         self.assertEqual(persons_service.get_short_persons_map([]), {})
         short_map = persons_service.get_short_persons_map([self.person_id])

--- a/tests/utils/test_movie.py
+++ b/tests/utils/test_movie.py
@@ -338,3 +338,17 @@ class MovieTestCase(unittest.TestCase):
 
         self.assertEqual(img_width, target_width * 8)
         self.assertEqual(img_height, 100 * rows)
+
+    def test_get_movie_fps(self):
+        for r_frame_rate, expected in [
+            ("25/1", 25),
+            ("25/2", 12.5),
+            ("30000/1001", 29.97),
+            ("24", 24),
+            ("0/0", 25),
+            ("garbage", 25),
+        ]:
+            fps = movie.get_movie_fps(
+                video_track={"r_frame_rate": r_frame_rate}
+            )
+            self.assertAlmostEqual(fps, expected, places=2, msg=r_frame_rate)

--- a/zou/app/blueprints/crud/comments.py
+++ b/zou/app/blueprints/crud/comments.py
@@ -422,7 +422,9 @@ class CommentResource(BaseModelResource):
         return comment
 
     def check_read_permissions(self, instance):
-        return permissions_service.check_comment_access(instance["id"])
+        return permissions_service.check_comment_access(
+            instance["id"], comment=instance
+        )
 
     def check_update_permissions(self, instance, data):
         if permissions.has_admin_permissions():

--- a/zou/app/blueprints/tasks/resources.py
+++ b/zou/app/blueprints/tasks/resources.py
@@ -449,7 +449,9 @@ class TaskCommentResource(MethodView):
         comment = tasks_service.get_comment(comment_id)
         if comment["object_id"] != task_id:
             raise CommentNotFoundException
-        permissions_service.check_comment_access(comment)
+        permissions_service.check_comment_access(
+            comment["id"], comment=comment
+        )
         return comment
 
     def pre_delete(self, comment):

--- a/zou/app/services/permissions_service.py
+++ b/zou/app/services/permissions_service.py
@@ -396,14 +396,17 @@ def check_supervisor_project_task_type_access(project_id, task_type_id):
     return is_allowed
 
 
-def check_comment_access(comment_id):
+def check_comment_access(comment_id, comment=None):
     """
-    Return true if current user can have access to a comment.
+    Return true if current user can have access to a comment. The comment
+    dict can be passed in to spare a reload when the caller already holds
+    it.
     """
     if permissions.has_admin_permissions():
         return True
     else:
-        comment = tasks_service.get_comment(comment_id)
+        if comment is None:
+            comment = tasks_service.get_comment(comment_id)
         person_id = comment["person_id"]
         task_id = comment["object_id"]
         task = tasks_service.get_task(task_id)

--- a/zou/app/services/persons_service.py
+++ b/zou/app/services/persons_service.py
@@ -48,6 +48,7 @@ def clear_person_cache():
     cache.cache.delete_memoized(get_person_by_email_desktop_login)
     cache.cache.delete_memoized(get_active_persons)
     cache.cache.delete_memoized(get_persons)
+    cache.cache.delete_memoized(get_short_person)
 
 
 def clear_organisation_cache():
@@ -193,25 +194,52 @@ def get_persons_by_ids(person_ids):
     return [person.serialize_safe() for person in persons]
 
 
+_SHORT_PERSON_COLUMNS = (
+    Person.id,
+    Person.first_name,
+    Person.last_name,
+    Person.has_avatar,
+    Person.role,
+)
+
+
 def build_short_person(person):
     """
-    Return minimal author data to embed a comment or news author, including guests.
+    Return minimal author data to embed a comment or news author, including
+    guests. Accepts a full person row or a row limited to the short
+    columns, hence the inlined full name.
     """
+    if person.first_name and person.last_name:
+        full_name = f"{person.first_name} {person.last_name}"
+    else:
+        full_name = f"{person.first_name}{person.last_name}"
     return {
         "id": str(person.id),
         "first_name": person.first_name,
         "last_name": person.last_name,
-        "full_name": person.full_name,
+        "full_name": full_name,
         "has_avatar": person.has_avatar,
         "role": getattr(person.role, "code", person.role),
     }
 
 
+@cache.memoize_function(240)
 def get_short_person(person_id):
     """
-    Return the minimal author dict for the person matching given id.
+    Return the minimal author dict for the person matching given id. Loads
+    only the columns it embeds instead of the full person row.
     """
-    return build_short_person(get_person_raw(person_id))
+    try:
+        row = (
+            Person.query.with_entities(*_SHORT_PERSON_COLUMNS)
+            .filter_by(id=person_id)
+            .first()
+        )
+    except StatementError:
+        raise PersonNotFoundException()
+    if row is None:
+        raise PersonNotFoundException()
+    return build_short_person(row)
 
 
 def get_short_persons_map(person_ids):
@@ -220,8 +248,10 @@ def get_short_persons_map(person_ids):
     """
     if not person_ids:
         return {}
-    persons = Person.query.filter(Person.id.in_(person_ids)).all()
-    return {str(person.id): build_short_person(person) for person in persons}
+    rows = Person.query.with_entities(*_SHORT_PERSON_COLUMNS).filter(
+        Person.id.in_(person_ids)
+    )
+    return {str(row.id): build_short_person(row) for row in rows}
 
 
 def get_person_by_email_raw(email):

--- a/zou/app/utils/commands.py
+++ b/zou/app/utils/commands.py
@@ -1239,4 +1239,8 @@ def list_plugins(output_format, verbose, filter_field, filter_value):
             rows = [p.values() for p in plugin_list]
             click.echo(tabulate(rows, headers, tablefmt="fancy_grid"))
         elif output_format == "json":
-            click.echo(json.dumps(plugin_list, indent=2, ensure_ascii=False))
+            click.echo(
+                json.dumps(plugin_list, option=json.OPT_INDENT_2).decode(
+                    "utf-8"
+                )
+            )

--- a/zou/utils/movie.py
+++ b/zou/utils/movie.py
@@ -1,13 +1,14 @@
-from collections import namedtuple
 import contextlib
-from fractions import Fraction
 import logging
-import os
 import math
+import os
 import shutil
 import subprocess
 import tempfile
 import uuid
+
+from collections import namedtuple
+from fractions import Fraction
 
 import ffmpeg
 

--- a/zou/utils/movie.py
+++ b/zou/utils/movie.py
@@ -1,5 +1,6 @@
 from collections import namedtuple
 import contextlib
+from fractions import Fraction
 import logging
 import os
 import math
@@ -180,10 +181,12 @@ def get_movie_fps(movie_path=None, video_track=None):
         video_track = get_video_track(movie_path, "get_movie_fps")
     fps = 25
     if video_track is not None:
-        numerator, denominator = [
-            float(number) for number in video_track["r_frame_rate"].split("/")
-        ]
-        fps = numerator / denominator
+        # ffprobe reports "0/0" for streams without reliable timing
+        # (attached cover art for instance): keep the default then.
+        try:
+            fps = float(Fraction(video_track["r_frame_rate"]))
+        except (ValueError, ZeroDivisionError):
+            pass
     return fps
 
 


### PR DESCRIPTION
**Problem**
- `zou list-plugins --format json` died on a `TypeError`: `commands.py` imports orjson as json and orjson rejects the `indent` and `ensure_ascii` keyword arguments
- Serving one comment loaded the full person row (password, 2FA secrets, salary included) to build a six-field author dict, on every read, and loaded the comment itself twice through two distinct memoize keys
- The task scoped comment route passed the whole comment dict where an id was expected, so `session.get` raised and every non-admin got a 500 (KITSU-API-4SG)
- Since #1199 `get_movie_fps` divides numerator by denominator: ffprobe reports `0/0` for streams without reliable timing (attached cover art for instance), which now raises `ZeroDivisionError`; a value without `/` breaks the unpacking, and none of the parsing was unit-tested

**Solution**
- Use the orjson `indent` option in the plugin listing command, covered by a CLI test that parses the output back
- Load only the short person columns, memoize the short dict alongside the other person caches, and let `check_comment_access` accept the comment its caller already holds
- Pass the comment id, not the dict, on the task comment route; covered by a route test reading a task comment as an artist
- Parse `r_frame_rate` with `fractions.Fraction` and keep the 25 fps default on `0/0` or malformed values, with a unit test covering `25/2`, `30000/1001`, `24`, `0/0` and garbage
