### PR TITLE
[breakdown] Stop losing episode casting on shot edits

### DIFF
--- a/tests/blueprints/breakdown/test_breakdown.py
+++ b/tests/blueprints/breakdown/test_breakdown.py
@@ -86,6 +86,50 @@ class BreakdownRoutesTestCase(ApiDBTestCase):
             403,
         )
 
+    def test_cast_asset_in_entities(self):
+        self._set_shot_casting()
+        result = self.put(
+            f"/data/projects/{self.project_id}"
+            f"/entities/casting/assets/{self.asset_character_id}",
+            {
+                "entity_ids": [self.shot_id, self.asset_id],
+                "nb_occurences": 3,
+                "label": "fixed",
+            },
+        )
+        self.assertEqual(set(result.keys()), {self.shot_id, self.asset_id})
+        shot_casting = self.get(
+            f"/data/projects/{self.project_id}"
+            f"/entities/{self.shot_id}/casting"
+        )
+        self.assertEqual(
+            {(c["asset_id"], c["nb_occurences"]) for c in shot_casting},
+            {(self.asset_id, 1), (self.asset_character_id, 3)},
+        )
+        asset_casting = self.get(
+            f"/data/projects/{self.project_id}"
+            f"/entities/{self.asset_id}/casting"
+        )
+        self.assertEqual(asset_casting[0]["label"], "fixed")
+
+    def test_cast_asset_in_entities_rejects_an_empty_selection(self):
+        self.put(
+            f"/data/projects/{self.project_id}"
+            f"/entities/casting/assets/{self.asset_id}",
+            {"entity_ids": []},
+            400,
+        )
+
+    def test_cast_asset_in_entities_as_artist_is_forbidden(self):
+        self.generate_fixture_user_cg_artist()
+        self.log_in_cg_artist()
+        self.put(
+            f"/data/projects/{self.project_id}"
+            f"/entities/casting/assets/{self.asset_id}",
+            {"entity_ids": [self.shot_id]},
+            403,
+        )
+
     def test_get_episodes_casting(self):
         self._set_shot_casting()
         result = self.get(f"/data/projects/{self.project_id}/episodes/casting")

--- a/tests/services/test_breakdown_service.py
+++ b/tests/services/test_breakdown_service.py
@@ -337,6 +337,85 @@ class EpisodeCastingTestCase(BreakdownTestCase):
         )
 
 
