### PR TITLE
[playlists] Sort temporary playlists by sequence again

### DIFF
--- a/tests/services/test_playlists_service.py
+++ b/tests/services/test_playlists_service.py
@@ -187,6 +187,38 @@ class PlaylistsServiceTestCase(ApiDBTestCase):
         self.assertEqual(str(self.shot.id), shots[0]["id"])
         self.assertEqual(len(shots[0]["preview_files"][task_type_id]), 2)
 
+    def test_generate_temp_playlist_sorted_by_sequence(self):
+        """
+        Shots of several sequences sort by sequence first, then by name:
+        never all the SH010 of every sequence in a row.
+        """
+        self.generate_fixture_preview_files()
+        sequence_1 = self.sequence
+        sequence_2 = self.generate_fixture_sequence("S02")
+        shot_ids = [
+            str(self.generate_fixture_shot(name, sequence_id=sequence_id).id)
+            for sequence_id, name in [
+                (sequence_2.id, "SH010"),
+                (sequence_1.id, "SH020"),
+                (sequence_2.id, "SH020"),
+                (sequence_1.id, "SH010"),
+            ]
+        ]
+        task_ids = [
+            self.generate_fixture_shot_task("Master", shot_id=shot_id).id
+            for shot_id in shot_ids
+        ]
+        entities = playlists_service.generate_temp_playlist(task_ids)
+        self.assertEqual(
+            [(e["sequence_name"], e["name"]) for e in entities],
+            [
+                ("S01", "SH010"),
+                ("S01", "SH020"),
+                ("S02", "SH010"),
+                ("S02", "SH020"),
+            ],
+        )
+
     def test_generate_temp_playlist_with_edit_task(self):
         self.generate_fixture_edit_task()
         entities = playlists_service.generate_temp_playlist(

--- a/zou/app/services/playlists_service.py
+++ b/zou/app/services/playlists_service.py
@@ -1176,26 +1176,18 @@ def generate_temp_playlist(task_ids, sort=True):
     for task_id in task_ids:
         entity = generate_playlisted_entity_from_task(task_id, task_type_links)
         entities.append(entity)
-    if len(entities) > 0:
-        if not sort:
-            return entities
-        try:
-            if "episode_name" in entities[0]:
-                return sorted(entities, key=itemgetter("episode_name", "name"))
-            elif "sequence_name" in entities[0]:
-                return sorted(
-                    entities, key=itemgetter("sequence_name", "name")
-                )
-            elif "asset_type_name" in entities[0]:
-                return sorted(
-                    entities, key=itemgetter("asset_type_name", "name")
-                )
-            else:
-                return entities
-        except Exception:
-            return entities
-    else:
-        return []
+    if not sort:
+        return entities
+    # Every entry carries the whole key set (empty when not applicable), so
+    # a single composite key sorts shots by sequence, edits by episode and
+    # assets by type. Probing one key at a time picked episode_name for
+    # shots and lost the sequence order.
+    return sorted(
+        entities,
+        key=itemgetter(
+            "episode_name", "sequence_name", "asset_type_name", "name"
+        ),
+    )
 
 
 def generate_playlisted_entity_from_task(task_id, task_type_links):


### PR DESCRIPTION
**Problem**

- A temporary playlist built from shots of several sequences lists every SH010 first, then every SH020: the sequence order is lost (cgwire/kitsu#2190).
- Since every playlist entry carries an empty `episode_name` key, the sort always picked `(episode_name, name)` for shots.

**Solution**

- Sort on one composite key `(episode_name, sequence_name, asset_type_name, name)`, valid for shots, edits and assets now that every entry has the whole key set.
- Add a service test covering shots spread across two sequences.