### PR TITLE
[previews] Let department supervisors update preview files

### DIFF
--- a/tests/blueprints/crud/test_preview_file.py
+++ b/tests/blueprints/crud/test_preview_file.py
@@ -4,6 +4,7 @@ from zou.app.utils import fields
 from zou.app.models.task import Task
 from zou.app.services import (
     tasks_service,
+    persons_service,
     projects_service,
 )
 
@@ -208,6 +209,30 @@ class PreviewFileTestCase(ApiDBTestCase):
         self.log_in_vendor()
         self.put(route2_2, {"name": "PROJ2_TASK2_PF1_EDIT"}, code=200)
         self.put(route2_1, {"name": "PROJ2_TASK1_PF1_EDIT"}, code=403)
+
+    def test_update_preview_file_for_supervisor(self):
+        """
+        A supervisor validates the previews of the tasks of their
+        departments, even when not assigned to them.
+        """
+        route1_1 = f"data/preview-files/{self.preview_file1_1.id!s}"
+        data = {"validation_status": "validated"}
+        self.generate_fixture_user_supervisor()
+        projects_service.add_team_member(
+            self.project1.id, self.user_supervisor["id"]
+        )
+        persons_service.add_to_department(
+            str(self.department_animation.id), self.user_supervisor["id"]
+        )
+
+        self.log_in_supervisor()
+        self.put(route1_1, data, code=403)
+
+        persons_service.add_to_department(
+            str(self.department.id), self.user_supervisor["id"]
+        )
+        self.put(route1_1, data)
+        self.assertEqual(self.get(route1_1)["validation_status"], "validated")
 
     def test_delete_preview_file(self):
         preview_files = self.get("data/preview-files")

--- a/zou/app/blueprints/crud/preview_file.py
+++ b/zou/app/blueprints/crud/preview_file.py
@@ -329,7 +329,15 @@ class PreviewFileResource(BaseModelResource):
         task = tasks_service.get_task(preview_file["task_id"])
         permissions_service.check_project_access(task["project_id"])
         if not permissions.has_manager_permissions():
-            permissions_service.check_working_on_task(preview_file["task_id"])
+            try:
+                permissions_service.check_working_on_task(
+                    preview_file["task_id"]
+                )
+            except permissions.PermissionDenied:
+                # Supervisors validate the previews of their department.
+                permissions_service.check_supervisor_project_task_type_access(
+                    task["project_id"], task["task_type_id"]
+                )
         return True
 
     def pre_update(self, instance_dict, data):


### PR DESCRIPTION
**Problem**

- Supervisors could only update the preview files of tasks they were assigned to, so they could not validate or reject the proposals of their department from the review player (cgwire/kitsu#2199).

**Solution**

- `PUT /data/preview-files/<id>` falls back to the department rule already used for task actions: a supervisor of the task type department, or without department, passes. Managers and assignees are unchanged.
- Test covering the other-department refusal and the own-department update.