+class AssetCastingTestCase(BreakdownTestCase):
+    """
+    Casting one asset at a time, the way the breakdown page works: the
+    other assets of the entity are left as they are, whatever the caller
+    believes the casting to be.
+    """
+
+    def test_casting_one_more_asset_leaves_the_others_alone(self):
+        self.cast(self.shot_id, self.asset_id)
+
+        breakdown_service.cast_asset(self.shot_id, self.asset_character_id)
+
+        self.assertEqual(
+            sorted(self.cast_asset_ids(self.shot_id)),
+            sorted([self.asset_id, self.asset_character_id]),
+        )
+        self.assertEqual(
+            entities_service.get_entity(self.shot_id)["nb_entities_out"], 2
+        )
+
+    def test_uncasting_an_asset_drops_it_alone(self):
+        self.cast(self.shot_id, self.asset_id, self.asset_character_id)
+        # Read before the change, so the count below comes from a cache
+        # that has something to invalidate.
+        self.assertEqual(
+            entities_service.get_entity(self.shot_id)["nb_entities_out"], 2
+        )
+
+        breakdown_service.uncast_asset(self.shot_id, self.asset_id)
+
+        self.assertEqual(
+            self.cast_asset_ids(self.shot_id), [self.asset_character_id]
+        )
+        self.assertEqual(
+            entities_service.get_entity(self.shot_id)["nb_entities_out"], 1
+        )
+
+    def test_casting_an_asset_again_sets_its_count_and_keeps_its_label(self):
+        breakdown_service.cast_asset(
+            self.shot_id, self.asset_id, 1, label="animate"
+        )
+
+        breakdown_service.cast_asset(self.shot_id, self.asset_id, 3)
+
+        link = breakdown_service.get_entity_link(self.shot_id, self.asset_id)
+        self.assertEqual(link["nb_occurences"], 3)
+        self.assertEqual(link["label"], "animate")
+
+        breakdown_service.cast_asset(
+            self.shot_id, self.asset_id, label="fixed"
+        )
+
+        link = breakdown_service.get_entity_link(self.shot_id, self.asset_id)
+        self.assertEqual(link["nb_occurences"], 3)
+        self.assertEqual(link["label"], "fixed")
+
+    def test_dropping_an_asset_from_an_episode_leaves_the_others_as_they_were(
+        self,
+    ):
+        """
+        The assets the episode got through its shots keep following the
+        shots after one of them is dropped from the episode side.
+        """
+        other_shot_id = str(self.generate_fixture_shot("SH02").id)
+        self.cast(self.shot_id, self.asset_id)
+        self.cast(other_shot_id, self.asset_character_id)
+
+        breakdown_service.uncast_asset(
+            self.episode_id, self.asset_character_id
+        )
+
+        self.assertEqual(self.cast_asset_ids(other_shot_id), [])
+        self.assertEqual(self.cast_asset_ids(self.episode_id), [self.asset_id])
+
+        self.cast(self.shot_id)
+
+        self.assertEqual(self.cast_asset_ids(self.episode_id), [])
+
+
 class CastingListingTestCase(BreakdownTestCase):
     """
     The casting of a whole branch of the production, keyed by the entity it

--- a/tests/services/test_breakdown_service.py
+++ b/tests/services/test_breakdown_service.py
@@ -268,6 +268,34 @@ class EpisodeCastingTestCase(BreakdownTestCase):
             entities_service.get_entity(self.episode_id)["nb_entities_out"], 0
         )
 
+    def test_the_episode_keeps_an_asset_it_was_given_by_hand(self):
+        """
+        Only the episode links derived from a shot casting follow the shots.
+        One a manager set from the episode breakdown is a decision of its
+        own: dropping the asset from its last shot must not undo it.
+        """
+        self.cast(self.episode_id, self.asset_id)
+        self.cast(self.shot_id, self.asset_id)
+
+        self.cast(self.shot_id)
+
+        self.assertEqual(self.cast_asset_ids(self.episode_id), [self.asset_id])
+        self.assertEqual(
+            entities_service.get_entity(self.episode_id)["nb_entities_out"], 1
+        )
+
+    def test_saving_the_episode_casting_makes_its_assets_its_own(self):
+        """
+        An asset that reached the episode through a shot becomes a decision
+        of the episode once its casting is saved from the episode side.
+        """
+        self.cast(self.shot_id, self.asset_id)
+        self.cast(self.episode_id, self.asset_id)
+
+        self.cast(self.shot_id)
+
+        self.assertEqual(self.cast_asset_ids(self.episode_id), [self.asset_id])
+
     def test_the_episode_losing_an_asset_is_announced(self):
         """
         The same way casting it in a shot emits an asset:update event, so

--- a/tests/services/test_permissions_service.py
+++ b/tests/services/test_permissions_service.py
@@ -7,6 +7,7 @@ from flask_jwt_extended import verify_jwt_in_request
 from tests.base import ApiDBTestCase
 
 from zou.app import app
