### PR TITLE
Day off reads for managers, picture fixes, burndown bounds and task type names

### DIFF
--- a/tests/blueprints/crud/test_day_off.py
+++ b/tests/blueprints/crud/test_day_off.py
@@ -1,7 +1,7 @@
 from tests.base import ApiDBTestCase
 
 from zou.app.models.time_spent import TimeSpent
-from zou.app.services import tasks_service
+from zou.app.services import projects_service, tasks_service
 from zou.app.utils import fields
 
 
@@ -32,6 +32,34 @@ class DayOffTestCase(ApiDBTestCase):
         day_off_again = self.get(f"data/day-offs/{day_off['id']}")
         self.assertEqual(day_off["id"], day_off_again["id"])
         self.get_404(f"data/day-offs/{fields.gen_uuid()}")
+
+    def test_get_day_off_as_a_manager_or_a_supervisor_of_the_person(self):
+        """
+        Reading a single day off follows the person routes: the managers
+        of a production the person is part of get it whole, its
+        supervisors get it without its description. The listing stays
+        with the admins, and so does writing.
+        """
+        self.generate_fixture_project()
+        day_off = self.day_off("2024-01-15", description="Vacation")
+        path = f"data/day-offs/{day_off['id']}"
+        manager = self.generate_fixture_user_manager()
+        supervisor = self.generate_fixture_user_supervisor()
+
+        self.log_in_manager()
+        self.get(path, 403)
+
+        for person_id in (self.person_id, manager["id"], supervisor["id"]):
+            projects_service.add_team_member(self.project.id, person_id)
+
+        self.assertEqual(self.get(path)["description"], "Vacation")
+        self.get("data/day-offs", 403)
+        self.put(path, {"description": "Sick leave"}, 403)
+        self.delete(path, 403)
+
+        self.log_in_supervisor()
+        self.assertNotIn("description", self.get(path))
+        self.get("data/day-offs", 403)
 
     def test_create_day_off(self):
         day_off = self.day_off("2024-01-15", "2024-01-16")

--- a/tests/blueprints/crud/test_task_type.py
+++ b/tests/blueprints/crud/test_task_type.py
@@ -35,6 +35,91 @@ class TaskTypeTestCase(ApiDBTestCase):
         task_types = self.get("data/task-types")
         self.assertEqual(len(task_types), 4)
 
+    def test_create_task_type_with_a_name_differing_only_by_case(self):
+        """
+        A case differing twin makes the task type unresolvable by name in the
+        clients, which filter on names, so it is refused like an exact one.
+        """
+        self.post(
+            "data/task-types",
+            {
+                "name": "compositing",
+                "color": "#000000",
+                "department_id": self.department_id,
+            },
+        )
+        self.post(
+            "data/task-types",
+            {
+                "name": "COMPOSITING",
+                "color": "#000000",
+                "department_id": self.department_id,
+            },
+            400,
+        )
+        self.assertEqual(len(self.get("data/task-types")), 4)
+
+    def test_rename_task_type_onto_a_name_differing_only_by_case(self):
+        self.post(
+            "data/task-types",
+            {
+                "name": "compositing",
+                "color": "#000000",
+                "department_id": self.department_id,
+            },
+        )
+        other = self.post(
+            "data/task-types",
+            {
+                "name": "layout",
+                "color": "#000000",
+                "department_id": self.department_id,
+            },
+        )
+        self.put(
+            f"data/task-types/{other['id']}", {"name": "COMPOSITING"}, 400
+        )
+
+    def test_rename_task_type_keeping_its_own_name_case(self):
+        task_type = self.post(
+            "data/task-types",
+            {
+                "name": "compositing",
+                "color": "#000000",
+                "department_id": self.department_id,
+            },
+        )
+        self.put(f"data/task-types/{task_type['id']}", {"name": "COMPOSITING"})
+        self.assertEqual(
+            self.get(f"data/task-types/{task_type['id']}")["name"],
+            "COMPOSITING",
+        )
+
+    def test_rename_task_type_with_a_legacy_case_twin(self):
+        """
+        Rows predating the guard can already differ only by case. Renaming
+        one of them must still see the other, whichever of the two the
+        lookup happens to return first, while an update carrying the row's
+        own name must go through: the clients send the whole form on a
+        colour change.
+        """
+        first = TaskType.create(
+            name="compositing", department_id=self.department_id
+        )
+        second = TaskType.create(
+            name="Compositing", department_id=self.department_id
+        )
+        self.put(f"data/task-types/{second.id}", {"name": "COMPOSITING"}, 400)
+        self.put(f"data/task-types/{first.id}", {"name": "COMPOSITING"}, 400)
+
+        self.put(
+            f"data/task-types/{second.id}",
+            {"name": "Compositing", "color": "#FFFFFF"},
+        )
+        self.assertEqual(
+            self.get(f"data/task-types/{second.id}")["color"], "#FFFFFF"
+        )
+
     def test_update_task_type(self):
         task_type = self.get_first("data/task-types")
         data = {"color": "#FFFFFF"}

--- a/tests/blueprints/persons/test_persons.py
+++ b/tests/blueprints/persons/test_persons.py
@@ -7,7 +7,7 @@ from tests.base import ApiDBTestCase
 from zou.app.models.day_off import DayOff
 from zou.app.models.person import Person
 from zou.app.stores import auth_tokens_store
-from zou.app.services import tasks_service
+from zou.app.services import projects_service, tasks_service
 from zou.app.utils import auth, fields
 
 
@@ -113,24 +113,117 @@ class PersonRoutesTestCase(ApiDBTestCase):
         )
         self.assertIsNotNone(result)
 
-    def test_get_person_day_off_for_date_is_admin_or_self(self):
-        # Leave is between the person and the admins, like the week, month
-        # and year routes and like the day off CRUD. A team calendar goes
-        # through /data/projects/<id>/day-offs, which scopes to the
-        # production and hands the detail to its managers only.
+    def test_reading_the_day_offs_of_somebody_else(self):
+        """
+        Leave is read by the person, the admins, the managers of a
+        production they are part of and, dates only, the supervisors of
+        that production supervising their department. Anybody else is
+        turned away, on the day, week, month and year routes alike.
+        """
         DayOff.create(
             date="2024-06-10",
             end_date="2024-06-10",
             person_id=self.person.id,
+            description="Dentist",
         )
-        path = f"/data/persons/{self.person_id}/day-offs/2024-06-10"
+        base = f"/data/persons/{self.person_id}/day-offs"
+        paths = [
+            f"{base}/2024-06-10",
+            f"{base}/week/2024/24",
+            f"{base}/month/2024/06",
+            f"{base}/year/2024",
+            base,
+        ]
 
-        self.generate_fixture_user_supervisor()
+        def read_it_through_each_route(expected_status=200):
+            day_offs = []
+            for path in paths:
+                with self.subTest(path=path):
+                    result = self.get(path, expected_status)
+                    if expected_status == 200:
+                        day_offs.append(
+                            result if isinstance(result, dict) else result[0]
+                        )
+            return day_offs
+
+        manager = self.generate_fixture_user_manager()
+        supervisor = self.generate_fixture_user_supervisor()
+        artist = self.generate_fixture_user_cg_artist()
+        animation = [str(self.department_animation.id)]
+
+        # A manager of no production of theirs.
+        self.log_in_manager()
+        read_it_through_each_route(403)
+
+        projects_service.add_team_member(self.project.id, manager["id"])
+        for day_off in read_it_through_each_route():
+            self.assertEqual(day_off["description"], "Dentist")
+
+        # A supervisor of the production, but of another department.
+        projects_service.add_team_member(self.project.id, supervisor["id"])
+        Person.get(supervisor["id"]).set_departments(animation)
         self.log_in_supervisor()
