### PR TITLE
[shots] Support the all pseudo-episode on with-tasks listings and typed playlist lists

### DIFF
--- a/tests/blueprints/playlists/test_playlists.py
+++ b/tests/blueprints/playlists/test_playlists.py
@@ -35,6 +35,29 @@ class PlaylistTestCase(ApiDBTestCase):
         playlists = self.get(f"data/projects/{self.project_id}/playlists")
         self.assertEqual(len(playlists), 1)
 
+    def test_get_all_episodes_playlists_filtered_by_entity(self):
+        self.generate_fixture_playlist(
+            "All assets", for_entity="asset", is_for_all=True
+        )
+        self.generate_fixture_playlist(
+            "All shots", for_entity="shot", is_for_all=True
+        )
+        self.generate_fixture_playlist(
+            "Episode shots", episode_id=self.episode_id
+        )
+        base = f"data/projects/{self.project_id}/episodes/all/playlists"
+        self.assertEqual(
+            {p["name"] for p in self.get(base)}, {"All assets", "All shots"}
+        )
+        self.assertEqual(
+            [p["name"] for p in self.get(f"{base}?for_entity=shot")],
+            ["All shots"],
+        )
+        self.assertEqual(
+            [p["name"] for p in self.get(f"{base}?for_entity=asset")],
+            ["All assets"],
+        )
+
     def test_crud_list_hides_internal_playlists_from_clients(self):
         self.generate_fixture_playlist("Internal")
         self.generate_fixture_playlist("For client", for_client=True)

--- a/tests/blueprints/shots/test_sequence_tasks.py
+++ b/tests/blueprints/shots/test_sequence_tasks.py
@@ -40,3 +40,11 @@ class SequenceTasksTestCase(ApiDBTestCase):
         self.assertDictEqual(
             task_types[0], self.task_type_animation.serialize()
         )
+
+    def test_get_sequences_and_tasks_all_episodes(self):
+        project_id = str(self.sequence.project_id)
+        sequences = self.get(
+            f"data/sequences/with-tasks?project_id={project_id}&episode_id=all"
+        )
+        self.assertEqual(len(sequences), 1)
+        self.assertEqual(sequences[0]["name"], "S01")

--- a/tests/blueprints/shots/test_shot_tasks.py
+++ b/tests/blueprints/shots/test_shot_tasks.py
@@ -127,3 +127,24 @@ class ShotTasksTestCase(ApiDBTestCase):
         self.assertDictEqual(
             task_types[0], self.task_type_animation.serialize()
         )
+
+    def test_get_shots_and_tasks_all_episodes(self):
+        project_id = str(self.project.id)
+        shots = self.get(
+            f"data/shots/with-tasks?project_id={project_id}&episode_id=all"
+        )
+        self.assertEqual(len(shots), 1)
+        self.assertEqual(shots[0]["episode_name"], "E01")
+
+    def test_get_sequences_and_tasks_all_episodes_as_vendor(self):
+        project_id = str(self.project.id)
+        self.generate_fixture_user_vendor()
+        vendor_id = self.user_vendor["id"]
+        projects_service.add_team_member(project_id, vendor_id)
+        tasks_service.assign_task(str(self.shot_task.id), vendor_id)
+        self.log_in_vendor()
+        sequences = self.get(
+            f"data/sequences/with-tasks?project_id={project_id}&episode_id=all"
+        )
+        self.assertEqual(len(sequences), 1)
+        self.assertEqual(sequences[0]["name"], "S01")

--- a/zou/app/blueprints/playlists/resources.py
+++ b/zou/app/blueprints/playlists/resources.py
@@ -153,6 +153,14 @@ class EpisodePlaylistsResource(MethodView, ArgsMixin):
               format: uuid
             description: Episode unique identifier or special value (main, all)
             example: a24a6ea4-ce75-4665-a070-57453082c25
+          - in: query
+            name: for_entity
+            required: false
+            schema:
+              type: string
+            description: Only list playlists of this entity type (asset,
+              shot, sequence, edit, episode)
+            example: shot
         responses:
           200:
             description: All playlists related to given episode
@@ -183,6 +191,7 @@ class EpisodePlaylistsResource(MethodView, ArgsMixin):
         page = self.get_page()
         sort_by = self.get_sort_by()
         task_type_id = self.get_text_parameter("task_type_id")