+from zou.app.models.entity import Entity
 from zou.app.services import (
     comments_service,
     permissions_service,
@@ -1079,3 +1080,42 @@ class CommentAccessTestCase(PermissionsTestCase):
         with self.as_role("client"):
             with self.denied():
                 permissions_service.check_comment_access(comment_id)
+
+
+class EntitiesBelongToProjectTestCase(ApiDBTestCase):
+    """
+    The routes taking a project and entity ids refuse an entity of another
+    project, before touching anything.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.generate_fixture_project_status()
+        self.generate_fixture_project()
+        self.generate_fixture_asset_type()
+        self.generate_fixture_episode()
+        self.generate_fixture_sequence()
+        self.generate_fixture_shot()
+        self.generate_fixture_asset()
+        self.project_id = str(self.project.id)
+
+    def test_the_entities_of_the_project_come_back(self):
+        entities = permissions_service.check_entities_belong_to_project(
+            [str(self.shot.id), str(self.asset.id)], self.project_id
+        )
+        self.assertEqual(
+            [entity["id"] for entity in entities],
+            [str(self.shot.id), str(self.asset.id)],
+        )
+
+    def test_an_entity_of_another_project_is_refused(self):
+        other_project = self.generate_fixture_project("Other")
+        stranger = Entity.create(
+            name="STRANGER",
+            project_id=other_project.id,
+            entity_type_id=self.shot_type.id,
+        )
+        with self.assertRaises(permissions.PermissionDenied):
+            permissions_service.check_entities_belong_to_project(
+                [str(self.shot.id), str(stranger.id)], self.project_id
+            )

--- a/zou/app/blueprints/breakdown/__init__.py
+++ b/zou/app/blueprints/breakdown/__init__.py
@@ -11,6 +11,7 @@ from zou.app.blueprints.breakdown.resources import (
     SceneCameraInstancesResource,
     CastingResource,
     EntitiesCastingResource,
+    EntitiesAssetCastingResource,
     AssetTypeCastingResource,
     SequenceCastingResource,
     EpisodeSequenceAllCastingResource,
@@ -25,6 +26,10 @@ routes = [
     (
         "/data/projects/<project_id>/entities/casting",
         EntitiesCastingResource,
+    ),
+    (
+        "/data/projects/<project_id>/entities/casting/assets/<asset_id>",
+        EntitiesAssetCastingResource,
     ),
     (
         "/data/projects/<project_id>/asset-types/<asset_type_id>/casting",

--- a/zou/app/blueprints/breakdown/resources.py
+++ b/zou/app/blueprints/breakdown/resources.py
@@ -80,9 +80,9 @@ class CastingResource(MethodView):
         permissions_service.check_project_access(project_id)
         if permissions.has_vendor_permissions():
             raise permissions.PermissionDenied
-        entity = entities_service.get_entity(entity_id)
-        if entity["project_id"] != project_id:
-            raise permissions.PermissionDenied
+        permissions_service.check_entities_belong_to_project(
+            [entity_id], project_id
+        )
         return breakdown_service.get_casting(entity_id)
 
     @jwt_required()
@@ -170,9 +170,9 @@ class CastingResource(MethodView):
                 "message": "Request body must be a JSON array",
             }, 400
         permissions_service.check_manager_project_access(project_id)
-        entity = entities_service.get_entity(entity_id)
-        if entity["project_id"] != project_id:
-            raise permissions.PermissionDenied
+        permissions_service.check_entities_belong_to_project(
+            [entity_id], project_id
+        )
         return breakdown_service.update_casting(entity_id, casting)
 
 
@@ -233,11 +233,9 @@ class EntitiesCastingResource(MethodView):
                 "entity ids to casting arrays",
             }, 400
         permissions_service.check_manager_project_access(project_id)
-        # Validate every entity before updating anything.
-        for entity_id in castings.keys():
-            entity = entities_service.get_entity(entity_id)
-            if entity["project_id"] != project_id:
-                raise permissions.PermissionDenied
+        permissions_service.check_entities_belong_to_project(
+            castings.keys(), project_id
+        )
         return {
             entity_id: breakdown_service.update_casting(entity_id, casting)
             for entity_id, casting in castings.items()
@@ -1045,7 +1043,7 @@ class ProjectEntityLinkResource(MethodView):
         """
         permissions_service.check_manager_project_access(project_id)
         link = entities_service.get_entity_link(entity_link_id)
-        entity = entities_service.get_entity(link["entity_in_id"])
-        if entity["project_id"] != project_id:
-            raise permissions.PermissionDenied
+        permissions_service.check_entities_belong_to_project(
+            [link["entity_in_id"]], project_id
+        )
         return entities_service.remove_entity_link(entity_link_id)

--- a/zou/app/blueprints/breakdown/resources.py
+++ b/zou/app/blueprints/breakdown/resources.py
@@ -17,6 +17,7 @@ from zou.app.utils import permissions, validation
 from zou.app.blueprints.breakdown.schemas import (
     AddAssetInstanceSchema,
     AddSceneAssetInstanceSchema,
+    CastAssetSchema,
 )
 
 
@@ -239,6 +240,92 @@ class EntitiesCastingResource(MethodView):
         return {
             entity_id: breakdown_service.update_casting(entity_id, casting)
             for entity_id, casting in castings.items()
+        }
+
+
+class EntitiesAssetCastingResource(MethodView):
+    @jwt_required()
+    def put(self, project_id, asset_id):
+        """
+        Cast one asset in several entities
+        ---
+        description: Set how given asset is cast in each given entity
+          (shots, assets or episodes of the project). Unlike the full
+          casting update, the other assets of each entity are left
+          untouched, so concurrent editors cannot erase each other's
+          work. A nb_occurences of 0 removes the asset from the casting.
+        tags:
+          - Breakdown
+        parameters:
+          - in: path
+            name: project_id
+            required: true
+            type: string
+            format: uuid
+            example: a24a6ea4-ce75-4665-a070-57453082c25
+            description: Unique identifier of the project
+          - in: path
+            name: asset_id
+            required: true
+            type: string
+            format: uuid
+            example: c46c8gc6-eg97-6887-c292-79675204e47
+            description: Unique identifier of the asset to cast
+        requestBody:
+          required: true
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - entity_ids
+                properties:
+                  entity_ids:
+                    type: array
+                    items:
+                      type: string
+                      format: uuid
+                    description: Entities to cast the asset in
+                  nb_occurences:
+                    type: integer
+                    description: Number of occurences, 0 removes the
+                      asset from the casting, omit to keep the current
+                      one (1 on a new link)
+                  label:
+                    type: string
+                    description: Casting label, omit to keep the
+                      current one
+        responses:
+          200:
+            description: Map of entity ids to their updated casting
+            content:
+              application/json:
+                schema:
+                  type: object
+          400:
+            description: Empty selection or negative number of occurences
+          403:
+            description: Not a manager of the project
+          404:
+            description: Unknown asset or entity
+        """
+        args = validation.validate_request_body(CastAssetSchema)
+        permissions_service.check_manager_project_access(project_id)
+        assets_service.get_asset(asset_id)
+        entity_ids = [str(entity_id) for entity_id in args.entity_ids]
+        permissions_service.check_entities_belong_to_project(
+            entity_ids, project_id
+        )
+        if args.nb_occurences == 0:
+            return {
+                entity_id: breakdown_service.uncast_asset(entity_id, asset_id)
+                for entity_id in entity_ids
+            }
+        return {
+            entity_id: breakdown_service.cast_asset(
+                entity_id, asset_id, args.nb_occurences, args.label
+            )
+            for entity_id in entity_ids
         }
 
 

--- a/zou/app/blueprints/breakdown/schemas.py
+++ b/zou/app/blueprints/breakdown/schemas.py
@@ -27,3 +27,22 @@ class AddSceneAssetInstanceSchema(BaseSchema):
 
     asset_id: UUID = Field(..., description="Asset unique identifier")
     description: Optional[str] = None
+
+
+class CastAssetSchema(BaseSchema):
+    """
+    Body for casting one asset in several entities at once.
+    """
+
+    entity_ids: list[UUID] = Field(
+        ..., min_length=1, description="Entities to cast the asset in"
+    )
+    nb_occurences: Optional[int] = Field(
+        default=None,
+        ge=0,
+        description="Number of occurences, 0 removes the asset from the "
+        "casting, omit to keep the current one",
+    )
+    label: Optional[str] = Field(
+        default=None, description="Casting label, omit to keep the current one"
+    )

--- a/zou/app/services/breakdown_service.py
+++ b/zou/app/services/breakdown_service.py
@@ -311,13 +311,24 @@ def update_casting(entity_id, casting):
                     project_id=str(entity.project_id),
                 )
 