-        self.get(path, 403)
+        read_it_through_each_route(403)
 
-        self.log_in_admin()
-        self.assertIsNotNone(self.get(path))
+        Person.get(self.person_id).set_departments(animation)
+        for day_off in read_it_through_each_route():
+            self.assertEqual(day_off["date"], "2024-06-10")
+            self.assertNotIn("description", day_off)
+
+        # A teammate.
+        projects_service.add_team_member(self.project.id, artist["id"])
+        self.log_in_cg_artist()
+        read_it_through_each_route(403)
+
+    def test_the_studio_wide_month_lists_what_the_caller_may_read(self):
+        """
+        /data/persons/day-offs/<year>/<month> holds the leave of everybody
+        for an admin, of oneself for an artist, of the team of one's
+        productions for a manager, and of the supervised part of it, dates
+        only, for a supervisor.
+        """
+        DayOff.create(
+            date="2024-06-10",
+            end_date="2024-06-10",
+            person_id=self.person.id,
+            description="Dentist",
+        )
+        manager = self.generate_fixture_user_manager()
+        DayOff.create(
+            date="2024-06-12",
+            end_date="2024-06-12",
+            person_id=manager["id"],
+            description="Moving",
+        )
+        path = "/data/persons/day-offs/2024/06"
+
+        def what_each_person_shows():
+            return {
+                day_off["person_id"]: day_off.get("description", "dates only")
+                for day_off in self.get(path)
+            }
+
+        self.assertEqual(
+            what_each_person_shows(),
+            {self.person_id: "Dentist", manager["id"]: "Moving"},
+        )
+
+        self.log_in_manager()
+        self.assertEqual(what_each_person_shows(), {manager["id"]: "Moving"})
+
+        projects_service.add_team_member(self.project.id, manager["id"])
+        self.assertEqual(
+            what_each_person_shows(),
+            {self.person_id: "Dentist", manager["id"]: "Moving"},
+        )
+
+        supervisor = self.generate_fixture_user_supervisor()
+        projects_service.add_team_member(self.project.id, supervisor["id"])
+        self.log_in_supervisor()
+        self.assertEqual(
+            what_each_person_shows(),
+            {self.person_id: "dates only", manager["id"]: "dates only"},
+        )
 
     def test_the_day_off_listings_each_hold_their_own_period(self):
         """

--- a/tests/blueprints/persons/test_persons.py
+++ b/tests/blueprints/persons/test_persons.py
@@ -7,7 +7,11 @@ from tests.base import ApiDBTestCase
 from zou.app.models.day_off import DayOff
 from zou.app.models.person import Person
 from zou.app.stores import auth_tokens_store
-from zou.app.services import projects_service, tasks_service
+from zou.app.services import (
+    persons_service,
+    projects_service,
+    tasks_service,
+)
 from zou.app.utils import auth, fields
 
 
@@ -149,7 +153,7 @@ class PersonRoutesTestCase(ApiDBTestCase):
         manager = self.generate_fixture_user_manager()
         supervisor = self.generate_fixture_user_supervisor()
         artist = self.generate_fixture_user_cg_artist()
-        animation = [str(self.department_animation.id)]
+        animation = str(self.department_animation.id)
 
         # A manager of no production of theirs.
         self.log_in_manager()
@@ -161,11 +165,11 @@ class PersonRoutesTestCase(ApiDBTestCase):
 
         # A supervisor of the production, but of another department.
         projects_service.add_team_member(self.project.id, supervisor["id"])
-        Person.get(supervisor["id"]).set_departments(animation)
+        persons_service.add_to_department(animation, supervisor["id"])
         self.log_in_supervisor()
         read_it_through_each_route(403)
 
-        Person.get(self.person_id).set_departments(animation)
+        persons_service.add_to_department(animation, self.person_id)
         for day_off in read_it_through_each_route():
             self.assertEqual(day_off["date"], "2024-06-10")
             self.assertNotIn("description", day_off)

--- a/tests/blueprints/source/shotgun/test_shotgun_import_steps.py
+++ b/tests/blueprints/source/shotgun/test_shotgun_import_steps.py
@@ -75,6 +75,66 @@ class ImportShotgunStepTestCase(ShotgunTestCase):
         task_type = task_types[0]
         self.assertEqual(task_type["name"], "Modeling Shaders")
 
+    def test_import_step_with_a_name_differing_only_by_case(self):
+        """
+        A step named after an existing task type in another case updates
+        that task type, which keeps its name, instead of creating a twin
+        the clients cannot tell apart.
+        """
+        api_path = "/import/shotgun/steps"
+        sg_step = {
+            "code": "Modeling Shaders",
+            "color": "50,149,253",
+            "id": 14,
+            "type": "Step",
+        }
+        self.post(api_path, [sg_step], 200)
+        sg_step = {
+            "code": "Modeling SHADERS",
+            "color": "0,0,0",
+            "id": 15,
+            "type": "Step",
+        }
+        self.post(api_path, [sg_step], 200)
+
+        task_types = self.get("/data/task-types")
+        self.assertEqual(len(task_types), 1)
+        self.assertEqual(task_types[0]["name"], "Modeling Shaders")
+        self.assertEqual(task_types[0]["shotgun_id"], 15)
+
+    def test_import_step_keeps_its_name_across_departments(self):
+        """
+        The first word of a step names its department, so a step differing
+        only by case can land in another department. The task type follows
+        the step there, as before, but still keeps its name.
+        """
+        api_path = "/import/shotgun/steps"
+        sg_step = {
+            "code": "Modeling Shaders",
+            "color": "50,149,253",
+            "id": 14,
+            "type": "Step",
+        }
+        self.post(api_path, [sg_step], 200)
+        sg_step = {
+            "code": "MODELING Shaders",
+            "color": "0,0,0",
+            "id": 15,
+            "type": "Step",
+        }
+        self.post(api_path, [sg_step], 200)
+
+        departments = {
+            department["name"]: department["id"]
+            for department in self.get("/data/departments")
+        }
+        task_types = self.get("/data/task-types")
+        self.assertEqual(len(task_types), 1)
+        self.assertEqual(task_types[0]["name"], "Modeling Shaders")
+        self.assertEqual(
+            task_types[0]["department_id"], departments["MODELING"]
+        )
+
     def test_import_step_twice(self):
         sg_step_animation = {
             "code": "Animation",

--- a/tests/blueprints/tasks/test_tasks.py
+++ b/tests/blueprints/tasks/test_tasks.py
@@ -921,7 +921,7 @@ class TaskListingTestCase(TaskTestCase):
         """
         Each bound falls back to the project dates independently, so the
         raw values can come out inverted. The announced window must stay
