### PR TITLE
[cli] Send the telemetry only when the schema actually moves

### DIFF
--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -2,7 +2,7 @@ import datetime
 import io
 import json as stdlib_json
 from contextlib import redirect_stdout
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from click.testing import CliRunner
 
@@ -428,3 +428,56 @@ class ListPluginsCommandTestCase(ApiDBTestCase):
         plugins = stdlib_json.loads(result.output)
         self.assertEqual(plugins[0]["Plugin ID"], "studio-tools")
         self.assertEqual(plugins[0]["Name"], "Studio Tools")
+
+
+class UpgradeDbTelemetryTestCase(ApiDBTestCase):
+    """
+    Most deployments run upgrade-db on every boot, so the telemetry has to
+    follow the schema moving, not the command running.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.runner = CliRunner()
+
+    def run_upgrade_db(self, current_rev, head_rev="head-rev", *args):
+        connection = MagicMock()
+        connection.execute.return_value.first.return_value = (
+            (current_rev,) if current_rev is not None else None
+        )
+        engine = MagicMock()
+        engine.connect.return_value.__enter__.return_value = connection
+
+        script = MagicMock()
+        script.get_current_head.return_value = head_rev
+        script.walk_revisions.return_value = [
+            MagicMock(revision=rev)
+            for rev in (current_rev, head_rev)
+            if rev is not None
+        ]
+
+        with patch("sqlalchemy.create_engine", return_value=engine), patch(
+            "alembic.script.ScriptDirectory.from_config", return_value=script
+        ), patch("alembic.command.upgrade"), patch(
+            "zou.app.services.telemetry_service.send_main_infos"
+        ) as send:
+            result = self.runner.invoke(cli, ["upgrade-db", *args])
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        return send
+
+    def test_no_telemetry_when_the_schema_did_not_move(self):
+        # The restart case: a container boots, upgrade-db is a no-op.
+        self.run_upgrade_db("head-rev").assert_not_called()
+
+    def test_telemetry_on_an_actual_upgrade(self):
+        self.run_upgrade_db("old-rev").assert_called_once()
+
+    def test_telemetry_on_a_fresh_install(self):
+        # No alembic_version table yet: that is a new instance to count.
+        self.run_upgrade_db(None).assert_called_once()
+
+    def test_no_telemetry_flag_still_wins(self):
+        self.run_upgrade_db(
+            "old-rev", "head-rev", "--no-telemetry"
+        ).assert_not_called()

--- a/zou/cli.py
+++ b/zou/cli.py
@@ -225,8 +225,10 @@ def upgrade_db(no_telemetry=False):
             current_rev = None
     engine.dispose()
 
+    script = ScriptDirectory.from_config(cfg)
+    head_rev = script.get_current_head()
+
     if current_rev is not None:
-        script = ScriptDirectory.from_config(cfg)
         known = {r.revision for r in script.walk_revisions()}
         if current_rev not in known:
             print(
@@ -245,7 +247,11 @@ def upgrade_db(no_telemetry=False):
         "on",
         "1",
     )
-    if not no_telemetry and is_self_hosted:
+    # Deployments run upgrade-db on every boot (Docker entrypoint, k8s init
+    # container, systemd unit), so sending on every invocation turned each
+    # restart into a telemetry POST. Only an actual schema move is a new
+    # install or a version upgrade worth counting.
+    if not no_telemetry and is_self_hosted and current_rev != head_rev:
         with _get_app().app_context():
             from zou.app.services import telemetry_service
 


### PR DESCRIPTION
**Problem**
- `zou upgrade-db` posts to the telemetry endpoint on every invocation, including when the upgrade is a no-op
- Most deployments run `upgrade-db` at boot (Docker entrypoint, k8s init container, systemd unit, the staging deploy workflow), so every restart, redeploy and scale-up is one POST
- A crash-looping instance spams the endpoint on its own

**Solution**
- Compare the revision read before the upgrade with the script head, and send only when they differ
- A fresh install (no `alembic_version` row) and a real version upgrade still report; a plain restart stays silent
- Add `UpgradeDbTelemetryTestCase` covering the restart, upgrade, fresh install and `--no-telemetry` cases