### PR TITLE
[edits] Accept the main and all episode sentinels on edits with-tasks

### DIFF
--- a/tests/services/test_edits_service.py
+++ b/tests/services/test_edits_service.py
@@ -85,6 +85,15 @@ class EditUtilsTestCase(ApiDBTestCase):
 
         self.assertEqual([edit["name"] for edit in edits], ["Edit"])
 
+    def test_get_edits_and_tasks_for_main_and_all_episodes(self):
+        self.generate_fixture_edit("Orphan", parent_id=None)
+
+        main = edits_service.get_edits_and_tasks({"episode_id": "main"})
+        self.assertEqual([edit["name"] for edit in main], ["Orphan"])
+
+        everything = edits_service.get_edits_and_tasks({"episode_id": "all"})
+        self.assertEqual(len(everything), 2)
+
     def test_get_edit(self):
         self.assertEqual(
             str(self.edit.id), edits_service.get_edit(self.edit.id)["id"]

--- a/zou/app/services/edits_service.py
+++ b/zou/app/services/edits_service.py
@@ -163,8 +163,11 @@ def get_edits_and_tasks(criterions=None):
             query = query.filter(Entity.id == criterions["id"])
         if "project_id" in criterions:
             query = query.filter(Entity.project_id == criterions["project_id"])
-        if "episode_id" in criterions:
-            query = query.filter(Entity.parent_id == criterions["episode_id"])
+        episode_id = criterions.get("episode_id")
+        if episode_id == "main":
+            query = query.filter(Entity.parent_id == None)
+        elif episode_id is not None and episode_id != "all":
+            query = query.filter(Entity.parent_id == episode_id)
         if assigned_to:
             has_assigned_task = (
                 db.session.query(Task.id)


### PR DESCRIPTION
**Problem**

- `GET /data/edits/with-tasks?episode_id=main` (or `all`) answers 500: the sentinel is injected into a UUID filter.

**Solution**

- Filter on a null parent for `main`, skip the filter for `all`, as assets and shots already do.

Fixes KITSU-COSMOS-MAYA-24