### PR TITLE
[previews] Stop paying six seconds for a missing movie version

### DIFF
--- a/tests/blueprints/previews/test_movie_streaming.py
+++ b/tests/blueprints/previews/test_movie_streaming.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 from tests.base import ApiDBTestCase
 from zou.app.blueprints.previews import resources as preview_resources
+from zou.app.services import files_service
 from zou.app.stores import file_store
 
 
@@ -141,3 +142,31 @@ class MovieStreamingRoutesTestCase(ApiDBTestCase):
             headers=self.base_headers,
         )
         self.assertEqual(response.status_code, 404)
+
+    def test_stored_movie_prefixes_are_recorded(self):
+        """
+        Which prefix holds the movie is known when it is stored: recording
+        it spares the movie routes from probing the storage on every read.
+        """
+        with_source = self.upload_movie_preview(save_source_file=True)
+        preview_file = files_service.get_preview_file(with_source)
+        self.assertEqual(
+            preview_file["data"][files_service.MOVIE_PREFIXES_KEY],
+            ["source"],
+        )
+
+        without_source = self.upload_movie_preview(save_source_file=False)
+        preview_file = files_service.get_preview_file(without_source)
+        self.assertEqual(
+            preview_file["data"][files_service.MOVIE_PREFIXES_KEY],
+            ["previews"],
+        )
+
+    def test_recorded_prefixes_spare_the_storage_probe(self):
+        preview_file_id = self.upload_movie_preview(save_source_file=True)
+        with patch.object(file_store, "exists_movie") as exists_movie:
+            self.assertEqual(
+                files_service.get_movie_prefixes(preview_file_id, lowdef=True),
+                ["source", "lowdef", "previews"],
+            )
+            exists_movie.assert_not_called()

--- a/tests/services/test_files_service.py
+++ b/tests/services/test_files_service.py
@@ -1,5 +1,7 @@
 import pytest
 
+from unittest.mock import patch
+
 from sqlalchemy import event
 
 from tests.base import ApiDBTestCase
@@ -18,6 +20,7 @@ from zou.app.services.exception import (
     SoftwareNotFoundException,
     WorkingFileNotFoundException,
 )
+from zou.app.stores import file_store
 from zou.app.utils import cache, fields
 
 
@@ -867,3 +870,135 @@ class PreviewBackgroundFileTestCase(FilesTestCase):
                 "is_default"
             ]
         )
