### PR TITLE
[previews] Keep the movie prefix record honest and cheap

### DIFF
--- a/tests/blueprints/previews/test_movie_streaming.py
+++ b/tests/blueprints/previews/test_movie_streaming.py
@@ -162,11 +162,55 @@ class MovieStreamingRoutesTestCase(ApiDBTestCase):
             ["previews"],
         )
 
+    def recorded_prefixes(self, preview_file_id):
+        return files_service.get_preview_file_for_access(preview_file_id)[
+            "movie_prefixes"
+        ]
+
+    def record_prefixes(self, preview_file_id, prefixes):
+        preview_file = files_service.get_preview_file_raw(preview_file_id)
+        preview_file.update(
+            {"data": {files_service.MOVIE_PREFIXES_KEY: prefixes}}
+        )
+        files_service.clear_preview_file_cache(preview_file_id)
+
+    def get_movie(self, preview_file_id):
+        return self.app.get(
+            f"/movies/originals/preview-files/{preview_file_id}.mp4",
+            headers=self.base_headers,
+        )
+
     def test_recorded_prefixes_spare_the_storage_probe(self):
         preview_file_id = self.upload_movie_preview(save_source_file=True)
         with patch.object(file_store, "exists_movie") as exists_movie:
-            self.assertEqual(
-                files_service.get_movie_prefixes(preview_file_id, lowdef=True),
-                ["source", "lowdef", "previews"],
-            )
+            self.assertEqual(self.get_movie(preview_file_id).status_code, 200)
             exists_movie.assert_not_called()
+
+    def test_missing_record_is_probed_once_then_written_back(self):
+        # A preview file stored before the record existed.
+        preview_file_id = self.upload_movie_preview(save_source_file=True)
+        preview_file = files_service.get_preview_file_raw(preview_file_id)
+        preview_file.update({"data": {"original_width": 1}})
+        files_service.clear_preview_file_cache(preview_file_id)
+
+        with patch.object(
+            file_store, "exists_movie", wraps=file_store.exists_movie
+        ) as exists_movie:
+            self.assertEqual(self.get_movie(preview_file_id).status_code, 200)
+            self.assertEqual(exists_movie.call_count, 3)
+            self.assertEqual(self.get_movie(preview_file_id).status_code, 200)
+            self.assertEqual(exists_movie.call_count, 3)
+        self.assertEqual(
+            files_service.get_preview_file(preview_file_id)["data"],
+            {
+                "original_width": 1,
+                files_service.MOVIE_PREFIXES_KEY: ["source"],
+            },
+        )
+
+    def test_stale_record_is_fixed_on_fallback(self):
+        preview_file_id = self.upload_movie_preview(save_source_file=True)
+        self.record_prefixes(preview_file_id, ["previews"])
+
+        self.assertEqual(self.get_movie(preview_file_id).status_code, 200)
+        self.assertEqual(self.recorded_prefixes(preview_file_id), ["source"])

--- a/tests/services/test_files_service.py
+++ b/tests/services/test_files_service.py
@@ -200,7 +200,8 @@ class LookupTestCase(FilesTestCase):
             event.remove(db.engine, "before_cursor_execute", record)
 
         self.assertEqual(
-            set(result.keys()), {"id", "task_id", "updated_at", "extension"}
+            set(result.keys()),
+            {"id", "task_id", "updated_at", "extension", "movie_prefixes"},
         )
         self.assertEqual(result["id"], preview_file_id)
         self.assertEqual(result["task_id"], task_id)
@@ -881,9 +882,8 @@ class MoviePrefixesTestCase(ApiDBTestCase):
 
     def setUp(self):
         super().setUp()
-        self.preview_file_id = str(fields.gen_uuid())
         self.generate_fixture_preview_file()
-        self.recorded_preview_file_id = str(self.preview_file.id)
+        self.preview_file_id = str(self.preview_file.id)
 
     def stored_under(self, stored_prefix):
         return patch.object(
@@ -893,112 +893,89 @@ class MoviePrefixesTestCase(ApiDBTestCase):
         )
 
     def test_stored_prefix_comes_first(self):
-        with self.stored_under("lowdef"):
-            self.assertEqual(
-                files_service.get_movie_prefixes(
-                    self.preview_file_id, lowdef=True
-                ),
-                ["lowdef", "previews", "source"],
-            )
+        self.assertEqual(
+            files_service.get_movie_prefixes(["lowdef"], lowdef=True),
+            ["lowdef", "previews", "source"],
+        )
+        self.assertEqual(
+            files_service.get_movie_prefixes(["source"], lowdef=True),
+            ["source", "lowdef", "previews"],
+        )
+        self.assertEqual(
+            files_service.get_movie_prefixes(["source"], lowdef=False),
+            ["source", "previews", "lowdef"],
+        )
 
-    def test_source_comes_first_when_normalization_was_skipped(self):
-        with self.stored_under("source"):
-            self.assertEqual(
-                files_service.get_movie_prefixes(
-                    self.preview_file_id, lowdef=True
-                ),
-                ["source", "lowdef", "previews"],
-            )
-            self.assertEqual(
-                files_service.get_movie_prefixes(
-                    f"{self.preview_file_id}-full"
-                ),
-                ["source", "previews", "lowdef"],
-            )
+    def test_recorded_prefixes_keep_the_route_order(self):
+        stored = ["previews", "lowdef"]
+        self.assertEqual(
+            files_service.get_movie_prefixes(stored, lowdef=True),
+            ["lowdef", "previews", "source"],
+        )
+        self.assertEqual(
+            files_service.get_movie_prefixes(stored, lowdef=False),
+            ["previews", "lowdef", "source"],
+        )
 
     def test_default_order_when_nothing_is_stored(self):
-        with self.stored_under(None):
-            self.assertEqual(
-                files_service.get_movie_prefixes(
-                    self.preview_file_id, lowdef=True
-                ),
-                ["lowdef", "previews", "source"],
-            )
+        self.assertEqual(
+            files_service.get_movie_prefixes([], lowdef=True),
+            ["lowdef", "previews", "source"],
+        )
 
-    def test_storage_error_does_not_break_the_resolution(self):
+    def test_probe_asks_the_storage_for_every_prefix(self):
+        with self.stored_under("lowdef") as exists_movie:
+            self.assertEqual(
+                files_service.probe_movie_prefixes(self.preview_file_id),
+                ["lowdef"],
+            )
+            self.assertEqual(exists_movie.call_count, 3)
+
+    def test_storage_error_does_not_break_the_probe(self):
         with patch.object(
             file_store, "exists_movie", side_effect=Exception("timeout")
         ):
             self.assertEqual(
-                files_service.get_movie_prefixes(
-                    self.preview_file_id, lowdef=True
-                ),
-                ["lowdef", "previews", "source"],
+                files_service.probe_movie_prefixes(self.preview_file_id), []
             )
 