-        ordered and contain every done day.
+        ordered, and a done day preceding it lands on its first day.
         """
         task = self.generate_fixture_task()
         task.update({"start_date": "2026-09-01", "due_date": None})
@@ -933,8 +933,80 @@ class TaskListingTestCase(TaskTestCase):
 
         task.update({"done_date": "2026-07-20T10:00:00"})
         burndown = self.get("/data/tasks/open-tasks/burndown")
-        self.assertEqual(burndown["start_date"], "2026-07-20")
+        self.assertEqual(burndown["start_date"], "2026-08-15")
         self.assertEqual(burndown["end_date"], "2026-09-01")
+        self.assertEqual(burndown["done_by_day"][0]["date"], "2026-08-15")
+
+    def test_open_tasks_burndown_folds_early_done_days(self):
+        """
+        An imported done date can predate the schedule by decades and used
+        to drag the whole window back to 1899. Such a day is folded onto
+        the first day of the window, where its amounts stay counted: they
+        belong to the total, and dropping them would leave the curve above
+        zero.
+        """
+        task = self.generate_fixture_task()
+        task.update(
+            {
+                "start_date": "2026-08-03",
+                "due_date": "2026-08-21",
+                "estimation": 480,
+                "done_date": "1899-12-31T00:00:00",
+            }
+        )
+        self.generate_fixture_shot_task()
+        self.shot_task.update(
+            {
+                "start_date": "2026-08-05",
+                "due_date": "2026-08-14",
+                "estimation": 960,
+                "done_date": "2026-08-10T10:00:00",
+            }
+        )
+
+        burndown = self.get("/data/tasks/open-tasks/burndown")
+        self.assertEqual(burndown["start_date"], "2026-08-03")
+        self.assertEqual(burndown["end_date"], "2026-08-21")
+        self.assertEqual(
+            burndown["done_by_day"],
+            [
+                {"date": "2026-08-03", "done": 1, "done_estimation": 480},
+                {"date": "2026-08-10", "done": 1, "done_estimation": 960},
+            ],
+        )
+
+        # a folded day merges into the activity already recorded there
+        self.shot_task.update({"done_date": "2026-08-03T09:00:00"})
+        burndown = self.get("/data/tasks/open-tasks/burndown")
+        self.assertEqual(
+            burndown["done_by_day"],
+            [{"date": "2026-08-03", "done": 2, "done_estimation": 1440}],
+        )
+
+    def test_open_tasks_burndown_keeps_early_done_days_without_start(self):
+        """
+        The fold needs a start date to anchor on. A pool carrying due
+        dates alone, with no project start date to fall back on, keeps
+        its activity where it happened: folded onto the due date, every
+        day would collapse into one point.
+        """
+        task = self.generate_fixture_task()
+        task.update(
+            {
+                "start_date": None,
+                "due_date": "2026-08-21",
+                "estimation": 480,
+                "done_date": "2026-08-10T10:00:00",
+            }
+        )
+
+        burndown = self.get("/data/tasks/open-tasks/burndown")
+        self.assertEqual(burndown["start_date"], "2026-08-10")
+        self.assertEqual(burndown["end_date"], "2026-08-21")
+        self.assertEqual(
+            burndown["done_by_day"],
+            [{"date": "2026-08-10", "done": 1, "done_estimation": 480}],
+        )
 
     def test_open_tasks_priority_filter(self):
         """

--- a/tests/services/test_permissions_service.py
+++ b/tests/services/test_permissions_service.py
@@ -8,7 +8,6 @@ from tests.base import ApiDBTestCase
 
 from zou.app import app
 from zou.app.models.entity import Entity