+
+
+class MoviePrefixesTestCase(ApiDBTestCase):
+    """
+    The movie routes probe up to three storage prefixes. Resolving the
+    one actually stored spares a round trip per missing object, paid on
+    every range request a player sends.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.preview_file_id = str(fields.gen_uuid())
+        self.generate_fixture_preview_file()
+        self.recorded_preview_file_id = str(self.preview_file.id)
+
+    def stored_under(self, stored_prefix):
+        return patch.object(
+            file_store,
+            "exists_movie",
+            side_effect=lambda prefix, _id: prefix == stored_prefix,
+        )
+
+    def test_stored_prefix_comes_first(self):
+        with self.stored_under("lowdef"):
+            self.assertEqual(
+                files_service.get_movie_prefixes(
+                    self.preview_file_id, lowdef=True
+                ),
+                ["lowdef", "previews", "source"],
+            )
+
+    def test_source_comes_first_when_normalization_was_skipped(self):
+        with self.stored_under("source"):
+            self.assertEqual(
+                files_service.get_movie_prefixes(
+                    self.preview_file_id, lowdef=True
+                ),
+                ["source", "lowdef", "previews"],
+            )
+            self.assertEqual(
+                files_service.get_movie_prefixes(
+                    f"{self.preview_file_id}-full"
+                ),
+                ["source", "previews", "lowdef"],
+            )
+
+    def test_default_order_when_nothing_is_stored(self):
+        with self.stored_under(None):
+            self.assertEqual(
+                files_service.get_movie_prefixes(
+                    self.preview_file_id, lowdef=True
+                ),
+                ["lowdef", "previews", "source"],
+            )
+
+    def test_storage_error_does_not_break_the_resolution(self):
+        with patch.object(
+            file_store, "exists_movie", side_effect=Exception("timeout")
+        ):
+            self.assertEqual(
+                files_service.get_movie_prefixes(
+                    self.preview_file_id, lowdef=True
+                ),
+                ["lowdef", "previews", "source"],
+            )
+
+    def test_resolution_is_memoized_and_invalidated(self):
+        with self.stored_under("source") as exists_movie:
+            for _ in range(3):
+                files_service.get_movie_prefixes(
+                    self.preview_file_id, lowdef=True
+                )
+            self.assertEqual(exists_movie.call_count, 3)
+
+            files_service.clear_preview_file_cache(self.preview_file_id)
+            files_service.get_movie_prefixes(self.preview_file_id, lowdef=True)
+            self.assertEqual(exists_movie.call_count, 6)
+
+    def record_prefixes(self, prefixes):
+        preview_file = files_service.get_preview_file_raw(
+            self.recorded_preview_file_id
+        )
+        preview_file.update(
+            {"data": {files_service.MOVIE_PREFIXES_KEY: prefixes}}
+        )
+        files_service.clear_preview_file_cache(self.recorded_preview_file_id)
+
+    def test_recorded_prefixes_win_over_the_probe(self):
+        self.record_prefixes(["source"])
+        with patch.object(file_store, "exists_movie") as exists_movie:
+            self.assertEqual(
+                files_service.get_movie_prefixes(
+                    self.recorded_preview_file_id, lowdef=True
+                ),
+                ["source", "lowdef", "previews"],
+            )
+            exists_movie.assert_not_called()
+
+    def test_recorded_prefixes_keep_the_route_order(self):
+        self.record_prefixes(["previews", "lowdef"])
+        self.assertEqual(
+            files_service.get_movie_prefixes(
+                self.recorded_preview_file_id, lowdef=True
+            ),
+            ["lowdef", "previews", "source"],
+        )
+        self.assertEqual(
+            files_service.get_movie_prefixes(self.recorded_preview_file_id),
+            ["previews", "lowdef", "source"],
+        )
+
+    def test_probe_takes_over_when_nothing_was_recorded(self):
+        self.record_prefixes([])
+        with self.stored_under("lowdef") as exists_movie:
+            self.assertEqual(
+                files_service.get_movie_prefixes(
+                    self.recorded_preview_file_id, lowdef=True
+                ),
+                ["lowdef", "previews", "source"],
+            )
+            exists_movie.assert_called()
+
+    def test_garbage_record_is_ignored(self):
+        self.record_prefixes("source")
+        with self.stored_under("source") as exists_movie:
+            self.assertEqual(
+                files_service.get_movie_prefixes(
+                    self.recorded_preview_file_id, lowdef=True
+                ),
+                ["source", "lowdef", "previews"],
+            )
+            exists_movie.assert_called()

--- a/tests/utils/test_fs.py
+++ b/tests/utils/test_fs.py
@@ -45,3 +45,164 @@ class GetFilePathAndFileTestCase(unittest.TestCase):
                         instance_id="does-not-exist",
                         extension="png",
                     )
+
+    def test_missing_object_is_not_retried(self):
+        # Swift and S3 do not raise FileNotFound: they surface their own
+        # exception carrying a 404. Sleeping three seconds and asking
+        # again for an object that is not there delays every fallback on
+        # the next prefix.
+        class SwiftClientException(Exception):
+            http_status = 404
+
+        calls = []
+
+        def open_file(prefix, instance_id):
+            calls.append(prefix)
+            raise SwiftClientException("Object GET failed: 404 Not Found")
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with mock.patch("zou.app.utils.fs.time.sleep") as sleep:
+                with pytest.raises(FileNotFound):
+                    fs.get_file_path_and_file(
+                        FakeConfig(tmp_dir),
+                        get_local_path=lambda prefix, instance_id: "",
+                        open_file=open_file,
+                        prefix="lowdef",
+                        instance_id="does-not-exist",
+                        extension="mp4",
+                    )
+                sleep.assert_not_called()
+        self.assertEqual(calls, ["lowdef"])
+
+    def test_transient_error_is_retried(self):
+        class ServerError(Exception):
+            http_status = 503
+
+        calls = []
+
+        def open_file(prefix, instance_id):
+            calls.append(prefix)
+            raise ServerError("Service Unavailable")
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with mock.patch("zou.app.utils.fs.time.sleep") as sleep:
+                with pytest.raises(FileNotFound):
+                    fs.get_file_path_and_file(
+                        FakeConfig(tmp_dir),
+                        get_local_path=lambda prefix, instance_id: "",
+                        open_file=open_file,
+                        prefix="lowdef",
+                        instance_id="does-not-exist",
+                        extension="mp4",
+                    )
+                sleep.assert_called_once()
+        self.assertEqual(calls, ["lowdef", "lowdef"])
+
+
+class IsMissingFileErrorTestCase(unittest.TestCase):
+    def test_file_not_found(self):
+        self.assertTrue(fs.is_missing_file_error(FileNotFound("key")))
+
+    def test_swift_client_exception(self):
+        exception = Exception("Object GET failed")
+        exception.http_status = 404
+        self.assertTrue(fs.is_missing_file_error(exception))
+
+    def test_botocore_client_error(self):
+        exception = Exception("An error occurred (NoSuchKey)")
+        exception.response = {
+            "Error": {"Code": "NoSuchKey"},
+            "ResponseMetadata": {"HTTPStatusCode": 404},
+        }
+        self.assertTrue(fs.is_missing_file_error(exception))
+
+    def test_transient_errors(self):
+        self.assertFalse(fs.is_missing_file_error(None))
+        self.assertFalse(fs.is_missing_file_error(IOError("connection")))
+        exception = Exception("Service Unavailable")
+        exception.http_status = 503
+        self.assertFalse(fs.is_missing_file_error(exception))
+
+
+class DownloadToFileTestCase(unittest.TestCase):
+    """
+    The cache entry is written through a temporary file: a download that
+    fails halfway must leave neither a truncated file nor a hole where a
+    concurrent request was reading.
+    """
+
+    def setUp(self):
+        self.tmp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp_dir.cleanup)
+        self.file_path = os.path.join(self.tmp_dir.name, "cache-previews-id")
+
+    def cache_files(self):
+        return sorted(os.listdir(self.tmp_dir.name))
+
+    def test_download_replaces_the_cache_entry(self):
+        def open_file(prefix, instance_id):
+            yield b"movie"
+            yield b"-bytes"
+
+        download_failed, exception = fs._download_to_file(
+            self.file_path, open_file, "previews", "id"
+        )
+
+        self.assertFalse(download_failed)
+        self.assertIsNone(exception)
+        with open(self.file_path, "rb") as cached:
+            self.assertEqual(cached.read(), b"movie-bytes")
+        self.assertEqual(self.cache_files(), ["cache-previews-id"])
+
+    def test_interrupted_download_leaves_the_cache_untouched(self):
+        with open(self.file_path, "wb") as cached:
+            cached.write(b"complete-movie")
+
+        def open_file(prefix, instance_id):
+            yield b"trunc"
+            raise IOError("connection reset")
+
+        download_failed, exception = fs._download_to_file(
+            self.file_path, open_file, "previews", "id"
+        )
+
+        self.assertTrue(download_failed)
+        self.assertIsInstance(exception, IOError)
+        with open(self.file_path, "rb") as cached:
+            self.assertEqual(cached.read(), b"complete-movie")
+        self.assertEqual(self.cache_files(), ["cache-previews-id"])
+
+    def test_failed_download_writes_no_cache_entry(self):
+        def open_file(prefix, instance_id):
+            raise IOError("connection reset")
+            yield b""
+
+        fs._download_to_file(self.file_path, open_file, "previews", "id")
+
+        self.assertFalse(os.path.exists(self.file_path))
+        self.assertEqual(self.cache_files(), [])
+
+    def test_concurrent_download_is_served_instead_of_a_404(self):
+        # The other request completed the cache entry while this one was
+        # failing: serving it beats answering a 404.
+        config = FakeConfig(self.tmp_dir.name)
+        cache_path = fs.get_cache_file_path(config, "previews", "id", "mp4")
+
+        def open_file(prefix, instance_id):
+            with open(cache_path, "wb") as cached:
+                cached.write(b"complete-movie")
+            raise IOError("connection reset")
+            yield b""
+
+        with mock.patch("zou.app.utils.fs.time.sleep"):
+            file_path = fs.get_file_path_and_file(
+                config,
+                get_local_path=lambda prefix, instance_id: "",
+                open_file=open_file,
+                prefix="previews",
+                instance_id="id",
+                extension="mp4",
+            )
+
+        with open(file_path, "rb") as cached:
+            self.assertEqual(cached.read(), b"complete-movie")

--- a/zou/app/blueprints/previews/resources.py
+++ b/zou/app/blueprints/previews/resources.py
@@ -126,11 +126,12 @@ def send_movie_file(
     SKIP_NORMALIZATION_HIGHDEF) stores a single version, and the uploaded
     source is the last resort. Note that the source is served as video/mp4
     whatever its real container, and carries no faststart flag.
+
+    The prefix order is resolved beforehand so that the version actually
+    stored comes first: a missing object costs a round trip on the object
+    storage, and a movie player asks for the same file once per range.
     """
