### PR TITLE
[previews] Fix movie streaming stalls, split movie processing

### DIFF
--- a/tests/blueprints/previews/test_movie_streaming.py
+++ b/tests/blueprints/previews/test_movie_streaming.py
@@ -214,3 +214,27 @@ class MovieStreamingRoutesTestCase(ApiDBTestCase):
 
         self.assertEqual(self.get_movie(preview_file_id).status_code, 200)
         self.assertEqual(self.recorded_prefixes(preview_file_id), ["source"])
+
+    def test_range_request_uses_a_seekable_file_wrapper(self):
+        # gunicorn's wsgi.file_wrapper is not seekable, so Werkzeug used to
+        # read the file from the start for every Range request. Hand the
+        # route a wrapper that cannot be iterated: the response only works
+        # if the route swapped it for Werkzeug's seekable one.
+        class NotSeekable:
+            def __init__(self, file, *args):
+                self.file = file
+
+            def __iter__(self):
+                raise AssertionError("range served without seeking")
+
+        preview_file_id = self.upload_movie_preview()
+        with open(self.movie_path, "rb") as movie_file:
+            movie_file.seek(1000)
+            expected = movie_file.read(500)
+        response = self.app.get(
+            f"/movies/originals/preview-files/{preview_file_id}.mp4",
+            headers={**self.base_headers, "Range": "bytes=1000-1499"},
+            environ_overrides={"wsgi.file_wrapper": NotSeekable},
+        )
+        self.assertEqual(response.status_code, 206)
+        self.assertEqual(response.data, expected)

--- a/tests/blueprints/previews/test_movie_streaming.py
+++ b/tests/blueprints/previews/test_movie_streaming.py
@@ -238,3 +238,54 @@ class MovieStreamingRoutesTestCase(ApiDBTestCase):
         )
         self.assertEqual(response.status_code, 206)
         self.assertEqual(response.data, expected)
+
+    def test_cold_cache_streams_the_range_from_the_storage(self):
+        # Remote backend, movie not in the local cache yet: the range is
+        # served from the storage right away and one background download
+        # fills the cache, instead of the request waiting for the whole
+        # file to land on the disk.
+        preview_file_id = self.upload_movie_preview()
+        with open(self.movie_path, "rb") as movie_file:
+            movie_content = movie_file.read()
+        fills = []
+
+        def read_movie_range(prefix, id, range_header=None):
+            self.assertEqual(range_header, "bytes=1000-1499")
+            total = len(movie_content)
+            return (
+                500,
+                f"bytes 1000-1499/{total}",
+                iter([movie_content[1000:1500]]),
+            )
+
+        with (
+            patch.object(
+                preview_resources.file_store,
+                "can_stream_movie_ranges",
+                return_value=True,
+            ),
+            patch.object(
+                preview_resources.file_store,
+                "read_movie_range",
+                side_effect=read_movie_range,
+            ),
+            patch.object(
+                preview_resources.fs,
+                "fill_cache_in_background",
+                side_effect=lambda *args: fills.append(args),
+            ),
+        ):
+            response = self.app.get(
+                f"/movies/originals/preview-files/{preview_file_id}.mp4",
+                headers={**self.base_headers, "Range": "bytes=1000-1499"},
+            )
+        self.assertEqual(response.status_code, 206)
+        self.assertEqual(
+            response.headers["Content-Range"],
+            f"bytes 1000-1499/{len(movie_content)}",
+        )
+        self.assertEqual(response.headers["Content-Length"], "500")
+        self.assertEqual(response.data, movie_content[1000:1500])
+        self.assertNotIn("ETag", response.headers)
+        self.assertEqual(len(fills), 1)
+        self.assertTrue(fills[0][0].endswith(f"-{preview_file_id}.mp4"))

