### PR TITLE
Answer 304 on unchanged task listings and with-tasks boards

### DIFF
--- a/tests/blueprints/shots/test_with_tasks_etag.py
+++ b/tests/blueprints/shots/test_with_tasks_etag.py
@@ -1,0 +1,98 @@
+from tests.base import ApiDBTestCase
+
+from zou.app.services import notifications_service
+
+
+class WithTasksConditionalGetTestCase(ApiDBTestCase):
+    """
+    The conditional GET contract of the with-tasks boards kitsu polls.
+    The validator must move with everything the payload embeds: the
+    entities themselves, their parents' names, the tasks and the
+    caller's subscriptions.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.generate_fixture_project()
+        self.project_id = str(self.project.id)
+        self.generate_fixture_episode()
+        self.generate_fixture_sequence()
+        self.generate_fixture_shot("SH01")
+        self.generate_fixture_asset()
+        self.generate_fixture_department()
+        self.generate_fixture_task_type()
+        self.generate_fixture_task_status()
+        self.generate_fixture_person()
+        self.generate_fixture_assigner()
+        self.shot_task = self.generate_fixture_shot_task()
+        self.shots_path = f"data/shots/with-tasks?project_id={self.project_id}"
+        # First hits lazily create missing entity types, which moves the
+        # fingerprint once: warm the boards up so the tests observe the
+        # steady state, as production does.
+        self.get_response(self.shots_path)
+        self.get_response(
+            f"data/assets/with-tasks?project_id={self.project_id}"
+        )
+
+    def get_response(self, path, headers=None):
+        return self.app.get(
+            path, headers={**self.base_headers, **(headers or {})}
+        )
+
+    def get_etag(self, path):
+        response = self.get_response(path)
+        self.assertEqual(response.status_code, 200)
+        etag = response.headers.get("ETag")
+        self.assertIsNotNone(etag)
+        return etag
+
+    def test_the_board_carries_a_validator_when_project_scoped(self):
+        response = self.get_response(self.shots_path)
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNotNone(response.headers.get("ETag"))
+        cache_control = response.headers.get("Cache-Control", "")
+        self.assertIn("private", cache_control)
+        self.assertIn("no-cache", cache_control)
+        unscoped = self.get_response("data/shots/with-tasks")
+        self.assertIsNone(unscoped.headers.get("ETag"))
+
+    def test_an_unchanged_board_answers_304(self):
+        etag = self.get_etag(self.shots_path)
+        second = self.get_response(
+            self.shots_path, headers={"If-None-Match": etag}
+        )
+        self.assertEqual(second.status_code, 304)
+        self.assertEqual(second.get_data(), b"")
+
+    def test_a_parent_rename_invalidates_the_board(self):
+        etag = self.get_etag(self.shots_path)
+        self.sequence.update({"name": "SQ_RENAMED"})
+        second = self.get_response(
+            self.shots_path, headers={"If-None-Match": etag}
+        )
+        self.assertEqual(second.status_code, 200)
+
+    def test_a_subscription_invalidates_the_board(self):
+        etag = self.get_etag(self.shots_path)
+        notifications_service.subscribe_to_task(
+            self.user["id"], str(self.shot_task.id)
+        )
+        second = self.get_response(
+            self.shots_path, headers={"If-None-Match": etag}
+        )
+        self.assertEqual(second.status_code, 200)
+
+    def test_the_compact_board_honors_the_validator_too(self):
+        path = f"{self.shots_path}&compact=true"
+        etag = self.get_etag(path)
+        second = self.get_response(path, headers={"If-None-Match": etag})
+        self.assertEqual(second.status_code, 304)
+
+    def test_the_assets_board_carries_the_same_contract(self):
+        path = f"data/assets/with-tasks?project_id={self.project_id}"
+        etag = self.get_etag(path)
+        second = self.get_response(path, headers={"If-None-Match": etag})
+        self.assertEqual(second.status_code, 304)
+        self.asset.update({"name": "Zebra"})
+        third = self.get_response(path, headers={"If-None-Match": etag})
+        self.assertEqual(third.status_code, 200)

--- a/tests/blueprints/tasks/test_project_tasks_etag.py
+++ b/tests/blueprints/tasks/test_project_tasks_etag.py
@@ -1,0 +1,63 @@
+from tests.base import ApiDBTestCase
+
+from zou.app.services import projects_service
+
+
+class ProjectTasksConditionalGetTestCase(ApiDBTestCase):
+    """
+    The conditional GET contract of the project tasks listing: kitsu
+    polls it, so an unchanged project must answer 304 from the freshness
+    signal alone, and the validator must be bound to the caller so a
+    role change or an account switch never validates someone else's
+    payload.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.generate_base_context()
+        self.generate_fixture_asset()
+        self.generate_fixture_person()
+        self.generate_fixture_assigner()
+        self.task = self.generate_fixture_task()
+        self.path = f"/data/projects/{self.project.id}/tasks"
+
+    def get_response(self, headers=None):
+        return self.app.get(
+            self.path, headers={**self.base_headers, **(headers or {})}
+        )
+
+    def test_the_listing_carries_a_validator(self):
+        response = self.get_response()
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNotNone(response.headers.get("ETag"))
+        cache_control = response.headers.get("Cache-Control", "")
+        self.assertIn("private", cache_control)
+        self.assertIn("no-cache", cache_control)
+
+    def test_an_unchanged_project_answers_304(self):
+        first = self.get_response()
+        etag = first.headers.get("ETag")
+        self.assertIsNotNone(etag)
+        second = self.get_response(headers={"If-None-Match": etag})
+        self.assertEqual(second.status_code, 304)
+        self.assertEqual(second.get_data(), b"")
+
+    def test_a_task_change_invalidates_the_etag(self):
+        first = self.get_response()
+        etag = first.headers.get("ETag")
+        self.assertIsNotNone(etag)
+        self.task.update({"priority": 3})
+        second = self.get_response(headers={"If-None-Match": etag})
+        self.assertEqual(second.status_code, 200)
+
+    def test_the_validator_is_bound_to_the_caller(self):
+        first = self.get_response()
+        etag = first.headers.get("ETag")
+        self.assertIsNotNone(etag)
+        self.generate_fixture_user_cg_artist()
+        projects_service.add_team_member(
+            str(self.project.id), self.user_cg_artist["id"]
+        )
+        self.log_in_cg_artist()
+        second = self.get_response(headers={"If-None-Match": etag})
+        self.assertEqual(second.status_code, 200)