-    if lowdef:
-        prefixes = ["lowdef", "previews", "source"]
-    else:
-        prefixes = ["previews", "lowdef", "source"]
+    prefixes = files_service.get_movie_prefixes(preview_file_id, lowdef=lowdef)
     for prefix in prefixes:
         try:
             return send_storage_file(

--- a/zou/app/services/files_service.py
+++ b/zou/app/services/files_service.py
@@ -31,11 +31,17 @@ from zou.app.services.exception import (
     PreviewBackgroundFileNotFoundException,
 )
 
-from zou.app.utils import cache, fields, events, query as query_utils
+from zou.app.stores import file_store
+
+from zou.app.utils import cache, fields, fs, events, query as query_utils
 
 from sqlalchemy import desc, func
 from sqlalchemy.exc import StatementError, IntegrityError
 from sqlalchemy.sql.expression import and_
+
+MOVIE_PREFIXES = ["previews", "lowdef", "source"]
+LOWDEF_MOVIE_PREFIXES = ["lowdef", "previews", "source"]
+MOVIE_PREFIXES_KEY = "movie_prefixes"
 
 
 def clear_preview_file_cache(preview_file_id):
@@ -44,6 +50,8 @@ def clear_preview_file_cache(preview_file_id):
     """
     cache.cache.delete_memoized(get_preview_file, preview_file_id)
     cache.cache.delete_memoized(get_preview_file_for_access, preview_file_id)
+    cache.cache.delete_memoized(get_movie_prefixes, preview_file_id, False)
+    cache.cache.delete_memoized(get_movie_prefixes, preview_file_id, True)
 
 
 def clear_output_file_cache(output_file_id):
@@ -832,6 +840,74 @@ def get_preview_file_for_access(preview_file_id):
         "updated_at": fields.serialize_value(row.updated_at),
         "extension": row.extension,
     }
+
+
+def _is_movie_stored(prefix, preview_file_id):
+    """
+    Tell whether the movie of given preview file sits under given prefix.
+    The local download cache is looked at first: a warm cache means the
+    movie routes will not hit the object storage at all.
+    """
+    if config.FS_BACKEND != "local":
+        file_path = fs.get_cache_file_path(
+            config, prefix, preview_file_id, "mp4"
+        )
+        if not fs.is_invalid_file(file_path):
+            return True
+    try:
+        return file_store.exists_movie(prefix, preview_file_id)
+    except Exception:
+        return False
+
+
+def get_stored_movie_prefixes(preview_file_id):
+    """
+    Return the storage prefixes the movie was written to, as recorded
+    when it was stored, or None for a preview file that predates that
+    record. Only the `data` column is read: the annotations sitting next
+    to it weigh several MB on a long shot.
+    """
+    try:
+        row = (
+            PreviewFile.query.with_entities(PreviewFile.data)
+            .filter_by(id=preview_file_id)
+            .first()
+        )
+    except StatementError:
+        return None
+    if row is None or not row.data:
+        return None
+    prefixes = row.data.get(MOVIE_PREFIXES_KEY)
+    if not isinstance(prefixes, list):
+        return None
+    return [prefix for prefix in prefixes if prefix in MOVIE_PREFIXES]
+
+
+@cache.memoize_function(600)
+def get_movie_prefixes(preview_file_id, lowdef=False):
+    """
+    Return the storage prefixes to try for given movie, best first.
+
+    A normalized movie is stored under `previews` and `lowdef`, a movie
+    uploaded with normalize=false under `source` only. Knowing which one
+    holds it spares the routes from downloading missing objects before
+    falling back on the right one, on every range a player asks for.
+
+    The prefixes are read from the preview file when they were recorded
+    at storage time, and probed on the storage otherwise. The ones that
+    are not expected to hold anything are kept as a tail: a record can
+    lag behind a movie that was re-encoded or copied over.
+    """
+    prefixes = LOWDEF_MOVIE_PREFIXES if lowdef else MOVIE_PREFIXES
+    stored = get_stored_movie_prefixes(preview_file_id)
+    if stored:
+        return [prefix for prefix in prefixes if prefix in stored] + [
+            prefix for prefix in prefixes if prefix not in stored
+        ]
+    for index, prefix in enumerate(prefixes):
+        if _is_movie_stored(prefix, preview_file_id):
+            return [prefix] + prefixes[:index] + prefixes[index + 1 :]
+    return list(prefixes)
 
 
 def get_preview_files_for_task(task_id):

--- a/zou/app/services/preview_files_service.py
+++ b/zou/app/services/preview_files_service.py
@@ -303,11 +303,17 @@ def prepare_and_store_movie(
     from zou.app import app as current_app
 
     with current_app.app_context():
+        # Which storage prefixes end up holding the movie depends on the
+        # normalization settings. It is recorded on the preview file so
+        # that the movie routes do not have to rediscover it by probing
+        # the object storage on every read.
+        stored_movie_prefixes = []
         if add_source_to_file_store:
             try:
                 file_store.add_movie(
                     "source", preview_file_id, uploaded_movie_path
                 )
+                stored_movie_prefixes.append("source")
             except Exception as exc:
                 _remove_temp_files(uploaded_movie_path)
                 return _abort_on_storage_failure(
@@ -411,6 +417,10 @@ def prepare_and_store_movie(
                     if normalize:
                         # Without the high def version, the low def one is
                         # the only movie the remote job uploaded.
+                        if skip_high_def:
+                            stored_movie_prefixes.append("lowdef")
+                        else:
+                            stored_movie_prefixes += ["previews", "lowdef"]
                         normalized_movie_path = fs.get_file_path_and_file(
                             config,
                             file_store.get_local_movie_path,
@@ -443,9 +453,11 @@ def prepare_and_store_movie(
                         file_store.add_movie(
                             "previews", preview_file_id, normalized_movie_path
                         )
+                        stored_movie_prefixes.append("previews")
                     file_store.add_movie(
                         "lowdef", preview_file_id, normalized_movie_low_path
                     )
+                    stored_movie_prefixes.append("lowdef")
                     if normalized_movie_path is None:
                         # Everything below (metadata, thumbnails, tile) works
                         # on the movie that was actually produced.
@@ -482,6 +494,7 @@ def prepare_and_store_movie(
                     file_store.add_movie(
                         "previews", preview_file_id, uploaded_movie_path
                     )
+                    stored_movie_prefixes.append("previews")
             except Exception as exc:
                 _remove_temp_files(uploaded_movie_path)
                 return _abort_on_storage_failure(
@@ -579,6 +592,12 @@ def prepare_and_store_movie(
                     "width": width,
                     "height": height,
                     "duration": duration,
+                    "data": {
+                        **(preview_file_raw.data or {}),
+                        files_service.MOVIE_PREFIXES_KEY: (
+                            stored_movie_prefixes
+                        ),
+                    },
                 },
             )
             tasks_service.update_preview_file_info(preview_file)
@@ -1792,7 +1811,7 @@ def copy_preview_file_on_storage(
 ):
     """
     Copy one stored preview to another prefix, skipping the copy when the
-    target already holds it.
+    target already holds it. Return True when a file was actually copied.
     """
     if config.FS_BACKEND == "local":
         file_path = get_path_func(prefix, original_preview_file_id)
@@ -1800,10 +1819,13 @@ def copy_preview_file_on_storage(
         if os.path.exists(file_path):
             os.makedirs(os.path.dirname(other_file_path), exist_ok=True)
             shutil.copyfile(file_path, other_file_path)
+            return True
     elif exists_func(prefix, original_preview_file_id):
         copy_func(
             prefix, original_preview_file_id, prefix, preview_file_to_update_id
         )
+        return True
+    return False
 
 
 def copy_preview_file_in_another_one(
@@ -1818,12 +1840,12 @@ def copy_preview_file_in_another_one(
     is_movie = original_preview_file["extension"] == "mp4"
     is_picture = original_preview_file["extension"] == "png"
 
+    stored_movie_prefixes = []
     if is_movie:
         # The source is copied too: when the normalization is skipped it is
         # the only stored movie, and the preview routes serve it.
-        prefixes = ["previews", "lowdef", "source"]
-        for prefix in prefixes:
-            copy_preview_file_on_storage(
+        for prefix in files_service.MOVIE_PREFIXES:
+            copied = copy_preview_file_on_storage(
                 file_store.get_local_movie_path,
                 file_store.exists_movie,
                 file_store.copy_movie,
@@ -1831,6 +1853,8 @@ def copy_preview_file_in_another_one(
                 original_preview_file_id,
                 preview_file_to_update_id,
             )
+            if copied:
+                stored_movie_prefixes.append(prefix)
 
     if is_movie or is_picture:
         prefixes = [
@@ -1861,17 +1885,27 @@ def copy_preview_file_in_another_one(
             preview_file_to_update_id,
         )
 
+    data = {
+        "extension": original_preview_file["extension"],
+        "original_name": original_preview_file["original_name"],
+        "status": original_preview_file["status"],
+        "file_size": original_preview_file["file_size"],
+        "width": original_preview_file["width"],
+        "height": original_preview_file["height"],
+        "duration": original_preview_file["duration"],
+    }
+    if is_movie:
+        # The copy knows which movie versions it found: record them so
+        # that the movie routes do not probe the storage again.
+        target_preview_file = files_service.get_preview_file(
+            preview_file_to_update_id
+        )
+        data["data"] = {
+            **(target_preview_file.get("data") or {}),
+            files_service.MOVIE_PREFIXES_KEY: stored_movie_prefixes,
+        }
     preview_file_to_update = update_preview_file(
-        preview_file_to_update_id,
-        {
-            "extension": original_preview_file["extension"],
-            "original_name": original_preview_file["original_name"],
-            "status": original_preview_file["status"],
-            "file_size": original_preview_file["file_size"],
-            "width": original_preview_file["width"],
-            "height": original_preview_file["height"],
-            "duration": original_preview_file["duration"],
-        },
+        preview_file_to_update_id, data
     )
     tasks_service.update_preview_file_info(preview_file_to_update)
     comment = tasks_service.get_comment_by_preview_file_id(

--- a/zou/app/utils/fs.py
+++ b/zou/app/utils/fs.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import time
+import uuid
 from flask_fs.errors import FileNotFound
 
 
@@ -22,11 +23,67 @@ def copyfile(src, dest):
     shutil.copyfile(src, dest)
 
 
+MISSING_OBJECT_ERROR_CODES = {
+    "404",
+    "NoSuchKey",
+    "NoSuchBucket",
+    "NotFound",
+}
+
+
+def is_missing_file_error(exception):
+    """
+    Tell a missing object apart from a transient storage failure.
+
+    Only the local backend raises FileNotFound: Swift surfaces its own
+    ClientException and S3 a botocore ClientError, both carrying a 404.
+    Retrying those is pointless, and the sleep it comes with is paid on
+    every request that falls back from one prefix to another.
+    """
+    if exception is None:
+        return False
+    if isinstance(exception, FileNotFound):
+        return True
+    for attribute in ("http_status", "status", "status_code"):
+        if getattr(exception, attribute, None) == 404:
+            return True
+    response = getattr(exception, "response", None)
+    if isinstance(response, dict):
+        metadata = response.get("ResponseMetadata") or {}
+        if metadata.get("HTTPStatusCode") == 404:
+            return True
+        error = response.get("Error") or {}
+        if error.get("Code") in MISSING_OBJECT_ERROR_CODES:
+            return True
+    return False
+
+
+def get_cache_file_path(config, prefix, instance_id, extension):
+    """
+    Path of the local copy kept for a file stored on a remote backend.
+    """
+    return os.path.join(
+        config.TMP_DIR,
+        f"cache-{prefix}-{instance_id}.{extension}",
+    )
+
+
 def _download_to_file(file_path, open_file, prefix, instance_id):
+    """
+    Download a stored file to the local cache.
+
+    The bytes land in a private temporary file that is renamed over the
+    cache entry once complete. Writing straight into it would truncate
+    what a concurrent request is already reading, and would leave a
+    partial file behind on any interruption: the size check that guards
+    the cache accepts a truncated file as valid, so it would be served
+    as is.
+    """
     download_failed = False
     exception = None
+    tmp_path = f"{file_path}.{uuid.uuid4().hex}.part"
     try:
-        with open(file_path, "wb") as tmp_file:
+        with open(tmp_path, "wb") as tmp_file:
             file_generator = open_file(prefix, instance_id)
             try:
                 for chunk in file_generator:
@@ -36,9 +93,12 @@ def _download_to_file(file_path, open_file, prefix, instance_id):
                     file_generator.close()
                 except (StopIteration, Exception):
                     pass
+        os.replace(tmp_path, file_path)
     except Exception as e:
         download_failed = True
         exception = e
+    finally:
+        rm_file(tmp_path)
     return download_failed, exception
 
 
@@ -56,10 +116,7 @@ def get_file_path_and_file(
         if is_invalid_file(file_path, file_size):
             raise FileNotFound
     else:
-        file_path = os.path.join(
-            config.TMP_DIR,
-            f"cache-{prefix}-{instance_id}.{extension}",
-        )
+        file_path = get_cache_file_path(config, prefix, instance_id, extension)
 
         if is_invalid_file(file_path, file_size):
             download_failed, exception = _download_to_file(
@@ -67,12 +124,22 @@ def get_file_path_and_file(
             )
 
             if is_invalid_file(file_path, file_size, download_failed):
-                time.sleep(3)
-                download_failed, exception = _download_to_file(
-                    file_path, open_file, prefix, instance_id
-                )
+                # An object that is not there will not be there three
+                # seconds later. Only a transient failure deserves the
+                # retry: the movie routes probe up to three prefixes and
+                # would otherwise sleep on each missing one.
+                if not is_missing_file_error(exception):
+                    time.sleep(3)
+                    download_failed, exception = _download_to_file(
+                        file_path, open_file, prefix, instance_id
+                    )
 
                 if is_invalid_file(file_path, file_size, download_failed):
+                    # The cache entry is only ever replaced as a whole, so
+                    # a concurrent request may well have completed it while
+                    # this one was failing.
+                    if not is_invalid_file(file_path, file_size):
+                        return file_path
                     rm_file(file_path)
                     if exception is not None:
                         if isinstance(exception, FileNotFound):


### PR DESCRIPTION
**Problem**
  - The movie routes try up to three storage prefixes in a row (lowdef, previews, source). Every prefix holding nothing costs a failed download, a three second sleep and a
    second failed download.
  - The retry in fs.get_file_path_and_file only skipped FileNotFound, which neither Swift nor S3 ever raises: they surface their own exception carrying a 404. The sleep was
    therefore paid on every miss, in every setup using an object storage.
  - A preview stored under source only — what an upload with normalize=false produces — answered in 8s instead of milliseconds, repeated for every range a video player requests.
  - _download_to_file opened the cache entry in "wb" before knowing whether the download would succeed: a concurrent request truncated the file another one was serving, and any
    interruption left a partial file that the size check accepts as valid and serves as is.

**Solution**
  - fs.is_missing_file_error tells a missing object apart from a transient failure (FileNotFound, Swift ClientException, botocore ClientError). A missing object is no longer
    retried; a transient failure keeps its retry and its sleep.
  - The prefixes actually holding the movie are recorded on the preview file (data["movie_prefixes"], no migration needed) when it is stored, covering the four storage paths
    (source kept, full local normalization, SKIP_NORMALIZATION_HIGHDEF, normalize=false without source), and propagated by copy_preview_file_in_another_one.
  - files_service.get_movie_prefixes reads that record and orders the prefixes accordingly, so the right one is tried first. Preview files that predate the record fall back on
    probing the storage, memoized for ten minutes and invalidated by clear_preview_file_cache. Unexpected prefixes stay as a tail: a record can lag behind a movie that was
    re-encoded.
  - _download_to_file writes to a private .part file renamed into place with os.replace. Before answering a 404, the cache is re-checked: a concurrent request may have completed
    it in the meantime.