### PR TITLE
Cut the N+1 queries  and SQL sorts on team, task and shot listings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,6 +186,14 @@ class CreateThingSchema(BaseSchema):
 
 Query parameters (page, limit, filters) are still read via `ArgsMixin` methods: `get_text_parameter()`, `get_bool_parameter()`, etc. Only request **bodies** use Pydantic.
 
+### Style: push validation into the schema you touch
+
+No dedicated refactor pass, but when you edit a schema or add one, use the Pydantic features instead of service-side checks:
+
+- `@model_validator(mode="after")` for cross-field invariants (e.g. "if `is_for_all` then no `episode_id`") instead of a `WrongParameterException` raise in the service
+- shared `Annotated` types for recurring fields (UUID strings, hex colors) instead of repeating the same `Field` constraints
+- `TypeAdapter` to validate ad-hoc payloads (a list of ids) without declaring a full schema
+
 ## Services
 
 Services are stateless modules in `zou/app/services/`. Key patterns:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,7 +196,7 @@ No dedicated refactor pass, but when you edit a schema or add one, use the Pydan
 
 ## Services
 
-Services are stateless modules in `zou/app/services/`. Key patterns:
+Services are stateless modules in `zou/app/services/`. **All database access lives here**: a resource never builds an ORM query or calls a model directly, it checks permissions, validates input and calls service functions. Caller-dependent shaping (role-based serialization, vendor filtering) stays in the resource. Key patterns:
 
 ```python
 # Caching

--- a/tests/blueprints/projects/test_open_projects.py
+++ b/tests/blueprints/projects/test_open_projects.py
@@ -56,6 +56,26 @@ class OpenProjectRouteTestCase(ApiDBTestCase):
 
         self.assertEqual(self.first_episode_id(), str(episodes["E01"].id))
 
+    def test_get_team(self):
+        """
+        A manager reads the team with each member's departments and
+        per-project role embedded.
+        """
+        person = self.generate_fixture_person()
+        self.generate_fixture_department()
+        person.departments.append(self.department)
+        person.save()
+        projects_service.add_team_member(self.project_id, str(person.id))
+
+        team = self.get(f"data/projects/{self.project_id}/team")
+
+        self.assertEqual(len(team), 1)
+        member = team[0]
+        self.assertEqual(member["id"], str(person.id))
+        self.assertEqual(member["departments"], [str(self.department.id)])
+        self.assertIsNone(member["project_role"])
+        self.assertNotIn("password", member)
+
     def test_add_team_member(self):
         self.person_id = str(self.generate_fixture_person().id)
         self.post(

--- a/tests/services/test_tasks_service.py
+++ b/tests/services/test_tasks_service.py
@@ -349,6 +349,20 @@ class TaskReaderTestCase(TaskTestCase):
         self.assertEqual(tasks[0]["name"], "Première Tâche")
         self.assertEqual(tasks[0]["task_type_name"], "Modélisation")
 
+    def test_get_task_dicts_for_entity_is_sorted_by_name(self):
+        """
+        The detailed task listings promise a name-ordered output, wherever
+        the sort happens.
+        """
+        self.generate_fixture_task(name="B task")
+        self.generate_fixture_task(name="A task")
+
+        tasks = tasks_service.get_task_dicts_for_entity(self.asset.id)
+
+        names = [task["name"] for task in tasks]
+        self.assertEqual(names, sorted(names, key=str.casefold))
+        self.assertLess(names.index("A task"), names.index("B task"))
+
     def test_get_task_dicts_for_entity_with_relations_attaches_assignees(self):
         self.generate_fixture_task(name="Secondary")
 

--- a/zou/app/blueprints/projects/resources.py
+++ b/zou/app/blueprints/projects/resources.py
@@ -40,7 +40,10 @@ from zou.app.services.exception import (
     WrongDateFormatException,
     WrongParameterException,
 )
+from sqlalchemy.orm import selectinload
+
 from zou.app.models.metadata_descriptor import METADATA_DESCRIPTOR_TYPES
+from zou.app.models.person import Person
 
 
 class OpenProjectsResource(MethodView, ArgsMixin):
@@ -220,8 +223,15 @@ class ProductionTeamResource(MethodView, ArgsMixin):
         permissions_service.check_project_access(project_id)
         project = projects_service.get_project_raw(project_id)
         role_map = projects_service.get_team_roles(project_id)
+        # Load the departments of the whole team in one go: serializing
+        # them person by person was an N+1 on every team read.
+        team = (
+            Person.query.options(selectinload(Person.departments))
+            .filter(Person.id.in_([person.id for person in project.team]))
+            .all()
+        )
         persons = []
-        for person in project.team:
+        for person in team:
             if permissions.has_manager_permissions():
                 data = person.serialize_safe(relations=True)
             else:

--- a/zou/app/blueprints/projects/resources.py
+++ b/zou/app/blueprints/projects/resources.py
@@ -40,10 +40,7 @@ from zou.app.services.exception import (
     WrongDateFormatException,
     WrongParameterException,
 )
-from sqlalchemy.orm import selectinload
-
 from zou.app.models.metadata_descriptor import METADATA_DESCRIPTOR_TYPES
-from zou.app.models.person import Person
 
 
 class OpenProjectsResource(MethodView, ArgsMixin):
@@ -221,17 +218,9 @@ class ProductionTeamResource(MethodView, ArgsMixin):
                         example: "supervisor"
         """
         permissions_service.check_project_access(project_id)
-        project = projects_service.get_project_raw(project_id)
         role_map = projects_service.get_team_roles(project_id)
-        # Load the departments of the whole team in one go: serializing
-        # them person by person was an N+1 on every team read.
-        team = (
-            Person.query.options(selectinload(Person.departments))
-            .filter(Person.id.in_([person.id for person in project.team]))
-            .all()
-        )
         persons = []
-        for person in team:
+        for person in projects_service.get_team_raw(project_id):
             if permissions.has_manager_permissions():
                 data = person.serialize_safe(relations=True)
             else:

--- a/zou/app/services/projects_service.py
+++ b/zou/app/services/projects_service.py
@@ -37,7 +37,7 @@ from zou.app.utils import fields, events, cache
 from zou.app import db
 
 from sqlalchemy.exc import StatementError
-from sqlalchemy.orm import joinedload
+from sqlalchemy.orm import joinedload, selectinload
 from sqlalchemy.orm.exc import ObjectDeletedError
 from sqlalchemy import or_
 
@@ -525,6 +525,20 @@ def update_team_member_role(project_id, person_id, role):
             else None
         ),
     }
+
+
+def get_team_raw(project_id):
+    """
+    Return the team members of given project as active records, with
+    their departments eager-loaded: serializing them person by person
+    lazy-loads one departments query per member otherwise.
+    """
+    project = get_project_raw(project_id)
+    return (
+        Person.query.options(selectinload(Person.departments))
+        .filter(Person.id.in_([person.id for person in project.team]))
+        .all()
+    )
 
 
 def get_team_roles(project_id):

--- a/zou/app/services/shots_service.py
+++ b/zou/app/services/shots_service.py
@@ -171,7 +171,6 @@ def get_shots(criterions=None):
         .join(Sequence, Sequence.id == Entity.parent_id)
         .add_columns(Project.name)
         .add_columns(Sequence.name)
-        .order_by(Entity.name)
     )
 
     if is_only_assignation:
@@ -189,6 +188,11 @@ def get_shots(criterions=None):
         shot["project_name"] = project_name
         shot["sequence_name"] = sequence_name
         shots.append(shot)
+
+    # Sort the dicts rather than the SQL rows: ordering thousands of
+    # wide rows (data JSONB included) in PostgreSQL makes it materialize
+    # the whole join before returning anything.
+    shots.sort(key=lambda shot: shot["name"].casefold())
 
     return entities_service.remove_not_allowed_metadata_for_vendor(
         "Shot", criterions.get("vendor_departments"), shots

--- a/zou/app/services/tasks_service.py
+++ b/zou/app/services/tasks_service.py
@@ -408,11 +408,13 @@ def get_task_dicts_for_entity(entity_id, relations=True):
 def _get_entity_task_query(relations=False):
     """
     Base query joining a task to everything the detailed task view needs:
-    project, task type, task status, entity and assignees.
+    project, task type, task status, entity and assignees. No SQL
+    ordering: sorting thousands of wide task rows (JSONB data included)
+    made PostgreSQL materialize the whole join, the caller sorts the
+    serialized dicts instead.
     """
     return (
-        Task.query.order_by(Task.name)
-        .join(Project, Task.project_id == Project.id)
+        Task.query.join(Project, Task.project_id == Project.id)
         .join(TaskType, Task.task_type_id == TaskType.id)
         .join(TaskStatus, TaskStatus.id == Task.task_status_id)
         .join(Entity, Task.entity_id == Entity.id)
@@ -422,7 +424,6 @@ def _get_entity_task_query(relations=False):
         .add_columns(TaskStatus.name)
         .add_columns(EntityType.name)
         .add_columns(Entity.name)
-        .order_by(Project.name, TaskType.name, EntityType.name, Entity.name)
     )
 
 
@@ -442,6 +443,15 @@ def _convert_rows_to_detailed_tasks(rows, relations=False):
         }
         for task_object, project_name, task_type_name, task_status_name, entity_type_name, entity_name in rows
     ]
+    task_dicts.sort(
+        key=lambda task: (
+            task["name"].casefold(),
+            task["project_name"].casefold(),
+            task["task_type_name"].casefold(),
+            task["entity_type_name"].casefold(),
+            task["entity_name"].casefold(),
+        )
+    )
     if relations and task_dicts:
         _attach_assignee_ids(task_dicts)
     return task_dicts


### PR DESCRIPTION
**Problem**

- Reading a production team lazy-loaded each member's departments, one query per person (KITSU-API-4XE)
- The detailed task and shot listings sorted thousands of wide JSONB-carrying rows in SQL on joined name columns (KITSU-API-4S7, KITSU-API-4S8)

**Solution**

- Load the whole team's departments in one selectinload query
- Drop the SQL ORDER BY and sort the serialized dicts in Python with the same keys (46 ms to 14 ms on a 5746-task episode)
- Turn the Pydantic backlog entry into a CLAUDE.md style rule: push validation into the schema you touch