### PR TITLE
[persons] Accept CSV choice values case-insensitively

### DIFF
--- a/tests/blueprints/source/csv/test_import_persons.py
+++ b/tests/blueprints/source/csv/test_import_persons.py
@@ -153,7 +153,16 @@ class ImportCsvPersonsTestCase(ApiDBTestCase):
         self._upload_csv(self._csv(Country="France"), code=400)
 
     def test_import_persons_invalid_position(self):
-        self._upload_csv(self._csv(Position="Boss"), code=400)
+        error = self._upload_csv(self._csv(Position="Boss"), code=400)
+        self.assertIn("accepted values", error["message"])
+
+    def test_import_persons_choice_columns_are_case_insensitive(self):
+        # "artist" is the lowercase label of role code "user": labels and
+        # codes both resolve regardless of casing.
+        self._upload_csv(self._csv(Role="artist", Seniority="SENIOR"))
+        person = Person.get_by(email="test.user@gmail.com")
+        self.assertEqual(person.role.code, "user")
+        self.assertEqual(person.seniority.code, "senior")
 
     def test_import_persons_invalid_daily_salary(self):
         self._upload_csv(self._csv(**{"Daily Salary": "lots"}), code=400)

--- a/zou/app/blueprints/source/csv/persons.py
+++ b/zou/app/blueprints/source/csv/persons.py
@@ -207,14 +207,16 @@ class PersonsCsvImportResource(BaseCsvImportResource):
     def map_choice(self, label, value, choice_map):
         """
         Accept either a human label ("Lead") or a stored code ("lead") for a
-        ChoiceType column and return the code. Raise ValueError (400) on an
-        unknown value, like the other typed columns.
+        ChoiceType column, case-insensitively, and return the code. Raise
+        ValueError (400) naming the accepted values on an unknown one.
         """
-        if value in choice_map:
-            return choice_map[value]
-        if value not in choice_map.values():
-            raise ValueError(f"{label}: {value}")
-        return value
+        folded = value.casefold()
+        for choice_label, code in choice_map.items():
+            if folded in (choice_label.casefold(), code.casefold()):
+                return code
+        raise ValueError(
+            f"{label}: {value} (accepted values: {', '.join(choice_map)})"
+        )
 
     def resolve_departments(self, departments_value):
         """


### PR DESCRIPTION
**Problem**

- The person CSV import rejects "artist" for Role while the UI displays the role as "Artist": labels and codes are matched case-sensitively.
- The 400 message does not say which values are accepted.

**Solution**

- Match Role, Contract Type, Position and Seniority against labels and codes case-insensitively.
- Name the accepted values in the invalid-value error message.