-from zou.app.models.person import Person
 from zou.app.services import (
     comments_service,
     permissions_service,
@@ -380,20 +379,20 @@ class PersonAccessTestCase(PermissionsTestCase):
         """
         artist = self.join_team(self.a_user("artist"))
         supervisor = self.join_team(self.a_user("supervisor"))
-        animation = [str(self.department_animation.id)]
+        animation = str(self.department_animation.id)
 
         with self.as_role("supervisor"):
             self.assertFalse(
                 permissions_service.check_day_off_read_access(artist["id"])
             )
 
-        Person.get(supervisor["id"]).set_departments(animation)
+        persons_service.add_to_department(animation, supervisor["id"])
 
         with self.as_role("supervisor"):
             with self.denied():
                 permissions_service.check_day_off_read_access(artist["id"])
 
-        Person.get(artist["id"]).set_departments(animation)
+        persons_service.add_to_department(animation, artist["id"])
 
         with self.as_role("supervisor"):
             self.assertFalse(
@@ -428,10 +427,12 @@ class PersonAccessTestCase(PermissionsTestCase):
         manager = self.join_team(self.a_user("manager"))
         supervisor = self.join_team(self.a_user("supervisor"))
         self.a_user("client")
-        animation = [str(self.department_animation.id)]
-        Person.get(artist["id"]).set_departments(animation)
-        Person.get(supervisor["id"]).set_departments(animation)
-        Person.get(manager["id"]).set_departments([str(self.department.id)])
+        animation = str(self.department_animation.id)
+        persons_service.add_to_department(animation, artist["id"])
+        persons_service.add_to_department(animation, supervisor["id"])
+        persons_service.add_to_department(
+            str(self.department.id), manager["id"]
+        )
 
         with self.as_role("admin"):
             self.assertIsNone(

--- a/tests/services/test_permissions_service.py
+++ b/tests/services/test_permissions_service.py
@@ -8,6 +8,7 @@ from tests.base import ApiDBTestCase
 
 from zou.app import app
 from zou.app.models.entity import Entity
+from zou.app.models.person import Person
 from zou.app.services import (
     comments_service,
     permissions_service,
@@ -331,6 +332,132 @@ class PersonAccessTestCase(PermissionsTestCase):
                 permissions_service.check_day_off_access(
                     {"person_id": self.a_user("artist")["id"]}
                 )
+            )
+
+    def test_check_day_off_read_access_of_the_person_and_the_admins(self):
+        with self.as_role("artist") as artist:
+            self.assertTrue(
+                permissions_service.check_day_off_read_access(artist["id"])
+            )
+            with self.denied():
+                permissions_service.check_day_off_read_access(self.user["id"])
+
+        with self.as_role("admin"):
+            self.assertTrue(
+                permissions_service.check_day_off_read_access(
+                    self.a_user("artist")["id"]
+                )
+            )
+
+    def test_check_day_off_read_access_of_a_manager(self):
+        """
+        A manager reads the leave of the team of their productions, with
+        its description, and nothing of anybody else: not of a person
+        outside their team, and nothing at all while on no team.
+        """
+        artist = self.join_team(self.a_user("artist"))
+        outsider = self.a_user("client")
+
+        with self.as_role("manager"):
+            with self.denied():
+                permissions_service.check_day_off_read_access(artist["id"])
+
+        self.join_team(self.a_user("manager"))
+
+        with self.as_role("manager"):
+            self.assertTrue(
+                permissions_service.check_day_off_read_access(artist["id"])
+            )
+            with self.denied():
+                permissions_service.check_day_off_read_access(outsider["id"])
+
+    def test_check_day_off_read_access_of_a_supervisor(self):
+        """
+        A supervisor reads the dates of the leave of the persons they
+        supervise on their productions: everybody on the team while
+        attached to no department, the persons sharing one of theirs
+        otherwise.
+        """
+        artist = self.join_team(self.a_user("artist"))
+        supervisor = self.join_team(self.a_user("supervisor"))
+        animation = [str(self.department_animation.id)]
+
+        with self.as_role("supervisor"):
+            self.assertFalse(
+                permissions_service.check_day_off_read_access(artist["id"])
+            )
+
+        Person.get(supervisor["id"]).set_departments(animation)
+
+        with self.as_role("supervisor"):
+            with self.denied():
+                permissions_service.check_day_off_read_access(artist["id"])
+
+        Person.get(artist["id"]).set_departments(animation)
+
+        with self.as_role("supervisor"):
+            self.assertFalse(
+                permissions_service.check_day_off_read_access(artist["id"])
+            )
+
+    def test_check_day_off_read_access_follows_the_project_role(self):
+        """
+        The role held on the production is the one that counts: an artist
+        made manager of it reads its leave, a manager demoted on it does
+        not.
+        """
+        artist = self.join_team(self.a_user("artist"), role="manager")
+        manager = self.join_team(self.a_user("manager"), role="user")
+
+        with self.as_role("artist"):
+            self.assertTrue(
+                permissions_service.check_day_off_read_access(manager["id"])
+            )
+
+        with self.as_role("manager"):
+            with self.denied():
+                permissions_service.check_day_off_read_access(artist["id"])
+
+    def test_get_day_off_readable_person_ids(self):
+        """
+        The same rule, read at once for a listing: everybody for an admin,
+        oneself for an artist, the team with description for a manager,
+        the supervised part of it, dates only, for a supervisor.
+        """
+        artist = self.join_team(self.a_user("artist"))
+        manager = self.join_team(self.a_user("manager"))
+        supervisor = self.join_team(self.a_user("supervisor"))
+        self.a_user("client")
+        animation = [str(self.department_animation.id)]
+        Person.get(artist["id"]).set_departments(animation)
+        Person.get(supervisor["id"]).set_departments(animation)
+        Person.get(manager["id"]).set_departments([str(self.department.id)])
+
+        with self.as_role("admin"):
+            self.assertIsNone(
+                permissions_service.get_day_off_readable_person_ids()
+            )
+
+        with self.as_role("artist"):
+            self.assertEqual(
+                permissions_service.get_day_off_readable_person_ids(),
+                {artist["id"]: True},
+            )
+
+        with self.as_role("manager"):
+            self.assertEqual(
+                permissions_service.get_day_off_readable_person_ids(),
+                {
+                    artist["id"]: True,
+                    manager["id"]: True,
+                    supervisor["id"]: True,
+                },
+            )
+
+        with self.as_role("supervisor"):
+            self.assertEqual(
+                permissions_service.get_day_off_readable_person_ids(),
+                {artist["id"]: False, supervisor["id"]: True},
             )
 
     def test_check_person_is_not_bot(self):

--- a/tests/services/test_tasks_service.py
+++ b/tests/services/test_tasks_service.py
@@ -783,6 +783,22 @@ class GetOrCreateTaskTypeTestCase(ApiDBTestCase):
         self.assertEqual(first["id"], second["id"])
         self.assertEqual(len(TaskType.get_all_by(name="Concept")), 1)
 
+    def test_return_existing_with_a_name_differing_only_by_case(self):
+        """
+        The bootstrap follows the same rule as the API: a name differing
+        only by case is the same task type, and the existing row keeps
+        its name.
+        """
+        first = tasks_service.get_or_create_task_type(
+            self.department, "Concept", "#8D6E63", 1
+        )
+        second = tasks_service.get_or_create_task_type(
+            self.department, "CONCEPT", "#8D6E63", 1
+        )
+        self.assertEqual(first["id"], second["id"])
+        self.assertEqual(second["name"], "Concept")
+        self.assertEqual(TaskType.get_all_by(name="CONCEPT"), [])
+
     def test_same_name_different_for_entity_coexist(self):
         asset_type = tasks_service.get_or_create_task_type(
             self.department, "Concept", "#8D6E63", 1

--- a/tests/utils/test_thumbnail.py
+++ b/tests/utils/test_thumbnail.py
@@ -5,6 +5,7 @@ from PIL import Image, ImageCms
 
 from werkzeug.datastructures import FileStorage
 
+from zou.app.services.exception import WrongParameterException
 from zou.app.utils import thumbnail, fs
 
 TEST_FOLDER = os.path.join("tests", "tmp")
@@ -75,6 +76,27 @@ class ThumbnailTestCase(unittest.TestCase):
         width, height = im.size
         self.assertEqual(width, 150)
         self.assertEqual(height, 100)
+
+    def test_save_file_rejects_a_file_that_is_not_a_picture(self):
+        source_path = os.path.join(TEST_FOLDER, "not-a-picture.png")
+        with open(source_path, "w") as source:
+            source.write("<svg xmlns='http://www.w3.org/2000/svg'/>")
+
+        with open(source_path, "rb") as stream:
+            th_file = FileStorage(stream=stream, filename="logo.png")
+            with self.assertLogs(thumbnail.logger, "WARNING") as logs:
+                with self.assertRaises(WrongParameterException) as refusal:
+                    thumbnail.save_file(TEST_FOLDER, "instance-id", th_file)
+
+        # The Pillow error and the temporary path go to the log, the
+        # response only says the file is not a picture.
+        self.assertIn("instance-id.png", logs.output[0])
+        self.assertNotIn("instance-id", str(refusal.exception))
+
+        # The temporary file must not survive the failure.
+        self.assertFalse(
+            os.path.exists(os.path.join(TEST_FOLDER, "instance-id.png"))
+        )
 
     def test_url_path(self):
         url_path = thumbnail.url_path("shots", "instance-id")

--- a/tests/utils/test_thumbnail.py
+++ b/tests/utils/test_thumbnail.py
@@ -193,6 +193,11 @@ class ThumbnailTestCase(unittest.TestCase):
         self.assertEqual(converted.mode, "RGBA")
         self.assertEqual(converted.getpixel((0, 0))[3], 0)
 
+        im = Image.new("I;16", (4, 4), 32768)
+        converted = thumbnail.to_srgb(im)
+        self.assertEqual(converted.mode, "L")
+        self.assertEqual(converted.getpixel((0, 0)), 128)
+
     def test_thumbnail_keeps_transparency(self):
         profile = ImageCms.ImageCmsProfile(
             ImageCms.createProfile("sRGB")
@@ -249,6 +254,17 @@ class ThumbnailTestCase(unittest.TestCase):
             self.assertEqual(
                 result.getchannel("A").getbbox(), expected_box, source_size
             )
+
+    def test_thumbnail_scales_a_16_bit_greyscale_picture(self):
+        # A greyscale PNG at depth 16 reads as mode I;16, which
+        # Image.convert() clamps at 255 instead of scaling: the picture used
+        # to come back solid white.
+        file_path = os.path.join(TEST_FOLDER, "grey-16-bit.png")
+        Image.new("I;16", (200, 100), 32768).save(file_path)
+        thumbnail.turn_into_thumbnail(file_path, thumbnail.BIG_SQUARE_SIZE)
+
+        result = Image.open(file_path).convert("RGBA")
+        self.assertEqual(result.getpixel((200, 200)), (128, 128, 128, 255))
 
     def test_turn_hdr_into_thumbnail(self):
         file_path_fixture = self.get_fixture_file_path("thumbnails/sample.hdr")

--- a/tests/utils/test_thumbnail.py
+++ b/tests/utils/test_thumbnail.py
@@ -164,6 +164,50 @@ class ThumbnailTestCase(unittest.TestCase):
         im = Image.new("L", (4, 4))
         self.assertEqual(thumbnail.to_srgb(im).mode, "L")
 
+        im = Image.new("RGB", (4, 4), (0, 0, 0))
+        im.info["transparency"] = (0, 0, 0)
+        im.info["icc_profile"] = profile
+        converted = thumbnail.to_srgb(im)
+        self.assertEqual(converted.mode, "RGBA")
+        self.assertEqual(converted.getpixel((0, 0))[3], 0)
+
+    def test_thumbnail_keeps_transparency(self):
+        profile = ImageCms.ImageCmsProfile(
+            ImageCms.createProfile("sRGB")
+        ).tobytes()
+
+        rgba = Image.new("RGBA", (600, 300), (0, 0, 0, 0))
+        rgba.paste((30, 120, 200, 255), (100, 100, 500, 200))
+        rgb = Image.new("RGB", (600, 300), (0, 0, 0))
+        rgb.paste((30, 120, 200), (100, 100, 500, 200))
+
+        # A PNG carries its transparency either as an alpha channel or, once
+        # it went through a converter such as ImageMagick, as a tRNS colour
+        # key on a truecolour picture. Both must survive the upload, with or
+        # without an embedded ICC profile.
+        sources = [
+            (rgba, {}),
+            (rgba, {"icc_profile": profile}),
+            (rgb, {"transparency": (0, 0, 0)}),
+            (rgb, {"transparency": (0, 0, 0), "icc_profile": profile}),
+        ]
+
+        for index, (im, params) in enumerate(sources):
+            source_path = os.path.join(TEST_FOLDER, f"logo-{index}.png")
+            im.save(source_path, **params)
+            with open(source_path, "rb") as stream:
+                logo_file = FileStorage(stream=stream, filename="logo.png")
+                file_path = thumbnail.save_file(
+                    TEST_FOLDER, f"instance-id-{index}", logo_file
+                )
+            thumbnail.turn_into_thumbnail(file_path, thumbnail.BIG_SQUARE_SIZE)
+
+            # The source is letterboxed to 400x200 pasted at y=100, so both
+            # pixels sit inside the picture and not in the empty bands.
+            result = Image.open(file_path).convert("RGBA")
+            self.assertEqual(result.getpixel((5, 200))[3], 0, params)
+            self.assertEqual(result.getpixel((200, 200))[3], 255, params)
+
     def test_turn_hdr_into_thumbnail(self):
         file_path_fixture = self.get_fixture_file_path("thumbnails/sample.hdr")
         full_path = os.path.join(TEST_FOLDER, "sample.hdr")

--- a/tests/utils/test_thumbnail.py
+++ b/tests/utils/test_thumbnail.py
@@ -208,6 +208,26 @@ class ThumbnailTestCase(unittest.TestCase):
             self.assertEqual(result.getpixel((5, 200))[3], 0, params)
             self.assertEqual(result.getpixel((200, 200))[3], 255, params)
 
+    def test_thumbnail_keeps_ratio_when_scaling_up(self):
+        # A picture smaller than the target box in both dimensions is
+        # scaled up to it. Doing that without keeping the ratio squashed
+        # every logo under 400x400.
+        cases = [
+            ((200, 100), (0, 100, 400, 300)),
+            ((100, 200), (100, 0, 300, 400)),
+            ((100, 100), (0, 0, 400, 400)),
+        ]
+        for index, (source_size, expected_box) in enumerate(cases):
+            file_path = os.path.join(TEST_FOLDER, f"small-{index}.png")
+            Image.new("RGBA", source_size, (30, 120, 200, 255)).save(file_path)
+            thumbnail.turn_into_thumbnail(file_path, thumbnail.BIG_SQUARE_SIZE)
+
+            result = Image.open(file_path)
+            self.assertEqual(result.size, thumbnail.BIG_SQUARE_SIZE)
+            self.assertEqual(
+                result.getchannel("A").getbbox(), expected_box, source_size
+            )
+
     def test_turn_hdr_into_thumbnail(self):
         file_path_fixture = self.get_fixture_file_path("thumbnails/sample.hdr")
         full_path = os.path.join(TEST_FOLDER, "sample.hdr")

--- a/zou/app/blueprints/crud/day_off.py
+++ b/zou/app/blueprints/crud/day_off.py
@@ -194,6 +194,7 @@ class DayOffsResource(BaseModelsResource):
 class DayOffResource(BaseModelResource):
     def __init__(self):
         BaseModelResource.__init__(self, DayOff)
+        self.with_description = True
 
     @jwt_required()
     def get(self, instance_id):
@@ -356,7 +357,19 @@ class DayOffResource(BaseModelResource):
         return permissions_service.check_day_off_access(instance_dict)
 
     def check_read_permissions(self, instance_dict):
-        return permissions_service.check_day_off_access(instance_dict)
+        # Reading follows the person routes: admins, the person and the
+        # managers of a production they are part of get the whole record,
+        # the supervisors of such a production the dates only. Writing
+        # stays between the person and the admins.
+        self.with_description = permissions_service.check_day_off_read_access(
+            instance_dict["person_id"]
+        )
+        return True
+
+    def clean_get_result(self, data):
+        if not self.with_description:
+            data.pop("description", None)
+        return data
 
     def check_update_permissions(self, instance_dict, data):
         if (

--- a/zou/app/blueprints/crud/task_type.py
+++ b/zou/app/blueprints/crud/task_type.py
@@ -153,12 +153,7 @@ class TaskTypesResource(BaseModelsResource):
 
     def update_data(self, data):
         data = super().update_data(data)
-        name = data.get("name", None)
-        task_type = TaskType.get_by(name=name)
-        if task_type is not None:
-            raise WrongParameterException(
-                "A task type with similar name already exists"
-            )
+        tasks_service.check_task_type_name_is_unique(data.get("name"))
         return data
 
     def post_creation(self, instance):
@@ -353,13 +348,14 @@ class TaskTypeResource(BaseModelResource):
 
     def update_data(self, data, instance_id):
         data = super().update_data(data, instance_id)
+        # only a change of name is checked: the clients send the whole
+        # form on every update, so a row already carrying a case twin
+        # must stay editable (colour, department) without renaming it
         name = data.get("name", None)
-        if name is not None:
-            task_type = TaskType.get_by(name=name)
-            if task_type is not None and instance_id != str(task_type.id):
-                raise WrongParameterException(
-                    "A task type with similar name already exists"
-                )
+        if name is not None and name != self.instance.name:
+            tasks_service.check_task_type_name_is_unique(
+                name, exclude_task_type_id=instance_id
+            )
         return data
 
     def post_update(self, instance_dict, data):

--- a/zou/app/blueprints/persons/resources.py
+++ b/zou/app/blueprints/persons/resources.py
@@ -66,6 +66,35 @@ def _get_project_department_ids_for_person_access(person_id):
     return (project_ids, department_ids)
 
 
+def _check_day_off_read_access(person_id):
+    """
+    Guard a day off read of given person, the rule being
+    permissions_service.check_day_off_read_access: return whether the
+    description is part of what the caller gets.
+    """
+    permissions_service.check_person_is_not_bot(person_id)
+    return permissions_service.check_day_off_read_access(person_id)
+
+
+def _dates_only(day_off):
+    """
+    Given serialized day off without its description, what a supervisor
+    gets to see of it.
+    """
+    return {
+        key: value for key, value in day_off.items() if key != "description"
+    }
+
+
+def _shape_day_offs(day_offs, with_description):
+    """
+    Serialized day offs as the caller gets them: whole, or the dates only.
+    """
+    if with_description:
+        return day_offs
+    return [_dates_only(day_off) for day_off in day_offs]
+
+
 class DesktopLoginsResource(MethodView, ArgsMixin):
 
     @jwt_required()
@@ -466,17 +495,12 @@ class DayOffResource(MethodView):
           400:
             description: Wrong date format
         """
-        permissions_service.check_person_is_not_bot(person_id)
-        # Same policy as the year, month, week and day routes below and as
-        # the day off CRUD: leave is between the person and the admins.
-        # Seeing a team calendar goes through
-        # /data/projects/<id>/day-offs, which scopes to the production and
-        # hands the detail to its managers only.
-        permissions_service.check_person_access(person_id)
+        with_description = _check_day_off_read_access(person_id)
         try:
-            return time_spents_service.get_day_off(person_id, date)
+            day_off = time_spents_service.get_day_off(person_id, date)
         except WrongDateFormatException:
             raise WrongParameterException("Invalid date format.")
+        return day_off if with_description else _dates_only(day_off)
 
 
 class PersonDurationTimeSpentsResource(MethodView, ArgsMixin):
@@ -1368,8 +1392,10 @@ class DayOffForMonthResource(MethodView, ArgsMixin):
         """
         Get day offs for month
         ---
-        description: Return all day off recorded for given month. Admins get all
-          day offs, regular users get only their own.
+        description: Return all day off recorded for given month, for
+          everybody the caller may read. Admins get them all, managers and
+          supervisors get the ones of the team of their productions, the
+          latter without description, everybody else gets their own only.
         tags:
           - Persons
         parameters:
@@ -1399,13 +1425,20 @@ class DayOffForMonthResource(MethodView, ArgsMixin):
                   items:
                     type: object
         """
-        if permissions.has_admin_permissions():
+        readable = permissions_service.get_day_off_readable_person_ids()
+        if readable is None:
             return time_spents_service.get_day_offs_for_month(year, month)
-        else:
-            person_id = persons_service.get_current_user()["id"]
-            return time_spents_service.get_person_day_offs_for_month(
-                person_id, year, month
+        day_offs = time_spents_service.get_day_offs_for_month(
+            year, month, person_ids=list(readable.keys())
+        )
+        return [
+            (
+                day_off
+                if readable[day_off["person_id"]]
+                else _dates_only(day_off)
             )
+            for day_off in day_offs
+        ]
 
 
 class PersonWeekDayOffResource(MethodView, ArgsMixin):
@@ -1453,10 +1486,12 @@ class PersonWeekDayOffResource(MethodView, ArgsMixin):
                   items:
                     type: object
         """
-        permissions_service.check_person_is_not_bot(person_id)
-        permissions_service.check_person_access(person_id)
-        return time_spents_service.get_person_day_offs_for_week(
-            person_id, year, week
+        with_description = _check_day_off_read_access(person_id)
+        return _shape_day_offs(
+            time_spents_service.get_person_day_offs_for_week(
+                person_id, year, week
+            ),
+            with_description,
         )
 
 
@@ -1505,10 +1540,12 @@ class PersonMonthDayOffResource(MethodView, ArgsMixin):
                   items:
                     type: object
         """
-        permissions_service.check_person_is_not_bot(person_id)
-        permissions_service.check_person_access(person_id)
-        return time_spents_service.get_person_day_offs_for_month(
-            person_id, year, month
+        with_description = _check_day_off_read_access(person_id)
+        return _shape_day_offs(
+            time_spents_service.get_person_day_offs_for_month(
+                person_id, year, month
+            ),
+            with_description,
         )
 
 
@@ -1548,10 +1585,10 @@ class PersonYearDayOffResource(MethodView, ArgsMixin):
                   items:
                     type: object
         """
-        permissions_service.check_person_is_not_bot(person_id)
-        permissions_service.check_person_access(person_id)
-        return time_spents_service.get_person_day_offs_for_year(
-            person_id, year
+        with_description = _check_day_off_read_access(person_id)
+        return _shape_day_offs(
+            time_spents_service.get_person_day_offs_for_year(person_id, year),
+            with_description,
         )
 
 
@@ -1584,10 +1621,10 @@ class PersonDayOffResource(MethodView, ArgsMixin):
                   items:
                     type: object
         """
-        permissions_service.check_person_is_not_bot(person_id)
-        permissions_service.check_person_access(person_id)
-        return time_spents_service.get_day_offs_between(
-            person_id=person_id,
+        with_description = _check_day_off_read_access(person_id)
+        return _shape_day_offs(
+            time_spents_service.get_day_offs_between(person_id=person_id),
+            with_description,
         )
 
 

--- a/zou/app/blueprints/source/shotgun/steps.py
+++ b/zou/app/blueprints/source/shotgun/steps.py
@@ -149,17 +149,23 @@ class ImportShotgunStepsResource(BaseImportShotgunResource):
     def save_task_type(self, department, data):
         task_type = TaskType.get_by(shotgun_id=data["shotgun_id"])
         data["department_id"] = department.id
+        matched_by_name = False
         if task_type is None:
-            task_type = TaskType.get_by(
+            # matched regardless of case: a step named after an existing
+            # task type must update it rather than create a twin the
+            # clients cannot tell apart, since they resolve them by name
+            # and lower-case it on the way
+            task_type = TaskType.get_by_case_insensitive(
                 name=data["name"], for_entity=data["for_entity"]
             )
+            matched_by_name = task_type is not None
 
         if task_type is None:
             task_type = TaskType(**data)
             task_type.save()
             current_app.logger.info(f"Task Type created: {task_type}")
         else:
-            existing_task_type = TaskType.get_by(
+            existing_task_type = TaskType.get_by_case_insensitive(
                 name=data["name"],
                 for_entity=data["for_entity"],
                 department_id=data["department_id"],
@@ -168,6 +174,10 @@ class ImportShotgunStepsResource(BaseImportShotgunResource):
                 data.pop("name", None)
                 data.pop("for_entity", None)
                 data.pop("department_id", None)
+            elif matched_by_name:
+                # a task type matched in another case keeps its name, even
+                # when the step moves it to another department
+                data.pop("name", None)
             task_type.update(data)
             tasks_service.clear_task_type_cache(str(task_type.id))
             current_app.logger.info(f"Task Type updated: {task_type}")

--- a/zou/app/models/base.py
+++ b/zou/app/models/base.py
@@ -68,10 +68,14 @@ class BaseMixin(object):
         return cls.query.filter(*criterions).filter_by(**kw).first()
 
     @classmethod
-    def get_by_case_insensitive(cls, **kw):
+    def get_by_case_insensitive(cls, *criterions, **kw):
         """
-        Shorthand to retrieve data by using filters. It returns the first
-        element of the returned data without checking case for any String type value.
+        Shorthand to retrieve data by using filters, without checking case
+        for any String type value. Extra criterions narrow the lookup, as
+        in get_by. It returns one of the matching rows with no ordering
+        guarantee, so it only tells whether a match exists. A caller
+        needing the row itself must disambiguate, for instance by
+        excluding in the query the rows it already knows about.
         """
         filters = []
         for key, value in kw.items():
@@ -81,7 +85,7 @@ class BaseMixin(object):
             else:
                 filters.append(column == value)
 
-        return cls.query.filter(*filters).first()
+        return cls.query.filter(*criterions).filter(*filters).first()
 
     @classmethod
     def get_all(cls):

--- a/zou/app/services/permissions_service.py
+++ b/zou/app/services/permissions_service.py
@@ -20,6 +20,7 @@ from zou.app.models.comment import (
     department_mentions_table,
     mentions_table,
 )
+from zou.app.models.person import DepartmentLink
 from zou.app.models.project import Project, ProjectPersonLink
 from zou.app.models.task import Task
 
@@ -807,3 +808,95 @@ def check_day_off_access(day_off):
     if not (is_admin or is_same_person):
         raise permissions.PermissionDenied
     return True
+
+
+def _day_off_read_scopes(person):
+    """
+    Map the productions given person is on the team of onto the role they
+    hold there, keeping the ones where that role reads the leave of the
+    team: manager or supervisor. The role set on the team link wins over
+    the global one, the way it does once a project is resolved.
+    """
+    scopes = {}
+    for link in ProjectPersonLink.query.filter_by(person_id=person["id"]):
+        role = getattr(link.role, "code", link.role) or person["role"]
+        if role in ("manager", "supervisor"):
+            scopes[str(link.project_id)] = role
+    return scopes
+
+
+def _supervised_person_ids(supervisor, person_ids):
+    """
+    Restrict given person ids to the ones given supervisor supervises: a
+    supervisor attached to no department supervises everybody, the others
+    the persons sharing at least one of their departments.
+    """
+    person_ids = set(person_ids)
+    if not supervisor["departments"] or not person_ids:
+        return person_ids
+    links = DepartmentLink.query.filter(
+        DepartmentLink.person_id.in_(list(person_ids)),
+        DepartmentLink.department_id.in_(supervisor["departments"]),
+    )
+    return {str(link.person_id) for link in links}
+
+
+def check_day_off_read_access(person_id):
+    """
+    Return True when the current user reads the day offs of given person
+    along with their description: an admin, the person, or a manager of a
+    production the person is part of. Return False when they read the
+    dates only: a supervisor of such a production, supervising the
+    person's department. Raise PermissionDenied otherwise. Writing a day
+    off stays between the person and the admins, see check_day_off_access.
+    """
+    person_id = str(person_id)
+    current_user = persons_service.get_current_user(relations=True)
+    if permissions.has_admin_permissions() or current_user["id"] == person_id:
+        return True
+
+    scopes = _day_off_read_scopes(current_user)
+    roles = set()
+    if scopes:
+        links = ProjectPersonLink.query.filter(
+            ProjectPersonLink.project_id.in_(list(scopes.keys())),
+            ProjectPersonLink.person_id == person_id,
+        )
+        roles = {scopes[str(link.project_id)] for link in links}
+    if "manager" in roles:
+        return True
+    if "supervisor" in roles and _supervised_person_ids(
+        current_user, [person_id]
+    ):
+        return False
+    raise permissions.PermissionDenied
+
+
+def get_day_off_readable_person_ids():
+    """
+    Return the persons whose day offs the current user reads, under the
+    rule of check_day_off_read_access, as a dict mapping each person id to
+    True when the description comes along and False when the dates only.
+    None stands for everybody, with description: the admins.
+    """
+    if permissions.has_admin_permissions():
+        return None
+    current_user = persons_service.get_current_user(relations=True)
+    readable = {current_user["id"]: True}
+    scopes = _day_off_read_scopes(current_user)
+    if not scopes:
+        return readable
+
+    supervised_ids = set()
+    links = ProjectPersonLink.query.filter(
+        ProjectPersonLink.project_id.in_(list(scopes.keys()))
+    )
+    for link in links:
+        person_id = str(link.person_id)
+        if scopes[str(link.project_id)] == "manager":
+            readable[person_id] = True
+        else:
+            supervised_ids.add(person_id)
+    for person_id in _supervised_person_ids(current_user, supervised_ids):
+        readable.setdefault(person_id, False)
+    return readable

--- a/zou/app/services/tasks_service.py
+++ b/zou/app/services/tasks_service.py
@@ -2723,6 +2723,31 @@ def get_open_tasks(
     return result
 
 
+def _fold_done_rows_before(done_rows, window_start):
+    """
+    Fold the activity days preceding the schedule window onto its first
+    day. A task carrying an imported done date (1899-12-31 and the like)
+    would otherwise drag the whole burndown window back to that date.
+    Folding rather than dropping them: those tasks count in the total, so
+    losing their done amount would keep the curve above zero.
+    """
+    if window_start is None:
+        return done_rows
+
+    early = [row for row in done_rows if row[0] < window_start]
+    if not early:
+        return done_rows
+
+    folded = early + [row for row in done_rows if row[0] == window_start]
+    return [
+        (
+            window_start,
+            sum(row[1] for row in folded),
+            sum(row[2] or 0 for row in folded),
+        )
+    ] + [row for row in done_rows if row[0] > window_start]
+
+
 def get_open_tasks_burndown(
     task_type_id=None,
     task_status_id=None,
@@ -2738,7 +2763,9 @@ def get_open_tasks_burndown(
     Return burndown aggregates for tasks matching given filters from open
     projects: totals, schedule bounds and the amount of tasks done per day.
     Schedule bounds come from the task dates and fall back to the
-    project dates when the tasks carry none.
+    project dates when the tasks carry none. Activity days preceding that
+    window are folded onto its first day, as long as a start date exists
+    to anchor them, late ones extend it.
     """
     query = (
         db.session.query(
@@ -2798,16 +2825,22 @@ def get_open_tasks_burndown(
     )
 
     # each bound falls back to the project dates independently, so the
-    # two raw values can come out inverted: announce the ordered window
-    # containing both of them and every done day
-    bounds = [
+    # two raw values can come out inverted: order them before anything
+    # reads them as a window
+    schedule_start = first_start_date or first_project_start
+    planning_dates = [
         date
-        for date in (
-            first_start_date or first_project_start,
-            last_due_date or last_project_end,
-        )
+        for date in (schedule_start, last_due_date or last_project_end)
         if date is not None
     ]
+    # the fold needs a start date to anchor on: a pool carrying due dates
+    # alone would otherwise see every day of its activity collapse onto
+    # the due date
+    window_start = min(planning_dates) if schedule_start is not None else None
+
+    done_rows = _fold_done_rows_before(done_rows, window_start)
+
+    bounds = list(planning_dates)
     if done_rows:
         bounds += [done_rows[0][0], done_rows[-1][0]]
 

--- a/zou/app/services/tasks_service.py
+++ b/zou/app/services/tasks_service.py
@@ -266,6 +266,27 @@ def get_task_type(task_type_id):
     return get_task_type_raw(task_type_id).serialize()
 
 
+def check_task_type_name_is_unique(name, exclude_task_type_id=None):
+    """
+    Check that no task type carries given name, compared regardless of
+    case: clients resolve a task type from its name and lower-case it on
+    the way, so a twin differing only by case collapses onto the same
+    entry. Raises WrongParameterException when one exists.
+
+    The task type being renamed is excluded in the query rather than by
+    comparing ids afterwards: a database can already hold such twins, and
+    a lookup free to return any of them could hand back the renamed row
+    and hide the conflict with the other.
+    """
+    criterions = []
+    if exclude_task_type_id is not None:
+        criterions.append(TaskType.id != exclude_task_type_id)
+    if TaskType.get_by_case_insensitive(*criterions, name=name) is not None:
+        raise WrongParameterException(
+            "A task type with similar name already exists"
+        )
+
+
 def get_task_raw(task_id):
     """
     Get task matching given id as an active record.
@@ -1871,9 +1892,13 @@ def get_or_create_task_type(
 ):
     """
     Create a new task type if it doesn't exist. If it exists, it returns the
-    type from database.
+    type from database. The name is matched regardless of case, so a
+    bootstrap or an import never creates a twin the clients cannot tell
+    apart (see check_task_type_name_is_unique).
     """
-    task_type = TaskType.get_by(name=name, for_entity=for_entity)
+    task_type = TaskType.get_by_case_insensitive(
+        name=name, for_entity=for_entity
+    )
     if task_type is None:
         task_type = TaskType.create(
             name=name,

--- a/zou/app/services/time_spents_service.py
+++ b/zou/app/services/time_spents_service.py
@@ -504,12 +504,13 @@ def _last_day_of(interval):
     return start, end - datetime.timedelta(days=1)
 
 
-def get_day_offs_for_month(year, month):
+def get_day_offs_for_month(year, month, person_ids=None):
     """
-    Get all day off entries for given year and month.
+    Get all day off entries for given year and month, restricted to given
+    persons when some are given.
     """
     start, end = _last_day_of(date_helpers.get_month_interval(year, month))
-    return get_day_offs_between(start, end)
+    return get_day_offs_between(start, end, person_ids=person_ids)
 
 
 def get_person_day_offs_for_week(person_id, year, week):
@@ -537,14 +538,17 @@ def get_person_day_offs_for_year(person_id, year):
 
 
 def get_day_offs_between(
-    start=None, end=None, person_id=None, exclude_id=None
+    start=None, end=None, person_id=None, exclude_id=None, person_ids=None
 ):
     """
-    Get all day off entries for given person, start and end date.
+    Get all day off entries for given person, or given persons, start and
+    end date.
     """
     query = DayOff.query
     if person_id is not None:
         query = query.filter(DayOff.person_id == person_id)
+    if person_ids is not None:
+        query = query.filter(DayOff.person_id.in_(person_ids))
 
     if start is not None:
         query = query.filter(

--- a/zou/app/utils/thumbnail.py
+++ b/zou/app/utils/thumbnail.py
@@ -32,6 +32,12 @@ def to_srgb(im, mode="RGB"):
     """
     if im.mode not in ("CMYK", "RGB", "RGBA"):
         return im
+    if im.mode == "RGB" and im.info.get("transparency") is not None:
+        # A tRNS colour key lives in im.info only, and littleCMS hands back
+        # a brand new picture whose info does not carry it over. Turn the
+        # key into a real alpha channel first, otherwise the colour it keys
+        # out (black, most of the time) comes back as an opaque background.
+        im = im.convert("RGBA")
     if im.mode == "RGBA":
         mode = "RGBA"
     icc_profile = im.info.get("icc_profile")

--- a/zou/app/utils/thumbnail.py
+++ b/zou/app/utils/thumbnail.py
@@ -23,6 +23,10 @@ PREVIEW_SIZE = 1200, 0
 BIG_SQUARE_SIZE = 400, 400
 BIG_RECTANGLE_SIZE = 300, 200
 SRGB_PROFILE = ImageCms.createProfile("sRGB")
+# Image.point() only scales I, I;16 and F: the byte order variants
+# (I;16B and friends) make it raise instead, and turning a colour problem
+# into a refused upload would be worse than leaving them as they were.
+HIGH_DEPTH_GREY_MODES = "I", "I;16"
 
 
 def to_srgb(im, mode="RGB"):
@@ -34,6 +38,12 @@ def to_srgb(im, mode="RGB"):
     Wide gamut pictures (Adobe RGB, Display P3) suffer from the same problem
     once a browser reads their pixels as sRGB.
     """
+    if im.mode in HIGH_DEPTH_GREY_MODES:
+        # A greyscale picture deeper than 8 bits (PNG colour type 0 at
+        # depth 16). Image.convert() clamps those samples at 255 instead of
+        # scaling them, so everything brighter than 1/256th of the range
+        # comes back solid white. Scale them down explicitly instead.
+        im = im.point(lambda value: value / 256).convert("L")
     if im.mode not in ("CMYK", "RGB", "RGBA"):
         return im
     if im.mode == "RGB" and im.info.get("transparency") is not None:

--- a/zou/app/utils/thumbnail.py
+++ b/zou/app/utils/thumbnail.py
@@ -101,10 +101,25 @@ def get_full_size_from_width(im, width):
 
 
 def make_im_bigger_if_needed(im, size):
+    """
+    Scale a picture smaller than the target box up to it, keeping its ratio.
+
+    Resizing straight to the target size stretches the picture: a 300x100
+    logo would come back square. Scale by the smaller of the two factors
+    instead, so the result fits in the box and fit_to_target_size has
+    nothing left to shorten.
+    """
     im_width, im_height = im.size
     width, height = size
     if im_width < width and im_height < height:
-        im = im.resize(size, Image.Resampling.LANCZOS)
+        ratio = min(width / im_width, height / im_height)
+        im = im.resize(
+            (
+                max(1, round(im_width * ratio)),
+                max(1, round(im_height * ratio)),
+            ),
+            Image.Resampling.LANCZOS,
+        )
     return im
 
 
@@ -124,7 +139,8 @@ def fit_to_target_size(im, size, crop=False):
         if w > width:
             w = width
             h = int(math.ceil(float(width) / original_ratio))
-        im = im.resize((w, h), Image.Resampling.LANCZOS)
+        if (w, h) != (im_width, im_height):
+            im = im.resize((w, h), Image.Resampling.LANCZOS)
     return im
 
 

--- a/zou/app/utils/thumbnail.py
+++ b/zou/app/utils/thumbnail.py
@@ -1,14 +1,18 @@
 import os
 import shutil
 import math
+import logging
 
 from io import BytesIO
 from pathlib import Path
 
-from PIL import Image, ImageCms, ImageFile
+from PIL import Image, ImageCms, ImageFile, UnidentifiedImageError
 
 from zou.app import config
+from zou.app.services.exception import WrongParameterException
 from zou.app.utils import fs
+
+logger = logging.getLogger(__name__)
 
 ImageFile.LOAD_TRUNCATED_IMAGES = True
 
@@ -65,9 +69,44 @@ def save_file(tmp_folder, instance_id, file_to_save):
     extension = "." + file_to_save.filename.split(".")[-1].lower()
     file_name = instance_id + extension.lower()
     file_path = os.path.join(tmp_folder, file_name)
-    file_to_save.save(file_path)
-    im = to_srgb(Image.open(file_path))
-    im.save(file_path, "PNG")
+    try:
+        file_to_save.save(file_path)
+        try:
+            im = Image.open(file_path)
+            # Image.open() only reads the header: decode the pixels now,
+            # so a broken picture fails here rather than at save() below.
+            im.load()
+            im = to_srgb(im)
+        except (
+            UnidentifiedImageError,
+            Image.DecompressionBombError,
+            OSError,
+            ValueError,
+            SyntaxError,
+        ) as exception:
+            # The upload is not a picture we can read (a SVG or a PDF
+            # renamed .png), is broken past what LOAD_TRUNCATED_IMAGES
+            # rescues, or is far past MAX_IMAGE_PIXELS. Pillow reports
+            # those as anything from OSError to SyntaxError, depending on
+            # the plugin that claimed the header. The file is the problem,
+            # not the server, so answer 400 instead of letting it bubble
+            # up as a 500. The Pillow message carries the temporary path:
+            # it goes to the log, where support can read it, and stays
+            # out of the response.
+            logger.warning(
+                f"Refusing upload {file_path}, not a readable picture: "
+                f"{type(exception).__name__}: {exception}"
+            )
+            raise WrongParameterException(
+                "Uploaded file is not a readable picture."
+            )
+        im.save(file_path, "PNG")
+    except Exception:
+        # Writing the upload and writing the converted picture back stay
+        # server side failures and keep their 500, but no path leaves a
+        # temporary file behind.
+        fs.rm_file(file_path)
+        raise
     return file_path
 
 


### PR DESCRIPTION
**Problem**
- Only the person and the admins could read days off. A manager planned a schedule without the absences of their team.
- The sRGB conversion lost the transparency of PNGs using a color key, and clamped 16-bit greyscale pictures to white.
- A small picture was scaled up to the target box without keeping its ratio, so small logos came back stretched.
- An avatar Pillow cannot decode, raised a 500, and left its temporary file behind.
- The burndown window started at the earliest done date. Imported 1899 dates stretched the axis over 127 empty years.
- Two task type names differing only by case were accepted. The clients collapse them onto one entry.

**Solution**
- Managers of a production read the day offs of its team whole. Its supervisors read the dates only, when they share a department. Writing stays admin or self.
- Turn the colour key into an alpha channel before the conversion, and scale 16 bit samples instead of clamping them.
- Scale by the smaller factor, so the picture fits the box and keeps its shape.
- Answer 400 on a file Pillow cannot read, and always remove the temporary file.
- Take the window from the planning dates, and fold the earlier activity onto its first day.
- Refuse such a name on create and rename, and reuse the existing task type in the bootstrap and the Shotgun import.
