### PR TITLE
[crud] Log client-side integrity errors as warnings

### DIFF
--- a/tests/blueprints/playlists/test_playlists.py
+++ b/tests/blueprints/playlists/test_playlists.py
@@ -1,4 +1,5 @@
 from tests.base import ApiDBTestCase
+from zou.app import app
 
 from zou.app.models.notification import Notification
 from zou.app.models.person import Person
@@ -209,6 +210,22 @@ class PlaylistTestCase(ApiDBTestCase):
                 "for_entity": "banana",
             },
             400,
+        )
+
+    def test_create_playlist_duplicate_name_is_a_client_error(self):
+        self.generate_fixture_playlist(
+            "Playlist 1", episode_id=self.episode_id
+        )
+        data = {
+            "name": "Playlist 1",
+            "project_id": self.project_id,
+            "episode_id": self.episode_id,
+        }
+        with self.assertNoLogs(app.logger, level="ERROR"):
+            result = self.post("data/playlists/", data, 400)
+        self.assertEqual(
+            result["message"],
+            "A record with the same unique values already exists.",
         )
 
     def test_update_playlist_rejects_unknown_for_entity(self):

--- a/zou/app/blueprints/crud/base.py
+++ b/zou/app/blueprints/crud/base.py
@@ -431,7 +431,7 @@ class BaseModelsResource(MethodView, ArgsMixin):
             StatementError,
             KeyError,
         ) as exception:
-            current_app.logger.error(str(exception), exc_info=1)
+            current_app.logger.warning(str(exception), exc_info=1)
             return {"message": build_db_error_message(exception)}, 400
 
     def emit_create_event(self, instance_dict):
@@ -587,7 +587,7 @@ class BaseModelResource(MethodView, ArgsMixin):
             result = self.clean_get_result(result)
 
         except StatementError as exception:
-            current_app.logger.error(str(exception), exc_info=1)
+            current_app.logger.warning(str(exception), exc_info=1)
             return {"message": str(exception)}, 400
 
         except ValueError:
@@ -684,7 +684,7 @@ class BaseModelResource(MethodView, ArgsMixin):
             IntegrityError,
             StatementError,
         ) as exception:
-            current_app.logger.error(str(exception), exc_info=1)
+            current_app.logger.warning(str(exception), exc_info=1)
             return {"message": build_db_error_message(exception)}, 400
 
     @jwt_required()


### PR DESCRIPTION
**Problem**

- CRUD POST, GET and PUT answer 400 on integrity and statement errors but log them at ERROR with a traceback, so each duplicate playlist name lands in Sentry as an event.

**Solution**

- Log those branches at WARNING, as DELETE already does, and cover the duplicate playlist case with a test.