+    _announce_casting_change(entity, added_asset_ids, removed_asset_ids)
+    return casting
+
+
+def _announce_casting_change(entity, added_asset_ids, removed_asset_ids):
+    """
+    Refresh what hangs from the casting of given entity once its links
+    changed: its link count, the cached serializations, the shot stats, the
+    episode links derived from the shots, and the listeners through a
+    casting-update event carrying the diff.
+    """
     entity_id = str(entity.id)
-    nb_entities_out = len(casting)
-    entity.update({"nb_entities_out": nb_entities_out})
+    nb_links = EntityLink.query.filter_by(entity_in_id=entity.id).count()
+    entity.update({"nb_entities_out": nb_links})
     _clear_casting_cache(entity_id)
     entity_dict = entity.serialize()
     casting_diff = {
-        "nb_entities_out": nb_entities_out,
+        "nb_entities_out": entity.nb_entities_out,
         "added_asset_ids": added_asset_ids,
         "removed_asset_ids": removed_asset_ids,
     }
@@ -345,7 +356,50 @@ def update_casting(entity_id, casting):
             {"asset_id": entity_id, **casting_diff},
             project_id=str(entity.project_id),
         )
-    return casting
+
+
+def cast_asset(entity_id, asset_id, nb_occurences=None, label=None):
+    """
+    Cast given asset in given entity, leaving the other assets of its
+    casting untouched: a caller working from a stale view of the casting
+    cannot erase them. A count or label of None keeps the current one (one
+    occurrence and no label on a new link).
+    """
+    entity = entities_service.get_entity_raw(entity_id)
+    link = get_entity_link_raw(entity_id, asset_id)
+    if nb_occurences is None:
+        nb_occurences = link.nb_occurences if link else 1
+    if label is None:
+        label = link.label if link else ""
+    create_casting_link(entity.id, asset_id, nb_occurences, label)
+    # The asset list of an episode is drawn from its casting: the asset
+    # just joined the episode, and only asset:update makes the clients
+    # reload it (same as update_casting on an episode).
+    if shots_service.is_episode(entity.serialize()):
+        events.emit(
+            "asset:update",
+            {"asset_id": str(asset_id)},
+            project_id=str(entity.project_id),
+        )
+    added_asset_ids = [] if link else [str(asset_id)]
+    _announce_casting_change(entity, added_asset_ids, [])
+    return get_casting(entity_id)
+
+
+def uncast_asset(entity_id, asset_id):
+    """
+    Remove given asset from the casting of given entity, leaving the other
+    assets untouched. Nothing happens when the asset was not cast.
+    """
+    link = get_entity_link_raw(entity_id, asset_id)
+    if link is None:
+        return get_casting(entity_id)
+    entity = entities_service.get_entity_raw(entity_id)
+    if shots_service.is_episode(entity.serialize()):
+        _remove_asset_from_episode_shots(asset_id, entity_id)
+    link.delete()
+    _announce_casting_change(entity, [], [str(asset_id)])
+    return get_casting(entity_id)
 
 
 def _clear_casting_cache(entity_id):