-    def test_resolution_is_memoized_and_invalidated(self):
-        with self.stored_under("source") as exists_movie:
-            for _ in range(3):
-                files_service.get_movie_prefixes(
-                    self.preview_file_id, lowdef=True
-                )
-            self.assertEqual(exists_movie.call_count, 3)
-
-            files_service.clear_preview_file_cache(self.preview_file_id)
-            files_service.get_movie_prefixes(self.preview_file_id, lowdef=True)
-            self.assertEqual(exists_movie.call_count, 6)
-
     def record_prefixes(self, prefixes):
-        preview_file = files_service.get_preview_file_raw(
-            self.recorded_preview_file_id
-        )
+        preview_file = files_service.get_preview_file_raw(self.preview_file_id)
         preview_file.update(
             {"data": {files_service.MOVIE_PREFIXES_KEY: prefixes}}
         )
-        files_service.clear_preview_file_cache(self.recorded_preview_file_id)
+        files_service.clear_preview_file_cache(self.preview_file_id)
 
-    def test_recorded_prefixes_win_over_the_probe(self):
+    def recorded_prefixes(self):
+        return files_service.get_preview_file_for_access(self.preview_file_id)[
+            "movie_prefixes"
+        ]
+
+    def test_access_lookup_carries_the_record(self):
+        self.assertIsNone(self.recorded_prefixes())
         self.record_prefixes(["source"])
-        with patch.object(file_store, "exists_movie") as exists_movie:
-            self.assertEqual(
-                files_service.get_movie_prefixes(
-                    self.recorded_preview_file_id, lowdef=True
-                ),
-                ["source", "lowdef", "previews"],
-            )
-            exists_movie.assert_not_called()
-
-    def test_recorded_prefixes_keep_the_route_order(self):
-        self.record_prefixes(["previews", "lowdef"])
-        self.assertEqual(
-            files_service.get_movie_prefixes(
-                self.recorded_preview_file_id, lowdef=True
-            ),
-            ["lowdef", "previews", "source"],
-        )
-        self.assertEqual(
-            files_service.get_movie_prefixes(self.recorded_preview_file_id),
-            ["previews", "lowdef", "source"],
-        )
-
-    def test_probe_takes_over_when_nothing_was_recorded(self):
+        self.assertEqual(self.recorded_prefixes(), ["source"])
         self.record_prefixes([])
-        with self.stored_under("lowdef") as exists_movie:
-            self.assertEqual(
-                files_service.get_movie_prefixes(
-                    self.recorded_preview_file_id, lowdef=True
-                ),
-                ["lowdef", "previews", "source"],
-            )
-            exists_movie.assert_called()
+        self.assertEqual(self.recorded_prefixes(), [])
 
-    def test_garbage_record_is_ignored(self):
+    def test_garbage_record_reads_as_none(self):
         self.record_prefixes("source")
-        with self.stored_under("source") as exists_movie:
-            self.assertEqual(
-                files_service.get_movie_prefixes(
-                    self.recorded_preview_file_id, lowdef=True
-                ),
-                ["source", "lowdef", "previews"],
-            )
-            exists_movie.assert_called()
+        self.assertIsNone(self.recorded_prefixes())
+        preview_file = files_service.get_preview_file_raw(self.preview_file_id)
+        preview_file.update({"data": ["source"]})
+        files_service.clear_preview_file_cache(self.preview_file_id)
+        self.assertIsNone(self.recorded_prefixes())
+        self.assertEqual(files_service.get_preview_file_data(preview_file), {})
+
+    def test_record_keeps_the_other_data(self):
+        preview_file = files_service.get_preview_file_raw(self.preview_file_id)
+        preview_file.update({"data": {"original_width": 1920}})
+        files_service.record_movie_prefixes(self.preview_file_id, ["lowdef"])
+        self.assertEqual(self.recorded_prefixes(), ["lowdef"])
+        self.assertEqual(
+            files_service.get_preview_file(self.preview_file_id)["data"],
+            {
+                "original_width": 1920,
+                files_service.MOVIE_PREFIXES_KEY: ["lowdef"],
+            },
+        )

--- a/tests/services/test_preview_files_service.py
+++ b/tests/services/test_preview_files_service.py
@@ -590,6 +590,59 @@ class PreviewFileServiceTestCase(PreviewFileTestCase):
         self.assertEqual(persisted["width"], 1920)
         self.assertEqual(persisted["file_size"], 1024)
 