+        for_entity = self.get_text_parameter("for_entity")
         if episode_id not in ["main", "all"]:
             shots_service.get_episode(episode_id)
         return playlists_service.all_playlists_for_episode(
@@ -192,6 +201,7 @@ class EpisodePlaylistsResource(MethodView, ArgsMixin):
             page=page,
             sort_by=sort_by,
             task_type_id=task_type_id,
+            for_entity=for_entity,
         )
 
 

--- a/zou/app/blueprints/shots/resources.py
+++ b/zou/app/blueprints/shots/resources.py
@@ -1234,7 +1234,7 @@ class SequenceAndTasksResource(MethodView):
         if permissions.has_vendor_permissions():
             # Vendors only see sequences holding a shot with a task assigned
             # to them, and only their own tasks on those sequences.
-            if criterions.get("episode_id"):
+            if criterions.get("episode_id") not in (None, "all"):
                 sequences = shots_service.get_sequences_for_episode(
                     criterions["episode_id"], only_assigned=True
                 )

--- a/zou/app/services/entities_service.py
+++ b/zou/app/services/entities_service.py
@@ -497,8 +497,6 @@ def get_entities_and_tasks(criterions=None):
     """
     if criterions is None:
         criterions = {}
-    if "episode_id" in criterions and criterions["episode_id"] == "all":
-        return []
 
     subscription_map = notifications_service.get_subscriptions_for_user(
         criterions.get("project_id", None),
@@ -512,7 +510,9 @@ def get_entities_and_tasks(criterions=None):
             )
         if "project_id" in criterions:
             query = query.filter(Entity.project_id == criterions["project_id"])
-        if "episode_id" in criterions:
+        # "all" is the cross-episode pseudo-episode Kitsu uses for its
+        # production-wide views: no episode filter, like shots_service.
+        if "episode_id" in criterions and criterions["episode_id"] != "all":
             query = query.filter(Entity.parent_id == criterions["episode_id"])
         if "entity_ids" in criterions:
             query = query.filter(Entity.id.in_(criterions["entity_ids"]))

--- a/zou/app/services/playlists_service.py
+++ b/zou/app/services/playlists_service.py
@@ -138,14 +138,20 @@ def all_playlists_for_episode(
     page=1,
     sort_by="updated_at",
     task_type_id=None,
+    for_entity=None,
 ):
     """
-    Return all playlists created for given episode.
+    Return all playlists created for given episode. The "all" pseudo-episode
+    lists the production-wide playlists of every entity type unless
+    `for_entity` narrows them (Kitsu splits them into All assets / All shots).
     """
     result = []
     query = Playlist.query
     if for_client:
         query = query.filter(Playlist.for_client)
+
+    if for_entity:
+        query = query.filter(Playlist.for_entity == for_entity)
 
     if task_type_id is not None and len(task_type_id) > 0:
         query = query.filter(Playlist.task_type_id == task_type_id)
@@ -1016,7 +1022,11 @@ def get_playlist_download_context_name(project, playlist):
             episode = shots_service.get_episode(episode_id)
             episode_name = episode["name"]
         elif playlist.get("is_for_all"):
-            episode_name = "all assets"
+            episode_name = (
+                "all assets"
+                if playlist.get("for_entity") == "asset"
+                else "all shots"
+            )
         else:
             episode_name = "main pack"
         context_name += f"_{slugify(episode_name, separator='_')}"


### PR DESCRIPTION
**Problem**
- `GET /data/sequences/with-tasks` and `GET /data/episodes/with-tasks` returned `[]` on `episode_id=all`, and the vendor branch of the sequences route crashed (500) on it, unlike the shots route.
- The `all` playlists listing mixed every production-wide playlist regardless of entity type, so Kitsu could not offer "All assets" and "All shots" separately.

**Solution**
- Treat the `all` pseudo-episode as "no episode filter" in `entities_service.get_entities_and_tasks` and in the vendor branch of `SequenceAndTasksResource`, like `shots_service` already does.
- Add an optional `for_entity` query parameter to `GET /data/projects/<project_id>/episodes/<episode_id>/playlists`, and name downloaded archives "all shots" for cross-episode shot playlists.
- Cover both with tests (including the vendor path).