--- a/tests/blueprints/previews/test_movie_upload_dispatch.py
+++ b/tests/blueprints/previews/test_movie_upload_dispatch.py
@@ -58,7 +58,9 @@ class MovieUploadDispatchTestCase(ApiDBTestCase):
         ), patch.object(
             preview_resources.config, "PREVIEW_SAVE_SOURCE_FILE", False
         ), patch.object(
-            preview_resources.queue_store, "job_queue", job_queue
+            preview_resources.preview_files_service.queue_store,
+            "job_queue",
+            job_queue,
         ):
             self.upload_file(
                 f"/pictures/preview-files/{preview_file_id}?normalize=false",
@@ -85,7 +87,9 @@ class MovieUploadDispatchTestCase(ApiDBTestCase):
         ), patch.object(
             preview_resources.config, "ENABLE_JOB_QUEUE", True
         ), patch.object(
-            preview_resources.queue_store, "job_queue", job_queue
+            preview_resources.preview_files_service.queue_store,
+            "job_queue",
+            job_queue,
         ):
             self.upload_file(
                 f"/pictures/preview-files/{preview_file_id}?normalize=false",

--- a/tests/stores/test_file_store.py
+++ b/tests/stores/test_file_store.py
@@ -96,3 +96,70 @@ class ReadGeneratorTestCase(unittest.TestCase):
         app.app_context().push()
         with pytest.raises(FileNotFound):
             list(file_store.open_picture("thumbnails", "does-not-exist"))
+
+
+class ReadMovieRangeTestCase(unittest.TestCase):
+    def test_s3_range_is_forwarded_and_the_body_closed(self):
+        from unittest.mock import patch
+
+        body = Mock()
+        body.iter_chunks.return_value = iter([b"ab", b"cd"])
+        s3_object = Mock()
+        s3_object.get.return_value = {
+            "Body": body,
+            "ContentLength": 4,
+            "ContentRange": "bytes 10-13/100",
+        }
+        movies = Mock()
+        movies.backend.encryptor = None
+        movies.backend.bucket.Object.return_value = s3_object
+
+        with (
+            patch.object(file_store, "movies", movies),
+            patch.object(file_store.config, "FS_BACKEND", "s3"),
+        ):
+            self.assertTrue(file_store.can_stream_movie_ranges())
+            length, content_range, generator = file_store.read_movie_range(
+                "lowdef", "1", "bytes=10-13"
+            )
+            self.assertEqual(b"".join(generator), b"abcd")
+
+        movies.backend.bucket.Object.assert_called_once_with("lowdef-1")
+        s3_object.get.assert_called_once_with(Range="bytes=10-13")
+        self.assertEqual((length, content_range), (4, "bytes 10-13/100"))
+        body.close.assert_called_once()
+
+    def test_missing_object_is_file_not_found(self):
+        from unittest.mock import patch
+
+        class ClientError(Exception):
+            response = {"Error": {"Code": "NoSuchKey"}}
+
+        movies = Mock()
+        movies.backend.bucket.Object.return_value.get.side_effect = (
+            ClientError()
+        )
+        with (
+            patch.object(file_store, "movies", movies),
+            patch.object(file_store.config, "FS_BACKEND", "s3"),
+        ):
+            with pytest.raises(FileNotFound):
+                file_store.read_movie_range("lowdef", "1", "bytes=0-1")
+
+    def test_refused_range_is_a_416(self):
+        from unittest.mock import patch
+        from werkzeug.exceptions import RequestedRangeNotSatisfiable
+
+        class ClientError(Exception):
+            response = {"Error": {"Code": "InvalidRange"}}
+
+        movies = Mock()
+        movies.backend.bucket.Object.return_value.get.side_effect = (
+            ClientError()
+        )
+        with (
+            patch.object(file_store, "movies", movies),
+            patch.object(file_store.config, "FS_BACKEND", "s3"),
+        ):
+            with pytest.raises(RequestedRangeNotSatisfiable):
+                file_store.read_movie_range("lowdef", "1", "bytes=999-")

--- a/tests/utils/test_fs.py
+++ b/tests/utils/test_fs.py
@@ -223,3 +223,46 @@ class DownloadToFileTestCase(unittest.TestCase):
         with open(file_path, "rb") as cached:
             self.assertEqual(cached.read(), b"complete-movie")
         sleep.assert_not_called()
+
+
+class FillCacheInBackgroundTestCase(unittest.TestCase):
+    def wait_for(self, path):
+        import time
+
+        for _ in range(100):
+            if os.path.exists(path):
+                return
+            time.sleep(0.05)
+        self.fail(f"{path} never appeared")
+
+    def test_downloads_once_under_the_lock(self):
+        import fcntl
+
+        calls = []
+
+        def open_file(prefix, instance_id):
+            calls.append(instance_id)
+            yield b"movie"
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            file_path = os.path.join(tmp_dir, "cache-lowdef-1.mp4")
+            lock_file = open(f"{file_path}.lock", "a")
+            fcntl.flock(lock_file, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            # Another worker is downloading: do not start a second one.
+            self.assertFalse(
+                fs.fill_cache_in_background(
+                    file_path, open_file, "lowdef", "1"
+                )
+            )
+            self.assertEqual(calls, [])
+            lock_file.close()
+
+            self.assertTrue(
+                fs.fill_cache_in_background(
+                    file_path, open_file, "lowdef", "1"
+                )
+            )
+            self.wait_for(file_path)
+            with open(file_path, "rb") as cached:
+                self.assertEqual(cached.read(), b"movie")
+            self.assertEqual(calls, ["1"])

--- a/zou/app/blueprints/previews/resources.py
+++ b/zou/app/blueprints/previews/resources.py
@@ -7,6 +7,7 @@ from flask.views import MethodView
 from flask_jwt_extended import jwt_required
 from flask_fs.errors import FileNotFound
 from werkzeug.exceptions import NotFound
+from werkzeug.wsgi import FileWrapper
 
 from zou.app import config
 from zou.app.mixin import ArgsMixin
@@ -267,6 +268,14 @@ def send_storage_file(
     if as_attachment:
         download_name = names_service.get_preview_file_name(preview_file_id)
 
+    # send_file wraps the file in whatever the WSGI server put in
+    # wsgi.file_wrapper, and Werkzeug's range wrapper only seeks when that
+    # wrapper has a seekable() method. gunicorn's FileWrapper has none, so
+    # every Range request read and discarded the file from byte 0 up to the
+    # range: linear in the offset, seconds per request at the end of a long
+    # movie, blocking the worker. Werkzeug's own FileWrapper (same name,
+    # different class) is seekable: swap it in for this response.
+    request.environ["wsgi.file_wrapper"] = FileWrapper
     try:
         response = flask_send_file(
             file_path,

--- a/zou/app/blueprints/previews/resources.py
+++ b/zou/app/blueprints/previews/resources.py
@@ -1,7 +1,7 @@
 import os
 import orjson as json
 
-from flask import request, current_app
+from flask import request, current_app, Response
 from flask import send_file as flask_send_file
 from flask.views import MethodView
 from flask_jwt_extended import jwt_required
@@ -117,6 +117,45 @@ def send_standard_file(
     )
 
 
+def stream_movie_from_storage(
+    prefix, preview_file_id, mimetype, as_attachment, download_name, max_age
+):
+    """
+    Serve a movie that is not in the local cache yet straight from the
+    object storage, so the first play does not wait for the whole file to
+    land on the disk. Only a single byte range is forwarded; a multipart
+    range gets the whole file, like no range at all.
+    """
+    range_header = None
+    byte_range = request.range
+    if (
+        byte_range is not None
+        and byte_range.units == "bytes"
+        and len(byte_range.ranges) == 1
+    ):
+        range_header = byte_range.to_header()
+    content_length, content_range, generator = file_store.read_movie_range(
+        prefix, preview_file_id, range_header
+    )
+    response = Response(
+        generator,
+        status=206 if content_range else 200,
+        mimetype=mimetype,
+        direct_passthrough=True,
+    )
+    response.headers["Accept-Ranges"] = "bytes"
+    response.headers["Content-Length"] = content_length
+    if content_range:
+        response.headers["Content-Range"] = content_range
+    if as_attachment:
+        response.headers.set(
+            "Content-Disposition", "attachment", filename=download_name
+        )
+    response.cache_control.private = True
+    response.cache_control.max_age = max_age
+    return response
+
+
 def send_movie_file(
     preview_file_id,
     as_attachment=False,
@@ -157,6 +196,7 @@ def send_movie_file(
                 mimetype="video/mp4",
                 as_attachment=as_attachment,
                 last_modified=last_modified,
+                stream_cold=True,
             )
         except FileNotFound:
             if prefix == prefixes[-1]:
@@ -233,10 +273,14 @@ def send_storage_file(
     max_age=config.CLIENT_CACHE_MAX_AGE,
     download_name="",
     last_modified=None,
+    stream_cold=False,
 ):
     """
     Send file from storage. If it's not a local storage, cache the file in
     a temporary folder before sending it. It accepts conditional headers.
+
+    With ``stream_cold``, a movie missing from that cache is streamed from
+    the storage right away while a background download fills the cache.
     """
     file_size = None
     try:
@@ -255,6 +299,30 @@ def send_storage_file(
                 file_size = preview_file["file_size"]
     except NotFound:
         pass
+    if as_attachment:
+        download_name = names_service.get_preview_file_name(preview_file_id)
+
+    if stream_cold and file_store.can_stream_movie_ranges():
+        cache_path = fs.get_cache_file_path(
+            config, prefix, preview_file_id, extension
+        )
+        if fs.is_invalid_file(cache_path, file_size):
+            fs.fill_cache_in_background(
+                cache_path, open_file, prefix, preview_file_id
+            )
+            # No ETag or Last-Modified on purpose: a browser that got one
+            # here would send it back as If-Range once the cache is warm,
+            # where send_file computes a different validator and would
+            # answer the whole file. The bytes are the same either way.
+            return stream_movie_from_storage(
+                prefix,
+                preview_file_id,
+                mimetype,
+                as_attachment,
+                download_name,
+                max_age,
+            )
+
     file_path = fs.get_file_path_and_file(
         config,
         get_local_path,
@@ -264,9 +332,6 @@ def send_storage_file(
         extension,
         file_size=file_size,
     )
-
-    if as_attachment:
-        download_name = names_service.get_preview_file_name(preview_file_id)
 
     # send_file wraps the file in whatever the WSGI server put in
     # wsgi.file_wrapper, and Werkzeug's range wrapper only seeks when that

--- a/zou/app/blueprints/previews/resources.py
+++ b/zou/app/blueprints/previews/resources.py
@@ -31,7 +31,6 @@ from zou.app.services import (
     tasks_service,
     permissions_service,
 )
-from zou.app.stores import queue_store
 from zou.utils import movie
 from zou.app.utils import (
     fields,
@@ -360,34 +359,20 @@ class BaseNewPreviewFilePicture:
                 f"storage ({written_size}/{expected_size} bytes); the "
                 f"temporary disk may be full."
             )
-        is_remote = preview_files_service.is_remote_normalization_enabled()
         # The remote worker reads the movie from the object storage, and
         # without normalization that source is the only movie stored: it has
         # to be uploaded whatever PREVIEW_SAVE_SOURCE_FILE says.
-        save_source_file = config.PREVIEW_SAVE_SOURCE_FILE or is_remote
-        # Even with normalization turned off, the remote worker is what
-        # builds the thumbnails and the tile, and dispatching it blocks until
-        # Nomad is done: keep it out of the request thread.
-        needs_job = normalize or is_remote
-        if needs_job and config.ENABLE_JOB_QUEUE and not no_job:
-            queue_store.job_queue.enqueue(
-                preview_files_service.prepare_and_store_movie,
-                args=(
-                    preview_file_id,
-                    uploaded_movie_path,
-                    normalize,
-                    save_source_file,
-                ),
-                job_timeout=int(config.JOB_QUEUE_TIMEOUT),
-                on_failure=preview_files_service.mark_broken_on_job_failure,
-            )
-        else:
-            preview_files_service.prepare_and_store_movie(
-                preview_file_id,
-                uploaded_movie_path,
-                normalize=normalize,
-                add_source_to_file_store=save_source_file,
-            )
+        save_source_file = (
+            config.PREVIEW_SAVE_SOURCE_FILE
+            or preview_files_service.is_remote_normalization_enabled()
+        )
+        preview_files_service.dispatch_movie_processing(
+            preview_file_id,
+            uploaded_movie_path,
+            normalize=normalize,
+            add_source_to_file_store=save_source_file,
+            no_job=no_job,
+        )
         return preview_file_id
 
     def save_file_preview(self, instance_id, uploaded_file, extension):

--- a/zou/app/services/preview_files_service.py
+++ b/zou/app/services/preview_files_service.py
@@ -14,7 +14,7 @@ from sqlalchemy.orm import aliased
 from sqlalchemy.orm.exc import ObjectDeletedError, StaleDataError
 
 from zou.app import config
-from zou.app.stores import config_store, file_store
+from zou.app.stores import config_store, file_store, queue_store
 from zou.app.stores.redis_lock import with_preview_file_lock
 
 from zou.app.models.entity import Entity
@@ -243,24 +243,6 @@ def _remove_temp_files(*paths):
                 pass
 
 
-def _abort_on_storage_failure(preview_file_id, operation, exc):
-    """
-    Log a file store backend failure (Swift 401, S3 timeout, network error,
-    etc.) and mark the preview file as broken so the worker does not crash on
-    transient or auth issues.
-    """
-    from zou.app import app as current_app
-
-    current_app.logger.error(
-        "Storage failure for preview %s during %s: %s",
-        preview_file_id,
-        operation,
-        exc,
-        exc_info=1,
-    )
-    return set_preview_file_as_broken(preview_file_id)
-
-
 def mark_broken_on_job_failure(
     job, connection, exc_type, exc_value, traceback
 ):
@@ -290,6 +272,42 @@ def mark_broken_on_job_failure(
             )
 
 
+def dispatch_movie_processing(
+    preview_file_id,
+    uploaded_movie_path,
+    normalize=True,
+    add_source_to_file_store=True,
+    no_job=False,
+):
+    """
+    Run prepare_and_store_movie on the job queue when one is enabled, in
+    the calling thread otherwise. A raw store is cheap enough to stay
+    synchronous, but the remote worker blocks until Nomad is done and is
+    what builds the thumbnails even without normalization: it never runs
+    in a request thread.
+    """
+    needs_job = normalize or is_remote_normalization_enabled()
+    if needs_job and config.ENABLE_JOB_QUEUE and not no_job:
+        queue_store.job_queue.enqueue(
+            prepare_and_store_movie,
+            args=(
+                preview_file_id,
+                uploaded_movie_path,
+                normalize,
+                add_source_to_file_store,
+            ),
+            job_timeout=int(config.JOB_QUEUE_TIMEOUT),
+            on_failure=mark_broken_on_job_failure,
+        )
+    else:
+        prepare_and_store_movie(
+            preview_file_id,
+            uploaded_movie_path,
+            normalize=normalize,
+            add_source_to_file_store=add_source_to_file_store,
+        )
+
+
 def prepare_and_store_movie(
     preview_file_id,
     uploaded_movie_path,
@@ -297,330 +315,324 @@ def prepare_and_store_movie(
     add_source_to_file_store=True,
 ):
     """
-    Prepare movie preview, normalize the movie as a .mp4, build the thumbnails
-    and store the files.
+    Turn an uploaded movie into a ready preview file: keep the source when
+    asked, encode the preview versions (here or on the remote worker),
+    build the thumbnails and the tile, then record the metadata and which
+    versions are stored. Any failure marks the preview file as broken, and
+    the temporary files are removed whatever happens.
     """
     from zou.app import app as current_app
 
+    temp_files = [uploaded_movie_path]
     with current_app.app_context():
-        if add_source_to_file_store:
-            try:
-                file_store.add_movie(
-                    "source", preview_file_id, uploaded_movie_path
-                )
-            except Exception as exc:
-                _remove_temp_files(uploaded_movie_path)
-                return _abort_on_storage_failure(
-                    preview_file_id, "source movie upload", exc
-                )
-        preview_file_raw = files_service.get_preview_file_raw(preview_file_id)
-
-        # Capture original metadata before normalization. This is a
-        # nice-to-have, so any failure here must not block the main pipeline.
-        # silent=True avoids emitting a second preview-file:update event
-        # alongside the final "ready" update at the end of this function.
         try:
-            original_width, original_height = movie.get_movie_size(
-                uploaded_movie_path
-            )
-            original_duration = movie.get_movie_duration(uploaded_movie_path)
-            original_file_size = os.path.getsize(uploaded_movie_path)
-            update_preview_file_raw(
-                preview_file_raw,
-                {
-                    "data": {
-                        **files_service.get_preview_file_data(
-                            preview_file_raw
-                        ),
-                        "original_width": original_width,
-                        "original_height": original_height,
-                        "original_duration": original_duration,
-                        "original_file_size": original_file_size,
-                    }
-                },
-                silent=True,
-            )
-        except PreviewFileNotFoundException:
-            current_app.logger.warning(
-                "Preview file %s was deleted while capturing original "
-                "video metadata; skipping metadata capture",
+            return _process_movie(
                 preview_file_id,
-            )
-        except Exception:
-            current_app.logger.warning(
-                "Failed to capture original video metadata for %s; "
-                "continuing without it",
                 uploaded_movie_path,
-                exc_info=1,
+                normalize,
+                add_source_to_file_store,
+                temp_files,
             )
-
-        normalized_movie_path = None
-        normalized_movie_low_path = None
-        original_picture_path = None
-        try:
-            project = get_project_from_preview_file(preview_file_id)
-            entity = get_entity_from_preview_file(preview_file_id)
-        except PreviewFileNotFoundException:
-            time.sleep(2)
-            try:
-                project = get_project_from_preview_file(preview_file_id)
-                entity = get_entity_from_preview_file(preview_file_id)
-            except PreviewFileNotFoundException:
-                current_app.logger.error(
-                    "Data is missing from database", exc_info=1
-                )
-                time.sleep(2)
-                preview_file = set_preview_file_as_broken(preview_file_id)
-                _remove_temp_files(uploaded_movie_path)
-                return preview_file
-
-        fps = get_preview_file_fps(project, entity)
-        width, height = get_preview_file_dimensions(project, entity)
-
-        is_remote = is_remote_normalization_enabled()
-
-        # SKIP_NORMALIZATION_FULL turns every upload into a raw store, as if
-        # the client had asked for normalize=false. SKIP_NORMALIZATION_HIGHDEF
-        # only drops the 28M encoding: the low def version is still built and
-        # becomes the only movie stored.
-        if config.SKIP_NORMALIZATION_FULL:
-            normalize = False
-        skip_high_def = config.SKIP_NORMALIZATION_HIGHDEF
-
-        # The remote job is also what builds the thumbnails and the tile, so
-        # it must run even when nothing has to be encoded.
-        if normalize or is_remote:
-            if normalize:
-                current_app.logger.info("start normalization")
-            else:
-                current_app.logger.info(
-                    "start remote preview processing without normalization"
-                )
-            try:
-                if is_remote:
-                    result = _run_remote_normalize_movie(
-                        current_app,
-                        preview_file_id,
-                        fps,
-                        width,
-                        height,
-                        skip_high_def=skip_high_def,
-                        skip_normalization=not normalize,
-                    )
-                    if result is not True:
-                        raise PreviewProcessingFailedException(result)
-
-                    if normalize:
-                        # Without the high def version, the low def one is
-                        # the only movie the remote job uploaded.
-                        normalized_movie_path = fs.get_file_path_and_file(
-                            config,
-                            file_store.get_local_movie_path,
-                            file_store.open_movie,
-                            "lowdef" if skip_high_def else "previews",
-                            preview_file_id,
-                            ".mp4",
-                        )
-                    else:
-                        # Nothing was encoded: the source uploaded for the
-                        # job stays the only movie, and it is still here.
-                        normalized_movie_path = uploaded_movie_path
-                else:
-                    (
-                        normalized_movie_path,
-                        normalized_movie_low_path,
-                        err,
-                    ) = movie.normalize_movie(
-                        uploaded_movie_path,
-                        fps=fps,
-                        width=width,
-                        height=height,
-                        skip_high_def=skip_high_def,
-                    )
-                    if err:
-                        # The normalized files were never produced: fail
-                        # before storing anything.
-                        raise PreviewProcessingFailedException(err)
-                    if normalized_movie_path is not None:
-                        file_store.add_movie(
-                            "previews", preview_file_id, normalized_movie_path
-                        )
-                    file_store.add_movie(
-                        "lowdef", preview_file_id, normalized_movie_low_path
-                    )
-                    if normalized_movie_path is None:
-                        # Everything below (metadata, thumbnails, tile) works
-                        # on the movie that was actually produced.
-                        normalized_movie_path = normalized_movie_low_path
-
-                if normalize:
-                    current_app.logger.info(
-                        f"file normalized {normalized_movie_path}"
-                    )
-                    current_app.logger.info("file stored")
-                else:
-                    current_app.logger.info(
-                        f"remote processing done, movie left as uploaded "
-                        f"{normalized_movie_path}"
-                    )
-            except Exception as exc:
-                if isinstance(exc, ffmpeg.Error):
-                    current_app.logger.error(exc.stderr)
-                current_app.logger.error("failed", exc_info=1)
-                preview_file = set_preview_file_as_broken(preview_file_id)
-                _remove_temp_files(
-                    uploaded_movie_path,
-                    normalized_movie_path,
-                    normalized_movie_low_path,
-                )
-                return preview_file
-        else:
-            # The uploaded movie is the preview. It only goes under the
-            # `previews` prefix when it was not already stored as the
-            # source: the movie routes fall back from one to the other, so
-            # a second copy of the same bytes buys nothing.
-            try:
-                if not add_source_to_file_store:
-                    file_store.add_movie(
-                        "previews", preview_file_id, uploaded_movie_path
-                    )
-            except Exception as exc:
-                _remove_temp_files(uploaded_movie_path)
-                return _abort_on_storage_failure(
-                    preview_file_id, "movie upload", exc
-                )
-            normalized_movie_path = uploaded_movie_path
-
-        # Build thumbnails (skipped when remote v2+, done by Nomad job).
-        # Any failure here must mark the preview file as broken: an
-        # uncaught exception would kill the job and leave the status
-        # stuck on "processing" forever.
-        try:
-            size = movie.get_movie_size(normalized_movie_path)
-            width, height = size
-            file_size = os.path.getsize(normalized_movie_path)
-            duration = movie.get_movie_duration(normalized_movie_path)
-
-            remote_handles_thumbnails = (
-                is_remote and REMOTE_NORMALIZE_VERSION >= 2
-            )
-            if not remote_handles_thumbnails:
-                original_picture_path = movie.generate_thumbnail(
-                    normalized_movie_path
-                )
-                thumbnail_utils.turn_into_thumbnail(
-                    original_picture_path, size
-                )
-                try:
-                    save_variants(preview_file_id, original_picture_path)
-                except Exception as exc:
-                    _remove_temp_files(
-                        uploaded_movie_path,
-                        normalized_movie_path,
-                        normalized_movie_low_path,
-                        original_picture_path,
-                    )
-                    return _abort_on_storage_failure(
-                        preview_file_id, "thumbnail variants upload", exc
-                    )
-                current_app.logger.info(
-                    f"thumbnail created {original_picture_path}"
-                )
-
-                # Build tiles
-                try:
-                    tile_path = movie.generate_tile(normalized_movie_path)
-                    file_store.add_picture("tiles", preview_file_id, tile_path)
-                    os.remove(tile_path)
-                    current_app.logger.info(f"tile created {tile_path}")
-                except Exception:
-                    current_app.logger.error(
-                        "Failed to create tile", exc_info=1
-                    )
-        except Exception:
-            current_app.logger.error(
-                f"Failed to build thumbnails for preview file "
-                f"{preview_file_id}",
-                exc_info=1,
-            )
-            preview_file = set_preview_file_as_broken(preview_file_id)
-            _remove_temp_files(
-                uploaded_movie_path,
-                normalized_movie_path,
-                normalized_movie_low_path,
-                original_picture_path,
-            )
-            return preview_file
-
-        # Remove files and update status
-        try:
-            os.remove(uploaded_movie_path)
-        except FileNotFoundError:
-            pass
-        if normalize:
-            try:
-                os.remove(normalized_movie_path)
-            except FileNotFoundError:
-                pass
-            if normalized_movie_low_path:
-                try:
-                    os.remove(normalized_movie_low_path)
-                except FileNotFoundError:
-                    pass
-
-        # Which storage prefixes hold the movie is recorded on the preview
-        # file so that the movie routes do not have to rediscover it by
-        # probing the object storage. Locally it follows from the flags
-        # above: the encoded versions when normalizing, the upload itself
-        # under `previews` when it was stored raw and not already kept as
-        # the source. A remote job is asked nothing: a runner that
-        # predates skip_high_def still uploads both encoded versions, so
-        # the storage is probed once instead.
-        if is_remote:
-            stored_movie_prefixes = files_service.probe_movie_prefixes(
-                preview_file_id
-            )
-        elif normalize:
-            stored_movie_prefixes = (
-                ["lowdef"] if skip_high_def else ["previews", "lowdef"]
-            )
-        elif add_source_to_file_store:
-            stored_movie_prefixes = []
-        else:
-            stored_movie_prefixes = ["previews"]
-        if add_source_to_file_store and "source" not in stored_movie_prefixes:
-            stored_movie_prefixes.insert(0, "source")
-
-        # Re-fetch preview file before updating (it may have been deleted during processing)
-        try:
-            preview_file_raw = files_service.get_preview_file_raw(
-                preview_file_id
-            )
-            preview_file = update_preview_file_raw(
-                preview_file_raw,
-                {
-                    "status": "ready",
-                    "file_size": file_size,
-                    "width": width,
-                    "height": height,
-                    "duration": duration,
-                    "data": {
-                        **files_service.get_preview_file_data(
-                            preview_file_raw
-                        ),
-                        files_service.MOVIE_PREFIXES_KEY: (
-                            stored_movie_prefixes
-                        ),
-                    },
-                },
-            )
-            tasks_service.update_preview_file_info(preview_file)
-            return preview_file
         except PreviewFileNotFoundException:
             current_app.logger.warning(
                 f"Preview file {preview_file_id} was deleted during processing"
             )
             return {"id": preview_file_id, "status": "broken"}
+        except Exception as exc:
+            if isinstance(exc, ffmpeg.Error):
+                current_app.logger.error(exc.stderr)
+            current_app.logger.error(
+                f"Movie processing failed for preview file {preview_file_id}",
+                exc_info=1,
+            )
+            try:
+                return set_preview_file_as_broken(preview_file_id)
+            except PreviewFileNotFoundException:
+                return {"id": preview_file_id, "status": "broken"}
+        finally:
+            _remove_temp_files(*temp_files)
+
+
+def _process_movie(
+    preview_file_id,
+    uploaded_movie_path,
+    normalize,
+    add_source_to_file_store,
+    temp_files,
+):
+    """
+    The movie pipeline itself, one step after the other. Every temporary
+    file it produces goes into temp_files, removed by the caller.
+    """
+    if add_source_to_file_store:
+        file_store.add_movie("source", preview_file_id, uploaded_movie_path)
+    _record_original_metadata(preview_file_id, uploaded_movie_path)
+    fps, width, height = _get_encoding_parameters(preview_file_id)
+
+    # SKIP_NORMALIZATION_FULL turns every upload into a raw store, as if
+    # the client had asked for normalize=false. SKIP_NORMALIZATION_HIGHDEF
+    # only drops the 28M encoding: the low def version is still built and
+    # becomes the only encoded movie.
+    is_remote = is_remote_normalization_enabled()
+    encode = normalize and not config.SKIP_NORMALIZATION_FULL
+    skip_high_def = config.SKIP_NORMALIZATION_HIGHDEF
+
+    if is_remote:
+        movie_path = _encode_on_remote_worker(
+            preview_file_id,
+            uploaded_movie_path,
+            fps,
+            width,
+            height,
+            encode,
+            skip_high_def,
+        )
+    elif encode:
+        movie_path = _encode_locally(
+            preview_file_id,
+            uploaded_movie_path,
+            fps,
+            width,
+            height,
+            skip_high_def,
+            temp_files,
+        )
+    else:
+        # The upload is the preview. It only goes under `previews` when it
+        # was not already stored as the source: the movie routes fall back
+        # from one to the other, so a second copy buys nothing.
+        if not add_source_to_file_store:
+            file_store.add_movie(
+                "previews", preview_file_id, uploaded_movie_path
+            )
+        movie_path = uploaded_movie_path
+
+    metadata = _read_movie_metadata(movie_path)
+    remote_handles_thumbnails = is_remote and REMOTE_NORMALIZE_VERSION >= 2
+    if not remote_handles_thumbnails:
+        _build_thumbnails_and_tile(
+            preview_file_id,
+            movie_path,
+            (metadata["width"], metadata["height"]),
+            temp_files,
+        )
+
+    stored_movie_prefixes = _get_stored_movie_prefixes(
+        preview_file_id,
+        is_remote,
+        encode,
+        skip_high_def,
+        add_source_to_file_store,
+    )
+    preview_file_raw = files_service.get_preview_file_raw(preview_file_id)
+    preview_file = update_preview_file_raw(
+        preview_file_raw,
+        {
+            "status": "ready",
+            **metadata,
+            "data": {
+                **files_service.get_preview_file_data(preview_file_raw),
+                files_service.MOVIE_PREFIXES_KEY: stored_movie_prefixes,
+            },
+        },
+    )
+    tasks_service.update_preview_file_info(preview_file)
+    return preview_file
+
+
+def _record_original_metadata(preview_file_id, uploaded_movie_path):
+    """
+    Keep the size and duration of the upload before it is encoded. A
+    nice-to-have: a failure here must not block the pipeline, and the
+    update is silent so the clients only hear about the final "ready" one.
+    """
+    from zou.app import app as current_app
+
+    try:
+        original_width, original_height = movie.get_movie_size(
+            uploaded_movie_path
+        )
+        preview_file_raw = files_service.get_preview_file_raw(preview_file_id)
+        update_preview_file_raw(
+            preview_file_raw,
+            {
+                "data": {
+                    **files_service.get_preview_file_data(preview_file_raw),
+                    "original_width": original_width,
+                    "original_height": original_height,
+                    "original_duration": movie.get_movie_duration(
+                        uploaded_movie_path
+                    ),
+                    "original_file_size": os.path.getsize(uploaded_movie_path),
+                }
+            },
+            silent=True,
+        )
+    except PreviewFileNotFoundException:
+        current_app.logger.warning(
+            f"Preview file {preview_file_id} was deleted while capturing "
+            f"original video metadata; skipping metadata capture"
+        )
+    except Exception:
+        current_app.logger.warning(
+            f"Failed to capture original video metadata for "
+            f"{uploaded_movie_path}; continuing without it",
+            exc_info=1,
+        )
+
+
+def _get_encoding_parameters(preview_file_id):
+    """
+    The fps and the resolution the previews are encoded at, from the
+    project or the entity overriding them. The job can start before the
+    upload's transaction is visible to it: one retry covers that.
+    """
+    for attempt in range(2):
+        try:
+            project = get_project_from_preview_file(preview_file_id)
+            entity = get_entity_from_preview_file(preview_file_id)
+            break
+        except PreviewFileNotFoundException:
+            if attempt == 1:
+                raise PreviewProcessingFailedException(
+                    "Data is missing from database"
+                )
+            time.sleep(2)
+    fps = get_preview_file_fps(project, entity)
+    width, height = get_preview_file_dimensions(project, entity)
+    return fps, width, height
+
+
+def _encode_locally(
+    preview_file_id,
+    uploaded_movie_path,
+    fps,
+    width,
+    height,
+    skip_high_def,
+    temp_files,
+):
+    """
+    Encode the preview versions with ffmpeg and store them. Return the
+    movie the metadata and the thumbnails are read from: the high def
+    one, or the low def one when the high def is skipped.
+    """
+    high_def_path, low_def_path, err = movie.normalize_movie(
+        uploaded_movie_path,
+        fps=fps,
+        width=width,
+        height=height,
+        skip_high_def=skip_high_def,
+    )
+    temp_files.extend(path for path in (high_def_path, low_def_path) if path)
+    if err:
+        raise PreviewProcessingFailedException(err)
+    if high_def_path is not None:
+        file_store.add_movie("previews", preview_file_id, high_def_path)
+    file_store.add_movie("lowdef", preview_file_id, low_def_path)
+    return high_def_path or low_def_path
+
+
+def _encode_on_remote_worker(
+    preview_file_id,
+    uploaded_movie_path,
+    fps,
+    width,
+    height,
+    encode,
+    skip_high_def,
+):
+    """
+    Hand the movie over to the remote worker, which reads the source from
+    the storage, encodes it and builds the thumbnails and the tile. It
+    runs even when nothing has to be encoded. Return the movie the
+    metadata is read from: the encoded version fetched back from the
+    storage, or the upload itself when nothing was encoded.
+    """
+    from zou.app import app as current_app
+
+    result = _run_remote_normalize_movie(
+        current_app,
+        preview_file_id,
+        fps,
+        width,
+        height,
+        skip_high_def=skip_high_def,
+        skip_normalization=not encode,
+    )
+    if result is not True:
+        raise PreviewProcessingFailedException(result)
+    if not encode:
+        return uploaded_movie_path
+    # The copy fetched here is the movie routes' cache entry: it stays.
+    return fs.get_file_path_and_file(
+        config,
+        file_store.get_local_movie_path,
+        file_store.open_movie,
+        "lowdef" if skip_high_def else "previews",
+        preview_file_id,
+        "mp4",
+    )
+
+
+def _read_movie_metadata(movie_path):
+    """
+    The fields recorded on the preview file once it is ready.
+    """
+    width, height = movie.get_movie_size(movie_path)
+    return {
+        "width": width,
+        "height": height,
+        "file_size": os.path.getsize(movie_path),
+        "duration": movie.get_movie_duration(movie_path),
+    }
+
+
+def _build_thumbnails_and_tile(preview_file_id, movie_path, size, temp_files):
+    """
+    Build the picture variants and the tile mosaic from the movie and
+    store them. A missing tile is logged, not fatal.
+    """
+    from zou.app import app as current_app
+
+    original_picture_path = movie.generate_thumbnail(movie_path)
+    temp_files.append(original_picture_path)
+    thumbnail_utils.turn_into_thumbnail(original_picture_path, size)
+    save_variants(preview_file_id, original_picture_path)
+    current_app.logger.info(f"thumbnail created {original_picture_path}")
+
+    try:
+        tile_path = movie.generate_tile(movie_path)
+        file_store.add_picture("tiles", preview_file_id, tile_path)
+        os.remove(tile_path)
+        current_app.logger.info(f"tile created {tile_path}")
+    except Exception:
+        current_app.logger.error("Failed to create tile", exc_info=1)
+
+
+def _get_stored_movie_prefixes(
+    preview_file_id, is_remote, encode, skip_high_def, add_source_to_file_store
+):
+    """
+    Which storage prefixes hold the movie, recorded on the preview file so
+    that the movie routes do not have to rediscover it by probing the
+    storage. Locally it follows from the flags: the encoded versions, or
+    the upload itself under `previews` when it was stored raw and not
+    already kept as the source. A remote job is asked nothing: a runner
+    that predates skip_high_def still uploads both encoded versions, so
+    the storage is probed once instead.
+    """
+    if is_remote:
+        prefixes = files_service.probe_movie_prefixes(preview_file_id)
+    elif encode:
+        prefixes = ["lowdef"] if skip_high_def else ["previews", "lowdef"]
+    elif add_source_to_file_store:
+        prefixes = []
+    else:
+        prefixes = ["previews"]
+    if add_source_to_file_store and "source" not in prefixes:
+        prefixes.insert(0, "source")
+    return prefixes
 
 
 def is_remote_normalization_enabled():

--- a/zou/app/stores/file_store.py
+++ b/zou/app/stores/file_store.py
@@ -7,6 +7,7 @@ from werkzeug.utils import cached_property
 from zou.app import config
 from flask_fs.backends.local import LocalBackend
 from flask_fs.errors import FileNotFound
+from werkzeug.exceptions import RequestedRangeNotSatisfiable
 
 from zou.app.utils import fs
 
@@ -341,8 +342,10 @@ def make_read_generator(bucket, key, bucket_name=None):
     When ``bucket_name`` is provided and Prometheus is enabled, the generator
     records a ``download`` operation with cumulative byte count.
     """
-    read_stream = _read_chunks(bucket, key)
+    return _measured_read(_read_chunks(bucket, key), key, bucket_name)
 
+
+def _measured_read(read_stream, key, bucket_name=None):
     def read_generator(read_stream):
         tracker = _ByteTracker()
         measured = (
@@ -366,6 +369,68 @@ def make_read_generator(bucket, key, bucket_name=None):
                     pass
 
     return read_generator(read_stream)
+
+
+RANGE_CHUNK_SIZE = 1024 * 1024
+
+
+def can_stream_movie_ranges():
+    """
+    Tell whether a movie can be served straight from the object storage by
+    byte range. Encrypted Swift objects cannot: the cipher stream has to be
+    read from its start.
+    """
+    return (
+        config.FS_BACKEND in ("s3", "swift")
+        and movies.backend.encryptor is None
+    )
+
+
+def read_movie_range(prefix, id, range_header=None):
+    """
+    Stream a movie from the object storage without caching it locally,
+    the given ``Range`` header value (``bytes=start-end``) applied by the
+    storage itself. Return ``(content_length, content_range, generator)``:
+    ``content_range`` is None when no range was asked.
+    """
+    key = make_key(prefix, id)
+    backend = movies.backend
+    try:
+        if config.FS_BACKEND == "s3":
+            kwargs = {"Range": range_header} if range_header else {}
+            obj = backend.bucket.Object(key).get(**kwargs)
+            body = obj["Body"]
+
+            def read_stream(body=body):
+                try:
+                    yield from body.iter_chunks(RANGE_CHUNK_SIZE)
+                finally:
+                    body.close()
+
+            content_length = obj["ContentLength"]
+            content_range = obj.get("ContentRange")
+            generator = read_stream()
+        else:
+            headers = {"Range": range_header} if range_header else None
+            resp_headers, generator = backend.conn.get_object(
+                backend.name,
+                key,
+                resp_chunk_size=RANGE_CHUNK_SIZE,
+                headers=headers,
+            )
+            content_length = int(resp_headers["content-length"])
+            content_range = resp_headers.get("content-range")
+    except Exception as exc:
+        if fs.is_missing_file_error(exc):
+            raise FileNotFound(key) from exc
+        if fs.is_range_error(exc):
+            raise RequestedRangeNotSatisfiable() from exc
+        raise
+    return (
+        content_length,
+        content_range,
+        _measured_read(generator, key, bucket_name="movies"),
+    )
 
 
 # ----------------------------------------------------------------------

--- a/zou/app/utils/commands.py
+++ b/zou/app/utils/commands.py
@@ -11,7 +11,7 @@ import orjson as json
 from tabulate import tabulate
 from ldap3 import Server, Connection, ALL, NTLM, SIMPLE
 from zou.app.utils import thumbnail as thumbnail_utils, auth
-from zou.app.stores import auth_tokens_store, file_store, queue_store
+from zou.app.stores import auth_tokens_store, file_store
 from zou.app.services import (
     assets_service,
     backup_service,
@@ -1089,24 +1089,12 @@ def renormalize_movie_preview_files(
                             f"empty at {uploaded_movie_path}; skipping "
                             f"renormalization of {preview_file_id}."
                         )
-                    if config.ENABLE_JOB_QUEUE:
-                        queue_store.job_queue.enqueue(
-                            preview_files_service.prepare_and_store_movie,
-                            args=(
-                                preview_file_id,
-                                uploaded_movie_path,
-                                True,
-                                False,
-                            ),
-                            job_timeout=int(config.JOB_QUEUE_TIMEOUT),
-                        )
-                    else:
-                        preview_files_service.prepare_and_store_movie(
-                            preview_file_id,
-                            uploaded_movie_path,
-                            normalize=True,
-                            add_source_to_file_store=False,
-                        )
+                    preview_files_service.dispatch_movie_processing(
+                        preview_file_id,
+                        uploaded_movie_path,
+                        normalize=True,
+                        add_source_to_file_store=False,
+                    )
                 except _SourceMovieMissing as e:
                     print(
                         f"Renormalization of preview file {preview_file_id} failed: {e}"

--- a/zou/app/utils/fs.py
+++ b/zou/app/utils/fs.py
@@ -1,6 +1,8 @@
+import fcntl
 import glob
 import os
 import shutil
+import threading
 import time
 import uuid
 from flask_fs.errors import FileNotFound
@@ -57,6 +59,24 @@ def is_missing_file_error(exception):
         error = response.get("Error") or {}
         if error.get("Code") in MISSING_OBJECT_ERROR_CODES:
             return True
+    return False
+
+
+def is_range_error(exception):
+    """
+    Tell a byte range the object storage refused (416) from other failures.
+    """
+    for attribute in ("http_status", "status", "status_code"):
+        if getattr(exception, attribute, None) == 416:
+            return True
+    response = getattr(exception, "response", None)
+    if isinstance(response, dict):
+        metadata = response.get("ResponseMetadata") or {}
+        error = response.get("Error") or {}
+        return (
+            metadata.get("HTTPStatusCode") == 416
+            or error.get("Code") == "InvalidRange"
+        )
     return False
 
 
@@ -119,6 +139,31 @@ def download_to_file(file_path, open_file, prefix, instance_id):
     finally:
         rm_file(tmp_path)
     return exception
+
+
+def fill_cache_in_background(file_path, open_file, prefix, instance_id):
+    """
+    Download a file to the local cache from a background thread, unless
+    another thread or worker process already is: the downloader holds a
+    flock on a sidecar lock file for the duration. Return whether a
+    download was started. The lock file is left behind: removing it would
+    race with the next locker.
+    """
+    lock_file = open(f"{file_path}.lock", "a")
+    try:
+        fcntl.flock(lock_file, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except OSError:
+        lock_file.close()
+        return False
+
+    def run():
+        try:
+            download_to_file(file_path, open_file, prefix, instance_id)
+        finally:
+            lock_file.close()
+
+    threading.Thread(target=run, daemon=True).start()
+    return True
 
 
 def get_file_path_and_file(


### PR DESCRIPTION
**Problem**

- Every Range request on a movie re-read the file from byte 0: Werkzeug's range wrapper cannot seek gunicorn's file wrapper, so the first byte grew with the offset and blocked the worker.
- On a remote backend the first request downloaded the whole movie to the local cache before answering (8 s for 80 MB, minutes for a long film), and concurrent cold requests each ran a full download.
- prepare_and_store_movie had grown to 330 lines with three failure paths and duplicated temp file cleanup; the upload route and the renormalize command dispatched by copy, and the remote-encoded movie was downloaded then deleted.

**Solution**

- Force Werkzeug's seekable FileWrapper before send_file so ranges seek.
- Stream the requested byte range straight from S3/Swift while one flock-guarded background thread fills the cache; refused ranges answer 416.
- Split the processing into named steps with one temp file cleanup, share dispatch_movie_processing between route and command, and keep the remote-encoded movie in the routes' cache.