--- a/zou/app/services/breakdown_service.py
+++ b/zou/app/services/breakdown_service.py
@@ -485,7 +485,9 @@ def _detach_asset_from_episode_if_unused(asset_id, episode_id):
         return
 
     link = EntityLink.get_by(entity_in_id=episode_id, entity_out_id=asset_id)
-    if link is None:
+    # A link the manager set from the episode breakdown carries no flag:
+    # it is a decision of its own, not a mirror of the shots.
+    if link is None or not (link.data or {}).get("auto"):
         return
 
     episode = entities_service.get_entity_raw(episode_id)
@@ -532,6 +534,7 @@ def _create_episode_casting_link(entity, asset_id, nb_occurences=1, label=""):
                     entity_out_id=asset_id,
                     nb_occurences=nb_occurences,
                     label=label,
+                    data={"auto": True},
                 )
                 # The count is what the breakdown of the episode is drawn
                 # from, and the detach path below decrements it: without

--- a/zou/app/services/permissions_service.py
+++ b/zou/app/services/permissions_service.py
@@ -452,6 +452,20 @@ def has_manager_project_access(project_id):
     )
 
 
+def check_entities_belong_to_project(entity_ids, project_id):
+    """
+    Return given entities, or raise a PermissionDenied exception if one of
+    them is not part of given project. Meant to run before a route touches
+    anything, so a mixed request changes nothing.
+    """
+    entities = [
+        entities_service.get_entity(str(entity_id)) for entity_id in entity_ids
+    ]
+    if any(entity["project_id"] != project_id for entity in entities):
+        raise permissions.PermissionDenied
+    return entities
+
+
 def check_manager_project_access(project_id):
     """
     Return true if current user is a manager and has a task assigned for this


### PR DESCRIPTION
**Problem**

- Removing an asset from its last shot also removed it from the episode, even when a manager had cast it there on purpose: episode breakdowns vanished as artists edited shots.
- The casting routes replace the whole casting with what the client sends, so a page with a stale view (locked, disconnected, or edited by two people) erases links it never saw.

**Solution**

- Flag episode links derived from a shot casting (`data.auto`) and only auto-detach those; links set from the episode side stay until removed there.
- Add `PUT /data/projects/<id>/entities/casting/assets/<asset_id>` to set one asset in several entities (`nb_occurences` 0 removes, omitted fields keep their value) while leaving the other assets untouched.