+    @patch("zou.app.services.preview_files_service.movie.get_movie_duration")
+    @patch("zou.app.services.preview_files_service.movie.get_movie_size")
+    @patch("zou.app.services.preview_files_service.fs.get_file_path_and_file")
+    @patch(
+        "zou.app.services.preview_files_service._run_remote_normalize_movie"
+    )
+    @patch(
+        "zou.app.services.preview_files_service"
+        ".is_remote_normalization_enabled"
+    )
+    def test_prepare_and_store_movie_remote_job_records_what_it_stored(
+        self,
+        mock_is_remote,
+        mock_run_remote,
+        mock_get_file,
+        mock_size,
+        mock_duration,
+    ):
+        """
+        A runner that predates skip_high_def uploads both encoded versions
+        whatever the flag: the record comes from the storage, not from
+        the flags.
+        """
+        preview_file = self.generate_fixture_preview_file(status="processing")
+        preview_file_id = str(preview_file.id)
+        uploaded_path = self._write_temp_movie()
+        mock_is_remote.return_value = True
+        mock_run_remote.return_value = True
+        mock_get_file.return_value = self._write_temp_movie()
+        mock_size.return_value = (1280, 720)
+        mock_duration.return_value = 10.0
+
+        with patch.object(
+            preview_files_service.config, "SKIP_NORMALIZATION_HIGHDEF", True
+        ), patch.object(
+            preview_files_service.file_store,
+            "exists_movie",
+            side_effect=lambda prefix, _id: prefix in ("previews", "lowdef"),
+        ):
+            preview_files_service.prepare_and_store_movie(
+                preview_file_id,
+                uploaded_path,
+                normalize=True,
+                add_source_to_file_store=False,
+            )
+
+        persisted = files_service.get_preview_file(preview_file_id)
+        self.assertEqual(persisted["status"], "ready")
+        self.assertEqual(
+            persisted["data"][files_service.MOVIE_PREFIXES_KEY],
+            ["previews", "lowdef"],
+        )
+
     def test_copying_a_movie_preview_carries_the_source_along(self):
         """
         A preview file whose normalization was skipped only holds a source

--- a/tests/services/test_sync_service.py
+++ b/tests/services/test_sync_service.py
@@ -704,10 +704,16 @@ class DownloadFileTestCase(unittest.TestCase):
             yield b"partial content"
             raise RuntimeError("stream interrupted")
 
+        with open(self.file_path, "wb") as previous:
+            previous.write(b"previous complete content")
+
         sync_service.download_file(
             self.file_path, "previews", failing_dl_func, "preview-id"
         )
-        self.assertFalse(os.path.exists(self.file_path))
+        # The previous download is not truncated either.
+        with open(self.file_path, "rb") as downloaded:
+            self.assertEqual(downloaded.read(), b"previous complete content")
+        self.assertEqual(os.listdir(self.folder), ["preview.mp4"])
 
     def test_successful_download_keeps_file(self):
         def dl_func(prefix, preview_file_id):

--- a/tests/stores/test_file_store.py
+++ b/tests/stores/test_file_store.py
@@ -1,6 +1,10 @@
 import unittest
 import os
 
+from unittest.mock import Mock
+
+import pytest
+from flask_fs.errors import FileNotFound
 
 from zou.app import app
 from zou.app.stores import file_store
@@ -60,3 +64,35 @@ class FileStoreTestCase(unittest.TestCase):
         file_name = "thumbnails-63e453f1-9655-49ad-acba-ff7f27c49e9d"
         result_path = file_store.path(file_store.pictures, file_name)
         self.assertTrue(os.path.exists(result_path))
+
+
+class ReadGeneratorTestCase(unittest.TestCase):
+    """
+    flask_fs turns every backend error into FileNotFound because its
+    existence check swallows them. The read generator has to keep a
+    missing object and a transient failure apart: only the former is
+    worth skipping the download retry for.
+    """
+
+    def make_bucket(self, error):
+        bucket = Mock()
+        bucket.backend.encryptor = None
+        bucket.backend.read_chunks.side_effect = error
+        return bucket
+
+    def test_missing_object_is_a_file_not_found(self):
+        error = Exception("Object GET failed")
+        error.http_status = 404
+        with pytest.raises(FileNotFound):
+            file_store.make_read_generator(self.make_bucket(error), "key")
+
+    def test_transient_failure_is_left_alone(self):
+        error = Exception("Service Unavailable")
+        error.http_status = 503
+        with pytest.raises(Exception, match="Service Unavailable"):
+            file_store.make_read_generator(self.make_bucket(error), "key")
+
+    def test_missing_local_file_is_a_file_not_found(self):
+        app.app_context().push()
+        with pytest.raises(FileNotFound):
+            list(file_store.open_picture("thumbnails", "does-not-exist"))

--- a/tests/utils/test_fs.py
+++ b/tests/utils/test_fs.py
@@ -142,7 +142,7 @@ class DownloadToFileTestCase(unittest.TestCase):
             yield b"movie"
             yield b"-bytes"
 
-        exception = fs._download_to_file(
+        exception = fs.download_to_file(
             self.file_path, open_file, "previews", "id"
         )
 
@@ -159,7 +159,7 @@ class DownloadToFileTestCase(unittest.TestCase):
             yield b"trunc"
             raise IOError("connection reset")
 
-        exception = fs._download_to_file(
+        exception = fs.download_to_file(
             self.file_path, open_file, "previews", "id"
         )
 
@@ -173,7 +173,7 @@ class DownloadToFileTestCase(unittest.TestCase):
             raise IOError("connection reset")
             yield b""
 
-        fs._download_to_file(self.file_path, open_file, "previews", "id")
+        fs.download_to_file(self.file_path, open_file, "previews", "id")
 
         self.assertFalse(os.path.exists(self.file_path))
         self.assertEqual(self.cache_files(), [])
@@ -191,7 +191,7 @@ class DownloadToFileTestCase(unittest.TestCase):
         def open_file(prefix, instance_id):
             yield b"movie"
 
-        fs._download_to_file(self.file_path, open_file, "previews", "id")
+        fs.download_to_file(self.file_path, open_file, "previews", "id")
 
         self.assertEqual(
             self.cache_files(),

--- a/tests/utils/test_fs.py
+++ b/tests/utils/test_fs.py
@@ -47,10 +47,8 @@ class GetFilePathAndFileTestCase(unittest.TestCase):
                     )
 
     def test_missing_object_is_not_retried(self):
-        # Swift and S3 do not raise FileNotFound: they surface their own
-        # exception carrying a 404. Sleeping three seconds and asking
-        # again for an object that is not there delays every fallback on
-        # the next prefix.
+        # Sleeping three seconds and asking again for an object that is
+        # not there delays every fallback on the next prefix.
         class SwiftClientException(Exception):
             http_status = 404
 
@@ -144,11 +142,10 @@ class DownloadToFileTestCase(unittest.TestCase):
             yield b"movie"
             yield b"-bytes"
 
-        download_failed, exception = fs._download_to_file(
+        exception = fs._download_to_file(
             self.file_path, open_file, "previews", "id"
         )
 
-        self.assertFalse(download_failed)
         self.assertIsNone(exception)
         with open(self.file_path, "rb") as cached:
             self.assertEqual(cached.read(), b"movie-bytes")
@@ -162,11 +159,10 @@ class DownloadToFileTestCase(unittest.TestCase):
             yield b"trunc"
             raise IOError("connection reset")
 
-        download_failed, exception = fs._download_to_file(
+        exception = fs._download_to_file(
             self.file_path, open_file, "previews", "id"
         )
 
-        self.assertTrue(download_failed)
         self.assertIsInstance(exception, IOError)
         with open(self.file_path, "rb") as cached:
             self.assertEqual(cached.read(), b"complete-movie")
@@ -182,9 +178,29 @@ class DownloadToFileTestCase(unittest.TestCase):
         self.assertFalse(os.path.exists(self.file_path))
         self.assertEqual(self.cache_files(), [])
 
+    def test_stale_part_is_swept_and_live_one_kept(self):
+        # A download killed with its process leaves its .part behind.
+        stale_path = f"{self.file_path}.dead.part"
+        live_path = f"{self.file_path}.live.part"
+        for path in (stale_path, live_path):
+            with open(path, "wb") as part:
+                part.write(b"partial")
+        old = os.path.getmtime(stale_path) - fs.STALE_PART_AGE - 1
+        os.utime(stale_path, (old, old))
+
+        def open_file(prefix, instance_id):
+            yield b"movie"
+
+        fs._download_to_file(self.file_path, open_file, "previews", "id")
+
+        self.assertEqual(
+            self.cache_files(),
+            ["cache-previews-id", "cache-previews-id.live.part"],
+        )
+
     def test_concurrent_download_is_served_instead_of_a_404(self):
         # The other request completed the cache entry while this one was
-        # failing: serving it beats answering a 404.
+        # failing: serving it beats answering a 404, and beats retrying.
         config = FakeConfig(self.tmp_dir.name)
         cache_path = fs.get_cache_file_path(config, "previews", "id", "mp4")
 
@@ -194,7 +210,7 @@ class DownloadToFileTestCase(unittest.TestCase):
             raise IOError("connection reset")
             yield b""
 
-        with mock.patch("zou.app.utils.fs.time.sleep"):
+        with mock.patch("zou.app.utils.fs.time.sleep") as sleep:
             file_path = fs.get_file_path_and_file(
                 config,
                 get_local_path=lambda prefix, instance_id: "",
@@ -206,3 +222,4 @@ class DownloadToFileTestCase(unittest.TestCase):
 
         with open(file_path, "rb") as cached:
             self.assertEqual(cached.read(), b"complete-movie")
+        sleep.assert_not_called()

--- a/zou/app/blueprints/previews/resources.py
+++ b/zou/app/blueprints/previews/resources.py
@@ -118,7 +118,11 @@ def send_standard_file(
 
 
 def send_movie_file(
-    preview_file_id, as_attachment=False, lowdef=False, last_modified=None
+    preview_file_id,
+    as_attachment=False,
+    lowdef=False,
+    last_modified=None,
+    preview_file=None,
 ):
     """
     Send the requested movie version, falling back on the other stored ones.