--- a/zou/app/blueprints/assets/resources.py
+++ b/zou/app/blueprints/assets/resources.py
@@ -2,11 +2,18 @@ from flask import request
 from flask.views import MethodView
 from flask_jwt_extended import jwt_required
 
-from zou.app.utils import flask_utils, permissions, query, validation
+from zou.app.utils import (
+    flask_utils,
+    http_cache,
+    permissions,
+    query,
+    validation,
+)
 from zou.app.mixin import ArgsMixin
 from zou.app.services import (
     assets_service,
     breakdown_service,
+    entities_service,
     persons_service,
     shots_service,
     tasks_service,
@@ -324,10 +331,16 @@ class AssetsAndTasksResource(MethodView, ArgsMixin):
         check_criterion_access(criterions)
         permissions_service.scope_criterions_to_vendor(criterions)
         only_user_projects = not permissions.has_admin_permissions()
+        etag = entities_service.get_project_board_etag(criterions)
+        if etag is not None and http_cache.is_fresh(etag):
+            return http_cache.not_modified(etag)
         if not stream and not compact:
-            return assets_service.get_assets_and_tasks(
+            body = assets_service.get_assets_and_tasks(
                 criterions, only_user_projects=only_user_projects
             )
+            if etag is None:
+                return body
+            return http_cache.json_response(body, etag)
 
         rows = assets_service.prepare_assets_and_tasks(
             criterions,
@@ -340,7 +353,14 @@ class AssetsAndTasksResource(MethodView, ArgsMixin):
                 assets_service.ASSETS_AND_TASKS_ASSET_FIELDS
             )
             header["task_fields"] = assets_service.ASSETS_AND_TASKS_TASK_FIELDS
-        return flask_utils.rows_response(header, rows, stream)
+        response = flask_utils.rows_response(header, rows, stream)
+        if etag is not None:
+            # rows_response returns a plain dict when not streaming.
+            if stream:
+                http_cache.mark(response, etag)
+            else:
+                response = http_cache.json_response(response, etag)
+        return response
 
 
 class AssetTypeResource(MethodView):

--- a/zou/app/blueprints/shots/resources.py
+++ b/zou/app/blueprints/shots/resources.py
@@ -21,6 +21,7 @@ from zou.app.mixin import ArgsMixin
 from zou.app.utils import (
     fields,
     flask_utils,
+    http_cache,
     permissions,
     query,
     validation,
@@ -1082,8 +1083,14 @@ class ShotsAndTasksResource(MethodView):
             criterions.get("project_id", None)
         )
         permissions_service.scope_criterions_to_vendor(criterions)
+        etag = entities_service.get_project_board_etag(criterions)
+        if etag is not None and http_cache.is_fresh(etag):
+            return http_cache.not_modified(etag)
         if not stream and not compact:
-            return shots_service.get_shots_and_tasks(criterions)
+            body = shots_service.get_shots_and_tasks(criterions)
+            if etag is None:
+                return body
+            return http_cache.json_response(body, etag)
 
         rows = shots_service.prepare_shots_and_tasks(
             criterions, compact=compact
@@ -1092,7 +1099,14 @@ class ShotsAndTasksResource(MethodView):
         if compact:
             header["shot_fields"] = shots_service.SHOTS_AND_TASKS_SHOT_FIELDS
             header["task_fields"] = shots_service.SHOTS_AND_TASKS_TASK_FIELDS
-        return flask_utils.rows_response(header, rows, stream)
+        response = flask_utils.rows_response(header, rows, stream)
+        if etag is not None:
+            # rows_response returns a plain dict when not streaming.
+            if stream:
+                http_cache.mark(response, etag)
+            else:
+                response = http_cache.json_response(response, etag)
+        return response
 
 
 class SceneAndTasksResource(MethodView):

--- a/zou/app/blueprints/tasks/resources.py
+++ b/zou/app/blueprints/tasks/resources.py
@@ -32,6 +32,7 @@ from zou.app.services import (
 )
 from zou.app.utils import (
     events,
+    http_cache,
     query,
     permissions,
     date_helpers,
@@ -2528,11 +2529,29 @@ class ProjectTasksResource(MethodView, ArgsMixin):
         """
         projects_service.get_project(project_id)
         permissions_service.check_project_access(project_id)
+        # The validator hashes everything that shapes the response: the
+        # tasks freshness signal, plus the caller and its effective role
+        # so a role change or an account switch on the same browser
+        # never validates a payload shaped for someone else.
+        current_user = persons_service.get_current_user()
+        etag = http_cache.build_etag(
+            tasks_service.get_project_tasks_fingerprint(project_id),
+            current_user["id"],
+            permissions.get_effective_role(),
+        )
+        if http_cache.is_fresh(etag):
+            return http_cache.not_modified(etag)
         page = self.get_page()
         task_type_id = self.get_task_type_id()
         episode_id = self.get_episode_id()
-        return tasks_service.get_tasks_for_project(
-            project_id, page, task_type_id=task_type_id, episode_id=episode_id
+        return http_cache.json_response(
+            tasks_service.get_tasks_for_project(
+                project_id,
+                page,
+                task_type_id=task_type_id,
+                episode_id=episode_id,
+            ),
+            etag,
         )
 
 

--- a/zou/app/services/entities_service.py
+++ b/zou/app/services/entities_service.py
@@ -1,9 +1,10 @@
-from sqlalchemy import cast, Text
+from sqlalchemy import cast, func, Text
 from sqlalchemy.exc import IntegrityError
 
 from zou.app.services import (
     assets_service,
     base_service,
+    persons_service,
     projects_service,
     notifications_service,
     shots_service,
@@ -15,6 +16,8 @@ from zou.app.utils import (
     cache,
     events,
     fields,
+    http_cache,
+    permissions,
     query as query_utils,
 )
 
@@ -22,6 +25,7 @@ from zou.app.models.entity import Entity, EntityLink, EntityConceptLink
 from zou.app.models.entity_type import EntityType
 from zou.app.models.preview_file import PreviewFile
 from zou.app.models.project import Project
+from zou.app.models.subscription import Subscription
 from zou.app.models.task import Task, TaskPersonLink
 
 from zou.app import db
@@ -425,6 +429,65 @@ def fetch_entity_task_map(
         return task
 
     return tasks_by_entity, build_task
+
+
+def get_project_board_fingerprint(project_id, user_id):
+    """
+    Cheap change signal for the with-tasks boards of given project. It
+    covers everything those payloads embed: the entities of the project
+    (parents' names included, a sequence is an entity too), the tasks
+    (assigning saves the task), the project row and the entity type
+    names, plus the caller's subscriptions. Five scalar reads, orders of
+    magnitude cheaper than the boards they guard.
+    """
+    signals = [
+        Entity.query.with_entities(
+            func.max(Entity.updated_at), func.count(Entity.id)
+        )
+        .filter(Entity.project_id == project_id)
+        .one(),
+        Task.query.with_entities(
+            func.max(Task.updated_at), func.count(Task.id)
+        )
+        .filter(Task.project_id == project_id)
+        .one(),
+        EntityType.query.with_entities(
+            func.max(EntityType.updated_at), func.count(EntityType.id)
+        ).one(),
+        Subscription.query.with_entities(
+            func.max(Subscription.updated_at), func.count(Subscription.id)
+        )
+        .filter(Subscription.person_id == user_id)
+        .one(),
+    ]
+    project_updated_at = (
+        Project.query.with_entities(Project.updated_at)
+        .filter(Project.id == project_id)
+        .scalar()
+    )
+    parts = [f"{updated_at}:{count}" for updated_at, count in signals]
+    parts.append(str(project_updated_at))
+    return "|".join(parts)
+
+
+def get_project_board_etag(criterions):
+    """
+    Build the conditional GET validator for a with-tasks board, or None
+    when the request is not scoped to one project. Hashes the board
+    fingerprint with the caller, its effective role and the resolved
+    criterions (vendor scoping included). Call it after the permission
+    checks: the effective role needs the project resolved.
+    """
+    project_id = criterions.get("project_id")
+    if project_id is None:
+        return None
+    user_id = persons_service.get_current_user()["id"]
+    return http_cache.build_etag(
+        get_project_board_fingerprint(project_id, user_id),
+        user_id,
+        permissions.get_effective_role(),
+        str(sorted(criterions.items())),
+    )
 
 
 def get_entities_and_tasks(criterions=None):

--- a/zou/app/services/tasks_service.py
+++ b/zou/app/services/tasks_service.py
@@ -2002,6 +2002,22 @@ def get_time_spents_for_project(project_id, page=0):
     return query_utils.get_paginated_results(query, page)
 
 
+def get_project_tasks_fingerprint(project_id):
+    """
+    Return a cheap change signal for the tasks of given project: the
+    latest update date and the row count. Any create, update, delete or
+    assignation (assigning saves the task) moves at least one of them.
+    """
+    max_updated_at, task_count = (
+        Task.query.with_entities(
+            func.max(Task.updated_at), func.count(Task.id)
+        )
+        .filter(Task.project_id == project_id)
+        .one()
+    )
+    return f"{max_updated_at}:{task_count}"
+
+
 def get_tasks_for_project(
     project_id, page=0, task_type_id=None, episode_id=None
 ):

--- a/zou/app/utils/http_cache.py
+++ b/zou/app/utils/http_cache.py
@@ -1,0 +1,62 @@
+"""
+Conditional GET support for permissioned JSON endpoints.
+
+The response copy lives in each client's browser cache. The ETag must
+capture every input that shapes the response: a cheap data freshness
+signal, and the caller identity and effective role, so that a role
+change or an account switch on the same browser fails revalidation
+instead of validating a payload shaped for someone else.
+
+Responses are marked "private, no-cache": the browser keeps the copy
+but revalidates on every request, so nothing is ever served without the
+server deciding with the current authentication in hand.
+"""
+
+import hashlib
+
+from flask import current_app, request
+
+from zou.app.utils.flask_utils import dumps_bytes
+
+
+def build_etag(*parts):
+    """
+    Hash the given response-shaping inputs into an ETag value.
+    """
+    raw = "|".join(str(part) for part in parts)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def is_fresh(etag):
+    """
+    Return True when the client's If-None-Match carries given ETag.
+    """
+    return request.if_none_match.contains(etag)
+
+
+def not_modified(etag):
+    """
+    Build an empty 304 response carrying given ETag.
+    """
+    return mark(current_app.response_class(status=304), etag)
+
+
+def json_response(body, etag):
+    """
+    Build a JSON response carrying given ETag.
+    """
+    response = current_app.response_class(
+        dumps_bytes(body), mimetype="application/json"
+    )
+    return mark(response, etag)
+
+
+def mark(response, etag):
+    """
+    Stamp an existing response with given ETag and the revalidation
+    cache policy.
+    """
+    response.set_etag(etag)
+    response.cache_control.private = True
+    response.cache_control.no_cache = True
+    return response

--- a/zou/app/utils/permissions.py
+++ b/zou/app/utils/permissions.py
@@ -56,6 +56,15 @@ def _effective_role():
     return role if role not in (None, "admin") else _global_role()
 
 
+def get_effective_role():
+    """
+    Public read of the effective role, for callers that must key a
+    response on it (e.g. an ETag). Resolve the project first, as for any
+    permission check.
+    """
+    return _effective_role()
+
+
 def has_manager_permissions():
     """
     Return True if user is an admin or a manager, using the project role


### PR DESCRIPTION
**Problem**

- Kitsu polls the project task listing and the shots/assets with-tasks boards: every poll ran the heaviest queries of the API and serialized thousands of rows even when nothing had changed

**Solution**

- Answer 304 from a cheap fingerprint (a few scalar reads covering the project's entities, tasks, entity type names and the caller's subscriptions) hashed with the caller id and effective role, so a role change or an account switch on a shared browser never validates someone else's payload
- Mark responses private, no-cache: the browser keeps the copy but the server re-decides on every request with the current authentication; wired on the three board response modes, for project-scoped requests only