@@ -127,14 +131,24 @@ def send_movie_file(
     source is the last resort. Note that the source is served as video/mp4
     whatever its real container, and carries no faststart flag.
 
-    The prefix order is resolved beforehand so that the version actually
-    stored comes first: a missing object costs a round trip on the object
-    storage, and a movie player asks for the same file once per range.
+    The versions actually stored come first: a missing object costs a
+    round trip on the object storage, and a movie player asks for the same
+    file once per range. They are read from the access lookup the route
+    already did (`preview_file`), probed on the storage for a preview file
+    that predates the record, and written back when missing or stale.
     """
-    prefixes = files_service.get_movie_prefixes(preview_file_id, lowdef=lowdef)
+    if preview_file is None:
+        preview_file = files_service.get_preview_file_for_access(
+            preview_file_id
+        )
+    recorded_prefixes = preview_file["movie_prefixes"]
+    stored_prefixes = recorded_prefixes
+    if stored_prefixes is None:
+        stored_prefixes = files_service.probe_movie_prefixes(preview_file_id)
+    prefixes = files_service.get_movie_prefixes(stored_prefixes, lowdef)
     for prefix in prefixes:
         try:
-            return send_storage_file(
+            response = send_storage_file(
                 file_store.get_local_movie_path,
                 file_store.open_movie,
                 prefix,
@@ -147,6 +161,22 @@ def send_movie_file(
         except FileNotFound:
             if prefix == prefixes[-1]:
                 raise
+            continue
+        if prefix != prefixes[0]:
+            # The record lags behind the storage (a version removed, a
+            # row imported from another instance): ask the storage again.
+            stored_prefixes = files_service.probe_movie_prefixes(
+                preview_file_id
+            )
+        # A probe that misses the movie just served failed itself: it is
+        # not worth recording.
+        if prefix in stored_prefixes and set(stored_prefixes) != set(
+            recorded_prefixes or []
+        ):
+            files_service.record_movie_prefixes(
+                preview_file_id, stored_prefixes
+            )
+        return response
 
 
 def send_source_movie_file(preview_file_id, last_modified=None):
@@ -820,7 +850,9 @@ class PreviewFileMovieResource(BasePreviewFileResource):
 
         try:
             return send_movie_file(
-                instance_id, last_modified=self.last_modified
+                instance_id,
+                last_modified=self.last_modified,
+                preview_file=self.preview_file,
             )
         except FileNotFound:
             if config.LOG_FILE_NOT_FOUND:
@@ -869,7 +901,10 @@ class PreviewFileLowMovieResource(BasePreviewFileResource):
             # send_movie_file already falls back on the full quality version
             # then on the source.
             return send_movie_file(
-                instance_id, lowdef=True, last_modified=self.last_modified
+                instance_id,
+                lowdef=True,
+                last_modified=self.last_modified,
+                preview_file=self.preview_file,
             )
         except FileNotFound:
             if config.LOG_FILE_NOT_FOUND:
@@ -964,6 +999,7 @@ class PreviewFileMovieDownloadResource(BasePreviewFileResource):
                 instance_id,
                 as_attachment=True,
                 last_modified=self.last_modified,
+                preview_file=self.preview_file,
             )
         except FileNotFound:
             if config.LOG_FILE_NOT_FOUND:
@@ -1104,6 +1140,7 @@ class PreviewFileDownloadResource(BasePreviewFileResource):
                     instance_id,
                     as_attachment=True,
                     last_modified=self.last_modified,
+                    preview_file=self.preview_file,
                 )
             else:
                 return send_standard_file(

--- a/zou/app/services/deletion_service.py
+++ b/zou/app/services/deletion_service.py
@@ -41,7 +41,7 @@ from zou.app.utils import events, fields, date_helpers
 from zou.app.stores import file_store
 from zou.app import config
 
-from zou.app.services import base_service
+from zou.app.services import base_service, files_service
 from zou.app.services.exception import (
     ProjectNotFoundException,
     AttachmentFileNotFoundException,
@@ -370,7 +370,7 @@ def clear_movie_files(preview_file_id):
     Remove all files related to given preview file, supposing the original file
     was a movie.
     """
-    for movie_type in ["previews", "lowdef", "source"]:
+    for movie_type in files_service.MOVIE_PREFIXES:
         _remove_quietly(file_store.remove_movie, movie_type, preview_file_id)
     for image_type in ["thumbnails", "thumbnails-square", "previews", "tiles"]:
         _remove_quietly(file_store.remove_picture, image_type, preview_file_id)

--- a/zou/app/services/files_service.py
+++ b/zou/app/services/files_service.py
@@ -50,8 +50,6 @@ def clear_preview_file_cache(preview_file_id):
     """
     cache.cache.delete_memoized(get_preview_file, preview_file_id)
     cache.cache.delete_memoized(get_preview_file_for_access, preview_file_id)
-    cache.cache.delete_memoized(get_movie_prefixes, preview_file_id, False)
-    cache.cache.delete_memoized(get_movie_prefixes, preview_file_id, True)
 
 
 def clear_output_file_cache(output_file_id):
@@ -814,10 +812,11 @@ def get_preview_file(preview_file_id):
 def get_preview_file_for_access(preview_file_id):
     """
     Lightweight lookup used by picture/movie download endpoints that only
-    need to check permissions and emit a Last-Modified header. Avoids
-    loading the JSONB annotations and data columns, which can weigh
-    several MB on long shots and dominate query time when the response
-    is a static file served from disk.
+    need to check permissions, emit a Last-Modified header and know which
+    versions of a movie are stored. Avoids loading the JSONB annotations
+    and data columns, which can weigh several MB on long shots and
+    dominate query time when the response is a static file served from
+    disk.
     """
     try:
         row = (
@@ -826,6 +825,7 @@ def get_preview_file_for_access(preview_file_id):
                 PreviewFile.task_id,
                 PreviewFile.updated_at,
                 PreviewFile.extension,
+                PreviewFile.data[MOVIE_PREFIXES_KEY].label("movie_prefixes"),
             )
             .filter_by(id=preview_file_id)
             .first()
@@ -839,7 +839,22 @@ def get_preview_file_for_access(preview_file_id):
         "task_id": str(row.task_id) if row.task_id else None,
         "updated_at": fields.serialize_value(row.updated_at),
         "extension": row.extension,
+        # None for a preview file that predates the record, a list of
+        # prefixes otherwise.
+        "movie_prefixes": (
+            row.movie_prefixes
+            if isinstance(row.movie_prefixes, list)
+            else None
+        ),
     }
+
+
+def get_preview_file_data(preview_file):
+    """
+    The data column is a bare JSONB that a PUT can set to anything: only
+    a dict is usable.
+    """
+    return preview_file.data if isinstance(preview_file.data, dict) else {}
 
 
 def _is_movie_stored(prefix, preview_file_id):
@@ -860,54 +875,47 @@ def _is_movie_stored(prefix, preview_file_id):
         return False
 
 
-def get_stored_movie_prefixes(preview_file_id):
+def probe_movie_prefixes(preview_file_id):
     """
-    Return the storage prefixes the movie was written to, as recorded
-    when it was stored, or None for a preview file that predates that
-    record. Only the `data` column is read: the annotations sitting next
-    to it weigh several MB on a long shot.
+    Ask the storage which versions of the movie exist, for a preview file
+    that predates the record written at storage time. Costs one round
+    trip per prefix.
     """
-    try:
-        row = (
-            PreviewFile.query.with_entities(PreviewFile.data)
-            .filter_by(id=preview_file_id)
-            .first()
-        )
-    except StatementError:
-        return None
-    if row is None or not row.data:
-        return None
-    prefixes = row.data.get(MOVIE_PREFIXES_KEY)
-    if not isinstance(prefixes, list):
-        return None
-    return [prefix for prefix in prefixes if prefix in MOVIE_PREFIXES]
+    return [
+        prefix
+        for prefix in MOVIE_PREFIXES
+        if _is_movie_stored(prefix, preview_file_id)
+    ]
 
 
-@cache.memoize_function(600)
-def get_movie_prefixes(preview_file_id, lowdef=False):
+def get_movie_prefixes(stored_prefixes, lowdef):
     """
-    Return the storage prefixes to try for given movie, best first.
-
-    A normalized movie is stored under `previews` and `lowdef`, a movie
-    uploaded with normalize=false under `source` only. Knowing which one
-    holds it spares the routes from downloading missing objects before
-    falling back on the right one, on every range a player asks for.
-
-    The prefixes are read from the preview file when they were recorded
-    at storage time, and probed on the storage otherwise. The ones that
-    are not expected to hold anything are kept as a tail: a record can
-    lag behind a movie that was re-encoded or copied over.
+    Return the storage prefixes to try for a movie, best first: the ones
+    holding it in the order the route prefers, then the others as a
+    tail, since a record can lag behind a movie that was re-encoded or
+    copied over.
     """
     prefixes = LOWDEF_MOVIE_PREFIXES if lowdef else MOVIE_PREFIXES
-    stored = get_stored_movie_prefixes(preview_file_id)
-    if stored:
-        return [prefix for prefix in prefixes if prefix in stored] + [
-            prefix for prefix in prefixes if prefix not in stored
-        ]
-    for index, prefix in enumerate(prefixes):
-        if _is_movie_stored(prefix, preview_file_id):
-            return [prefix] + prefixes[:index] + prefixes[index + 1 :]
-    return list(prefixes)
+    return [prefix for prefix in prefixes if prefix in stored_prefixes] + [
+        prefix for prefix in prefixes if prefix not in stored_prefixes
+    ]
+
+
+def record_movie_prefixes(preview_file_id, prefixes):
+    """
+    Remember on the preview file which versions of its movie are stored,
+    without notifying anyone: nothing the clients see changes.
+    """
+    preview_file = get_preview_file_raw(preview_file_id)
+    preview_file.update(
+        {
+            "data": {
+                **get_preview_file_data(preview_file),
+                MOVIE_PREFIXES_KEY: prefixes,
+            }
+        }
+    )
+    clear_preview_file_cache(preview_file_id)
 
 
 def get_preview_files_for_task(task_id):

--- a/zou/app/services/playlists_service.py
+++ b/zou/app/services/playlists_service.py
@@ -11,7 +11,6 @@ from pathlib import Path
 from shutil import copyfile
 from zipfile import ZipFile
 
-from flask_fs.errors import FileNotFound
 from slugify import slugify
 from sqlalchemy import or_
 from sqlalchemy.orm import defer, joinedload
@@ -28,7 +27,7 @@ from zou.app.models.task import Task
 from zou.app.models.task_type import TaskType
 
 from zou.utils import movie
-from zou.app.utils import fields, events, remote_job, emails
+from zou.app.utils import fields, events, fs, remote_job, emails
 from zou.app.utils import query as query_utils
 from zou.app.stores.redis_lock import with_playlist_lock
 
@@ -742,34 +741,27 @@ def retrieve_playlist_tmp_file(preview_file):
     if preview_file["extension"] == "mp4":
         get_path_func = file_store.get_local_movie_path
         open_func = file_store.open_movie
-        exists_func = file_store.exists_movie
         prefix = "previews"
     elif preview_file["extension"] == "png":
         get_path_func = file_store.get_local_picture_path
         open_func = file_store.open_picture
-        exists_func = file_store.exists_picture
         prefix = "original"
     else:
         get_path_func = file_store.get_local_file_path
         open_func = file_store.open_file
-        exists_func = file_store.exists_file
         prefix = "previews"
 
-    if config.FS_BACKEND == "local":
-        file_path = get_path_func(prefix, preview_file["id"])
-    else:
-        file_path = os.path.join(
-            config.TMP_DIR,
-            f"cache-previews-{preview_file['id']}.{preview_file['extension']}",
-        )
-        if not os.path.exists(file_path) or os.path.getsize(file_path) == 0:
-            if exists_func(prefix, preview_file["id"]):
-                with open(file_path, "wb") as tmp_file:
-                    try:
-                        for chunk in open_func(prefix, preview_file["id"]):
-                            tmp_file.write(chunk)
-                    except FileNotFound:
-                        pass
+    # Same cache entry as the preview routes, written the same way: a
+    # download interrupted halfway must not leave a truncated file that
+    # the next build would concatenate as is.
+    file_path = fs.get_file_path_and_file(
+        config,
+        get_path_func,
+        open_func,
+        prefix,
+        preview_file["id"],
+        preview_file["extension"],
+    )
     file_name = names_service.get_preview_file_name(preview_file["id"])
     tmp_file_path = os.path.join(config.TMP_DIR, file_name)
     copyfile(file_path, tmp_file_path)

--- a/zou/app/services/preview_files_service.py
+++ b/zou/app/services/preview_files_service.py
@@ -568,21 +568,27 @@ def prepare_and_store_movie(
                 except FileNotFoundError:
                     pass
 
-        # Which storage prefixes hold the movie follows from the flags
+        # Which storage prefixes hold the movie is recorded on the preview
+        # file so that the movie routes do not have to rediscover it by
+        # probing the object storage. Locally it follows from the flags
         # above: the encoded versions when normalizing, the upload itself
         # under `previews` when it was stored raw and not already kept as
-        # the source (a remote job stores nothing in that case). It is
-        # recorded on the preview file so that the movie routes do not
-        # have to rediscover it by probing the object storage.
-        if normalize:
+        # the source. A remote job is asked nothing: a runner that
+        # predates skip_high_def still uploads both encoded versions, so
+        # the storage is probed once instead.
+        if is_remote:
+            stored_movie_prefixes = files_service.probe_movie_prefixes(
+                preview_file_id
+            )
+        elif normalize:
             stored_movie_prefixes = (
                 ["lowdef"] if skip_high_def else ["previews", "lowdef"]
             )
-        elif add_source_to_file_store or is_remote:
+        elif add_source_to_file_store:
             stored_movie_prefixes = []
         else:
             stored_movie_prefixes = ["previews"]
-        if add_source_to_file_store:
+        if add_source_to_file_store and "source" not in stored_movie_prefixes:
             stored_movie_prefixes.insert(0, "source")
 
         # Re-fetch preview file before updating (it may have been deleted during processing)
@@ -683,12 +689,9 @@ def clear_variant_from_cache(preview_file_id, prefix, extension="png"):
     Clear a variant from the cache to force to redownload from object storage.
     """
     if config.FS_BACKEND != "local":
-        file_path = os.path.join(
-            config.TMP_DIR,
-            f"cache-{prefix}-{preview_file_id}.{extension}",
+        fs.rm_file(
+            fs.get_cache_file_path(config, prefix, preview_file_id, extension)
         )
-        if os.path.exists(file_path):
-            os.remove(file_path)
     return preview_file_id
 
 

--- a/zou/app/services/preview_files_service.py
+++ b/zou/app/services/preview_files_service.py
@@ -303,17 +303,11 @@ def prepare_and_store_movie(
     from zou.app import app as current_app
 
     with current_app.app_context():
-        # Which storage prefixes end up holding the movie depends on the
-        # normalization settings. It is recorded on the preview file so
-        # that the movie routes do not have to rediscover it by probing
-        # the object storage on every read.
-        stored_movie_prefixes = []
         if add_source_to_file_store:
             try:
                 file_store.add_movie(
                     "source", preview_file_id, uploaded_movie_path
                 )
-                stored_movie_prefixes.append("source")
             except Exception as exc:
                 _remove_temp_files(uploaded_movie_path)
                 return _abort_on_storage_failure(
@@ -335,7 +329,9 @@ def prepare_and_store_movie(
                 preview_file_raw,
                 {
                     "data": {
-                        **(preview_file_raw.data or {}),
+                        **files_service.get_preview_file_data(
+                            preview_file_raw
+                        ),
                         "original_width": original_width,
                         "original_height": original_height,
                         "original_duration": original_duration,
@@ -417,10 +413,6 @@ def prepare_and_store_movie(
                     if normalize:
                         # Without the high def version, the low def one is
                         # the only movie the remote job uploaded.
-                        if skip_high_def:
-                            stored_movie_prefixes.append("lowdef")
-                        else:
-                            stored_movie_prefixes += ["previews", "lowdef"]
                         normalized_movie_path = fs.get_file_path_and_file(
                             config,
                             file_store.get_local_movie_path,
@@ -453,11 +445,9 @@ def prepare_and_store_movie(
                         file_store.add_movie(
                             "previews", preview_file_id, normalized_movie_path
                         )
-                        stored_movie_prefixes.append("previews")
                     file_store.add_movie(
                         "lowdef", preview_file_id, normalized_movie_low_path
                     )
-                    stored_movie_prefixes.append("lowdef")
                     if normalized_movie_path is None:
                         # Everything below (metadata, thumbnails, tile) works
                         # on the movie that was actually produced.
@@ -494,7 +484,6 @@ def prepare_and_store_movie(
                     file_store.add_movie(
                         "previews", preview_file_id, uploaded_movie_path
                     )
-                    stored_movie_prefixes.append("previews")
             except Exception as exc:
                 _remove_temp_files(uploaded_movie_path)
                 return _abort_on_storage_failure(
@@ -579,6 +568,23 @@ def prepare_and_store_movie(
                 except FileNotFoundError:
                     pass
 
+        # Which storage prefixes hold the movie follows from the flags
+        # above: the encoded versions when normalizing, the upload itself
+        # under `previews` when it was stored raw and not already kept as
+        # the source (a remote job stores nothing in that case). It is
+        # recorded on the preview file so that the movie routes do not
+        # have to rediscover it by probing the object storage.
+        if normalize:
+            stored_movie_prefixes = (
+                ["lowdef"] if skip_high_def else ["previews", "lowdef"]
+            )
+        elif add_source_to_file_store or is_remote:
+            stored_movie_prefixes = []
+        else:
+            stored_movie_prefixes = ["previews"]
+        if add_source_to_file_store:
+            stored_movie_prefixes.insert(0, "source")
+
         # Re-fetch preview file before updating (it may have been deleted during processing)
         try:
             preview_file_raw = files_service.get_preview_file_raw(
@@ -593,7 +599,9 @@ def prepare_and_store_movie(
                     "height": height,
                     "duration": duration,
                     "data": {
-                        **(preview_file_raw.data or {}),
+                        **files_service.get_preview_file_data(
+                            preview_file_raw
+                        ),
                         files_service.MOVIE_PREFIXES_KEY: (
                             stored_movie_prefixes
                         ),
@@ -1897,11 +1905,11 @@ def copy_preview_file_in_another_one(
     if is_movie:
         # The copy knows which movie versions it found: record them so
         # that the movie routes do not probe the storage again.
-        target_preview_file = files_service.get_preview_file(
+        target_preview_file = files_service.get_preview_file_raw(
             preview_file_to_update_id
         )
         data["data"] = {
-            **(target_preview_file.get("data") or {}),
+            **files_service.get_preview_file_data(target_preview_file),
             files_service.MOVIE_PREFIXES_KEY: stored_movie_prefixes,
         }
     preview_file_to_update = update_preview_file(

--- a/zou/app/services/sync_service.py
+++ b/zou/app/services/sync_service.py
@@ -69,7 +69,7 @@ from zou.app.models.working_file import WorkingFile
 
 from zou.app.services import deletion_service, tasks_service, projects_service
 from zou.app.stores import file_store
-from zou.app.utils import events, date_helpers
+from zou.app.utils import events, date_helpers, fs
 from zou.app import config
 
 logger = logging.getLogger()
@@ -1144,21 +1144,20 @@ def download_file(file_path, prefix, dl_func, preview_file_id):
     Download preview file for given preview from object storage and store it
     locally.
     """
-    dirname = os.path.dirname(file_path)
-    if not os.path.exists(dirname):
-        os.makedirs(dirname)
-    try:
-        with open(file_path, "wb") as tmp_file:
-            for chunk in dl_func(prefix, preview_file_id):
-                tmp_file.write(chunk)
+    os.makedirs(os.path.dirname(file_path), exist_ok=True)
+    # Written through a temporary file: a partial download would be
+    # mistaken for a valid one on the next sync run. Logged rather than
+    # raised, one file must not fail the whole sync.
+    exception = fs.download_to_file(
+        file_path, dl_func, prefix, preview_file_id
+    )
+    if exception is None:
         logger.info(f"{file_path} downloaded")
-    except Exception:
-        # A partial file would be mistaken for a valid download on the
-        # next sync run: remove it and log instead of failing the whole
-        # sync for one file.
-        logger.exception(f"Failed to download {prefix} {preview_file_id}")
-        if os.path.exists(file_path):
-            os.remove(file_path)
+    else:
+        logger.error(
+            f"Failed to download {prefix} {preview_file_id}",
+            exc_info=exception,
+        )
 
 
 def download_preview(preview_file):

--- a/zou/app/stores/file_store.py
+++ b/zou/app/stores/file_store.py
@@ -6,6 +6,9 @@ from flask import current_app
 from werkzeug.utils import cached_property
 from zou.app import config
 from flask_fs.backends.local import LocalBackend
+from flask_fs.errors import FileNotFound
+
+from zou.app.utils import fs
 
 # ----------------------------------------------------------------------
 # Module state
@@ -310,6 +313,25 @@ def _copy(bucket, key, target, bucket_name):
         return bucket.copy(key, target)
 
 
+def _read_chunks(bucket, key):
+    """
+    flask_fs checks that the object exists before reading it, and the S3
+    and Swift backends answer False to any error, a 503 included: every
+    failure would reach the caller as FileNotFound. Read straight from
+    the backend so that only a genuine 404 becomes one.
+    """
+    backend = bucket.backend
+    try:
+        generator = backend.read_chunks(key)
+    except Exception as exc:
+        if fs.is_missing_file_error(exc):
+            raise FileNotFound(key) from exc
+        raise
+    if backend.encryptor is not None:
+        generator = backend.encryptor.decrypt_file_from_generator(generator)
+    return generator
+
+
 def make_read_generator(bucket, key, bucket_name=None):
     """
     Create a generator that yields chunks from the storage bucket.
@@ -319,7 +341,7 @@ def make_read_generator(bucket, key, bucket_name=None):
     When ``bucket_name`` is provided and Prometheus is enabled, the generator
     records a ``download`` operation with cumulative byte count.
     """
-    read_stream = bucket.read_chunks(key)
+    read_stream = _read_chunks(bucket, key)
 
     def read_generator(read_stream):
         tracker = _ByteTracker()
@@ -333,6 +355,9 @@ def make_read_generator(bucket, key, bucket_name=None):
                 for chunk in read_stream:
                     tracker.add(len(chunk))
                     yield chunk
+        except FileNotFoundError as exc:
+            # The local backend only opens the file on the first read.
+            raise FileNotFound(key) from exc
         finally:
             if hasattr(read_stream, "close"):
                 try:

--- a/zou/app/utils/fs.py
+++ b/zou/app/utils/fs.py
@@ -87,7 +87,7 @@ def _remove_stale_parts(file_path):
             pass
 
 
-def _download_to_file(file_path, open_file, prefix, instance_id):
+def download_to_file(file_path, open_file, prefix, instance_id):
     """
     Download a stored file to the local cache. Return the exception that
     interrupted it, or None.
@@ -138,7 +138,7 @@ def get_file_path_and_file(
         file_path = get_cache_file_path(config, prefix, instance_id, extension)
 
         if is_invalid_file(file_path, file_size):
-            exception = _download_to_file(
+            exception = download_to_file(
                 file_path, open_file, prefix, instance_id
             )
             # The cache entry is only ever replaced as a whole, so a
@@ -152,7 +152,7 @@ def get_file_path_and_file(
                 file_path, file_size
             ) and not is_missing_file_error(exception):
                 time.sleep(3)
-                exception = _download_to_file(
+                exception = download_to_file(
                     file_path, open_file, prefix, instance_id
                 )
 

--- a/zou/app/utils/fs.py
+++ b/zou/app/utils/fs.py
@@ -1,3 +1,4 @@
+import glob
 import os
 import shutil
 import time
@@ -35,14 +36,15 @@ def is_missing_file_error(exception):
     """
     Tell a missing object apart from a transient storage failure.
 
-    Only the local backend raises FileNotFound: Swift surfaces its own
-    ClientException and S3 a botocore ClientError, both carrying a 404.
-    Retrying those is pointless, and the sleep it comes with is paid on
-    every request that falls back from one prefix to another.
+    The file store raises FileNotFound for a missing object whatever the
+    backend, and lets the other failures through as they are: a Swift
+    ClientException, a botocore ClientError. Retrying a missing object is
+    pointless, and the sleep it comes with is paid on every request that
+    falls back from one prefix to another.
     """
     if exception is None:
         return False
-    if isinstance(exception, FileNotFound):
+    if isinstance(exception, (FileNotFound, FileNotFoundError)):
         return True
     for attribute in ("http_status", "status", "status_code"):
         if getattr(exception, attribute, None) == 404:
@@ -68,9 +70,27 @@ def get_cache_file_path(config, prefix, instance_id, extension):
     )
 
 
+STALE_PART_AGE = 3600
+
+
+def _remove_stale_parts(file_path):
+    """
+    A download killed with its process (OOM, SIGKILL, job timeout) never
+    reaches its cleanup and leaves its .part behind. A live download
+    keeps the mtime of its .part fresh, so an old one is safe to drop.
+    """
+    for part_path in glob.glob(f"{glob.escape(file_path)}.*.part"):
+        try:
+            if time.time() - os.path.getmtime(part_path) > STALE_PART_AGE:
+                os.remove(part_path)
+        except OSError:
+            pass
+
+
 def _download_to_file(file_path, open_file, prefix, instance_id):
     """
-    Download a stored file to the local cache.
+    Download a stored file to the local cache. Return the exception that
+    interrupted it, or None.
 
     The bytes land in a private temporary file that is renamed over the
     cache entry once complete. Writing straight into it would truncate
@@ -79,7 +99,7 @@ def _download_to_file(file_path, open_file, prefix, instance_id):
     the cache accepts a truncated file as valid, so it would be served
     as is.
     """
-    download_failed = False
+    _remove_stale_parts(file_path)
     exception = None
     tmp_path = f"{file_path}.{uuid.uuid4().hex}.part"
     try:
@@ -95,11 +115,10 @@ def _download_to_file(file_path, open_file, prefix, instance_id):
                     pass
         os.replace(tmp_path, file_path)
     except Exception as e:
-        download_failed = True
         exception = e
     finally:
         rm_file(tmp_path)
-    return download_failed, exception
+    return exception
 
 
 def get_file_path_and_file(
@@ -119,48 +138,46 @@ def get_file_path_and_file(
         file_path = get_cache_file_path(config, prefix, instance_id, extension)
 
         if is_invalid_file(file_path, file_size):
-            download_failed, exception = _download_to_file(
+            exception = _download_to_file(
                 file_path, open_file, prefix, instance_id
             )
+            # The cache entry is only ever replaced as a whole, so a
+            # concurrent request may well have completed it while this
+            # one was failing: the disk is checked before paying for a
+            # retry. An object that is not there will not be there three
+            # seconds later either, only a transient failure deserves the
+            # retry: the movie routes probe up to three prefixes and
+            # would otherwise sleep on each missing one.
+            if is_invalid_file(
+                file_path, file_size
+            ) and not is_missing_file_error(exception):
+                time.sleep(3)
+                exception = _download_to_file(
+                    file_path, open_file, prefix, instance_id
+                )
 
-            if is_invalid_file(file_path, file_size, download_failed):
-                # An object that is not there will not be there three
-                # seconds later. Only a transient failure deserves the
-                # retry: the movie routes probe up to three prefixes and
-                # would otherwise sleep on each missing one.
-                if not is_missing_file_error(exception):
-                    time.sleep(3)
-                    download_failed, exception = _download_to_file(
-                        file_path, open_file, prefix, instance_id
-                    )
-
-                if is_invalid_file(file_path, file_size, download_failed):
-                    # The cache entry is only ever replaced as a whole, so
-                    # a concurrent request may well have completed it while
-                    # this one was failing.
-                    if not is_invalid_file(file_path, file_size):
-                        return file_path
-                    rm_file(file_path)
-                    if exception is not None:
-                        if isinstance(exception, FileNotFound):
-                            raise exception
-                        raise FileNotFound(
-                            f"{prefix}-{instance_id}"
-                        ) from exception
-                    else:
-                        # The download reported success but the file is still
-                        # missing or empty: treat it as absent (404) like the
-                        # local backend does, not an unhandled 500.
-                        raise FileNotFound(f"{prefix}-{instance_id}")
+            if is_invalid_file(file_path, file_size):
+                rm_file(file_path)
+                if exception is not None:
+                    if isinstance(exception, FileNotFound):
+                        raise exception
+                    raise FileNotFound(
+                        f"{prefix}-{instance_id}"
+                    ) from exception
+                else:
+                    # The download reported success but the file is still
+                    # missing or empty: treat it as absent (404) like the
+                    # local backend does, not an unhandled 500.
+                    raise FileNotFound(f"{prefix}-{instance_id}")
 
     return file_path
 
 
-def is_invalid_file(file_path, file_size=None, download_failed=False):
+def is_invalid_file(file_path, file_size=None):
     """
     Check if file is absent, is empty or does match given size.
     """
-    if download_failed or not os.path.exists(file_path):
+    if not os.path.exists(file_path):
         return True
     elif file_size is None:
         return get_file_size(file_path) == 0


### PR DESCRIPTION
**Problem**

- Follow-up on #1215: flask_fs turns every S3/Swift error into FileNotFound, so the new no-retry path answered 404 on a transient failure and could mark a fresh upload broken
- Each range request paid a second memoized lookup and three cache keys, and a record that went stale (import, removed version, older remote runner) was trusted forever
- A non-dict JSONB `data` made every movie route 500, the copy merged a stale serialized row, a killed download left its `.part` behind, and the retry slept even when a concurrent request had already filled the cache
- The playlist build and the sync still wrote cache entries directly, so an interrupted download left a truncated file; the prefix list and cache path were duplicated in three places

**Solution**

- Read straight from the storage backend and translate only a genuine 404 into FileNotFound
- Carry the stored prefixes in the access lookup the routes already do, make the ordering a pure function, probe only rows without a record or after a remote job, and write the result back, also after a fallback
- Guard `data` with a dict check, read the copy target from the raw row, sweep stale `.part` files, re-check the disk before the retry, compute the stored prefixes once from the normalization flags
- Route the playlist build and the sync through the shared temporary-file download, and build the prefix list and cache path in one place
